### PR TITLE
Include retired legislators in manual data find

### DIFF
--- a/scripts/manual_data.py
+++ b/scripts/manual_data.py
@@ -42,7 +42,9 @@ def generate_template_csv(abbreviations, filename, missing_id=None):
 
 def find_by_id(id):
     id = id.split('/')[1]
-    choices = glob.glob(os.path.join(get_data_dir('*'), 'people', f'*-{id}.yml'))
+    choices = glob.glob(
+        os.path.join(get_data_dir('*'), 'people', f'*-{id}.yml')
+    ) + glob.glob(os.path.join(get_data_dir("*"), "retired", f"*-{id}.yml"))
     if len(choices) != 1:
         raise ValueError(f'unknown id {id}')
     return choices[0]


### PR DESCRIPTION
Manual Data load currently errors out if there is a retired legislator included. This allows manual load to with retired legislators.