### PR TITLE
Update Indiana legislators and committees for 2019

### DIFF
--- a/data/in/organizations/Agriculture-13a6aef0-8b55-4788-8276-862b330ab483.yml
+++ b/data/in/organizations/Agriculture-13a6aef0-8b55-4788-8276-862b330ab483.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/agriculture_and_natural_resources_3100
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_agriculture_and_natural_resources_3100
+- url: http://iga.in.gov/legislative/2019/committees/agriculture_and_natural_resources_3100
+- url: https://api.iga.in.gov/2019/standing-committees/committee_agriculture_and_natural_resources_3100
 memberships:
 - id: ocd-person/40ea5143-d0ab-4b9a-a0bc-2cc04f984888
   name: Jean Leising
@@ -17,17 +17,31 @@ memberships:
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
   name: Brian Buchanan
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
+  end_date: '2018-11-06'
 - id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
   name: Mark Messmer
+  end_date: '2018-11-06'
 - id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
   name: Chip Perfect
 - id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
   name: James Tomes
 - id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
   name: Andy Zay
+  end_date: '2018-11-06'
+- id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
+  name: Timothy Lanane
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/fc270bf0-2220-476a-ad9c-15db82d62192
+  name: Justin Busch
+  start_date: '2018-11-07'
+- id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
+  name: Greg Taylor
+  start_date: '2018-11-07'

--- a/data/in/organizations/Agriculture-and-Rural-Development-1eb4c6ca-0a21-4ba2-94c7-036f21f74d6f.yml
+++ b/data/in/organizations/Agriculture-and-Rural-Development-1eb4c6ca-0a21-4ba2-94c7-036f21f74d6f.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/agriculture_and_rural_development_0100
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_agriculture_and_rural_development_0100
+- url: http://iga.in.gov/legislative/2019/committees/agriculture_and_rural_development_0100
+- url: https://api.iga.in.gov/2019/standing-committees/committee_agriculture_and_rural_development_0100
 memberships:
 - id: ocd-person/e9843d9e-d8d9-4310-bb12-676f1dd486aa
   name: Don Lehe
@@ -14,26 +14,56 @@ memberships:
 - id: ocd-person/3e2f70f5-2f3a-425f-99ed-c7277eb2f13c
   name: Alan Morrison
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/7fa8b319-d3d7-4612-a0d2-0baf3f0c4382
   name: Melanie Wright
   role: Ranking Minority Member
 - id: ocd-person/650c6338-9a20-44df-82e3-5f0d372bc415
   name: James Baird
+  end_date: '2018-11-06'
 - id: ocd-person/0a4c7269-3039-425c-8acb-d428c88e6a8a
   name: Greg Beumer
+  end_date: '2018-11-06'
 - id: ocd-person/0f2d19a6-7ae8-4e2c-8111-6b8965284a01
   name: William Friend
+  end_date: '2018-11-06'
 - id: ocd-person/53a0eb12-72c3-4e7e-9258-d264de2bee6c
   name: Doug Gutwein
 - id: ocd-person/70b18ef2-1df3-494e-a9ac-dac5b71a3b4f
   name: Richard Hamm
+  end_date: '2018-11-06'
 - id: ocd-person/ed771fd3-4bd9-4c99-bb42-4bd9f5d1ff8d
   name: Dave Heine
 - id: ocd-person/68f44f31-ba0b-4641-a656-f05e91c02cd8
   name: Sheila Klinker
+  end_date: '2018-11-06'
 - id: ocd-person/0f97edaa-0f48-4c61-82dd-c70aeb05a5ff
   name: Justin Moed
 - id: ocd-person/61f57248-4172-4ac6-b075-df82cff344cf
   name: Scott Pelath
+  end_date: '2018-11-06'
 - id: ocd-person/a90c6c3f-a4c0-4bbe-a1a6-6d1c82345769
   name: Sally Siegrist
+  end_date: '2018-11-06'
+- id: ocd-person/df749cfb-56e8-482f-bf4b-183a1fb52594
+  name: Steve Bartels
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/a8ed53f7-00fb-428b-a629-7532efaf902d
+  name: Beau Baird
+  start_date: '2018-11-07'
+- id: ocd-person/6629fcea-f482-4e63-872d-d2f8734502ca
+  name: Brad Barrett
+  start_date: '2018-11-07'
+- id: ocd-person/17a999cc-8bc7-4ecd-8e82-c741fa8ac1be
+  name: Terry Goodin
+  start_date: '2018-11-07'
+- id: ocd-person/bdae77c7-d89e-426d-b6f6-52e1a48bc87a
+  name: Ethan Manning
+  start_date: '2018-11-07'
+- id: ocd-person/dcba8890-86e8-4a0c-a4a5-77b2fa98a267
+  name: J.D. Prescott
+  start_date: '2018-11-07'
+- id: ocd-person/2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f
+  name: Christy Stutzman
+  start_date: '2018-11-07'

--- a/data/in/organizations/Appropriations-42258cc2-7d2d-4e25-9388-be9d222ba657.yml
+++ b/data/in/organizations/Appropriations-42258cc2-7d2d-4e25-9388-be9d222ba657.yml
@@ -5,24 +5,25 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/appropriations_3700
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_appropriations_3700
+- url: http://iga.in.gov/legislative/2019/committees/appropriations_3700
+- url: https://api.iga.in.gov/2019/standing-committees/committee_appropriations_3700
 memberships:
 - id: ocd-person/010e5ebe-683c-4fe2-9696-46f7f0b4bea6
   name: Ryan Mishler
   role: Chair
 - id: ocd-person/d9013459-1dea-46ee-bdd5-5b2874b76e0a
   name: Liz Brown
-  role: Vice Chair
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
   role: Ranking Minority Member
 - id: ocd-person/2d517236-2a88-435f-bc1f-ce09de86c6f9
   name: Eric Bassler
+  role: Vice Chair
 - id: ocd-person/dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02
   name: Philip Boots
 - id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
   name: Rodric Bray
+  end_date: '2018-11-06'
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/ce2c81c3-e2d6-4394-b960-8787d896bfe5
@@ -31,9 +32,20 @@ memberships:
   name: Michael Crider
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
+  end_date: '2018-11-06'
 - id: ocd-person/aa948d0d-f7d1-4a11-a58b-986b0d61ebf7
   name: Travis Holdman
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
+  end_date: '2018-11-06'
+- id: ocd-person/dd0b774c-0fc8-4ce4-944f-91e254fda0ce
+  name: Jon Ford
+  start_date: '2018-11-07'
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+  start_date: '2018-11-07'
+- id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
+  name: Eddie Melton
+  start_date: '2018-11-07'

--- a/data/in/organizations/Civil-Law-9ebc62d7-6cab-4fa1-915d-a212d7017683.yml
+++ b/data/in/organizations/Civil-Law-9ebc62d7-6cab-4fa1-915d-a212d7017683.yml
@@ -14,6 +14,7 @@ memberships:
 - id: ocd-person/80a66e08-e30e-4828-b3d7-85a952af56e8
   name: Joseph Zakas
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
   role: Ranking Minority Member
@@ -23,6 +24,7 @@ memberships:
   name: James Buck
 - id: ocd-person/b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a
   name: Aaron Freeman
+  end_date: '2018-11-06'
 - id: ocd-person/a7974310-0d01-4bc1-9c14-29561ec68a60
   name: Eric Koch
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd

--- a/data/in/organizations/Commerce-Small-Business-and-Economic-Development-6c3699b8-0704-4d03-a842-2928541b89db.yml
+++ b/data/in/organizations/Commerce-Small-Business-and-Economic-Development-6c3699b8-0704-4d03-a842-2928541b89db.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/commerce_small_business_and_economic_development_0200
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_commerce_small_business_and_economic_development_0200
+- url: http://iga.in.gov/legislative/2019/committees/commerce_small_business_and_economic_development_0200
+- url: https://api.iga.in.gov/2019/standing-committees/committee_commerce_small_business_and_economic_development_0200
 memberships:
 - id: ocd-person/20851625-bc7c-41ed-841e-27af062bc03e
   name: Robert Morris
@@ -17,23 +17,48 @@ memberships:
 - id: ocd-person/ec6a3cce-3eca-4020-8809-a7a1875e1663
   name: Carey Hamilton
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/df43dec4-b355-43cc-a420-a3c162b3840f
   name: Ronald Bacon
 - id: ocd-person/1b9ddafb-fca9-4924-b565-d651c2ca133b
   name: Martin Carbaugh
 - id: ocd-person/3758fe74-9190-4daf-9a3e-790b01e3d2d4
   name: Dan Forestal
+  end_date: '2018-11-06'
 - id: ocd-person/12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55
   name: Jack Jordan
+  end_date: '2018-11-06'
 - id: ocd-person/96c8ce73-904d-45f9-a2e1-cb9c72596e40
   name: Randy Lyness
 - id: ocd-person/74c79726-70e0-46c4-8ed0-b26da994e0a4
   name: Karlee Macer
 - id: ocd-person/df8a1659-63b2-4e11-8dce-17bce11f8162
   name: Julie Olthoff
+  end_date: '2018-11-06'
 - id: ocd-person/3918dc6e-fbf5-4ea0-b62a-376729b463ec
   name: Jim Pressel
+  end_date: '2018-11-06'
 - id: ocd-person/ea2c35cb-7071-43de-8dc6-e91756d03f11
   name: Ben Smaltz
 - id: ocd-person/7fa8b319-d3d7-4612-a0d2-0baf3f0c4382
   name: Melanie Wright
+  end_date: '2018-11-06'
+- id: ocd-person/03416080-75a4-4eb2-acde-6d59f0967666
+  name: Rita Fleming
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a8ed53f7-00fb-428b-a629-7532efaf902d
+  name: Beau Baird
+  start_date: '2018-11-07'
+- id: ocd-person/43a1d29d-81cc-4240-a367-46271d4aa3be
+  name: Lisa Beck
+  start_date: '2018-11-07'
+- id: ocd-person/77a93fc3-bbc5-41b6-b1af-0069670dd5af
+  name: Steven Davisson
+  start_date: '2018-11-07'
+- id: ocd-person/4c9685ab-f2a4-46e0-980a-699bb01d26cf
+  name: Ragen Hatcher
+  start_date: '2018-11-07'
+- id: ocd-person/2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f
+  name: Christy Stutzman
+  start_date: '2018-11-07'

--- a/data/in/organizations/Commerce-and-Technology-a86cdd58-4eeb-4647-bf89-5d1b97a50dc0.yml
+++ b/data/in/organizations/Commerce-and-Technology-a86cdd58-4eeb-4647-bf89-5d1b97a50dc0.yml
@@ -5,31 +5,52 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/commerce_technology
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_commerce_technology
+- url: http://iga.in.gov/legislative/2019/committees/commerce_technology
+- url: https://api.iga.in.gov/2019/standing-committees/committee_commerce_technology
 memberships:
 - id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
   name: Mark Messmer
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
   role: Vice Chair
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
-  role: Ranking Minority Member
 - id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
   name: Brian Buchanan
+  end_date: '2018-11-06'
 - id: ocd-person/c44e058d-5b65-48bd-8994-431e624f43cf
   name: Michael Delph
+  end_date: '2018-11-06'
 - id: ocd-person/05cfdc73-ff21-4d74-833e-e3da82ed7509
   name: Erin Houchin
 - id: ocd-person/a7974310-0d01-4bc1-9c14-29561ec68a60
   name: Eric Koch
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
+  end_date: '2018-11-06'
 - id: ocd-person/40ea5143-d0ab-4b9a-a0bc-2cc04f984888
   name: Jean Leising
 - id: ocd-person/8bb659ad-1a77-40f2-8916-39b18c55ac52
   name: Mark Stoops
 - id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
   name: James Tomes
+  end_date: '2018-11-06'
+- id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
+  name: Chip Perfect
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
+  name: Blake Doriot
+  start_date: '2018-11-07'
+- id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+  name: Chris Garten
+  start_date: '2018-11-07'
+- id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
+  name: Andy Zay
+  start_date: '2018-11-07'

--- a/data/in/organizations/Committee-on-Joint-Rules-8a8da044-5b3e-42b6-b145-a3ecc1e52e08.yml
+++ b/data/in/organizations/Committee-on-Joint-Rules-8a8da044-5b3e-42b6-b145-a3ecc1e52e08.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/committee_on_joint_rules
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_committee_on_joint_rules
+- url: http://iga.in.gov/legislative/2019/committees/committee_on_joint_rules
+- url: https://api.iga.in.gov/2019/standing-committees/committee_committee_on_joint_rules
 memberships:
 - id: ocd-person/a52a0e0d-3abd-4181-bd89-71c79eb36fcb
   name: Brian Bosma
@@ -17,7 +17,12 @@ memberships:
 - id: ocd-person/43b9cb7b-a913-4624-859b-6f28e10d871a
   name: B Patrick Bauer
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/16b01fca-3a93-41a3-ad6a-f2bf9209ddf7
   name: Ryan Dvorak
 - id: ocd-person/ea2c35cb-7071-43de-8dc6-e91756d03f11
   name: Ben Smaltz
+- id: ocd-person/d1e89034-ef4a-4a10-b16d-16dc617dcdf1
+  name: Philip GiaQuinta
+  role: Ranking Minority Member
+  start_date: '2018-11-07'

--- a/data/in/organizations/Corrections-and-Criminal-Law-3930b843-ee95-49d1-b011-066c2bdea9dd.yml
+++ b/data/in/organizations/Corrections-and-Criminal-Law-3930b843-ee95-49d1-b011-066c2bdea9dd.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/corrections_and_criminal_law_3000
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_corrections_and_criminal_law_3000
+- url: http://iga.in.gov/legislative/2019/committees/corrections_and_criminal_law_3000
+- url: https://api.iga.in.gov/2019/standing-committees/committee_corrections_and_criminal_law_3000
 memberships:
 - id: ocd-person/01bb6149-aa0f-457f-b759-1338b6c8ae5f
   name: Michael Young
@@ -17,15 +17,33 @@ memberships:
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
   name: Mike Bohacek
 - id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
   name: Rodric Bray
+  end_date: '2018-11-06'
 - id: ocd-person/b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a
   name: Aaron Freeman
+  end_date: '2018-11-06'
 - id: ocd-person/a7974310-0d01-4bc1-9c14-29561ec68a60
   name: Eric Koch
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
+  end_date: '2018-11-06'
 - id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
   name: James Tomes
+  end_date: '2018-11-06'
+- id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
+  name: Karen Tallian
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/fc270bf0-2220-476a-ad9c-15db82d62192
+  name: Justin Busch
+  start_date: '2018-11-07'
+- id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
+  name: Lonnie Randolph
+  start_date: '2018-11-07'
+- id: ocd-person/05364e0a-5596-47b0-b2e2-cf6998d5eeed
+  name: Jack Sandlin
+  start_date: '2018-11-07'

--- a/data/in/organizations/Courts-and-Criminal-Code-18fd9c75-ca5a-4b3a-9a27-3bb94dba6716.yml
+++ b/data/in/organizations/Courts-and-Criminal-Code-18fd9c75-ca5a-4b3a-9a27-3bb94dba6716.yml
@@ -5,35 +5,49 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/courts_and_criminal_code_0300
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_courts_and_criminal_code_0300
+- url: http://iga.in.gov/legislative/2019/committees/courts_and_criminal_code_0300
+- url: https://api.iga.in.gov/2019/standing-committees/committee_courts_and_criminal_code_0300
 memberships:
 - id: ocd-person/0c49328e-c3a6-4d21-988c-ceb32e2179e3
   name: Thomas Washburne
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/5df40faa-22e6-4300-b749-89abfdc2e554
   name: Sharon Negele
-  role: Vice Chair
 - id: ocd-person/45d8ea46-0d3f-4a80-bf4e-ca016bd458a8
   name: Edward DeLaney
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/16b01fca-3a93-41a3-ad6a-f2bf9209ddf7
   name: Ryan Dvorak
 - id: ocd-person/58bbda21-7c3e-4189-9d02-0ba7f95a6471
   name: Ryan Hatfield
+  end_date: '2018-11-06'
 - id: ocd-person/291429c7-c347-40a1-831e-8f0dd870b2ca
   name: Cindy Kirchhofer
 - id: ocd-person/c16ddc1a-c07f-419b-b9b3-33f3a7adec18
   name: Kevin Mahan
 - id: ocd-person/ac2c89af-df39-4057-bdeb-15ca57b7ef9f
   name: Wendy McNamara
+  role: Chair
 - id: ocd-person/c66bcc9b-d5e6-478b-b11e-25be7f4e0aaa
   name: Matt Pierce
 - id: ocd-person/062c9921-6c7e-489b-bcc2-b140231cd2c2
   name: Donna Schaibley
+  role: Vice Chair
 - id: ocd-person/3ee97114-199a-4084-903f-5eaa231ca656
   name: Gregory Steuerwald
 - id: ocd-person/be047f92-01da-453f-beec-d6c68b14b403
   name: John Young
 - id: ocd-person/78b84e11-85f1-49fb-8243-49b15a457523
   name: Cindy Ziemke
+- id: ocd-person/4c9685ab-f2a4-46e0-980a-699bb01d26cf
+  name: Ragen Hatcher
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/df749cfb-56e8-482f-bf4b-183a1fb52594
+  name: Steve Bartels
+  start_date: '2018-11-07'
+- id: ocd-person/43a1d29d-81cc-4240-a367-46271d4aa3be
+  name: Lisa Beck
+  start_date: '2018-11-07'

--- a/data/in/organizations/Education-970d9105-76be-491a-87c5-603a96aa5c9a.yml
+++ b/data/in/organizations/Education-970d9105-76be-491a-87c5-603a96aa5c9a.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/education_0400
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_education_0400
+- url: http://iga.in.gov/legislative/2019/committees/education_0400
+- url: https://api.iga.in.gov/2019/standing-committees/committee_education_0400
 memberships:
 - id: ocd-person/3d215bfb-c08a-47f0-91d3-eb114b33c56d
   name: Robert Behning
@@ -27,6 +27,7 @@ memberships:
   name: Dale DeVon
 - id: ocd-person/98feacbe-3be5-407e-a437-66d65a836a5e
   name: Sue Errington
+  end_date: '2018-11-06'
 - id: ocd-person/12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55
   name: Jack Jordan
 - id: ocd-person/68f44f31-ba0b-4641-a656-f05e91c02cd8
@@ -37,3 +38,10 @@ memberships:
   name: Jeffrey Thompson
 - id: ocd-person/fbcd4d2c-32c6-4c97-837b-4e4ed80c43df
   name: Timothy Wesco
+  end_date: '2018-11-06'
+- id: ocd-person/e9844fde-43a6-4aa8-9248-85ab1ad79c20
+  name: Chuck Goodrich
+  start_date: '2018-11-07'
+- id: ocd-person/0f97a586-0089-4eb8-86c1-40f42bc1f594
+  name: Tonya Pfaff
+  start_date: '2018-11-07'

--- a/data/in/organizations/Education-and-Career-Development-62a07c39-e0c8-4b24-aa16-e68d3b8c8e42.yml
+++ b/data/in/organizations/Education-and-Career-Development-62a07c39-e0c8-4b24-aa16-e68d3b8c8e42.yml
@@ -5,24 +5,26 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/education_and_career_development_3400
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_education_and_career_development_3400
+- url: http://iga.in.gov/legislative/2019/committees/education_and_career_development_3400
+- url: https://api.iga.in.gov/2019/standing-committees/committee_education_and_career_development_3400
 memberships:
 - id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
   name: Dennis Kruse
-  role: Chair
 - id: ocd-person/4267823b-aec1-452a-a040-25b337f04c54
   name: Jeff Raatz
-  role: Vice Chair
+  role: Chair
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
   role: Ranking Minority Member
 - id: ocd-person/2d517236-2a88-435f-bc1f-ce09de86c6f9
   name: Eric Bassler
+  end_date: '2018-11-06'
 - id: ocd-person/ed4d2a15-ec36-4f60-8a07-b79e15d34760
   name: John Crane
+  role: Vice Chair
 - id: ocd-person/b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a
   name: Aaron Freeman
+  end_date: '2018-11-06'
 - id: ocd-person/40ea5143-d0ab-4b9a-a0bc-2cc04f984888
   name: Jean Leising
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
@@ -33,3 +35,10 @@ memberships:
   name: Mark Stoops
 - id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
   name: Andy Zay
+  end_date: '2018-11-06'
+- id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
+  name: Brian Buchanan
+  start_date: '2018-11-07'
+- id: ocd-person/b5f001ff-6e60-49b9-b074-bb83139410b4
+  name: Linda Rogers
+  start_date: '2018-11-07'

--- a/data/in/organizations/Elections-9b77601f-2ed0-4373-8c6f-9e8ff1db4040.yml
+++ b/data/in/organizations/Elections-9b77601f-2ed0-4373-8c6f-9e8ff1db4040.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/elections_3500
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_elections_3500
+- url: http://iga.in.gov/legislative/2019/committees/elections_3500
+- url: https://api.iga.in.gov/2019/standing-committees/committee_elections_3500
 memberships:
 - id: ocd-person/0bee6f8c-db8b-4e92-8bd4-799c71c55c2c
   name: Greg Walker
@@ -17,8 +17,10 @@ memberships:
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
   name: Mike Bohacek
+  end_date: '2018-11-06'
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/ed4d2a15-ec36-4f60-8a07-b79e15d34760
@@ -29,3 +31,14 @@ memberships:
   name: Erin Houchin
 - id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
   name: Dennis Kruse
+  end_date: '2018-11-06'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/01cb22d6-e0f5-478e-99b2-801ffbf32d2b
+  name: Mike Gaskill
+  start_date: '2018-11-07'
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+  start_date: '2018-11-07'

--- a/data/in/organizations/Elections-and-Apportionment-05110ccc-81b7-4cb3-8803-5a63526f0ba5.yml
+++ b/data/in/organizations/Elections-and-Apportionment-05110ccc-81b7-4cb3-8803-5a63526f0ba5.yml
@@ -5,30 +5,37 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/elections_and_apportionment_0500
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_elections_and_apportionment_0500
+- url: http://iga.in.gov/legislative/2019/committees/elections_and_apportionment_0500
+- url: https://api.iga.in.gov/2019/standing-committees/committee_elections_and_apportionment_0500
 memberships:
 - id: ocd-person/a3cca3aa-1783-4eae-b3e7-2ee7832dfcb6
   name: Milo Smith
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/78e2597b-60d2-4902-af7c-a98e84b71b9a
   name: Kathy Richardson
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/58bbda21-7c3e-4189-9d02-0ba7f95a6471
   name: Ryan Hatfield
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/5ceabc0e-ec47-41b5-b014-5eddcdc154f3
   name: John Bartlett
+  end_date: '2018-11-06'
 - id: ocd-person/35824e09-976c-44b7-9825-0787030f0e4e
   name: Chris Judy
 - id: ocd-person/7081abcc-348a-4eff-84a1-74f6a2c7ef01
   name: Clyde Kersey
+  end_date: '2018-11-06'
 - id: ocd-person/70f005b9-1417-4132-9956-ad93942ca87d
   name: Jim Lucas
 - id: ocd-person/17fd494d-905d-4c82-a828-6d975cbf02f3
   name: Charles Moseley
+  role: Ranking Minority Member
 - id: ocd-person/7eb86096-7906-4bac-8bb5-98e3ecd5029c
   name: Curt Nisly
+  end_date: '2018-11-06'
 - id: ocd-person/3918dc6e-fbf5-4ea0-b62a-376729b463ec
   name: Jim Pressel
 - id: ocd-person/3fbcc2a9-c620-456c-b38f-03e0f9063c3f
@@ -37,3 +44,23 @@ memberships:
   name: Jeffrey Thompson
 - id: ocd-person/fbcd4d2c-32c6-4c97-837b-4e4ed80c43df
   name: Timothy Wesco
+  role: Chair
+- id: ocd-person/3e2f70f5-2f3a-425f-99ed-c7277eb2f13c
+  name: Alan Morrison
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/8dde5c26-4718-45e7-a021-487d7fa6a924
+  name: Pat Boy
+  start_date: '2018-11-07'
+- id: ocd-person/c0e3527e-b990-4190-8ffe-43258158ac58
+  name: Robert Cherry
+  start_date: '2018-11-07'
+- id: ocd-person/3758fe74-9190-4daf-9a3e-790b01e3d2d4
+  name: Dan Forestal
+  start_date: '2018-11-07'
+- id: ocd-person/0f97a586-0089-4eb8-86c1-40f42bc1f594
+  name: Tonya Pfaff
+  start_date: '2018-11-07'
+- id: ocd-person/585e1d84-c51f-4d50-90d2-e5828a5c2d02
+  name: Jerry Torr
+  start_date: '2018-11-07'

--- a/data/in/organizations/Employment-Labor-and-Pensions-2a357702-ce1a-4257-99b0-21eaff75c8eb.yml
+++ b/data/in/organizations/Employment-Labor-and-Pensions-2a357702-ce1a-4257-99b0-21eaff75c8eb.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/employment_labor_and_pensions_0600
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_employment_labor_and_pensions_0600
+- url: http://iga.in.gov/legislative/2019/committees/employment_labor_and_pensions_0600
+- url: https://api.iga.in.gov/2019/standing-committees/committee_employment_labor_and_pensions_0600
 memberships:
 - id: ocd-person/113063ff-6e21-4bf7-b9d0-f06aafc349f2
   name: Heath VanNatter
@@ -17,14 +17,17 @@ memberships:
 - id: ocd-person/5b9af417-d7e1-4a3d-96bb-647e8fd734d5
   name: Joe Taylor
   role: Ranking Minority Member
+  end_date: '2018-12-03'
 - id: ocd-person/5ceabc0e-ec47-41b5-b014-5eddcdc154f3
   name: John Bartlett
 - id: ocd-person/1b9ddafb-fca9-4924-b565-d651c2ca133b
   name: Martin Carbaugh
 - id: ocd-person/512b492f-8d12-48f6-a509-f0a4a12ee11a
   name: Linda Lawson
+  end_date: '2018-11-06'
 - id: ocd-person/423b3123-c1b6-4e2f-92f4-5610130de844
   name: Matt Lehman
+  end_date: '2018-11-06'
 - id: ocd-person/839dc3a8-6b1a-4aff-b5cf-342da0cac11d
   name: Daniel Leonard
 - id: ocd-person/20851625-bc7c-41ed-841e-27af062bc03e
@@ -32,7 +35,22 @@ memberships:
 - id: ocd-person/17fd494d-905d-4c82-a828-6d975cbf02f3
   name: Charles Moseley
 - name: David Ober
+  end_date: '2018-11-06'
 - id: ocd-person/ed0facaa-4220-4f7d-899f-2bb0d576e9ef
   name: Mike Speedy
+  end_date: '2018-11-06'
 - id: ocd-person/585e1d84-c51f-4d50-90d2-e5828a5c2d02
   name: Jerry Torr
+- id: ocd-person/43a1d29d-81cc-4240-a367-46271d4aa3be
+  name: Lisa Beck
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a080b584-c899-4694-a797-73cca22610fe
+  name: David Abbott
+  start_date: '2018-11-07'
+- id: ocd-person/e9844fde-43a6-4aa8-9248-85ab1ad79c20
+  name: Chuck Goodrich
+  start_date: '2018-11-07'
+- id: ocd-person/fbcd4d2c-32c6-4c97-837b-4e4ed80c43df
+  name: Timothy Wesco
+  start_date: '2018-11-07'

--- a/data/in/organizations/Environmental-Affairs-2adb8d25-c07d-47b7-8e0c-3ac935f1dcd9.yml
+++ b/data/in/organizations/Environmental-Affairs-2adb8d25-c07d-47b7-8e0c-3ac935f1dcd9.yml
@@ -5,24 +5,29 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/environmental_affairs_4800
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_environmental_affairs_4800
+- url: http://iga.in.gov/legislative/2019/committees/environmental_affairs_4800
+- url: https://api.iga.in.gov/2019/standing-committees/committee_environmental_affairs_4800
 memberships:
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/2d517236-2a88-435f-bc1f-ce09de86c6f9
   name: Eric Bassler
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/8bb659ad-1a77-40f2-8916-39b18c55ac52
   name: Mark Stoops
   role: Ranking Minority Member
 - id: ocd-person/b6be97c1-d574-443d-b493-224dcb6e2a7f
   name: Vaneta Becker
+  end_date: '2018-11-06'
 - id: ocd-person/d9013459-1dea-46ee-bdd5-5b2874b76e0a
   name: Liz Brown
+  end_date: '2018-11-06'
 - id: ocd-person/0b243d61-c607-4711-bc54-aecc21281540
   name: Rick Niemeyer
+  role: Vice Chair
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
 - id: ocd-person/381cb345-33c1-437d-b092-705a9055bed9
@@ -33,3 +38,16 @@ memberships:
   name: Victoria Spartz
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
+- id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
+  name: Mark Messmer
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/8c8f7869-329e-4063-ab55-30e4eca00529
+  name: James Buck
+  start_date: '2018-11-07'
+- id: ocd-person/4267823b-aec1-452a-a040-25b337f04c54
+  name: Jeff Raatz
+  start_date: '2018-11-07'
+- id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
+  name: Andy Zay
+  start_date: '2018-11-07'

--- a/data/in/organizations/Environmental-Affairs-e429fac0-4fca-4d19-a6d0-cfda5efc52f1.yml
+++ b/data/in/organizations/Environmental-Affairs-e429fac0-4fca-4d19-a6d0-cfda5efc52f1.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/environmental_affairs_0700
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_environmental_affairs_0700
+- url: http://iga.in.gov/legislative/2019/committees/environmental_affairs_0700
+- url: https://api.iga.in.gov/2019/standing-committees/committee_environmental_affairs_0700
 memberships:
 - id: ocd-person/27d571a8-12b3-439d-86ee-5457d41fb250
   name: David Wolkins
@@ -14,19 +14,23 @@ memberships:
 - id: ocd-person/0a4c7269-3039-425c-8acb-d428c88e6a8a
   name: Greg Beumer
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/98feacbe-3be5-407e-a437-66d65a836a5e
   name: Sue Errington
   role: Ranking Minority Member
 - id: ocd-person/2ca76c73-5db4-499b-b718-c83294b5f68e
   name: Mike Aylesworth
+  role: Vice Chair
 - id: ocd-person/43b9cb7b-a913-4624-859b-6f28e10d871a
   name: B Patrick Bauer
 - id: ocd-person/16b01fca-3a93-41a3-ad6a-f2bf9209ddf7
   name: Ryan Dvorak
+  end_date: '2018-11-06'
 - id: ocd-person/48ceb261-5010-477c-a0e6-9d331b10054a
   name: Sean Eberhart
 - id: ocd-person/0f2d19a6-7ae8-4e2c-8111-6b8965284a01
   name: William Friend
+  end_date: '2018-11-06'
 - id: ocd-person/53a0eb12-72c3-4e7e-9258-d264de2bee6c
   name: Doug Gutwein
 - id: ocd-person/ec6a3cce-3eca-4020-8809-a7a1875e1663
@@ -37,3 +41,12 @@ memberships:
   name: Doug Miller
 - id: ocd-person/113063ff-6e21-4bf7-b9d0-f06aafc349f2
   name: Heath VanNatter
+- id: ocd-person/a8ed53f7-00fb-428b-a629-7532efaf902d
+  name: Beau Baird
+  start_date: '2018-11-07'
+- id: ocd-person/16ded3c5-7034-4910-b5d1-76efa7b2f02f
+  name: Carolyn Jackson
+  start_date: '2018-11-07'
+- id: ocd-person/dcba8890-86e8-4a0c-a4a5-77b2fa98a267
+  name: J.D. Prescott
+  start_date: '2018-11-07'

--- a/data/in/organizations/Ethics-1412eedd-7424-4df6-9b0c-7b450d18af92.yml
+++ b/data/in/organizations/Ethics-1412eedd-7424-4df6-9b0c-7b450d18af92.yml
@@ -5,20 +5,36 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/statutory_committee_on_ethics_2400
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_statutory_committee_on_ethics_2400
+- url: http://iga.in.gov/legislative/2019/committees/statutory_committee_on_ethics_2400
+- url: https://api.iga.in.gov/2019/standing-committees/committee_statutory_committee_on_ethics_2400
 memberships:
 - id: ocd-person/3ee97114-199a-4084-903f-5eaa231ca656
   name: Gregory Steuerwald
-  role: Chair
 - id: ocd-person/7081abcc-348a-4eff-84a1-74f6a2c7ef01
   name: Clyde Kersey
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/650c6338-9a20-44df-82e3-5f0d372bc415
   name: James Baird
+  end_date: '2018-11-06'
 - id: ocd-person/98feacbe-3be5-407e-a437-66d65a836a5e
   name: Sue Errington
 - id: ocd-person/78e2597b-60d2-4902-af7c-a98e84b71b9a
   name: Kathy Richardson
+  end_date: '2018-11-06'
 - id: ocd-person/f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf
   name: Steven Stemler
+  end_date: '2018-11-06'
+- id: ocd-person/5df40faa-22e6-4300-b749-89abfdc2e554
+  name: Sharon Negele
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/cc8462eb-3089-4961-816f-fe3b0e1986f5
+  name: Terri Jo Austin
+  start_date: '2018-11-07'
+- id: ocd-person/efa78779-f35e-49fb-8b6b-5cccd00c870a
+  name: Karen Engleman
+  start_date: '2018-11-07'
+- id: ocd-person/c66bcc9b-d5e6-478b-b11e-25be7f4e0aaa
+  name: Matt Pierce
+  start_date: '2018-11-07'

--- a/data/in/organizations/Ethics-d80a157a-cee5-4398-86e2-42cd833e35d9.yml
+++ b/data/in/organizations/Ethics-d80a157a-cee5-4398-86e2-42cd833e35d9.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/ethics_3600
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_ethics_3600
+- url: http://iga.in.gov/legislative/2019/committees/ethics_3600
+- url: https://api.iga.in.gov/2019/standing-committees/committee_ethics_3600
 memberships:
 - id: ocd-person/d9013459-1dea-46ee-bdd5-5b2874b76e0a
   name: Liz Brown
@@ -14,11 +14,20 @@ memberships:
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
+  end_date: '2018-11-06'
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
 - id: ocd-person/0bee6f8c-db8b-4e92-8bd4-799c71c55c2c
   name: Greg Walker
+- id: ocd-person/ce2c81c3-e2d6-4394-b960-8787d896bfe5
+  name: Ed Charbonneau
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
+  name: Frank Mrvan
+  start_date: '2018-11-07'

--- a/data/in/organizations/Family-Children-and-Human-Affairs-e215fdf0-f0a7-499a-9829-f962f5ac8420.yml
+++ b/data/in/organizations/Family-Children-and-Human-Affairs-e215fdf0-f0a7-499a-9829-f962f5ac8420.yml
@@ -5,35 +5,63 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/family_children_and_human_affairs_0800
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_family_children_and_human_affairs_0800
+- url: http://iga.in.gov/legislative/2019/committees/family_children_and_human_affairs_0800
+- url: https://api.iga.in.gov/2019/standing-committees/committee_family_children_and_human_affairs_0800
 memberships:
 - id: ocd-person/54dab91e-52a0-4217-963f-212102e54516
   name: David Frizzell
   role: Chair
 - id: ocd-person/78b84e11-85f1-49fb-8243-49b15a457523
   name: Cindy Ziemke
-  role: Vice Chair
 - id: ocd-person/51d00dd2-d18c-4d77-9ad1-710016d30448
   name: Vanessa Summers
   role: Ranking Minority Member
 - id: ocd-person/df749cfb-56e8-482f-bf4b-183a1fb52594
   name: Steve Bartels
+  end_date: '2018-11-06'
 - id: ocd-person/487ec8e1-4249-49aa-bc17-742cb10b1794
   name: Anthony Cook
 - id: ocd-person/da8afc87-2b9a-4544-8fb9-2f03f426a451
   name: Dale DeVon
 - id: ocd-person/70b18ef2-1df3-494e-a9ac-dac5b71a3b4f
   name: Richard Hamm
+  end_date: '2018-11-06'
 - id: ocd-person/68f44f31-ba0b-4641-a656-f05e91c02cd8
   name: Sheila Klinker
+  end_date: '2018-11-06'
 - id: ocd-person/c16ddc1a-c07f-419b-b9b3-33f3a7adec18
   name: Kevin Mahan
+  end_date: '2018-11-06'
 - id: ocd-person/df8a1659-63b2-4e11-8dce-17bce11f8162
   name: Julie Olthoff
+  end_date: '2018-11-06'
 - id: ocd-person/a3cca3aa-1783-4eae-b3e7-2ee7832dfcb6
   name: Milo Smith
+  end_date: '2018-11-06'
 - id: ocd-person/5b9af417-d7e1-4a3d-96bb-647e8fd734d5
   name: Joe Taylor
+  end_date: '2018-12-03'
 - id: ocd-person/7fa8b319-d3d7-4612-a0d2-0baf3f0c4382
   name: Melanie Wright
+- id: ocd-person/e9b068a4-93fc-42c1-937a-584445fa46d4
+  name: Thomas Saunders
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/3d215bfb-c08a-47f0-91d3-eb114b33c56d
+  name: Robert Behning
+  start_date: '2018-11-07'
+- id: ocd-person/8dde5c26-4718-45e7-a021-487d7fa6a924
+  name: Pat Boy
+  start_date: '2018-11-07'
+- id: ocd-person/16ded3c5-7034-4910-b5d1-76efa7b2f02f
+  name: Carolyn Jackson
+  start_date: '2018-11-07'
+- id: ocd-person/d96c807a-9e72-4861-bca4-67d787cbf49f
+  name: Ryan Lauer
+  start_date: '2018-11-07'
+- id: ocd-person/2a0b391a-a59d-4b7f-907b-87980c2714d8
+  name: Shane Lindauer
+  start_date: '2018-11-07'
+- id: ocd-person/be047f92-01da-453f-beec-d6c68b14b403
+  name: John Young
+  start_date: '2018-11-07'

--- a/data/in/organizations/Family-and-Children-Services-2e498054-3848-477d-9554-adee9f606167.yml
+++ b/data/in/organizations/Family-and-Children-Services-2e498054-3848-477d-9554-adee9f606167.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/family_and_children
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_family_and_children
+- url: http://iga.in.gov/legislative/2019/committees/family_and_children
+- url: https://api.iga.in.gov/2019/standing-committees/committee_family_and_children
 memberships:
 - id: ocd-person/2af033d5-2fa7-40c5-a01b-bb12bf909510
   name: Ronald Grooms
@@ -17,8 +17,10 @@ memberships:
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
   name: Mike Bohacek
+  end_date: '2018-11-06'
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/ed4d2a15-ec36-4f60-8a07-b79e15d34760
@@ -29,3 +31,14 @@ memberships:
   name: Erin Houchin
 - id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
   name: Dennis Kruse
+  end_date: '2018-11-06'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/01cb22d6-e0f5-478e-99b2-801ffbf32d2b
+  name: Mike Gaskill
+  start_date: '2018-11-07'
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+  start_date: '2018-11-07'

--- a/data/in/organizations/Financial-Institutions-f8ad33f5-33b8-4e91-96e4-95469a812856.yml
+++ b/data/in/organizations/Financial-Institutions-f8ad33f5-33b8-4e91-96e4-95469a812856.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/financial_institutions_0900
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_financial_institutions_0900
+- url: http://iga.in.gov/legislative/2019/committees/financial_institutions_0900
+- url: https://api.iga.in.gov/2019/standing-committees/committee_financial_institutions_0900
 memberships:
 - id: ocd-person/8c51d564-ae76-46c4-90a7-ff9e79ab1f2c
   name: Woody Burton
@@ -17,16 +17,21 @@ memberships:
 - id: ocd-person/0f97edaa-0f48-4c61-82dd-c70aeb05a5ff
   name: Justin Moed
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/0a4c7269-3039-425c-8acb-d428c88e6a8a
   name: Greg Beumer
+  end_date: '2018-11-06'
 - id: ocd-person/731524ef-ec61-42c8-af9c-61411d9592f1
   name: Wes Culver
+  end_date: '2018-11-06'
 - id: ocd-person/613fe860-b0c3-4d2e-8af8-47a76ed5ebe9
   name: Jeff Ellington
 - id: ocd-person/d1e89034-ef4a-4a10-b16d-16dc617dcdf1
   name: Philip GiaQuinta
+  end_date: '2018-11-06'
 - id: ocd-person/ec6a3cce-3eca-4020-8809-a7a1875e1663
   name: Carey Hamilton
+  role: Ranking Minority Member
 - id: ocd-person/ed771fd3-4bd9-4c99-bb42-4bd9f5d1ff8d
   name: Dave Heine
 - id: ocd-person/062c9921-6c7e-489b-bcc2-b140231cd2c2
@@ -37,3 +42,19 @@ memberships:
   name: Mike Speedy
 - id: ocd-person/0c49328e-c3a6-4d21-988c-ceb32e2179e3
   name: Thomas Washburne
+  end_date: '2018-11-06'
+- id: ocd-person/987df48a-c7d6-47c7-be9c-3f0d222a6a0c
+  name: Chris Chyung
+  start_date: '2018-11-07'
+- id: ocd-person/48ceb261-5010-477c-a0e6-9d331b10054a
+  name: Sean Eberhart
+  start_date: '2018-11-07'
+- id: ocd-person/3758fe74-9190-4daf-9a3e-790b01e3d2d4
+  name: Dan Forestal
+  start_date: '2018-11-07'
+- id: ocd-person/423b3123-c1b6-4e2f-92f4-5610130de844
+  name: Matt Lehman
+  start_date: '2018-11-07'
+- id: ocd-person/113063ff-6e21-4bf7-b9d0-f06aafc349f2
+  name: Heath VanNatter
+  start_date: '2018-11-07'

--- a/data/in/organizations/Government-and-Regulatory-Reform-4f4c2436-6d55-48fc-b91b-804483b534a9.yml
+++ b/data/in/organizations/Government-and-Regulatory-Reform-4f4c2436-6d55-48fc-b91b-804483b534a9.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/government_and_regulatory_reform_1000
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_government_and_regulatory_reform_1000
+- url: http://iga.in.gov/legislative/2019/committees/government_and_regulatory_reform_1000
+- url: https://api.iga.in.gov/2019/standing-committees/committee_government_and_regulatory_reform_1000
 memberships:
 - id: ocd-person/c16ddc1a-c07f-419b-b9b3-33f3a7adec18
   name: Kevin Mahan
@@ -14,15 +14,19 @@ memberships:
 - id: ocd-person/70f005b9-1417-4132-9956-ad93942ca87d
   name: Jim Lucas
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf
   name: Steven Stemler
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/5ceabc0e-ec47-41b5-b014-5eddcdc154f3
   name: John Bartlett
 - id: ocd-person/c0e3527e-b990-4190-8ffe-43258158ac58
   name: Robert Cherry
+  end_date: '2018-11-06'
 - id: ocd-person/487ec8e1-4249-49aa-bc17-742cb10b1794
   name: Anthony Cook
+  end_date: '2018-11-06'
 - id: ocd-person/efa78779-f35e-49fb-8b6b-5cccd00c870a
   name: Karen Engleman
 - id: ocd-person/ac2c89af-df39-4057-bdeb-15ca57b7ef9f
@@ -31,9 +35,31 @@ memberships:
   name: Doug Miller
 - id: ocd-person/3918dc6e-fbf5-4ea0-b62a-376729b463ec
   name: Jim Pressel
+  role: Vice Chair
 - id: ocd-person/d15f8f7e-148b-47fc-858d-84ad23347f64
   name: Robin Shackleford
 - id: ocd-person/86b7914b-08e6-4ac7-bcd6-b4afa4dceb09
   name: Vernon Smith
+  end_date: '2018-11-06'
 - id: ocd-person/be047f92-01da-453f-beec-d6c68b14b403
   name: John Young
+  end_date: '2018-11-06'
+- id: ocd-person/a2b2e61b-e27c-4ead-8c81-6703ea817037
+  name: Chris Campbell
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a080b584-c899-4694-a797-73cca22610fe
+  name: David Abbott
+  start_date: '2018-11-07'
+- id: ocd-person/e0aaea95-033f-49d8-9be6-3875fc3b8efe
+  name: Earl Harris
+  start_date: '2018-11-07'
+- id: ocd-person/d96c807a-9e72-4861-bca4-67d787cbf49f
+  name: Ryan Lauer
+  start_date: '2018-11-07'
+- id: ocd-person/96c8ce73-904d-45f9-a2e1-cb9c72596e40
+  name: Randy Lyness
+  start_date: '2018-11-07'
+- id: ocd-person/7eb86096-7906-4bac-8bb5-98e3ecd5029c
+  name: Curt Nisly
+  start_date: '2018-11-07'

--- a/data/in/organizations/Health-and-Provider-Services-ac8b91c5-afef-4904-9f43-ff1950baae62.yml
+++ b/data/in/organizations/Health-and-Provider-Services-ac8b91c5-afef-4904-9f43-ff1950baae62.yml
@@ -5,15 +5,14 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/health_and_provider_services_3900
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_health_and_provider_services_3900
+- url: http://iga.in.gov/legislative/2019/committees/health_and_provider_services_3900
+- url: https://api.iga.in.gov/2019/standing-committees/committee_health_and_provider_services_3900
 memberships:
 - id: ocd-person/ce2c81c3-e2d6-4394-b960-8787d896bfe5
   name: Ed Charbonneau
   role: Chair
 - id: ocd-person/010e5ebe-683c-4fe2-9696-46f7f0b4bea6
   name: Ryan Mishler
-  role: Vice Chair
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
   role: Ranking Minority Member
@@ -27,11 +26,20 @@ memberships:
   name: Ronald Grooms
 - id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
   name: Randall Head
+  end_date: '2018-11-06'
 - id: ocd-person/40ea5143-d0ab-4b9a-a0bc-2cc04f984888
   name: Jean Leising
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
 - id: ocd-person/381cb345-33c1-437d-b092-705a9055bed9
   name: John Ruckelshaus
+  role: Vice Chair
 - id: ocd-person/8bb659ad-1a77-40f2-8916-39b18c55ac52
   name: Mark Stoops
+  end_date: '2018-11-06'
+- id: ocd-person/fc270bf0-2220-476a-ad9c-15db82d62192
+  name: Justin Busch
+  start_date: '2018-11-07'
+- id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
+  name: Eddie Melton
+  start_date: '2018-11-07'

--- a/data/in/organizations/Homeland-Security-and-Transportation-1ca9502b-9321-4e07-9ff4-1fa3c11cffc1.yml
+++ b/data/in/organizations/Homeland-Security-and-Transportation-1ca9502b-9321-4e07-9ff4-1fa3c11cffc1.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/homeland_security_transportation
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_homeland_security_transportation
+- url: http://iga.in.gov/legislative/2019/committees/homeland_security_transportation
+- url: https://api.iga.in.gov/2019/standing-committees/committee_homeland_security_transportation
 memberships:
 - id: ocd-person/6ffd10c6-9fd6-4378-8841-63ce4ca88764
   name: Michael Crider
@@ -14,20 +14,35 @@ memberships:
 - id: ocd-person/c44e058d-5b65-48bd-8994-431e624f43cf
   name: Michael Delph
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
 - id: ocd-person/dd0b774c-0fc8-4ce4-944f-91e254fda0ce
   name: Jon Ford
+  end_date: '2018-11-06'
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
+  role: Ranking Minority Member
 - id: ocd-person/0b243d61-c607-4711-bc54-aecc21281540
   name: Rick Niemeyer
 - id: ocd-person/05364e0a-5596-47b0-b2e2-cf6998d5eeed
   name: Jack Sandlin
+  end_date: '2018-11-06'
+- id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
+  name: James Tomes
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02
+  name: Philip Boots
+  start_date: '2018-11-07'
+- id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+  name: Chris Garten
+  start_date: '2018-11-07'

--- a/data/in/organizations/Insurance-and-Financial-Institutions-6385a10c-2ed5-4789-8728-852f2a198c85.yml
+++ b/data/in/organizations/Insurance-and-Financial-Institutions-6385a10c-2ed5-4789-8728-852f2a198c85.yml
@@ -5,27 +5,53 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/insurance_4000
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_insurance_4000
+- url: http://iga.in.gov/legislative/2019/committees/insurance_4000
+- url: https://api.iga.in.gov/2019/standing-committees/committee_insurance_4000
 memberships:
 - id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
   name: Chip Perfect
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/0bee6f8c-db8b-4e92-8bd4-799c71c55c2c
   name: Greg Walker
-  role: Vice Chair
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
+  end_date: '2018-11-06'
 - id: ocd-person/4267823b-aec1-452a-a040-25b337f04c54
   name: Jeff Raatz
+  end_date: '2018-11-06'
 - id: ocd-person/381cb345-33c1-437d-b092-705a9055bed9
   name: John Ruckelshaus
 - id: ocd-person/b5faa5ff-e642-457b-a54d-4ba21daf626b
   name: Victoria Spartz
+  end_date: '2018-11-06'
 - id: ocd-person/80a66e08-e30e-4828-b3d7-85a952af56e8
   name: Joseph Zakas
+  end_date: '2018-11-06'
 - id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
   name: Andy Zay
+  role: Vice Chair
+- id: ocd-person/2d517236-2a88-435f-bc1f-ce09de86c6f9
+  name: Eric Bassler
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
+  name: Jean Breaux
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
+  name: Mike Bohacek
+  start_date: '2018-11-07'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  start_date: '2018-11-07'
+- id: ocd-person/01cb22d6-e0f5-478e-99b2-801ffbf32d2b
+  name: Mike Gaskill
+  start_date: '2018-11-07'
+- id: ocd-person/05364e0a-5596-47b0-b2e2-cf6998d5eeed
+  name: Jack Sandlin
+  start_date: '2018-11-07'

--- a/data/in/organizations/Insurance-c42eff2a-766e-42bc-8a95-b07d744d0384.yml
+++ b/data/in/organizations/Insurance-c42eff2a-766e-42bc-8a95-b07d744d0384.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/insurance_1100
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_insurance_1100
+- url: http://iga.in.gov/legislative/2019/committees/insurance_1100
+- url: https://api.iga.in.gov/2019/standing-committees/committee_insurance_1100
 memberships:
 - id: ocd-person/1b9ddafb-fca9-4924-b565-d651c2ca133b
   name: Martin Carbaugh
@@ -14,13 +14,16 @@ memberships:
 - id: ocd-person/70b18ef2-1df3-494e-a9ac-dac5b71a3b4f
   name: Richard Hamm
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/cc8462eb-3089-4961-816f-fe3b0e1986f5
   name: Terri Jo Austin
   role: Ranking Minority Member
 - id: ocd-person/fe83212e-72d8-4d9c-80cb-338c7f318f09
   name: Bruce Borders
+  role: Vice Chair
 - id: ocd-person/e0aaea95-033f-49d8-9be6-3875fc3b8efe
   name: Earl Harris
+  end_date: '2018-11-06'
 - id: ocd-person/791928fe-00bb-46bf-9b57-36b7a40e0250
   name: Robert Heaton
 - id: ocd-person/291429c7-c347-40a1-831e-8f0dd870b2ca
@@ -37,3 +40,13 @@ memberships:
   name: Donna Schaibley
 - id: ocd-person/86b7914b-08e6-4ac7-bcd6-b4afa4dceb09
   name: Vernon Smith
+  end_date: '2018-11-06'
+- id: ocd-person/43b9cb7b-a913-4624-859b-6f28e10d871a
+  name: B Patrick Bauer
+  start_date: '2018-11-07'
+- id: ocd-person/a2b2e61b-e27c-4ead-8c81-6703ea817037
+  name: Chris Campbell
+  start_date: '2018-11-07'
+- id: ocd-person/35824e09-976c-44b7-9825-0787030f0e4e
+  name: Chris Judy
+  start_date: '2018-11-07'

--- a/data/in/organizations/Interstate-and-International-Cooperation-c9d7a555-37e5-41dc-8e5c-e351af767029.yml
+++ b/data/in/organizations/Interstate-and-International-Cooperation-c9d7a555-37e5-41dc-8e5c-e351af767029.yml
@@ -5,35 +5,69 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/statutory_committee_on_interstate_and_international_cooperation_2300
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_statutory_committee_on_interstate_and_international_cooperation_2300
+- url: http://iga.in.gov/legislative/2019/committees/statutory_committee_on_interstate_and_international_cooperation_2300
+- url: https://api.iga.in.gov/2019/standing-committees/committee_statutory_committee_on_interstate_and_international_cooperation_2300
 memberships:
 - id: ocd-person/731524ef-ec61-42c8-af9c-61411d9592f1
   name: Wes Culver
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/e9b068a4-93fc-42c1-937a-584445fa46d4
   name: Thomas Saunders
-  role: Vice Chair
 - id: ocd-person/4b96e94b-2384-4bff-b54d-9b6587d19a17
   name: Charlie Brown
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/df43dec4-b355-43cc-a420-a3c162b3840f
   name: Ronald Bacon
+  role: Chair
 - id: ocd-person/613fe860-b0c3-4d2e-8af8-47a76ed5ebe9
   name: Jeff Ellington
+  end_date: '2018-11-06'
 - id: ocd-person/7081abcc-348a-4eff-84a1-74f6a2c7ef01
   name: Clyde Kersey
+  end_date: '2018-11-06'
 - id: ocd-person/f1571a79-9c64-42b2-82d2-ec9f512722eb
   name: Chris May
+  role: Vice Chair
 - id: ocd-person/7eb86096-7906-4bac-8bb5-98e3ecd5029c
   name: Curt Nisly
 - id: ocd-person/61f57248-4172-4ac6-b075-df82cff344cf
   name: Scott Pelath
+  end_date: '2018-11-06'
 - id: ocd-person/78e2597b-60d2-4902-af7c-a98e84b71b9a
   name: Kathy Richardson
+  end_date: '2018-11-06'
 - id: ocd-person/062c9921-6c7e-489b-bcc2-b140231cd2c2
   name: Donna Schaibley
+  end_date: '2018-11-06'
 - id: ocd-person/51d00dd2-d18c-4d77-9ad1-710016d30448
   name: Vanessa Summers
+  end_date: '2018-11-06'
 - id: ocd-person/be047f92-01da-453f-beec-d6c68b14b403
   name: John Young
+- id: ocd-person/86e50c79-ff31-4cdb-99df-52a775bdb81f
+  name: Mara Candelaria Reardon
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/5ceabc0e-ec47-41b5-b014-5eddcdc154f3
+  name: John Bartlett
+  start_date: '2018-11-07'
+- id: ocd-person/8dde5c26-4718-45e7-a021-487d7fa6a924
+  name: Pat Boy
+  start_date: '2018-11-07'
+- id: ocd-person/4c9685ab-f2a4-46e0-980a-699bb01d26cf
+  name: Ragen Hatcher
+  start_date: '2018-11-07'
+- id: ocd-person/344cb784-deed-4671-94f1-0616555296e3
+  name: Michael Karickhoff
+  start_date: '2018-11-07'
+- id: ocd-person/e9843d9e-d8d9-4310-bb12-676f1dd486aa
+  name: Don Lehe
+  start_date: '2018-11-07'
+- id: ocd-person/423b3123-c1b6-4e2f-92f4-5610130de844
+  name: Matt Lehman
+  start_date: '2018-11-07'
+- id: ocd-person/2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f
+  name: Christy Stutzman
+  start_date: '2018-11-07'

--- a/data/in/organizations/Joint-Rules-9e511826-daf3-41ba-a2dc-5482b9f19eb4.yml
+++ b/data/in/organizations/Joint-Rules-9e511826-daf3-41ba-a2dc-5482b9f19eb4.yml
@@ -5,17 +5,21 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/joint_rules_4900
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_joint_rules_4900
+- url: http://iga.in.gov/legislative/2019/committees/joint_rules_4900
+- url: https://api.iga.in.gov/2019/standing-committees/committee_joint_rules_4900
 memberships:
 - id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
   name: Rodric Bray
-  role: Chair
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
 - id: ocd-person/c22c2b28-d509-4891-a325-cc06e73e788e
   name: David Long
+  end_date: '2018-11-06'
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
+- id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
+  name: Mark Messmer
+  role: Chair
+  start_date: '2018-11-07'

--- a/data/in/organizations/Judiciary-685d4deb-0e70-4942-871d-6cdb1db0d4a8.yml
+++ b/data/in/organizations/Judiciary-685d4deb-0e70-4942-871d-6cdb1db0d4a8.yml
@@ -5,29 +5,46 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/judiciary_4200
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_judiciary_4200
+- url: http://iga.in.gov/legislative/2019/committees/judiciary_4200
+- url: https://api.iga.in.gov/2019/standing-committees/committee_judiciary_4200
 memberships:
 - id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
   name: Rodric Bray
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/01bb6149-aa0f-457f-b759-1338b6c8ae5f
   name: Michael Young
-  role: Vice Chair
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
   role: Ranking Minority Member
 - id: ocd-person/c44e058d-5b65-48bd-8994-431e624f43cf
   name: Michael Delph
+  end_date: '2018-11-06'
 - id: ocd-person/b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a
   name: Aaron Freeman
+  end_date: '2018-11-06'
 - id: ocd-person/a0b2ce58-2c2d-4b71-a9e2-7b8ae153d53f
   name: Susan Glick
 - id: ocd-person/a7974310-0d01-4bc1-9c14-29561ec68a60
   name: Eric Koch
+  role: Vice Chair
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
 - id: ocd-person/80a66e08-e30e-4828-b3d7-85a952af56e8
   name: Joseph Zakas
+  end_date: '2018-11-06'
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
+  name: Mike Bohacek
+  start_date: '2018-11-07'
+- id: ocd-person/8c8f7869-329e-4063-ab55-30e4eca00529
+  name: James Buck
+  start_date: '2018-11-07'
+- id: ocd-person/b5f001ff-6e60-49b9-b074-bb83139410b4
+  name: Linda Rogers
+  start_date: '2018-11-07'

--- a/data/in/organizations/Judiciary-c1c0363c-c6c0-4444-9adf-caf08a278951.yml
+++ b/data/in/organizations/Judiciary-c1c0363c-c6c0-4444-9adf-caf08a278951.yml
@@ -5,15 +5,13 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/judiciary_1200
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_judiciary_1200
+- url: http://iga.in.gov/legislative/2019/committees/judiciary_1200
+- url: https://api.iga.in.gov/2019/standing-committees/committee_judiciary_1200
 memberships:
 - id: ocd-person/3ee97114-199a-4084-903f-5eaa231ca656
   name: Gregory Steuerwald
-  role: Chair
 - id: ocd-person/ac2c89af-df39-4057-bdeb-15ca57b7ef9f
   name: Wendy McNamara
-  role: Vice Chair
 - id: ocd-person/43b9cb7b-a913-4624-859b-6f28e10d871a
   name: B Patrick Bauer
   role: Ranking Minority Member
@@ -33,7 +31,13 @@ memberships:
   name: Chris May
 - id: ocd-person/585e1d84-c51f-4d50-90d2-e5828a5c2d02
   name: Jerry Torr
+  role: Chair
 - id: ocd-person/0c49328e-c3a6-4d21-988c-ceb32e2179e3
   name: Thomas Washburne
+  end_date: '2018-11-06'
 - id: ocd-person/be047f92-01da-453f-beec-d6c68b14b403
   name: John Young
+  role: Vice Chair
+- id: ocd-person/487ec8e1-4249-49aa-bc17-742cb10b1794
+  name: Anthony Cook
+  start_date: '2018-11-07'

--- a/data/in/organizations/Legislative-Council-43cb113c-dbe7-4cea-82bd-2362cf78cf17.yml
+++ b/data/in/organizations/Legislative-Council-43cb113c-dbe7-4cea-82bd-2362cf78cf17.yml
@@ -1,0 +1,44 @@
+id: ocd-organization/43cb113c-dbe7-4cea-82bd-2362cf78cf17
+name: Legislative Council
+jurisdiction: ocd-jurisdiction/country:us/state:in/government
+parent: legislature
+classification: committee
+links: []
+sources:
+- url: http://iga.in.gov/legislative/2019/committees/i_legislative_council
+- url: https://api.iga.in.gov/2019/interim-committees/committee_i_legislative_council
+memberships:
+- id: ocd-person/a52a0e0d-3abd-4181-bd89-71c79eb36fcb
+  name: Brian Bosma
+  role: Chair
+- id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
+  name: Rodric Bray
+  role: Vice Chair
+- id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
+  name: Jean Breaux
+- id: ocd-person/a0c6af20-56b0-41be-abf7-9d2265988a48
+  name: Timothy Brown
+- id: ocd-person/86e50c79-ff31-4cdb-99df-52a775bdb81f
+  name: Mara Candelaria Reardon
+- id: ocd-person/d1e89034-ef4a-4a10-b16d-16dc617dcdf1
+  name: Philip GiaQuinta
+- id: ocd-person/a0b2ce58-2c2d-4b71-a9e2-7b8ae153d53f
+  name: Susan Glick
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+- id: ocd-person/d2667b82-c381-495d-b533-c70a9ae92ec0
+  name: Todd Huston
+- id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
+  name: Timothy Lanane
+- id: ocd-person/423b3123-c1b6-4e2f-92f4-5610130de844
+  name: Matt Lehman
+- id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
+  name: James Merritt
+- id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
+  name: Mark Messmer
+- id: ocd-person/8db4d04c-3afe-44c1-940b-7761cd035800
+  name: Cherrish Pryor
+- id: ocd-person/3ee97114-199a-4084-903f-5eaa231ca656
+  name: Gregory Steuerwald
+- id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
+  name: Karen Tallian

--- a/data/in/organizations/Local-Government-11d0f4bc-701c-4288-a64d-bb469f4e9613.yml
+++ b/data/in/organizations/Local-Government-11d0f4bc-701c-4288-a64d-bb469f4e9613.yml
@@ -5,18 +5,16 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/local_government_1300
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_local_government_1300
+- url: http://iga.in.gov/legislative/2019/committees/local_government_1300
+- url: https://api.iga.in.gov/2019/standing-committees/committee_local_government_1300
 memberships:
 - id: ocd-person/d748047f-9a19-4e0b-a3e0-446aa337349c
   name: Dennis Zent
   role: Chair
 - id: ocd-person/fe83212e-72d8-4d9c-80cb-338c7f318f09
   name: Bruce Borders
-  role: Vice Chair
 - id: ocd-person/8db4d04c-3afe-44c1-940b-7761cd035800
   name: Cherrish Pryor
-  role: Ranking Minority Member
 - id: ocd-person/2ca76c73-5db4-499b-b718-c83294b5f68e
   name: Mike Aylesworth
 - id: ocd-person/613fe860-b0c3-4d2e-8af8-47a76ed5ebe9
@@ -27,13 +25,23 @@ memberships:
   name: Randy Lyness
 - id: ocd-person/f1571a79-9c64-42b2-82d2-ec9f512722eb
   name: Chris May
+  role: Vice Chair
 - id: ocd-person/5b58dd7d-acb3-4554-9e4e-c1281155f4ab
   name: Doug Miller
+  end_date: '2018-11-06'
 - id: ocd-person/0f97edaa-0f48-4c61-82dd-c70aeb05a5ff
   name: Justin Moed
 - id: ocd-person/61f57248-4172-4ac6-b075-df82cff344cf
   name: Scott Pelath
+  end_date: '2018-11-06'
 - id: ocd-person/e9b068a4-93fc-42c1-937a-584445fa46d4
   name: Thomas Saunders
 - id: ocd-person/86b7914b-08e6-4ac7-bcd6-b4afa4dceb09
   name: Vernon Smith
+- id: ocd-person/987df48a-c7d6-47c7-be9c-3f0d222a6a0c
+  name: Chris Chyung
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa
+  name: Matt Hostettler
+  start_date: '2018-11-07'

--- a/data/in/organizations/Local-Government-3ddce9ea-9a3a-4f75-990b-d262d066bbc9.yml
+++ b/data/in/organizations/Local-Government-3ddce9ea-9a3a-4f75-990b-d262d066bbc9.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/local_government_4300
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_local_government_4300
+- url: http://iga.in.gov/legislative/2019/committees/local_government_4300
+- url: https://api.iga.in.gov/2019/standing-committees/committee_local_government_4300
 memberships:
 - id: ocd-person/8c8f7869-329e-4063-ab55-30e4eca00529
   name: James Buck
@@ -14,22 +14,53 @@ memberships:
 - id: ocd-person/b961beb9-b315-481d-840a-a727c52783c9
   name: James Smith
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/9569c3da-b86b-4b33-a9ad-8d6174323569
   name: Mike Bohacek
 - id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
   name: Brian Buchanan
+  end_date: '2018-11-06'
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
+  end_date: '2018-11-06'
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
+  end_date: '2018-11-06'
 - id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
   name: Randall Head
+  end_date: '2018-11-06'
 - id: ocd-person/0b243d61-c607-4711-bc54-aecc21281540
   name: Rick Niemeyer
+  role: Vice Chair
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
+  end_date: '2018-11-06'
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
+  end_date: '2018-11-06'
+- id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
+  name: Frank Mrvan
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/2af033d5-2fa7-40c5-a01b-bb12bf909510
+  name: Ronald Grooms
+  start_date: '2018-11-07'
+- id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
+  name: Dennis Kruse
+  start_date: '2018-11-07'
+- id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
+  name: Timothy Lanane
+  start_date: '2018-11-07'
+- id: ocd-person/b5f001ff-6e60-49b9-b074-bb83139410b4
+  name: Linda Rogers
+  start_date: '2018-11-07'
+- id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
+  name: Greg Taylor
+  start_date: '2018-11-07'
+- id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
+  name: James Tomes
+  start_date: '2018-11-07'

--- a/data/in/organizations/Natural-Resources-31ecf3d6-fa90-4018-a3fe-f20bd72357a5.yml
+++ b/data/in/organizations/Natural-Resources-31ecf3d6-fa90-4018-a3fe-f20bd72357a5.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/natural_resources
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_natural_resources
+- url: http://iga.in.gov/legislative/2019/committees/natural_resources
+- url: https://api.iga.in.gov/2019/standing-committees/committee_natural_resources
 memberships:
 - id: ocd-person/a0b2ce58-2c2d-4b71-a9e2-7b8ae153d53f
   name: Susan Glick
@@ -17,17 +17,31 @@ memberships:
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
   name: Brian Buchanan
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
 - id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
   name: Mark Messmer
+  end_date: '2018-11-06'
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
+  end_date: '2018-11-06'
 - id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
   name: Chip Perfect
 - id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
   name: James Tomes
 - id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
   name: Andy Zay
+  end_date: '2018-11-06'
+- id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
+  name: Timothy Lanane
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/fc270bf0-2220-476a-ad9c-15db82d62192
+  name: Justin Busch
+  start_date: '2018-11-07'
+- id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
+  name: Greg Taylor
+  start_date: '2018-11-07'

--- a/data/in/organizations/Natural-Resources-46827875-bf13-4270-b449-00f1056454c1.yml
+++ b/data/in/organizations/Natural-Resources-46827875-bf13-4270-b449-00f1056454c1.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/natural_resources_1400
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_natural_resources_1400
+- url: http://iga.in.gov/legislative/2019/committees/natural_resources_1400
+- url: https://api.iga.in.gov/2019/standing-committees/committee_natural_resources_1400
 memberships:
 - id: ocd-person/48ceb261-5010-477c-a0e6-9d331b10054a
   name: Sean Eberhart
@@ -17,23 +17,44 @@ memberships:
 - id: ocd-person/7081abcc-348a-4eff-84a1-74f6a2c7ef01
   name: Clyde Kersey
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/2ca76c73-5db4-499b-b718-c83294b5f68e
   name: Mike Aylesworth
 - id: ocd-person/df749cfb-56e8-482f-bf4b-183a1fb52594
   name: Steve Bartels
+  end_date: '2018-11-06'
 - id: ocd-person/98feacbe-3be5-407e-a437-66d65a836a5e
   name: Sue Errington
 - id: ocd-person/0f2d19a6-7ae8-4e2c-8111-6b8965284a01
   name: William Friend
+  end_date: '2018-11-06'
 - id: ocd-person/344cb784-deed-4671-94f1-0616555296e3
   name: Michael Karickhoff
 - id: ocd-person/512b492f-8d12-48f6-a509-f0a4a12ee11a
   name: Linda Lawson
+  end_date: '2018-11-06'
 - id: ocd-person/2a0b391a-a59d-4b7f-907b-87980c2714d8
   name: Shane Lindauer
 - id: ocd-person/0f97edaa-0f48-4c61-82dd-c70aeb05a5ff
   name: Justin Moed
+  end_date: '2018-11-06'
 - id: ocd-person/3e2f70f5-2f3a-425f-99ed-c7277eb2f13c
   name: Alan Morrison
 - id: ocd-person/27d571a8-12b3-439d-86ee-5457d41fb250
   name: David Wolkins
+- id: ocd-person/0f97a586-0089-4eb8-86c1-40f42bc1f594
+  name: Tonya Pfaff
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a080b584-c899-4694-a797-73cca22610fe
+  name: David Abbott
+  start_date: '2018-11-07'
+- id: ocd-person/16b01fca-3a93-41a3-ad6a-f2bf9209ddf7
+  name: Ryan Dvorak
+  start_date: '2018-11-07'
+- id: ocd-person/03416080-75a4-4eb2-acde-6d59f0967666
+  name: Rita Fleming
+  start_date: '2018-11-07'
+- id: ocd-person/dcba8890-86e8-4a0c-a4a5-77b2fa98a267
+  name: J.D. Prescott
+  start_date: '2018-11-07'

--- a/data/in/organizations/Pensions-and-Labor-6ef6fe23-2988-40dc-8f95-b8f18ca82de4.yml
+++ b/data/in/organizations/Pensions-and-Labor-6ef6fe23-2988-40dc-8f95-b8f18ca82de4.yml
@@ -5,15 +5,14 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/pensions_and_labor_4500
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_pensions_and_labor_4500
+- url: http://iga.in.gov/legislative/2019/committees/pensions_and_labor_4500
+- url: https://api.iga.in.gov/2019/standing-committees/committee_pensions_and_labor_4500
 memberships:
 - id: ocd-person/dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02
   name: Philip Boots
   role: Chair
 - id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
   name: Chip Perfect
-  role: Vice Chair
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
   role: Ranking Minority Member
@@ -21,17 +20,27 @@ memberships:
   name: John Crane
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
+  role: Vice Chair
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
+  end_date: '2018-11-06'
 - id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
   name: Dennis Kruse
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
+  end_date: '2018-11-06'
 - id: ocd-person/b961beb9-b315-481d-840a-a727c52783c9
   name: James Smith
+  end_date: '2018-11-06'
 - id: ocd-person/b5faa5ff-e642-457b-a54d-4ba21daf626b
   name: Victoria Spartz
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
 - id: ocd-person/0bee6f8c-db8b-4e92-8bd4-799c71c55c2c
   name: Greg Walker
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  start_date: '2018-11-07'
+- id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+  name: Chris Garten
+  start_date: '2018-11-07'

--- a/data/in/organizations/Public-Health-459c950b-9420-4a7e-b8b5-38029ee5cf50.yml
+++ b/data/in/organizations/Public-Health-459c950b-9420-4a7e-b8b5-38029ee5cf50.yml
@@ -5,24 +5,26 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/public_health_1500
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_public_health_1500
+- url: http://iga.in.gov/legislative/2019/committees/public_health_1500
+- url: https://api.iga.in.gov/2019/standing-committees/committee_public_health_1500
 memberships:
 - id: ocd-person/291429c7-c347-40a1-831e-8f0dd870b2ca
   name: Cindy Kirchhofer
   role: Chair
 - id: ocd-person/df43dec4-b355-43cc-a420-a3c162b3840f
   name: Ronald Bacon
-  role: Vice Chair
 - id: ocd-person/d15f8f7e-148b-47fc-858d-84ad23347f64
   name: Robin Shackleford
   role: Ranking Minority Member
 - id: ocd-person/43b9cb7b-a913-4624-859b-6f28e10d871a
   name: B Patrick Bauer
+  end_date: '2018-11-06'
 - id: ocd-person/3d215bfb-c08a-47f0-91d3-eb114b33c56d
   name: Robert Behning
+  end_date: '2018-11-06'
 - id: ocd-person/4b96e94b-2384-4bff-b54d-9b6587d19a17
   name: Charlie Brown
+  end_date: '2018-11-06'
 - id: ocd-person/77a93fc3-bbc5-41b6-b1af-0069670dd5af
   name: Steven Davisson
 - id: ocd-person/54dab91e-52a0-4217-963f-212102e54516
@@ -33,7 +35,25 @@ memberships:
   name: Gregory Porter
 - id: ocd-person/b71e9f3a-2c59-4e18-80e6-da0a7cc51648
   name: Harold Slager
+  end_date: '2018-11-06'
 - id: ocd-person/d748047f-9a19-4e0b-a3e0-446aa337349c
   name: Dennis Zent
 - id: ocd-person/78b84e11-85f1-49fb-8243-49b15a457523
   name: Cindy Ziemke
+  end_date: '2018-11-06'
+- id: ocd-person/2a0b391a-a59d-4b7f-907b-87980c2714d8
+  name: Shane Lindauer
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/6629fcea-f482-4e63-872d-d2f8734502ca
+  name: Brad Barrett
+  start_date: '2018-11-07'
+- id: ocd-person/03416080-75a4-4eb2-acde-6d59f0967666
+  name: Rita Fleming
+  start_date: '2018-11-07'
+- id: ocd-person/58bbda21-7c3e-4189-9d02-0ba7f95a6471
+  name: Ryan Hatfield
+  start_date: '2018-11-07'
+- id: ocd-person/bdae77c7-d89e-426d-b6f6-52e1a48bc87a
+  name: Ethan Manning
+  start_date: '2018-11-07'

--- a/data/in/organizations/Public-Policy-21a593a5-4f7c-4ec0-b169-b4c252d6bbb8.yml
+++ b/data/in/organizations/Public-Policy-21a593a5-4f7c-4ec0-b169-b4c252d6bbb8.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/public_policy_4400
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_public_policy_4400
+- url: http://iga.in.gov/legislative/2019/committees/public_policy_4400
+- url: https://api.iga.in.gov/2019/standing-committees/committee_public_policy_4400
 memberships:
 - id: ocd-person/91572a47-dcdf-4be5-8fec-99630da33a39
   name: Ron Alting
@@ -17,6 +17,7 @@ memberships:
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/dd0b774c-0fc8-4ce4-944f-91e254fda0ce
   name: Jon Ford
 - id: ocd-person/2af033d5-2fa7-40c5-a01b-bb12bf909510
@@ -27,7 +28,12 @@ memberships:
   name: Mark Messmer
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
+  role: Ranking Minority Member
 - id: ocd-person/05364e0a-5596-47b0-b2e2-cf6998d5eeed
   name: Jack Sandlin
+  end_date: '2018-11-06'
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
+- id: ocd-person/dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02
+  name: Philip Boots
+  start_date: '2018-11-07'

--- a/data/in/organizations/Public-Policy-5c569343-e92c-45fb-9a33-0f602638acb2.yml
+++ b/data/in/organizations/Public-Policy-5c569343-e92c-45fb-9a33-0f602638acb2.yml
@@ -5,30 +5,33 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/public_policy_1600
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_public_policy_1600
+- url: http://iga.in.gov/legislative/2019/committees/public_policy_1600
+- url: https://api.iga.in.gov/2019/standing-committees/committee_public_policy_1600
 memberships:
 - id: ocd-person/ea2c35cb-7071-43de-8dc6-e91756d03f11
   name: Ben Smaltz
   role: Chair
 - id: ocd-person/fbcd4d2c-32c6-4c97-837b-4e4ed80c43df
   name: Timothy Wesco
-  role: Vice Chair
 - id: ocd-person/d1e89034-ef4a-4a10-b16d-16dc617dcdf1
   name: Philip GiaQuinta
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/cc8462eb-3089-4961-816f-fe3b0e1986f5
   name: Terri Jo Austin
 - id: ocd-person/4b96e94b-2384-4bff-b54d-9b6587d19a17
   name: Charlie Brown
+  end_date: '2018-11-06'
 - id: ocd-person/d01b6bbc-9c5e-4479-afd6-3e7410946367
   name: Edward Clere
 - id: ocd-person/48ceb261-5010-477c-a0e6-9d331b10054a
   name: Sean Eberhart
 - id: ocd-person/d2667b82-c381-495d-b533-c70a9ae92ec0
   name: Todd Huston
+  end_date: '2018-11-06'
 - id: ocd-person/35824e09-976c-44b7-9825-0787030f0e4e
   name: Chris Judy
+  end_date: '2018-11-06'
 - id: ocd-person/423b3123-c1b6-4e2f-92f4-5610130de844
   name: Matt Lehman
 - id: ocd-person/70f005b9-1417-4132-9956-ad93942ca87d
@@ -37,3 +40,17 @@ memberships:
   name: Peggy Mayfield
 - id: ocd-person/51d00dd2-d18c-4d77-9ad1-710016d30448
   name: Vanessa Summers
+- id: ocd-person/2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f
+  name: Christy Stutzman
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/0f97edaa-0f48-4c61-82dd-c70aeb05a5ff
+  name: Justin Moed
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/3758fe74-9190-4daf-9a3e-790b01e3d2d4
+  name: Dan Forestal
+  start_date: '2018-11-07'
+- id: ocd-person/be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa
+  name: Matt Hostettler
+  start_date: '2018-11-07'

--- a/data/in/organizations/Roads-and-Transportation-9b46460f-8c35-45cd-81ce-2318e81d949b.yml
+++ b/data/in/organizations/Roads-and-Transportation-9b46460f-8c35-45cd-81ce-2318e81d949b.yml
@@ -5,12 +5,11 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/roads_and_transportation_1700
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_roads_and_transportation_1700
+- url: http://iga.in.gov/legislative/2019/committees/roads_and_transportation_1700
+- url: https://api.iga.in.gov/2019/standing-committees/committee_roads_and_transportation_1700
 memberships:
 - id: ocd-person/3fbcc2a9-c620-456c-b38f-03e0f9063c3f
   name: Edmond Soliday
-  role: Chair
 - id: ocd-person/ed0facaa-4220-4f7d-899f-2bb0d576e9ef
   name: Mike Speedy
   role: Vice Chair
@@ -21,6 +20,7 @@ memberships:
   name: Mara Candelaria Reardon
 - id: ocd-person/731524ef-ec61-42c8-af9c-61411d9592f1
   name: Wes Culver
+  end_date: '2018-11-06'
 - id: ocd-person/df0cd4fe-e276-4381-9ad2-affd3bffc9e4
   name: Randall Frye
 - id: ocd-person/2a0b391a-a59d-4b7f-907b-87980c2714d8
@@ -33,7 +33,16 @@ memberships:
   name: Ben Smaltz
 - id: ocd-person/f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf
   name: Steven Stemler
+  end_date: '2018-11-06'
 - id: ocd-person/636b7e08-fde1-4068-8bd8-323ce56dbfb4
   name: Holli Sullivan
+  role: Chair
 - id: ocd-person/5b9af417-d7e1-4a3d-96bb-647e8fd734d5
   name: Joe Taylor
+  end_date: '2018-12-03'
+- id: ocd-person/987df48a-c7d6-47c7-be9c-3f0d222a6a0c
+  name: Chris Chyung
+  start_date: '2018-11-07'
+- id: ocd-person/3918dc6e-fbf5-4ea0-b62a-376729b463ec
+  name: Jim Pressel
+  start_date: '2018-11-07'

--- a/data/in/organizations/Rules-and-Legislative-Procedure-214cde7e-5b20-44b8-90ae-7d5007e6447c.yml
+++ b/data/in/organizations/Rules-and-Legislative-Procedure-214cde7e-5b20-44b8-90ae-7d5007e6447c.yml
@@ -5,20 +5,21 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/rules_and_legislative_procedure_4700
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_rules_and_legislative_procedure_4700
+- url: http://iga.in.gov/legislative/2019/committees/rules_and_legislative_procedure_4700
+- url: https://api.iga.in.gov/2019/standing-committees/committee_rules_and_legislative_procedure_4700
 memberships:
 - id: ocd-person/c22c2b28-d509-4891-a325-cc06e73e788e
   name: David Long
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/aa948d0d-f7d1-4a11-a58b-986b0d61ebf7
   name: Travis Holdman
-  role: Vice Chair
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
   role: Ranking Minority Member
 - id: ocd-person/766cf9c2-a001-49a1-8fba-075a0510767d
   name: Rodric Bray
+  role: Chair
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
 - id: ocd-person/ce2c81c3-e2d6-4394-b960-8787d896bfe5
@@ -27,11 +28,23 @@ memberships:
   name: Michael Crider
 - id: ocd-person/2ac8fe4a-56d1-4781-8a6f-837174ce4265
   name: Douglas Eckerty
+  end_date: '2018-11-06'
 - id: ocd-person/e17c68ed-749d-4a65-88f6-60302e6435a4
   name: Dennis Kruse
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
+  end_date: '2018-11-06'
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
+- id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
+  name: Mark Messmer
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/e5238773-c2c9-4caf-9ddf-b2769c5944d1
+  name: Randall Head
+  start_date: '2018-11-07'
+- id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
+  name: David Niezgodski
+  start_date: '2018-11-07'

--- a/data/in/organizations/Rules-and-Legislative-Procedures-a94e1c29-b56c-481f-b0dc-ec62ba81c615.yml
+++ b/data/in/organizations/Rules-and-Legislative-Procedures-a94e1c29-b56c-481f-b0dc-ec62ba81c615.yml
@@ -5,15 +5,14 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/rules_and_legislative_procedures_1800
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_rules_and_legislative_procedures_1800
+- url: http://iga.in.gov/legislative/2019/committees/rules_and_legislative_procedures_1800
+- url: https://api.iga.in.gov/2019/standing-committees/committee_rules_and_legislative_procedures_1800
 memberships:
 - id: ocd-person/585e1d84-c51f-4d50-90d2-e5828a5c2d02
   name: Jerry Torr
-  role: Chair
+  role: Vice Chair
 - id: ocd-person/3ee97114-199a-4084-903f-5eaa231ca656
   name: Gregory Steuerwald
-  role: Vice Chair
 - id: ocd-person/16b01fca-3a93-41a3-ad6a-f2bf9209ddf7
   name: Ryan Dvorak
   role: Ranking Minority Member
@@ -21,12 +20,25 @@ memberships:
   name: Terri Jo Austin
 - id: ocd-person/8c51d564-ae76-46c4-90a7-ff9e79ab1f2c
   name: Woody Burton
+  end_date: '2018-11-06'
 - id: ocd-person/c0e3527e-b990-4190-8ffe-43258158ac58
   name: Robert Cherry
 - id: ocd-person/d2667b82-c381-495d-b533-c70a9ae92ec0
   name: Todd Huston
 - name: David Ober
+  end_date: '2018-11-06'
 - id: ocd-person/c66bcc9b-d5e6-478b-b11e-25be7f4e0aaa
   name: Matt Pierce
 - id: ocd-person/3fbcc2a9-c620-456c-b38f-03e0f9063c3f
   name: Edmond Soliday
+  end_date: '2018-11-06'
+- id: ocd-person/839dc3a8-6b1a-4aff-b5cf-342da0cac11d
+  name: Daniel Leonard
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/ea2c35cb-7071-43de-8dc6-e91756d03f11
+  name: Ben Smaltz
+  start_date: '2018-11-07'
+- id: ocd-person/636b7e08-fde1-4068-8bd8-323ce56dbfb4
+  name: Holli Sullivan
+  start_date: '2018-11-07'

--- a/data/in/organizations/School-Funding-f29ba6bb-1297-48c7-b97a-b1722083b655.yml
+++ b/data/in/organizations/School-Funding-f29ba6bb-1297-48c7-b97a-b1722083b655.yml
@@ -5,8 +5,8 @@ parent: ocd-organization/42258cc2-7d2d-4e25-9388-be9d222ba657
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/school_funding_subcommittee
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_school_funding_subcommittee
+- url: http://iga.in.gov/legislative/2019/committees/school_funding_subcommittee
+- url: https://api.iga.in.gov/2019/standing-committees/committee_school_funding_subcommittee
 memberships:
 - id: ocd-person/2d517236-2a88-435f-bc1f-ce09de86c6f9
   name: Eric Bassler
@@ -21,3 +21,7 @@ memberships:
   name: Karen Tallian
 - id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
   name: Greg Taylor
+  end_date: '2018-11-06'
+- id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
+  name: Eddie Melton
+  start_date: '2018-11-07'

--- a/data/in/organizations/Select-Committee-on-Government-Reduction-9ffed974-1228-455b-9fa0-7454ec2d8bf6.yml
+++ b/data/in/organizations/Select-Committee-on-Government-Reduction-9ffed974-1228-455b-9fa0-7454ec2d8bf6.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/select_committee_on_government_reduction_1900
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_select_committee_on_government_reduction_1900
+- url: http://iga.in.gov/legislative/2019/committees/select_committee_on_government_reduction_1900
+- url: https://api.iga.in.gov/2019/standing-committees/committee_select_committee_on_government_reduction_1900
 memberships:
 - id: ocd-person/53a0eb12-72c3-4e7e-9258-d264de2bee6c
   name: Doug Gutwein
@@ -14,26 +14,56 @@ memberships:
 - id: ocd-person/2ca76c73-5db4-499b-b718-c83294b5f68e
   name: Mike Aylesworth
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/86e50c79-ff31-4cdb-99df-52a775bdb81f
   name: Mara Candelaria Reardon
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/efa78779-f35e-49fb-8b6b-5cccd00c870a
   name: Karen Engleman
 - id: ocd-person/d1e89034-ef4a-4a10-b16d-16dc617dcdf1
   name: Philip GiaQuinta
+  end_date: '2018-11-06'
 - id: ocd-person/e0aaea95-033f-49d8-9be6-3875fc3b8efe
   name: Earl Harris
 - id: ocd-person/344cb784-deed-4671-94f1-0616555296e3
   name: Michael Karickhoff
 - id: ocd-person/2a0b391a-a59d-4b7f-907b-87980c2714d8
   name: Shane Lindauer
+  end_date: '2018-11-06'
 - id: ocd-person/7eb86096-7906-4bac-8bb5-98e3ecd5029c
   name: Curt Nisly
 - id: ocd-person/a90c6c3f-a4c0-4bbe-a1a6-6d1c82345769
   name: Sally Siegrist
+  end_date: '2018-11-06'
 - id: ocd-person/a3cca3aa-1783-4eae-b3e7-2ee7832dfcb6
   name: Milo Smith
+  end_date: '2018-11-06'
 - id: ocd-person/5b9af417-d7e1-4a3d-96bb-647e8fd734d5
   name: Joe Taylor
+  end_date: '2018-12-03'
 - id: ocd-person/27d571a8-12b3-439d-86ee-5457d41fb250
   name: David Wolkins
+- id: ocd-person/70f005b9-1417-4132-9956-ad93942ca87d
+  name: Jim Lucas
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/16ded3c5-7034-4910-b5d1-76efa7b2f02f
+  name: Carolyn Jackson
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/c0e3527e-b990-4190-8ffe-43258158ac58
+  name: Robert Cherry
+  start_date: '2018-11-07'
+- id: ocd-person/be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa
+  name: Matt Hostettler
+  start_date: '2018-11-07'
+- id: ocd-person/12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55
+  name: Jack Jordan
+  start_date: '2018-11-07'
+- id: ocd-person/86b7914b-08e6-4ac7-bcd6-b4afa4dceb09
+  name: Vernon Smith
+  start_date: '2018-11-07'
+- id: ocd-person/51d00dd2-d18c-4d77-9ad1-710016d30448
+  name: Vanessa Summers
+  start_date: '2018-11-07'

--- a/data/in/organizations/Tax-and-Fiscal-Policy-4d13b93c-51f0-41d7-bb5d-f2aa376fa185.yml
+++ b/data/in/organizations/Tax-and-Fiscal-Policy-4d13b93c-51f0-41d7-bb5d-f2aa376fa185.yml
@@ -5,26 +5,26 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/tax_and_fiscal_policy_4600
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_tax_and_fiscal_policy_4600
+- url: http://iga.in.gov/legislative/2019/committees/tax_and_fiscal_policy_4600
+- url: https://api.iga.in.gov/2019/standing-committees/committee_tax_and_fiscal_policy_4600
 memberships:
 - id: ocd-person/aa948d0d-f7d1-4a11-a58b-986b0d61ebf7
   name: Travis Holdman
   role: Chair
 - id: ocd-person/0bee6f8c-db8b-4e92-8bd4-799c71c55c2c
   name: Greg Walker
-  role: Vice Chair
 - id: ocd-person/8bb659ad-1a77-40f2-8916-39b18c55ac52
   name: Mark Stoops
-  role: Ranking Minority Member
 - id: ocd-person/0224fa74-0bc2-49ca-83db-03445f40b976
   name: Jean Breaux
+  end_date: '2018-11-06'
 - id: ocd-person/8c8f7869-329e-4063-ab55-30e4eca00529
   name: James Buck
 - id: ocd-person/ce2c81c3-e2d6-4394-b960-8787d896bfe5
   name: Ed Charbonneau
 - id: ocd-person/05cfdc73-ff21-4d74-833e-e3da82ed7509
   name: Erin Houchin
+  role: Vice Chair
 - id: ocd-person/010e5ebe-683c-4fe2-9696-46f7f0b4bea6
   name: Ryan Mishler
 - id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
@@ -33,7 +33,26 @@ memberships:
   name: Jeff Raatz
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
+  end_date: '2018-11-06'
 - id: ocd-person/b961beb9-b315-481d-840a-a727c52783c9
   name: James Smith
+  end_date: '2018-11-06'
 - id: ocd-person/1887cf43-1eec-47b3-9fae-5d7303c44557
   name: Karen Tallian
+  end_date: '2018-11-06'
+- id: ocd-person/39798614-3cb2-40b7-adad-4f5c53ff59e5
+  name: Greg Taylor
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
+  name: Brian Buchanan
+  start_date: '2018-11-07'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  start_date: '2018-11-07'
+- id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
+  name: Mark Messmer
+  start_date: '2018-11-07'
+- id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
+  name: David Niezgodski
+  start_date: '2018-11-07'

--- a/data/in/organizations/Utilities-38286ca4-3702-4b82-ab8f-607344a05846.yml
+++ b/data/in/organizations/Utilities-38286ca4-3702-4b82-ab8f-607344a05846.yml
@@ -5,8 +5,8 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/utilities_3800
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_utilities_3800
+- url: http://iga.in.gov/legislative/2019/committees/utilities_3800
+- url: https://api.iga.in.gov/2019/standing-committees/committee_utilities_3800
 memberships:
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
@@ -14,22 +14,43 @@ memberships:
 - id: ocd-person/eb196828-cccf-4897-b3d3-790e53761534
   name: Mark Messmer
   role: Vice Chair
+  end_date: '2018-11-06'
 - id: ocd-person/8bb659ad-1a77-40f2-8916-39b18c55ac52
   name: Mark Stoops
-  role: Ranking Minority Member
 - id: ocd-person/0482a330-c9fb-4f41-b136-88a4aef2de6a
   name: Brian Buchanan
+  end_date: '2018-11-06'
 - id: ocd-person/c44e058d-5b65-48bd-8994-431e624f43cf
   name: Michael Delph
+  end_date: '2018-11-06'
 - id: ocd-person/05cfdc73-ff21-4d74-833e-e3da82ed7509
   name: Erin Houchin
 - id: ocd-person/a7974310-0d01-4bc1-9c14-29561ec68a60
   name: Eric Koch
 - id: ocd-person/cf84a4e4-8c27-420d-a69d-af4bb78a5f72
   name: Timothy Lanane
+  end_date: '2018-11-06'
 - id: ocd-person/40ea5143-d0ab-4b9a-a0bc-2cc04f984888
   name: Jean Leising
 - id: ocd-person/a48f9631-3436-4445-b8fc-87c143f373cd
   name: Lonnie Randolph
 - id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
   name: James Tomes
+  end_date: '2018-11-06'
+- id: ocd-person/24f5ad99-8af0-4e08-a4cb-8c5c0606eb43
+  name: Chip Perfect
+  role: Vice Chair
+  start_date: '2018-11-07'
+- id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+  name: J.D. Ford
+  role: Ranking Minority Member
+  start_date: '2018-11-07'
+- id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
+  name: Blake Doriot
+  start_date: '2018-11-07'
+- id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+  name: Chris Garten
+  start_date: '2018-11-07'
+- id: ocd-person/85c3a6e4-8292-4e3f-a8f4-475aede6b9d6
+  name: Andy Zay
+  start_date: '2018-11-07'

--- a/data/in/organizations/Utilities-Energy-and-Telecommunications-c3aaa426-ef16-46f5-ac6c-f859e50d4443.yml
+++ b/data/in/organizations/Utilities-Energy-and-Telecommunications-c3aaa426-ef16-46f5-ac6c-f859e50d4443.yml
@@ -5,11 +5,12 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/utilities_and_energy_2000
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_utilities_and_energy_2000
+- url: http://iga.in.gov/legislative/2019/committees/utilities_and_energy_2000
+- url: https://api.iga.in.gov/2019/standing-committees/committee_utilities_and_energy_2000
 memberships:
 - name: David Ober
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/da8afc87-2b9a-4544-8fb9-2f03f426a451
   name: Dale DeVon
   role: Vice Chair
@@ -30,9 +31,21 @@ memberships:
   name: Alan Morrison
 - id: ocd-person/8db4d04c-3afe-44c1-940b-7761cd035800
   name: Cherrish Pryor
+  end_date: '2018-11-06'
 - id: ocd-person/3fbcc2a9-c620-456c-b38f-03e0f9063c3f
   name: Edmond Soliday
+  role: Chair
 - id: ocd-person/ed0facaa-4220-4f7d-899f-2bb0d576e9ef
   name: Mike Speedy
 - id: ocd-person/113063ff-6e21-4bf7-b9d0-f06aafc349f2
   name: Heath VanNatter
+  end_date: '2018-11-06'
+- id: ocd-person/86e50c79-ff31-4cdb-99df-52a775bdb81f
+  name: Mara Candelaria Reardon
+  start_date: '2018-11-07'
+- id: ocd-person/bdae77c7-d89e-426d-b6f6-52e1a48bc87a
+  name: Ethan Manning
+  start_date: '2018-11-07'
+- id: ocd-person/3918dc6e-fbf5-4ea0-b62a-376729b463ec
+  name: Jim Pressel
+  start_date: '2018-11-07'

--- a/data/in/organizations/Veterans-Affairs-and-Public-Safety-e635e3a4-6535-4832-9048-4157bd71d377.yml
+++ b/data/in/organizations/Veterans-Affairs-and-Public-Safety-e635e3a4-6535-4832-9048-4157bd71d377.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/veterans_affairs_and_public_safety_2100
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_veterans_affairs_and_public_safety_2100
+- url: http://iga.in.gov/legislative/2019/committees/veterans_affairs_and_public_safety_2100
+- url: https://api.iga.in.gov/2019/standing-committees/committee_veterans_affairs_and_public_safety_2100
 memberships:
 - id: ocd-person/df0cd4fe-e276-4381-9ad2-affd3bffc9e4
   name: Randall Frye
@@ -19,6 +19,7 @@ memberships:
   role: Ranking Minority Member
 - id: ocd-person/650c6338-9a20-44df-82e3-5f0d372bc415
   name: James Baird
+  end_date: '2018-11-06'
 - id: ocd-person/df749cfb-56e8-482f-bf4b-183a1fb52594
   name: Steve Bartels
 - id: ocd-person/fe83212e-72d8-4d9c-80cb-338c7f318f09
@@ -27,13 +28,28 @@ memberships:
   name: Doug Gutwein
 - id: ocd-person/ec6a3cce-3eca-4020-8809-a7a1875e1663
   name: Carey Hamilton
+  end_date: '2018-11-06'
 - id: ocd-person/12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55
   name: Jack Jordan
+  end_date: '2018-11-06'
 - id: ocd-person/68f44f31-ba0b-4641-a656-f05e91c02cd8
   name: Sheila Klinker
 - id: ocd-person/17fd494d-905d-4c82-a828-6d975cbf02f3
   name: Charles Moseley
 - id: ocd-person/df8a1659-63b2-4e11-8dce-17bce11f8162
   name: Julie Olthoff
+  end_date: '2018-11-06'
 - id: ocd-person/d748047f-9a19-4e0b-a3e0-446aa337349c
   name: Dennis Zent
+- id: ocd-person/987df48a-c7d6-47c7-be9c-3f0d222a6a0c
+  name: Chris Chyung
+  start_date: '2018-11-07'
+- id: ocd-person/e9844fde-43a6-4aa8-9248-85ab1ad79c20
+  name: Chuck Goodrich
+  start_date: '2018-11-07'
+- id: ocd-person/d96c807a-9e72-4861-bca4-67d787cbf49f
+  name: Ryan Lauer
+  start_date: '2018-11-07'
+- id: ocd-person/f1571a79-9c64-42b2-82d2-ec9f512722eb
+  name: Chris May
+  start_date: '2018-11-07'

--- a/data/in/organizations/Veterans-Affairs-and-The-Military-f7382fe3-69c7-4de4-8e1f-78080fb689c7.yml
+++ b/data/in/organizations/Veterans-Affairs-and-The-Military-f7382fe3-69c7-4de4-8e1f-78080fb689c7.yml
@@ -5,29 +5,44 @@ parent: upper
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/veterans_affairs_the_military
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_veterans_affairs_the_military
+- url: http://iga.in.gov/legislative/2019/committees/veterans_affairs_the_military
+- url: https://api.iga.in.gov/2019/standing-committees/committee_veterans_affairs_the_military
 memberships:
 - id: ocd-person/c44e058d-5b65-48bd-8994-431e624f43cf
   name: Michael Delph
   role: Chair
+  end_date: '2018-11-06'
 - id: ocd-person/6ffd10c6-9fd6-4378-8841-63ce4ca88764
   name: Michael Crider
   role: Vice Chair
 - id: ocd-person/1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371
   name: David Niezgodski
   role: Ranking Minority Member
+  end_date: '2018-11-06'
 - id: ocd-person/a1002ff1-ffd8-4d82-8db9-3a8295ca5e06
   name: Blake Doriot
 - id: ocd-person/dd0b774c-0fc8-4ce4-944f-91e254fda0ce
   name: Jon Ford
+  end_date: '2018-11-06'
 - id: ocd-person/c0faf1f8-7c27-46cd-9ff4-e740f4e5b376
   name: Eddie Melton
 - id: ocd-person/006f23b2-efae-4ba6-bfa1-5a3df4ee832a
   name: James Merritt
 - id: ocd-person/7dacbdba-68ea-4b74-8864-d1b19a1ff4c0
   name: Frank Mrvan
+  role: Ranking Minority Member
 - id: ocd-person/0b243d61-c607-4711-bc54-aecc21281540
   name: Rick Niemeyer
 - id: ocd-person/05364e0a-5596-47b0-b2e2-cf6998d5eeed
   name: Jack Sandlin
+  end_date: '2018-11-06'
+- id: ocd-person/c2c98fe8-fef2-4d38-93f6-9eff4d591bed
+  name: James Tomes
+  role: Chair
+  start_date: '2018-11-07'
+- id: ocd-person/dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02
+  name: Philip Boots
+  start_date: '2018-11-07'
+- id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+  name: Chris Garten
+  start_date: '2018-11-07'

--- a/data/in/organizations/Ways-and-Means-1ed71c49-314c-4bc8-95c7-0c53073e4a25.yml
+++ b/data/in/organizations/Ways-and-Means-1ed71c49-314c-4bc8-95c7-0c53073e4a25.yml
@@ -5,8 +5,8 @@ parent: lower
 classification: committee
 links: []
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/committees/ways_and_means_2200
-- url: https://api.iga.in.gov/2018ss1/standing-committees/committee_ways_and_means_2200
+- url: http://iga.in.gov/legislative/2019/committees/ways_and_means_2200
+- url: https://api.iga.in.gov/2019/standing-committees/committee_ways_and_means_2200
 memberships:
 - id: ocd-person/a0c6af20-56b0-41be-abf7-9d2265988a48
   name: Timothy Brown
@@ -19,8 +19,10 @@ memberships:
   role: Ranking Minority Member
 - id: ocd-person/650c6338-9a20-44df-82e3-5f0d372bc415
   name: James Baird
+  end_date: '2018-11-06'
 - id: ocd-person/86e50c79-ff31-4cdb-99df-52a775bdb81f
   name: Mara Candelaria Reardon
+  end_date: '2018-11-06'
 - id: ocd-person/d01b6bbc-9c5e-4479-afd6-3e7410946367
   name: Edward Clere
 - id: ocd-person/77a93fc3-bbc5-41b6-b1af-0069670dd5af
@@ -49,13 +51,31 @@ memberships:
   name: Cherrish Pryor
 - id: ocd-person/a90c6c3f-a4c0-4bbe-a1a6-6d1c82345769
   name: Sally Siegrist
+  end_date: '2018-11-06'
 - id: ocd-person/b71e9f3a-2c59-4e18-80e6-da0a7cc51648
   name: Harold Slager
+  end_date: '2018-11-06'
 - id: ocd-person/f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf
   name: Steven Stemler
+  end_date: '2018-11-06'
 - id: ocd-person/636b7e08-fde1-4068-8bd8-323ce56dbfb4
   name: Holli Sullivan
 - id: ocd-person/6835c75a-05e6-44d8-9d8b-7ee4559892b2
   name: Jeffrey Thompson
 - id: ocd-person/7fa8b319-d3d7-4612-a0d2-0baf3f0c4382
   name: Melanie Wright
+- id: ocd-person/6629fcea-f482-4e63-872d-d2f8734502ca
+  name: Brad Barrett
+  start_date: '2018-11-07'
+- id: ocd-person/a2b2e61b-e27c-4ead-8c81-6703ea817037
+  name: Chris Campbell
+  start_date: '2018-11-07'
+- id: ocd-person/ec6a3cce-3eca-4020-8809-a7a1875e1663
+  name: Carey Hamilton
+  start_date: '2018-11-07'
+- id: ocd-person/12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55
+  name: Jack Jordan
+  start_date: '2018-11-07'
+- id: ocd-person/78b84e11-85f1-49fb-8243-49b15a457523
+  name: Cindy Ziemke
+  start_date: '2018-11-07'

--- a/data/in/people/Aaron-Freeman-b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a.yml
+++ b/data/in/people/Aaron-Freeman-b5e2b0b8-ae2a-4852-9c40-c9bf4a32fe1a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_aaron_freeman_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_aaron_freeman_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_aaron_freeman_1
-- url: https://api.iga.in.gov/2018ss1/legislators/aaron_freeman_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_aaron_freeman_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_aaron_freeman_1
+- url: https://api.iga.in.gov/2019/legislators/aaron_freeman_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_aaron_freeman_1
 other_identifiers:
 - identifier: INL000285
   scheme: legacy_openstates

--- a/data/in/people/Alan-Morrison-3e2f70f5-2f3a-425f-99ed-c7277eb2f13c.yml
+++ b/data/in/people/Alan-Morrison-3e2f70f5-2f3a-425f-99ed-c7277eb2f13c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_alan_morrison_1115
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_alan_morrison_1115
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_alan_morrison_1115
-- url: https://api.iga.in.gov/2018ss1/legislators/alan_morrison_1115
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_alan_morrison_1115
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_alan_morrison_1115
+- url: https://api.iga.in.gov/2019/legislators/alan_morrison_1115
+image: http://iga.in.gov/legislative/2019/portraits/legislator_alan_morrison_1115
 other_identifiers:
 - identifier: INL000172
   scheme: legacy_openstates

--- a/data/in/people/Andy-Zay-85c3a6e4-8292-4e3f-a8f4-475aede6b9d6.yml
+++ b/data/in/people/Andy-Zay-85c3a6e4-8292-4e3f-a8f4-475aede6b9d6.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_andy_zay_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_andy_zay_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_andy_zay_1
-- url: https://api.iga.in.gov/2018ss1/legislators/andy_zay_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_andy_zay_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_andy_zay_1
+- url: https://api.iga.in.gov/2019/legislators/andy_zay_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_andy_zay_1
 other_identifiers:
 - identifier: INL000302
   scheme: legacy_openstates

--- a/data/in/people/Anthony-Cook-487ec8e1-4249-49aa-bc17-742cb10b1794.yml
+++ b/data/in/people/Anthony-Cook-487ec8e1-4249-49aa-bc17-742cb10b1794.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_anthony_cook_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_anthony_cook_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_anthony_cook_1
-- url: https://api.iga.in.gov/2018ss1/legislators/anthony_cook_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_anthony_cook_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_anthony_cook_1
+- url: https://api.iga.in.gov/2019/legislators/anthony_cook_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_anthony_cook_1
 other_identifiers:
 - identifier: INL000276
   scheme: legacy_openstates

--- a/data/in/people/B-Patrick-Bauer-43b9cb7b-a913-4624-859b-6f28e10d871a.yml
+++ b/data/in/people/B-Patrick-Bauer-43b9cb7b-a913-4624-859b-6f28e10d871a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_b_patrick_bauer_178
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_b_patrick_bauer_178
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_b_patrick_bauer_178
-- url: https://api.iga.in.gov/2018ss1/legislators/b_patrick_bauer_178
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_b_patrick_bauer_178
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_b_patrick_bauer_178
+- url: https://api.iga.in.gov/2019/legislators/b_patrick_bauer_178
+image: http://iga.in.gov/legislative/2019/portraits/legislator_b_patrick_bauer_178
 other_identifiers:
 - identifier: INL000057
   scheme: legacy_openstates

--- a/data/in/people/Beau-Baird-a8ed53f7-00fb-428b-a629-7532efaf902d.yml
+++ b/data/in/people/Beau-Baird-a8ed53f7-00fb-428b-a629-7532efaf902d.yml
@@ -1,0 +1,21 @@
+id: ocd-person/a8ed53f7-00fb-428b-a629-7532efaf902d
+name: Beau Baird
+party:
+- name: Republican
+roles:
+- district: '44'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_beau_baird_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_beau_baird_1
+- url: https://api.iga.in.gov/2019/legislators/beau_baird_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_beau_baird_1
+given_name: Beau
+family_name: Baird

--- a/data/in/people/Ben-Smaltz-ea2c35cb-7071-43de-8dc6-e91756d03f11.yml
+++ b/data/in/people/Ben-Smaltz-ea2c35cb-7071-43de-8dc6-e91756d03f11.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ben_smaltz_1118
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ben_smaltz_1118
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ben_smaltz_1118
-- url: https://api.iga.in.gov/2018ss1/legislators/ben_smaltz_1118
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ben_smaltz_1118
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ben_smaltz_1118
+- url: https://api.iga.in.gov/2019/legislators/ben_smaltz_1118
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ben_smaltz_1118
 other_identifiers:
 - identifier: INL000179
   scheme: legacy_openstates

--- a/data/in/people/Blake-Doriot-a1002ff1-ffd8-4d82-8db9-3a8295ca5e06.yml
+++ b/data/in/people/Blake-Doriot-a1002ff1-ffd8-4d82-8db9-3a8295ca5e06.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_blake_doriot_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_blake_doriot_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_blake_doriot_1
-- url: https://api.iga.in.gov/2018ss1/legislators/blake_doriot_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_blake_doriot_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_blake_doriot_1
+- url: https://api.iga.in.gov/2019/legislators/blake_doriot_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_blake_doriot_1
 other_identifiers:
 - identifier: INL000287
   scheme: legacy_openstates

--- a/data/in/people/Brad-Barrett-6629fcea-f482-4e63-872d-d2f8734502ca.yml
+++ b/data/in/people/Brad-Barrett-6629fcea-f482-4e63-872d-d2f8734502ca.yml
@@ -1,0 +1,21 @@
+id: ocd-person/6629fcea-f482-4e63-872d-d2f8734502ca
+name: Brad Barrett
+party:
+- name: Republican
+roles:
+- district: '56'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_bradford_barrett_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_bradford_barrett_1
+- url: https://api.iga.in.gov/2019/legislators/bradford_barrett_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_bradford_barrett_1
+given_name: Brad
+family_name: Barrett

--- a/data/in/people/Brian-Bosma-a52a0e0d-3abd-4181-bd89-71c79eb36fcb.yml
+++ b/data/in/people/Brian-Bosma-a52a0e0d-3abd-4181-bd89-71c79eb36fcb.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_brian_bosma_69
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_brian_bosma_69
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_brian_bosma_69
-- url: https://api.iga.in.gov/2018ss1/legislators/brian_bosma_69
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_brian_bosma_69
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_brian_bosma_69
+- url: https://api.iga.in.gov/2019/legislators/brian_bosma_69
+image: http://iga.in.gov/legislative/2019/portraits/legislator_brian_bosma_69
 other_identifiers:
 - identifier: INL000060
   scheme: legacy_openstates

--- a/data/in/people/Brian-Buchanan-0482a330-c9fb-4f41-b136-88a4aef2de6a.yml
+++ b/data/in/people/Brian-Buchanan-0482a330-c9fb-4f41-b136-88a4aef2de6a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_brian_buchanan_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_brian_buchanan_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_brian_buchanan_1
-- url: https://api.iga.in.gov/2018ss1/legislators/brian_buchanan_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_brian_buchanan_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_brian_buchanan_1
+- url: https://api.iga.in.gov/2019/legislators/brian_buchanan_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_brian_buchanan_1
 other_identifiers:
 - identifier: INL000310
   scheme: legacy_openstates

--- a/data/in/people/Bruce-Borders-fe83212e-72d8-4d9c-80cb-338c7f318f09.yml
+++ b/data/in/people/Bruce-Borders-fe83212e-72d8-4d9c-80cb-338c7f318f09.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_bruce_borders_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_bruce_borders_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_bruce_borders_1
-- url: https://api.iga.in.gov/2018ss1/legislators/bruce_borders_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_bruce_borders_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_bruce_borders_1
+- url: https://api.iga.in.gov/2019/legislators/bruce_borders_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_bruce_borders_1
 other_identifiers:
 - identifier: INL000059
   scheme: legacy_openstates

--- a/data/in/people/Carey-Hamilton-ec6a3cce-3eca-4020-8809-a7a1875e1663.yml
+++ b/data/in/people/Carey-Hamilton-ec6a3cce-3eca-4020-8809-a7a1875e1663.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_carey_hamilton_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_carey_hamilton_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_carey_hamilton_1
-- url: https://api.iga.in.gov/2018ss1/legislators/carey_hamilton_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_carey_hamilton_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_carey_hamilton_1
+- url: https://api.iga.in.gov/2019/legislators/carey_hamilton_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_carey_hamilton_1
 other_identifiers:
 - identifier: INL000286
   scheme: legacy_openstates

--- a/data/in/people/Carolyn-Jackson-16ded3c5-7034-4910-b5d1-76efa7b2f02f.yml
+++ b/data/in/people/Carolyn-Jackson-16ded3c5-7034-4910-b5d1-76efa7b2f02f.yml
@@ -1,0 +1,21 @@
+id: ocd-person/16ded3c5-7034-4910-b5d1-76efa7b2f02f
+name: Carolyn Jackson
+party:
+- name: Democratic
+roles:
+- district: '1'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_carolyn_jackson_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_carolyn_jackson_1
+- url: https://api.iga.in.gov/2019/legislators/carolyn_jackson_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_carolyn_jackson_1
+given_name: Carolyn
+family_name: Jackson

--- a/data/in/people/Charles-Moseley-17fd494d-905d-4c82-a828-6d975cbf02f3.yml
+++ b/data/in/people/Charles-Moseley-17fd494d-905d-4c82-a828-6d975cbf02f3.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_charles_moseley_973
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_charles_moseley_973
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_charles_moseley_973
-- url: https://api.iga.in.gov/2018ss1/legislators/charles_moseley_973
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_charles_moseley_973
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_charles_moseley_973
+- url: https://api.iga.in.gov/2019/legislators/charles_moseley_973
+image: http://iga.in.gov/legislative/2019/portraits/legislator_charles_moseley_973
 other_identifiers:
 - identifier: INL000114
   scheme: legacy_openstates

--- a/data/in/people/Cherrish-Pryor-8db4d04c-3afe-44c1-940b-7761cd035800.yml
+++ b/data/in/people/Cherrish-Pryor-8db4d04c-3afe-44c1-940b-7761cd035800.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cherrish_pryor_990
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cherrish_pryor_990
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cherrish_pryor_990
-- url: https://api.iga.in.gov/2018ss1/legislators/cherrish_pryor_990
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_cherrish_pryor_990
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cherrish_pryor_990
+- url: https://api.iga.in.gov/2019/legislators/cherrish_pryor_990
+image: http://iga.in.gov/legislative/2019/portraits/legislator_cherrish_pryor_990
 other_identifiers:
 - identifier: INL000124
   scheme: legacy_openstates

--- a/data/in/people/Chip-Perfect-24f5ad99-8af0-4e08-a4cb-8c5c0606eb43.yml
+++ b/data/in/people/Chip-Perfect-24f5ad99-8af0-4e08-a4cb-8c5c0606eb43.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_chip_perfect_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chip_perfect_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_chip_perfect_1
-- url: https://api.iga.in.gov/2018ss1/legislators/chip_perfect_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_chip_perfect_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chip_perfect_1
+- url: https://api.iga.in.gov/2019/legislators/chip_perfect_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_chip_perfect_1
 other_identifiers:
 - identifier: INL000264
   scheme: legacy_openstates

--- a/data/in/people/Chris-Campbell-a2b2e61b-e27c-4ead-8c81-6703ea817037.yml
+++ b/data/in/people/Chris-Campbell-a2b2e61b-e27c-4ead-8c81-6703ea817037.yml
@@ -1,0 +1,21 @@
+id: ocd-person/a2b2e61b-e27c-4ead-8c81-6703ea817037
+name: Chris Campbell
+party:
+- name: Democratic
+roles:
+- district: '26'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christine_campbell_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christine_campbell_1
+- url: https://api.iga.in.gov/2019/legislators/christine_campbell_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_christine_campbell_1
+given_name: Chris
+family_name: Campbell

--- a/data/in/people/Chris-Chyung-987df48a-c7d6-47c7-be9c-3f0d222a6a0c.yml
+++ b/data/in/people/Chris-Chyung-987df48a-c7d6-47c7-be9c-3f0d222a6a0c.yml
@@ -1,0 +1,21 @@
+id: ocd-person/987df48a-c7d6-47c7-be9c-3f0d222a6a0c
+name: Chris Chyung
+party:
+- name: Democratic
+roles:
+- district: '15'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christopher_chyung_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christopher_chyung_1
+- url: https://api.iga.in.gov/2019/legislators/christopher_chyung_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_christopher_chyung_1
+given_name: Chris
+family_name: Chyung

--- a/data/in/people/Chris-Garten-dc07e0d2-7372-46c2-967c-878ec522879d.yml
+++ b/data/in/people/Chris-Garten-dc07e0d2-7372-46c2-967c-878ec522879d.yml
@@ -1,0 +1,21 @@
+id: ocd-person/dc07e0d2-7372-46c2-967c-878ec522879d
+name: Chris Garten
+party:
+- name: Republican
+roles:
+- district: '45'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: upper
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9467
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chris_garten_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chris_garten_1
+- url: https://api.iga.in.gov/2019/legislators/chris_garten_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_chris_garten_1
+given_name: Chris
+family_name: Garten

--- a/data/in/people/Chris-Judy-35824e09-976c-44b7-9825-0787030f0e4e.yml
+++ b/data/in/people/Chris-Judy-35824e09-976c-44b7-9825-0787030f0e4e.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_christopher_judy_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christopher_judy_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_christopher_judy_1
-- url: https://api.iga.in.gov/2018ss1/legislators/christopher_judy_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_christopher_judy_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christopher_judy_1
+- url: https://api.iga.in.gov/2019/legislators/christopher_judy_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_christopher_judy_1
 other_identifiers:
 - identifier: INL000256
   scheme: legacy_openstates

--- a/data/in/people/Chris-May-f1571a79-9c64-42b2-82d2-ec9f512722eb.yml
+++ b/data/in/people/Chris-May-f1571a79-9c64-42b2-82d2-ec9f512722eb.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_chris_may_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chris_may_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_chris_may_1
-- url: https://api.iga.in.gov/2018ss1/legislators/chris_may_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_chris_may_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chris_may_1
+- url: https://api.iga.in.gov/2019/legislators/chris_may_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_chris_may_1
 other_identifiers:
 - identifier: INL000288
   scheme: legacy_openstates

--- a/data/in/people/Christy-Stutzman-2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f.yml
+++ b/data/in/people/Christy-Stutzman-2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f.yml
@@ -1,0 +1,21 @@
+id: ocd-person/2ef0e09b-37a5-4a48-a5ad-fcaabffd3f8f
+name: Christy Stutzman
+party:
+- name: Republican
+roles:
+- district: '49'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christy_stutzman_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_christy_stutzman_1
+- url: https://api.iga.in.gov/2019/legislators/christy_stutzman_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_christy_stutzman_1
+given_name: Christy
+family_name: Stutzman

--- a/data/in/people/Chuck-Goodrich-e9844fde-43a6-4aa8-9248-85ab1ad79c20.yml
+++ b/data/in/people/Chuck-Goodrich-e9844fde-43a6-4aa8-9248-85ab1ad79c20.yml
@@ -1,0 +1,21 @@
+id: ocd-person/e9844fde-43a6-4aa8-9248-85ab1ad79c20
+name: Chuck Goodrich
+party:
+- name: Republican
+roles:
+- district: '29'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chuck_goodrich_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_chuck_goodrich_1
+- url: https://api.iga.in.gov/2019/legislators/chuck_goodrich_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_chuck_goodrich_1
+given_name: Chuck
+family_name: Goodrich

--- a/data/in/people/Cindy-Kirchhofer-291429c7-c347-40a1-831e-8f0dd870b2ca.yml
+++ b/data/in/people/Cindy-Kirchhofer-291429c7-c347-40a1-831e-8f0dd870b2ca.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cindy_kirchhofer_1037
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cindy_kirchhofer_1037
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cindy_kirchhofer_1037
-- url: https://api.iga.in.gov/2018ss1/legislators/cindy_kirchhofer_1037
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_cindy_kirchhofer_1037
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cindy_kirchhofer_1037
+- url: https://api.iga.in.gov/2019/legislators/cindy_kirchhofer_1037
+image: http://iga.in.gov/legislative/2019/portraits/legislator_cindy_kirchhofer_1037
 other_identifiers:
 - identifier: INL000098
   scheme: legacy_openstates

--- a/data/in/people/Cindy-Ziemke-78b84e11-85f1-49fb-8243-49b15a457523.yml
+++ b/data/in/people/Cindy-Ziemke-78b84e11-85f1-49fb-8243-49b15a457523.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cindy_ziemke_1119
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cindy_ziemke_1119
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_cindy_ziemke_1119
-- url: https://api.iga.in.gov/2018ss1/legislators/cindy_ziemke_1119
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_cindy_ziemke_1119
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_cindy_ziemke_1119
+- url: https://api.iga.in.gov/2019/legislators/cindy_ziemke_1119
+image: http://iga.in.gov/legislative/2019/portraits/legislator_cindy_ziemke_1119
 other_identifiers:
 - identifier: INL000182
   scheme: legacy_openstates

--- a/data/in/people/Curt-Nisly-7eb86096-7906-4bac-8bb5-98e3ecd5029c.yml
+++ b/data/in/people/Curt-Nisly-7eb86096-7906-4bac-8bb5-98e3ecd5029c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_curt_nisly_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_curt_nisly_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_curt_nisly_1
-- url: https://api.iga.in.gov/2018ss1/legislators/curt_nisly_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_curt_nisly_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_curt_nisly_1
+- url: https://api.iga.in.gov/2019/legislators/curt_nisly_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_curt_nisly_1
 other_identifiers:
 - identifier: INL000261
   scheme: legacy_openstates

--- a/data/in/people/Dale-DeVon-da8afc87-2b9a-4544-8fb9-2f03f426a451.yml
+++ b/data/in/people/Dale-DeVon-da8afc87-2b9a-4544-8fb9-2f03f426a451.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dale_devon_1108
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dale_devon_1108
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dale_devon_1108
-- url: https://api.iga.in.gov/2018ss1/legislators/dale_devon_1108
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_dale_devon_1108
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dale_devon_1108
+- url: https://api.iga.in.gov/2019/legislators/dale_devon_1108
+image: http://iga.in.gov/legislative/2019/portraits/legislator_dale_devon_1108
 other_identifiers:
 - identifier: INL000160
   scheme: legacy_openstates

--- a/data/in/people/Dan-Forestal-3758fe74-9190-4daf-9a3e-790b01e3d2d4.yml
+++ b/data/in/people/Dan-Forestal-3758fe74-9190-4daf-9a3e-790b01e3d2d4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dan_forestal_1129
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dan_forestal_1129
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dan_forestal_1129
-- url: https://api.iga.in.gov/2018ss1/legislators/dan_forestal_1129
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_dan_forestal_1129
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dan_forestal_1129
+- url: https://api.iga.in.gov/2019/legislators/dan_forestal_1129
+image: http://iga.in.gov/legislative/2019/portraits/legislator_dan_forestal_1129
 other_identifiers:
 - identifier: INL000162
   scheme: legacy_openstates

--- a/data/in/people/Daniel-Leonard-839dc3a8-6b1a-4aff-b5cf-342da0cac11d.yml
+++ b/data/in/people/Daniel-Leonard-839dc3a8-6b1a-4aff-b5cf-342da0cac11d.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_daniel_leonard_711
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_daniel_leonard_711
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_daniel_leonard_711
-- url: https://api.iga.in.gov/2018ss1/legislators/daniel_leonard_711
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_daniel_leonard_711
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_daniel_leonard_711
+- url: https://api.iga.in.gov/2019/legislators/daniel_leonard_711
+image: http://iga.in.gov/legislative/2019/portraits/legislator_daniel_leonard_711
 other_identifiers:
 - identifier: INL000106
   scheme: legacy_openstates

--- a/data/in/people/Dave-Heine-ed771fd3-4bd9-4c99-bb42-4bd9f5d1ff8d.yml
+++ b/data/in/people/Dave-Heine-ed771fd3-4bd9-4c99-bb42-4bd9f5d1ff8d.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dave_heine_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dave_heine_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dave_heine_1
-- url: https://api.iga.in.gov/2018ss1/legislators/dave_heine_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_dave_heine_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dave_heine_1
+- url: https://api.iga.in.gov/2019/legislators/dave_heine_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_dave_heine_1
 other_identifiers:
 - identifier: INL000293
   scheme: legacy_openstates

--- a/data/in/people/David-Abbott-a080b584-c899-4694-a797-73cca22610fe.yml
+++ b/data/in/people/David-Abbott-a080b584-c899-4694-a797-73cca22610fe.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_abbott_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_abbott_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_abbott_1
-- url: https://api.iga.in.gov/2018ss1/legislators/david_abbott_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_david_abbott_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_abbott_1
+- url: https://api.iga.in.gov/2019/legislators/david_abbott_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_david_abbott_1
 other_identifiers:
 - identifier: INL000311
   scheme: legacy_openstates

--- a/data/in/people/David-Frizzell-54dab91e-52a0-4217-963f-212102e54516.yml
+++ b/data/in/people/David-Frizzell-54dab91e-52a0-4217-963f-212102e54516.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_frizzell_92
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_frizzell_92
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_frizzell_92
-- url: https://api.iga.in.gov/2018ss1/legislators/david_frizzell_92
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_david_frizzell_92
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_frizzell_92
+- url: https://api.iga.in.gov/2019/legislators/david_frizzell_92
+image: http://iga.in.gov/legislative/2019/portraits/legislator_david_frizzell_92
 other_identifiers:
 - identifier: INL000085
   scheme: legacy_openstates

--- a/data/in/people/David-Niezgodski-1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371.yml
+++ b/data/in/people/David-Niezgodski-1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_niezgodski_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_niezgodski_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_niezgodski_1
-- url: https://api.iga.in.gov/2018ss1/legislators/david_niezgodski_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_david_niezgodski_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_niezgodski_1
+- url: https://api.iga.in.gov/2019/legislators/david_niezgodski_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_david_niezgodski_1
 other_identifiers:
 - identifier: INL000298
   scheme: legacy_openstates

--- a/data/in/people/David-Wolkins-27d571a8-12b3-439d-86ee-5457d41fb250.yml
+++ b/data/in/people/David-Wolkins-27d571a8-12b3-439d-86ee-5457d41fb250.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_wolkins_104
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_wolkins_104
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_david_wolkins_104
-- url: https://api.iga.in.gov/2018ss1/legislators/david_wolkins_104
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_david_wolkins_104
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_david_wolkins_104
+- url: https://api.iga.in.gov/2019/legislators/david_wolkins_104
+image: http://iga.in.gov/legislative/2019/portraits/legislator_david_wolkins_104
 other_identifiers:
 - identifier: INL000149
   scheme: legacy_openstates

--- a/data/in/people/Dennis-Kruse-e17c68ed-749d-4a65-88f6-60302e6435a4.yml
+++ b/data/in/people/Dennis-Kruse-e17c68ed-749d-4a65-88f6-60302e6435a4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dennis_kruse_780
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dennis_kruse_780
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dennis_kruse_780
-- url: https://api.iga.in.gov/2018ss1/legislators/dennis_kruse_780
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_dennis_kruse_780
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dennis_kruse_780
+- url: https://api.iga.in.gov/2019/legislators/dennis_kruse_780
+image: http://iga.in.gov/legislative/2019/portraits/legislator_dennis_kruse_780
 other_identifiers:
 - identifier: INL000021
   scheme: legacy_openstates

--- a/data/in/people/Dennis-Zent-d748047f-9a19-4e0b-a3e0-446aa337349c.yml
+++ b/data/in/people/Dennis-Zent-d748047f-9a19-4e0b-a3e0-446aa337349c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dennis_zent_1117
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dennis_zent_1117
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_dennis_zent_1117
-- url: https://api.iga.in.gov/2018ss1/legislators/dennis_zent_1117
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_dennis_zent_1117
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_dennis_zent_1117
+- url: https://api.iga.in.gov/2019/legislators/dennis_zent_1117
+image: http://iga.in.gov/legislative/2019/portraits/legislator_dennis_zent_1117
 other_identifiers:
 - identifier: INL000181
   scheme: legacy_openstates

--- a/data/in/people/Don-Lehe-e9843d9e-d8d9-4310-bb12-676f1dd486aa.yml
+++ b/data/in/people/Don-Lehe-e9843d9e-d8d9-4310-bb12-676f1dd486aa.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_don_lehe_698
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_don_lehe_698
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_don_lehe_698
-- url: https://api.iga.in.gov/2018ss1/legislators/don_lehe_698
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_don_lehe_698
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_don_lehe_698
+- url: https://api.iga.in.gov/2019/legislators/don_lehe_698
+image: http://iga.in.gov/legislative/2019/portraits/legislator_don_lehe_698
 other_identifiers:
 - identifier: INL000104
   scheme: legacy_openstates

--- a/data/in/people/Donna-Schaibley-062c9921-6c7e-489b-bcc2-b140231cd2c2.yml
+++ b/data/in/people/Donna-Schaibley-062c9921-6c7e-489b-bcc2-b140231cd2c2.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_donna_schaibley_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_donna_schaibley_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_donna_schaibley_1
-- url: https://api.iga.in.gov/2018ss1/legislators/donna_schaibley_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_donna_schaibley_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_donna_schaibley_1
+- url: https://api.iga.in.gov/2019/legislators/donna_schaibley_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_donna_schaibley_1
 other_identifiers:
 - identifier: INL000275
   scheme: legacy_openstates

--- a/data/in/people/Doug-Gutwein-53a0eb12-72c3-4e7e-9258-d264de2bee6c.yml
+++ b/data/in/people/Doug-Gutwein-53a0eb12-72c3-4e7e-9258-d264de2bee6c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_doug_gutwein_992
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_doug_gutwein_992
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_doug_gutwein_992
-- url: https://api.iga.in.gov/2018ss1/legislators/doug_gutwein_992
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_doug_gutwein_992
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_doug_gutwein_992
+- url: https://api.iga.in.gov/2019/legislators/doug_gutwein_992
+image: http://iga.in.gov/legislative/2019/portraits/legislator_doug_gutwein_992
 other_identifiers:
 - identifier: INL000091
   scheme: legacy_openstates

--- a/data/in/people/Doug-Miller-5b58dd7d-acb3-4554-9e4e-c1281155f4ab.yml
+++ b/data/in/people/Doug-Miller-5b58dd7d-acb3-4554-9e4e-c1281155f4ab.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_doug_miller_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_doug_miller_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_doug_miller_1
-- url: https://api.iga.in.gov/2018ss1/legislators/doug_miller_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_doug_miller_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_doug_miller_1
+- url: https://api.iga.in.gov/2019/legislators/doug_miller_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_doug_miller_1
 other_identifiers:
 - identifier: INL000273
   scheme: legacy_openstates

--- a/data/in/people/Earl-Harris-e0aaea95-033f-49d8-9be6-3875fc3b8efe.yml
+++ b/data/in/people/Earl-Harris-e0aaea95-033f-49d8-9be6-3875fc3b8efe.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_earl_harris_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_earl_harris_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_earl_harris_1
-- url: https://api.iga.in.gov/2018ss1/legislators/earl_harris_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_earl_harris_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_earl_harris_1
+- url: https://api.iga.in.gov/2019/legislators/earl_harris_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_earl_harris_1
 other_identifiers:
 - identifier: INL000301
   scheme: legacy_openstates

--- a/data/in/people/Ed-Charbonneau-ce2c81c3-e2d6-4394-b960-8787d896bfe5.yml
+++ b/data/in/people/Ed-Charbonneau-ce2c81c3-e2d6-4394-b960-8787d896bfe5.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ed_charbonneau_919
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ed_charbonneau_919
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ed_charbonneau_919
-- url: https://api.iga.in.gov/2018ss1/legislators/ed_charbonneau_919
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ed_charbonneau_919
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ed_charbonneau_919
+- url: https://api.iga.in.gov/2019/legislators/ed_charbonneau_919
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ed_charbonneau_919
 other_identifiers:
 - identifier: INL000010
   scheme: legacy_openstates

--- a/data/in/people/Eddie-Melton-c0faf1f8-7c27-46cd-9ff4-e740f4e5b376.yml
+++ b/data/in/people/Eddie-Melton-c0faf1f8-7c27-46cd-9ff4-e740f4e5b376.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eddie_melton_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eddie_melton_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eddie_melton_1
-- url: https://api.iga.in.gov/2018ss1/legislators/eddie_melton_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_eddie_melton_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eddie_melton_1
+- url: https://api.iga.in.gov/2019/legislators/eddie_melton_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_eddie_melton_1
 other_identifiers:
 - identifier: INL000290
   scheme: legacy_openstates

--- a/data/in/people/Edmond-Soliday-3fbcc2a9-c620-456c-b38f-03e0f9063c3f.yml
+++ b/data/in/people/Edmond-Soliday-3fbcc2a9-c620-456c-b38f-03e0f9063c3f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edmond_soliday_864
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edmond_soliday_864
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edmond_soliday_864
-- url: https://api.iga.in.gov/2018ss1/legislators/edmond_soliday_864
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_edmond_soliday_864
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edmond_soliday_864
+- url: https://api.iga.in.gov/2019/legislators/edmond_soliday_864
+image: http://iga.in.gov/legislative/2019/portraits/legislator_edmond_soliday_864
 other_identifiers:
 - identifier: INL000132
   scheme: legacy_openstates

--- a/data/in/people/Edward-Clere-d01b6bbc-9c5e-4479-afd6-3e7410946367.yml
+++ b/data/in/people/Edward-Clere-d01b6bbc-9c5e-4479-afd6-3e7410946367.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edward_clere_984
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edward_clere_984
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edward_clere_984
-- url: https://api.iga.in.gov/2018ss1/legislators/edward_clere_984
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_edward_clere_984
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edward_clere_984
+- url: https://api.iga.in.gov/2019/legislators/edward_clere_984
+image: http://iga.in.gov/legislative/2019/portraits/legislator_edward_clere_984
 other_identifiers:
 - identifier: INL000067
   scheme: legacy_openstates

--- a/data/in/people/Edward-DeLaney-45d8ea46-0d3f-4a80-bf4e-ca016bd458a8.yml
+++ b/data/in/people/Edward-DeLaney-45d8ea46-0d3f-4a80-bf4e-ca016bd458a8.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edward_delaney_988
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edward_delaney_988
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_edward_delaney_988
-- url: https://api.iga.in.gov/2018ss1/legislators/edward_delaney_988
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_edward_delaney_988
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_edward_delaney_988
+- url: https://api.iga.in.gov/2019/legislators/edward_delaney_988
+image: http://iga.in.gov/legislative/2019/portraits/legislator_edward_delaney_988
 other_identifiers:
 - identifier: INL000074
   scheme: legacy_openstates

--- a/data/in/people/Eric-Bassler-2d517236-2a88-435f-bc1f-ce09de86c6f9.yml
+++ b/data/in/people/Eric-Bassler-2d517236-2a88-435f-bc1f-ce09de86c6f9.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eric_bassler_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eric_bassler_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eric_bassler_1
-- url: https://api.iga.in.gov/2018ss1/legislators/eric_bassler_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_eric_bassler_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eric_bassler_1
+- url: https://api.iga.in.gov/2019/legislators/eric_bassler_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_eric_bassler_1
 other_identifiers:
 - identifier: INL000271
   scheme: legacy_openstates

--- a/data/in/people/Eric-Koch-a7974310-0d01-4bc1-9c14-29561ec68a60.yml
+++ b/data/in/people/Eric-Koch-a7974310-0d01-4bc1-9c14-29561ec68a60.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eric_koch_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eric_koch_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_eric_koch_1
-- url: https://api.iga.in.gov/2018ss1/legislators/eric_koch_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_eric_koch_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_eric_koch_1
+- url: https://api.iga.in.gov/2019/legislators/eric_koch_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_eric_koch_1
 other_identifiers:
 - identifier: INL000303
   scheme: legacy_openstates

--- a/data/in/people/Erin-Houchin-05cfdc73-ff21-4d74-833e-e3da82ed7509.yml
+++ b/data/in/people/Erin-Houchin-05cfdc73-ff21-4d74-833e-e3da82ed7509.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_erin_houchin_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_erin_houchin_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_erin_houchin_1
-- url: https://api.iga.in.gov/2018ss1/legislators/erin_houchin_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_erin_houchin_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_erin_houchin_1
+- url: https://api.iga.in.gov/2019/legislators/erin_houchin_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_erin_houchin_1
 other_identifiers:
 - identifier: INL000262
   scheme: legacy_openstates

--- a/data/in/people/Ethan-Manning-bdae77c7-d89e-426d-b6f6-52e1a48bc87a.yml
+++ b/data/in/people/Ethan-Manning-bdae77c7-d89e-426d-b6f6-52e1a48bc87a.yml
@@ -1,0 +1,21 @@
+id: ocd-person/bdae77c7-d89e-426d-b6f6-52e1a48bc87a
+name: Ethan Manning
+party:
+- name: Republican
+roles:
+- district: '23'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ethan_manning_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ethan_manning_1
+- url: https://api.iga.in.gov/2019/legislators/ethan_manning_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ethan_manning_1
+given_name: Ethan
+family_name: Manning

--- a/data/in/people/Frank-Mrvan-7dacbdba-68ea-4b74-8864-d1b19a1ff4c0.yml
+++ b/data/in/people/Frank-Mrvan-7dacbdba-68ea-4b74-8864-d1b19a1ff4c0.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_frank_mrvan_536
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_frank_mrvan_536
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_frank_mrvan_536
-- url: https://api.iga.in.gov/2018ss1/legislators/frank_mrvan_536
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_frank_mrvan_536
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_frank_mrvan_536
+- url: https://api.iga.in.gov/2019/legislators/frank_mrvan_536
+image: http://iga.in.gov/legislative/2019/portraits/legislator_frank_mrvan_536
 other_identifiers:
 - identifier: INL000030
   scheme: legacy_openstates

--- a/data/in/people/Greg-Taylor-39798614-3cb2-40b7-adad-4f5c53ff59e5.yml
+++ b/data/in/people/Greg-Taylor-39798614-3cb2-40b7-adad-4f5c53ff59e5.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_greg_taylor_976
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_greg_taylor_976
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_greg_taylor_976
-- url: https://api.iga.in.gov/2018ss1/legislators/greg_taylor_976
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_greg_taylor_976
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_greg_taylor_976
+- url: https://api.iga.in.gov/2019/legislators/greg_taylor_976
+image: http://iga.in.gov/legislative/2019/portraits/legislator_greg_taylor_976
 other_identifiers:
 - identifier: INL000041
   scheme: legacy_openstates

--- a/data/in/people/Greg-Walker-0bee6f8c-db8b-4e92-8bd4-799c71c55c2c.yml
+++ b/data/in/people/Greg-Walker-0bee6f8c-db8b-4e92-8bd4-799c71c55c2c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_greg_walker_867
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_greg_walker_867
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_greg_walker_867
-- url: https://api.iga.in.gov/2018ss1/legislators/greg_walker_867
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_greg_walker_867
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_greg_walker_867
+- url: https://api.iga.in.gov/2019/legislators/greg_walker_867
+image: http://iga.in.gov/legislative/2019/portraits/legislator_greg_walker_867
 other_identifiers:
 - identifier: INL000043
   scheme: legacy_openstates

--- a/data/in/people/Gregory-Porter-6bc40502-e00f-4b16-8c1d-9f5a613a4e88.yml
+++ b/data/in/people/Gregory-Porter-6bc40502-e00f-4b16-8c1d-9f5a613a4e88.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_gregory_porter_115
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_gregory_porter_115
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_gregory_porter_115
-- url: https://api.iga.in.gov/2018ss1/legislators/gregory_porter_115
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_gregory_porter_115
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_gregory_porter_115
+- url: https://api.iga.in.gov/2019/legislators/gregory_porter_115
+image: http://iga.in.gov/legislative/2019/portraits/legislator_gregory_porter_115
 other_identifiers:
 - identifier: INL000123
   scheme: legacy_openstates

--- a/data/in/people/Gregory-Steuerwald-3ee97114-199a-4084-903f-5eaa231ca656.yml
+++ b/data/in/people/Gregory-Steuerwald-3ee97114-199a-4084-903f-5eaa231ca656.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_gregory_steuerwald_927
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_gregory_steuerwald_927
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_gregory_steuerwald_927
-- url: https://api.iga.in.gov/2018ss1/legislators/gregory_steuerwald_927
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_gregory_steuerwald_927
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_gregory_steuerwald_927
+- url: https://api.iga.in.gov/2019/legislators/gregory_steuerwald_927
+image: http://iga.in.gov/legislative/2019/portraits/legislator_gregory_steuerwald_927
 other_identifiers:
 - identifier: INL000135
   scheme: legacy_openstates

--- a/data/in/people/Heath-VanNatter-113063ff-6e21-4bf7-b9d0-f06aafc349f2.yml
+++ b/data/in/people/Heath-VanNatter-113063ff-6e21-4bf7-b9d0-f06aafc349f2.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_heath_vannatter_956
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_heath_vannatter_956
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_heath_vannatter_956
-- url: https://api.iga.in.gov/2018ss1/legislators/heath_vannatter_956
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_heath_vannatter_956
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_heath_vannatter_956
+- url: https://api.iga.in.gov/2019/legislators/heath_vannatter_956
+image: http://iga.in.gov/legislative/2019/portraits/legislator_heath_vannatter_956
 other_identifiers:
 - identifier: INL000146
   scheme: legacy_openstates

--- a/data/in/people/Holli-Sullivan-636b7e08-fde1-4068-8bd8-323ce56dbfb4.yml
+++ b/data/in/people/Holli-Sullivan-636b7e08-fde1-4068-8bd8-323ce56dbfb4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_holli_sullivan_834
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_holli_sullivan_834
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_holli_sullivan_834
-- url: https://api.iga.in.gov/2018ss1/legislators/holli_sullivan_834
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_holli_sullivan_834
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_holli_sullivan_834
+- url: https://api.iga.in.gov/2019/legislators/holli_sullivan_834
+image: http://iga.in.gov/legislative/2019/portraits/legislator_holli_sullivan_834
 other_identifiers:
 - identifier: INL000251
   scheme: legacy_openstates

--- a/data/in/people/JD-Ford-85b8c0cf-3df4-45a1-8c38-d220b7122226.yml
+++ b/data/in/people/JD-Ford-85b8c0cf-3df4-45a1-8c38-d220b7122226.yml
@@ -1,0 +1,21 @@
+id: ocd-person/85b8c0cf-3df4-45a1-8c38-d220b7122226
+name: J.D. Ford
+party:
+- name: Democratic
+roles:
+- district: '29'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: upper
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9467
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jd_ford_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jd_ford_1
+- url: https://api.iga.in.gov/2019/legislators/jd_ford_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jd_ford_1
+given_name: J.D.
+family_name: Ford

--- a/data/in/people/JD-Prescott-dcba8890-86e8-4a0c-a4a5-77b2fa98a267.yml
+++ b/data/in/people/JD-Prescott-dcba8890-86e8-4a0c-a4a5-77b2fa98a267.yml
@@ -1,0 +1,21 @@
+id: ocd-person/dcba8890-86e8-4a0c-a4a5-77b2fa98a267
+name: J.D. Prescott
+party:
+- name: Republican
+roles:
+- district: '33'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_prescott_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_prescott_1
+- url: https://api.iga.in.gov/2019/legislators/john_prescott_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_john_prescott_1
+given_name: J.D.
+family_name: Prescott

--- a/data/in/people/Jack-Jordan-12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55.yml
+++ b/data/in/people/Jack-Jordan-12a4df88-7cf2-453c-9cb8-dc5d4a2f6b55.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jack_jordan_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jack_jordan_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jack_jordan_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jack_jordan_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jack_jordan_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jack_jordan_1
+- url: https://api.iga.in.gov/2019/legislators/jack_jordan_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jack_jordan_1
 other_identifiers:
 - identifier: INL000289
   scheme: legacy_openstates

--- a/data/in/people/Jack-Sandlin-05364e0a-5596-47b0-b2e2-cf6998d5eeed.yml
+++ b/data/in/people/Jack-Sandlin-05364e0a-5596-47b0-b2e2-cf6998d5eeed.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jack_sandlin_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jack_sandlin_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jack_sandlin_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jack_sandlin_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jack_sandlin_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jack_sandlin_1
+- url: https://api.iga.in.gov/2019/legislators/jack_sandlin_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jack_sandlin_1
 other_identifiers:
 - identifier: INL000295
   scheme: legacy_openstates

--- a/data/in/people/James-Buck-8c8f7869-329e-4063-ab55-30e4eca00529.yml
+++ b/data/in/people/James-Buck-8c8f7869-329e-4063-ab55-30e4eca00529.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_buck_124
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_buck_124
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_buck_124
-- url: https://api.iga.in.gov/2018ss1/legislators/james_buck_124
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_james_buck_124
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_buck_124
+- url: https://api.iga.in.gov/2019/legislators/james_buck_124
+image: http://iga.in.gov/legislative/2019/portraits/legislator_james_buck_124
 other_identifiers:
 - identifier: INL000009
   scheme: legacy_openstates

--- a/data/in/people/James-Merritt-006f23b2-efae-4ba6-bfa1-5a3df4ee832a.yml
+++ b/data/in/people/James-Merritt-006f23b2-efae-4ba6-bfa1-5a3df4ee832a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_merritt_140
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_merritt_140
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_merritt_140
-- url: https://api.iga.in.gov/2018ss1/legislators/james_merritt_140
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_james_merritt_140
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_merritt_140
+- url: https://api.iga.in.gov/2019/legislators/james_merritt_140
+image: http://iga.in.gov/legislative/2019/portraits/legislator_james_merritt_140
 other_identifiers:
 - identifier: INL000027
   scheme: legacy_openstates

--- a/data/in/people/James-Tomes-c2c98fe8-fef2-4d38-93f6-9eff4d591bed.yml
+++ b/data/in/people/James-Tomes-c2c98fe8-fef2-4d38-93f6-9eff4d591bed.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_tomes_1041
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_tomes_1041
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_james_tomes_1041
-- url: https://api.iga.in.gov/2018ss1/legislators/james_tomes_1041
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_james_tomes_1041
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_james_tomes_1041
+- url: https://api.iga.in.gov/2019/legislators/james_tomes_1041
+image: http://iga.in.gov/legislative/2019/portraits/legislator_james_tomes_1041
 other_identifiers:
 - identifier: INL000042
   scheme: legacy_openstates

--- a/data/in/people/Jean-Breaux-0224fa74-0bc2-49ca-83db-03445f40b976.yml
+++ b/data/in/people/Jean-Breaux-0224fa74-0bc2-49ca-83db-03445f40b976.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jean_breaux_889
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jean_breaux_889
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jean_breaux_889
-- url: https://api.iga.in.gov/2018ss1/legislators/jean_breaux_889
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jean_breaux_889
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jean_breaux_889
+- url: https://api.iga.in.gov/2019/legislators/jean_breaux_889
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jean_breaux_889
 other_identifiers:
 - identifier: INL000007
   scheme: legacy_openstates

--- a/data/in/people/Jean-Leising-40ea5143-d0ab-4b9a-a0bc-2cc04f984888.yml
+++ b/data/in/people/Jean-Leising-40ea5143-d0ab-4b9a-a0bc-2cc04f984888.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jean_leising_136
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jean_leising_136
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jean_leising_136
-- url: https://api.iga.in.gov/2018ss1/legislators/jean_leising_136
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jean_leising_136
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jean_leising_136
+- url: https://api.iga.in.gov/2019/legislators/jean_leising_136
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jean_leising_136
 other_identifiers:
 - identifier: INL000025
   scheme: legacy_openstates

--- a/data/in/people/Jeff-Ellington-613fe860-b0c3-4d2e-8af8-47a76ed5ebe9.yml
+++ b/data/in/people/Jeff-Ellington-613fe860-b0c3-4d2e-8af8-47a76ed5ebe9.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeff_ellington_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeff_ellington_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeff_ellington_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jeff_ellington_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jeff_ellington_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeff_ellington_1
+- url: https://api.iga.in.gov/2019/legislators/jeff_ellington_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jeff_ellington_1
 other_identifiers:
 - identifier: INL000281
   scheme: legacy_openstates

--- a/data/in/people/Jeff-Raatz-4267823b-aec1-452a-a040-25b337f04c54.yml
+++ b/data/in/people/Jeff-Raatz-4267823b-aec1-452a-a040-25b337f04c54.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeff_raatz_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeff_raatz_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeff_raatz_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jeff_raatz_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jeff_raatz_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeff_raatz_1
+- url: https://api.iga.in.gov/2019/legislators/jeff_raatz_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jeff_raatz_1
 other_identifiers:
 - identifier: INL000260
   scheme: legacy_openstates

--- a/data/in/people/Jeffrey-Thompson-6835c75a-05e6-44d8-9d8b-7ee4559892b2.yml
+++ b/data/in/people/Jeffrey-Thompson-6835c75a-05e6-44d8-9d8b-7ee4559892b2.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeffrey_thompson_529
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeffrey_thompson_529
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jeffrey_thompson_529
-- url: https://api.iga.in.gov/2018ss1/legislators/jeffrey_thompson_529
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jeffrey_thompson_529
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jeffrey_thompson_529
+- url: https://api.iga.in.gov/2019/legislators/jeffrey_thompson_529
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jeffrey_thompson_529
 other_identifiers:
 - identifier: INL000139
   scheme: legacy_openstates

--- a/data/in/people/Jerry-Torr-585e1d84-c51f-4d50-90d2-e5828a5c2d02.yml
+++ b/data/in/people/Jerry-Torr-585e1d84-c51f-4d50-90d2-e5828a5c2d02.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jerry_torr_117
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jerry_torr_117
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jerry_torr_117
-- url: https://api.iga.in.gov/2018ss1/legislators/jerry_torr_117
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jerry_torr_117
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jerry_torr_117
+- url: https://api.iga.in.gov/2019/legislators/jerry_torr_117
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jerry_torr_117
 other_identifiers:
 - identifier: INL000140
   scheme: legacy_openstates

--- a/data/in/people/Jim-Lucas-70f005b9-1417-4132-9956-ad93942ca87d.yml
+++ b/data/in/people/Jim-Lucas-70f005b9-1417-4132-9956-ad93942ca87d.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jim_lucas_1123
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jim_lucas_1123
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jim_lucas_1123
-- url: https://api.iga.in.gov/2018ss1/legislators/jim_lucas_1123
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jim_lucas_1123
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jim_lucas_1123
+- url: https://api.iga.in.gov/2019/legislators/jim_lucas_1123
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jim_lucas_1123
 other_identifiers:
 - identifier: INL000168
   scheme: legacy_openstates

--- a/data/in/people/Jim-Pressel-3918dc6e-fbf5-4ea0-b62a-376729b463ec.yml
+++ b/data/in/people/Jim-Pressel-3918dc6e-fbf5-4ea0-b62a-376729b463ec.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jim_pressel_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jim_pressel_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jim_pressel_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jim_pressel_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jim_pressel_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jim_pressel_1
+- url: https://api.iga.in.gov/2019/legislators/jim_pressel_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jim_pressel_1
 other_identifiers:
 - identifier: INL000291
   scheme: legacy_openstates

--- a/data/in/people/John-Bartlett-5ceabc0e-ec47-41b5-b014-5eddcdc154f3.yml
+++ b/data/in/people/John-Bartlett-5ceabc0e-ec47-41b5-b014-5eddcdc154f3.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_bartlett_942
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_bartlett_942
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_bartlett_942
-- url: https://api.iga.in.gov/2018ss1/legislators/john_bartlett_942
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_john_bartlett_942
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_bartlett_942
+- url: https://api.iga.in.gov/2019/legislators/john_bartlett_942
+image: http://iga.in.gov/legislative/2019/portraits/legislator_john_bartlett_942
 other_identifiers:
 - identifier: INL000055
   scheme: legacy_openstates

--- a/data/in/people/John-Crane-ed4d2a15-ec36-4f60-8a07-b79e15d34760.yml
+++ b/data/in/people/John-Crane-ed4d2a15-ec36-4f60-8a07-b79e15d34760.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_crane_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_crane_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_crane_1
-- url: https://api.iga.in.gov/2018ss1/legislators/john_crane_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_john_crane_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_crane_1
+- url: https://api.iga.in.gov/2019/legislators/john_crane_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_john_crane_1
 other_identifiers:
 - identifier: INL000294
   scheme: legacy_openstates

--- a/data/in/people/John-Ruckelshaus-381cb345-33c1-437d-b092-705a9055bed9.yml
+++ b/data/in/people/John-Ruckelshaus-381cb345-33c1-437d-b092-705a9055bed9.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_ruckelshaus_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_ruckelshaus_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_ruckelshaus_1
-- url: https://api.iga.in.gov/2018ss1/legislators/john_ruckelshaus_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_john_ruckelshaus_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_ruckelshaus_1
+- url: https://api.iga.in.gov/2019/legislators/john_ruckelshaus_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_john_ruckelshaus_1
 other_identifiers:
 - identifier: INL000296
   scheme: legacy_openstates

--- a/data/in/people/John-Young-be047f92-01da-453f-beec-d6c68b14b403.yml
+++ b/data/in/people/John-Young-be047f92-01da-453f-beec-d6c68b14b403.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_young_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_young_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_john_young_1
-- url: https://api.iga.in.gov/2018ss1/legislators/john_young_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_john_young_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_john_young_1
+- url: https://api.iga.in.gov/2019/legislators/john_young_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_john_young_1
 other_identifiers:
 - identifier: INL000299
   scheme: legacy_openstates

--- a/data/in/people/Jon-Ford-dd0b774c-0fc8-4ce4-944f-91e254fda0ce.yml
+++ b/data/in/people/Jon-Ford-dd0b774c-0fc8-4ce4-944f-91e254fda0ce.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jon_ford_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jon_ford_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_jon_ford_1
-- url: https://api.iga.in.gov/2018ss1/legislators/jon_ford_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_jon_ford_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_jon_ford_1
+- url: https://api.iga.in.gov/2019/legislators/jon_ford_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_jon_ford_1
 other_identifiers:
 - identifier: INL000272
   scheme: legacy_openstates

--- a/data/in/people/Justin-Busch-fc270bf0-2220-476a-ad9c-15db82d62192.yml
+++ b/data/in/people/Justin-Busch-fc270bf0-2220-476a-ad9c-15db82d62192.yml
@@ -1,0 +1,21 @@
+id: ocd-person/fc270bf0-2220-476a-ad9c-15db82d62192
+name: Justin Busch
+party:
+- name: Republican
+roles:
+- district: '16'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: upper
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9467
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_justin_busch_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_justin_busch_1
+- url: https://api.iga.in.gov/2019/legislators/justin_busch_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_justin_busch_1
+given_name: Justin
+family_name: Busch

--- a/data/in/people/Justin-Moed-0f97edaa-0f48-4c61-82dd-c70aeb05a5ff.yml
+++ b/data/in/people/Justin-Moed-0f97edaa-0f48-4c61-82dd-c70aeb05a5ff.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_justin_moed_908
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_justin_moed_908
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_justin_moed_908
-- url: https://api.iga.in.gov/2018ss1/legislators/justin_moed_908
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_justin_moed_908
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_justin_moed_908
+- url: https://api.iga.in.gov/2019/legislators/justin_moed_908
+image: http://iga.in.gov/legislative/2019/portraits/legislator_justin_moed_908
 other_identifiers:
 - identifier: INL000171
   scheme: legacy_openstates

--- a/data/in/people/Karen-Engleman-efa78779-f35e-49fb-8b6b-5cccd00c870a.yml
+++ b/data/in/people/Karen-Engleman-efa78779-f35e-49fb-8b6b-5cccd00c870a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karen_engleman_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karen_engleman_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karen_engleman_1
-- url: https://api.iga.in.gov/2018ss1/legislators/karen_engleman_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_karen_engleman_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karen_engleman_1
+- url: https://api.iga.in.gov/2019/legislators/karen_engleman_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_karen_engleman_1
 other_identifiers:
 - identifier: INL000284
   scheme: legacy_openstates

--- a/data/in/people/Karen-Tallian-1887cf43-1eec-47b3-9fae-5d7303c44557.yml
+++ b/data/in/people/Karen-Tallian-1887cf43-1eec-47b3-9fae-5d7303c44557.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karen_tallian_845
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karen_tallian_845
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karen_tallian_845
-- url: https://api.iga.in.gov/2018ss1/legislators/karen_tallian_845
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_karen_tallian_845
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karen_tallian_845
+- url: https://api.iga.in.gov/2019/legislators/karen_tallian_845
+image: http://iga.in.gov/legislative/2019/portraits/legislator_karen_tallian_845
 other_identifiers:
 - identifier: INL000040
   scheme: legacy_openstates

--- a/data/in/people/Karlee-Macer-74c79726-70e0-46c4-8ed0-b26da994e0a4.yml
+++ b/data/in/people/Karlee-Macer-74c79726-70e0-46c4-8ed0-b26da994e0a4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karlee_macer_1127
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karlee_macer_1127
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_karlee_macer_1127
-- url: https://api.iga.in.gov/2018ss1/legislators/karlee_macer_1127
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_karlee_macer_1127
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_karlee_macer_1127
+- url: https://api.iga.in.gov/2019/legislators/karlee_macer_1127
+image: http://iga.in.gov/legislative/2019/portraits/legislator_karlee_macer_1127
 other_identifiers:
 - identifier: INL000169
   scheme: legacy_openstates

--- a/data/in/people/Kevin-Mahan-c16ddc1a-c07f-419b-b9b3-33f3a7adec18.yml
+++ b/data/in/people/Kevin-Mahan-c16ddc1a-c07f-419b-b9b3-33f3a7adec18.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_kevin_mahan_1028
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_kevin_mahan_1028
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_kevin_mahan_1028
-- url: https://api.iga.in.gov/2018ss1/legislators/kevin_mahan_1028
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_kevin_mahan_1028
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_kevin_mahan_1028
+- url: https://api.iga.in.gov/2019/legislators/kevin_mahan_1028
+image: http://iga.in.gov/legislative/2019/portraits/legislator_kevin_mahan_1028
 other_identifiers:
 - identifier: INL000108
   scheme: legacy_openstates

--- a/data/in/people/Linda-Rogers-b5f001ff-6e60-49b9-b074-bb83139410b4.yml
+++ b/data/in/people/Linda-Rogers-b5f001ff-6e60-49b9-b074-bb83139410b4.yml
@@ -1,0 +1,21 @@
+id: ocd-person/b5f001ff-6e60-49b9-b074-bb83139410b4
+name: Linda Rogers
+party:
+- name: Republican
+roles:
+- district: '11'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: upper
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9467
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_linda_rogers_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_linda_rogers_1
+- url: https://api.iga.in.gov/2019/legislators/linda_rogers_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_linda_rogers_1
+given_name: Linda
+family_name: Rogers

--- a/data/in/people/Lisa-Beck-43a1d29d-81cc-4240-a367-46271d4aa3be.yml
+++ b/data/in/people/Lisa-Beck-43a1d29d-81cc-4240-a367-46271d4aa3be.yml
@@ -1,0 +1,21 @@
+id: ocd-person/43a1d29d-81cc-4240-a367-46271d4aa3be
+name: Lisa Beck
+party:
+- name: Democratic
+roles:
+- district: '19'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_lisa_beck_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_lisa_beck_1
+- url: https://api.iga.in.gov/2019/legislators/lisa_beck_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_lisa_beck_1
+given_name: Lisa
+family_name: Beck

--- a/data/in/people/Liz-Brown-d9013459-1dea-46ee-bdd5-5b2874b76e0a.yml
+++ b/data/in/people/Liz-Brown-d9013459-1dea-46ee-bdd5-5b2874b76e0a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_liz_brown_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_liz_brown_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_liz_brown_1
-- url: https://api.iga.in.gov/2018ss1/legislators/liz_brown_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_liz_brown_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_liz_brown_1
+- url: https://api.iga.in.gov/2019/legislators/liz_brown_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_liz_brown_1
 other_identifiers:
 - identifier: INL000258
   scheme: legacy_openstates

--- a/data/in/people/Lonnie-Randolph-a48f9631-3436-4445-b8fc-87c143f373cd.yml
+++ b/data/in/people/Lonnie-Randolph-a48f9631-3436-4445-b8fc-87c143f373cd.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_lonnie_randolph_160
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_lonnie_randolph_160
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_lonnie_randolph_160
-- url: https://api.iga.in.gov/2018ss1/legislators/lonnie_randolph_160
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_lonnie_randolph_160
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_lonnie_randolph_160
+- url: https://api.iga.in.gov/2019/legislators/lonnie_randolph_160
+image: http://iga.in.gov/legislative/2019/portraits/legislator_lonnie_randolph_160
 other_identifiers:
 - identifier: INL000033
   scheme: legacy_openstates

--- a/data/in/people/Mara-Candelaria-Reardon-86e50c79-ff31-4cdb-99df-52a775bdb81f.yml
+++ b/data/in/people/Mara-Candelaria-Reardon-86e50c79-ff31-4cdb-99df-52a775bdb81f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mara_candelaria_reardon_870
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mara_candelaria_reardon_870
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mara_candelaria_reardon_870
-- url: https://api.iga.in.gov/2018ss1/legislators/mara_candelaria_reardon_870
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_mara_candelaria_reardon_870
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mara_candelaria_reardon_870
+- url: https://api.iga.in.gov/2019/legislators/mara_candelaria_reardon_870
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mara_candelaria_reardon_870
 other_identifiers:
 - identifier: INL000282
   scheme: legacy_openstates

--- a/data/in/people/Mark-Messmer-eb196828-cccf-4897-b3d3-790e53761534.yml
+++ b/data/in/people/Mark-Messmer-eb196828-cccf-4897-b3d3-790e53761534.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mark_messmer_983
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mark_messmer_983
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mark_messmer_983
-- url: https://api.iga.in.gov/2018ss1/legislators/mark_messmer_983
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_mark_messmer_983
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mark_messmer_983
+- url: https://api.iga.in.gov/2019/legislators/mark_messmer_983
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mark_messmer_983
 other_identifiers:
 - identifier: INL000112
   scheme: legacy_openstates

--- a/data/in/people/Mark-Stoops-8bb659ad-1a77-40f2-8916-39b18c55ac52.yml
+++ b/data/in/people/Mark-Stoops-8bb659ad-1a77-40f2-8916-39b18c55ac52.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mark_stoops_1107
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mark_stoops_1107
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mark_stoops_1107
-- url: https://api.iga.in.gov/2018ss1/legislators/mark_stoops_1107
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_mark_stoops_1107
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mark_stoops_1107
+- url: https://api.iga.in.gov/2019/legislators/mark_stoops_1107
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mark_stoops_1107
 other_identifiers:
 - identifier: INL000155
   scheme: legacy_openstates

--- a/data/in/people/Martin-Carbaugh-1b9ddafb-fca9-4924-b565-d651c2ca133b.yml
+++ b/data/in/people/Martin-Carbaugh-1b9ddafb-fca9-4924-b565-d651c2ca133b.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_martin_carbaugh_1125
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_martin_carbaugh_1125
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_martin_carbaugh_1125
-- url: https://api.iga.in.gov/2018ss1/legislators/martin_carbaugh_1125
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_martin_carbaugh_1125
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_martin_carbaugh_1125
+- url: https://api.iga.in.gov/2019/legislators/martin_carbaugh_1125
+image: http://iga.in.gov/legislative/2019/portraits/legislator_martin_carbaugh_1125
 other_identifiers:
 - identifier: INL000159
   scheme: legacy_openstates

--- a/data/in/people/Matt-Hostettler-be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa.yml
+++ b/data/in/people/Matt-Hostettler-be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa.yml
@@ -1,0 +1,21 @@
+id: ocd-person/be7ad6b3-da1b-4b8d-b41b-6b6e48a9bdfa
+name: Matt Hostettler
+party:
+- name: Republican
+roles:
+- district: '64'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_hostettler_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_hostettler_1
+- url: https://api.iga.in.gov/2019/legislators/matthew_hostettler_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_matthew_hostettler_1
+given_name: Matt
+family_name: Hostettler

--- a/data/in/people/Matt-Lehman-423b3123-c1b6-4e2f-92f4-5610130de844.yml
+++ b/data/in/people/Matt-Lehman-423b3123-c1b6-4e2f-92f4-5610130de844.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_matthew_lehman_987
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_lehman_987
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_matthew_lehman_987
-- url: https://api.iga.in.gov/2018ss1/legislators/matthew_lehman_987
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_matthew_lehman_987
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_lehman_987
+- url: https://api.iga.in.gov/2019/legislators/matthew_lehman_987
+image: http://iga.in.gov/legislative/2019/portraits/legislator_matthew_lehman_987
 other_identifiers:
 - identifier: INL000105
   scheme: legacy_openstates

--- a/data/in/people/Matt-Pierce-c66bcc9b-d5e6-478b-b11e-25be7f4e0aaa.yml
+++ b/data/in/people/Matt-Pierce-c66bcc9b-d5e6-478b-b11e-25be7f4e0aaa.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_matthew_pierce_708
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_pierce_708
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_matthew_pierce_708
-- url: https://api.iga.in.gov/2018ss1/legislators/matthew_pierce_708
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_matthew_pierce_708
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_matthew_pierce_708
+- url: https://api.iga.in.gov/2019/legislators/matthew_pierce_708
+image: http://iga.in.gov/legislative/2019/portraits/legislator_matthew_pierce_708
 other_identifiers:
 - identifier: INL000121
   scheme: legacy_openstates

--- a/data/in/people/Melanie-Wright-7fa8b319-d3d7-4612-a0d2-0baf3f0c4382.yml
+++ b/data/in/people/Melanie-Wright-7fa8b319-d3d7-4612-a0d2-0baf3f0c4382.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_melanie_wright_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_melanie_wright_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_melanie_wright_1
-- url: https://api.iga.in.gov/2018ss1/legislators/melanie_wright_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_melanie_wright_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_melanie_wright_1
+- url: https://api.iga.in.gov/2019/legislators/melanie_wright_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_melanie_wright_1
 other_identifiers:
 - identifier: INL000259
   scheme: legacy_openstates

--- a/data/in/people/Michael-Crider-6ffd10c6-9fd6-4378-8841-63ce4ca88764.yml
+++ b/data/in/people/Michael-Crider-6ffd10c6-9fd6-4378-8841-63ce4ca88764.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_crider_1130
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_crider_1130
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_crider_1130
-- url: https://api.iga.in.gov/2018ss1/legislators/michael_crider_1130
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_michael_crider_1130
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_crider_1130
+- url: https://api.iga.in.gov/2019/legislators/michael_crider_1130
+image: http://iga.in.gov/legislative/2019/portraits/legislator_michael_crider_1130
 other_identifiers:
 - identifier: INL000154
   scheme: legacy_openstates

--- a/data/in/people/Michael-Karickhoff-344cb784-deed-4671-94f1-0616555296e3.yml
+++ b/data/in/people/Michael-Karickhoff-344cb784-deed-4671-94f1-0616555296e3.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_karickhoff_1027
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_karickhoff_1027
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_karickhoff_1027
-- url: https://api.iga.in.gov/2018ss1/legislators/michael_karickhoff_1027
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_michael_karickhoff_1027
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_karickhoff_1027
+- url: https://api.iga.in.gov/2019/legislators/michael_karickhoff_1027
+image: http://iga.in.gov/legislative/2019/portraits/legislator_michael_karickhoff_1027
 other_identifiers:
 - identifier: INL000096
   scheme: legacy_openstates

--- a/data/in/people/Michael-Young-01bb6149-aa0f-457f-b759-1338b6c8ae5f.yml
+++ b/data/in/people/Michael-Young-01bb6149-aa0f-457f-b759-1338b6c8ae5f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_r_michael_young_645
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_r_michael_young_645
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_r_michael_young_645
-- url: https://api.iga.in.gov/2018ss1/legislators/r_michael_young_645
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_r_michael_young_645
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_r_michael_young_645
+- url: https://api.iga.in.gov/2019/legislators/r_michael_young_645
+image: http://iga.in.gov/legislative/2019/portraits/legislator_r_michael_young_645
 other_identifiers:
 - identifier: INL000297
   scheme: legacy_openstates

--- a/data/in/people/Mike-Aylesworth-2ca76c73-5db4-499b-b718-c83294b5f68e.yml
+++ b/data/in/people/Mike-Aylesworth-2ca76c73-5db4-499b-b718-c83294b5f68e.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mike_aylesworth_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_aylesworth_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mike_aylesworth_1
-- url: https://api.iga.in.gov/2018ss1/legislators/mike_aylesworth_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_mike_aylesworth_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_aylesworth_1
+- url: https://api.iga.in.gov/2019/legislators/mike_aylesworth_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mike_aylesworth_1
 other_identifiers:
 - identifier: INL000266
   scheme: legacy_openstates

--- a/data/in/people/Mike-Bohacek-9569c3da-b86b-4b33-a9ad-8d6174323569.yml
+++ b/data/in/people/Mike-Bohacek-9569c3da-b86b-4b33-a9ad-8d6174323569.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mike_bohacek_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_bohacek_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_mike_bohacek_1
-- url: https://api.iga.in.gov/2018ss1/legislators/mike_bohacek_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_mike_bohacek_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_bohacek_1
+- url: https://api.iga.in.gov/2019/legislators/mike_bohacek_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mike_bohacek_1
 other_identifiers:
 - identifier: INL000300
   scheme: legacy_openstates

--- a/data/in/people/Mike-Gaskill-01cb22d6-e0f5-478e-99b2-801ffbf32d2b.yml
+++ b/data/in/people/Mike-Gaskill-01cb22d6-e0f5-478e-99b2-801ffbf32d2b.yml
@@ -1,0 +1,21 @@
+id: ocd-person/01cb22d6-e0f5-478e-99b2-801ffbf32d2b
+name: Mike Gaskill
+party:
+- name: Republican
+roles:
+- district: '26'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: upper
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9467
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_gaskill_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_mike_gaskill_1
+- url: https://api.iga.in.gov/2019/legislators/mike_gaskill_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_mike_gaskill_1
+given_name: Mike
+family_name: Gaskill

--- a/data/in/people/Mike-Speedy-ed0facaa-4220-4f7d-899f-2bb0d576e9ef.yml
+++ b/data/in/people/Mike-Speedy-ed0facaa-4220-4f7d-899f-2bb0d576e9ef.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_speedy_1038
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_speedy_1038
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_michael_speedy_1038
-- url: https://api.iga.in.gov/2018ss1/legislators/michael_speedy_1038
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_michael_speedy_1038
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_michael_speedy_1038
+- url: https://api.iga.in.gov/2019/legislators/michael_speedy_1038
+image: http://iga.in.gov/legislative/2019/portraits/legislator_michael_speedy_1038
 other_identifiers:
 - identifier: INL000133
   scheme: legacy_openstates

--- a/data/in/people/Pat-Boy-8dde5c26-4718-45e7-a021-487d7fa6a924.yml
+++ b/data/in/people/Pat-Boy-8dde5c26-4718-45e7-a021-487d7fa6a924.yml
@@ -1,0 +1,21 @@
+id: ocd-person/8dde5c26-4718-45e7-a021-487d7fa6a924
+name: Pat Boy
+party:
+- name: Democratic
+roles:
+- district: '9'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_patricia_boy_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_patricia_boy_1
+- url: https://api.iga.in.gov/2019/legislators/patricia_boy_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_patricia_boy_1
+given_name: Pat
+family_name: Boy

--- a/data/in/people/Peggy-Mayfield-0acb3367-1e1e-404e-89c8-82e3c6754235.yml
+++ b/data/in/people/Peggy-Mayfield-0acb3367-1e1e-404e-89c8-82e3c6754235.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_peggy_mayfield_1121
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_peggy_mayfield_1121
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_peggy_mayfield_1121
-- url: https://api.iga.in.gov/2018ss1/legislators/peggy_mayfield_1121
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_peggy_mayfield_1121
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_peggy_mayfield_1121
+- url: https://api.iga.in.gov/2019/legislators/peggy_mayfield_1121
+image: http://iga.in.gov/legislative/2019/portraits/legislator_peggy_mayfield_1121
 other_identifiers:
 - identifier: INL000170
   scheme: legacy_openstates

--- a/data/in/people/Philip-Boots-dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02.yml
+++ b/data/in/people/Philip-Boots-dd9ef5e5-8d91-4241-a31e-d2c4cfa2af02.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_philip_boots_865
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_philip_boots_865
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_philip_boots_865
-- url: https://api.iga.in.gov/2018ss1/legislators/philip_boots_865
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_philip_boots_865
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_philip_boots_865
+- url: https://api.iga.in.gov/2019/legislators/philip_boots_865
+image: http://iga.in.gov/legislative/2019/portraits/legislator_philip_boots_865
 other_identifiers:
 - identifier: INL000005
   scheme: legacy_openstates

--- a/data/in/people/Philip-GiaQuinta-d1e89034-ef4a-4a10-b16d-16dc617dcdf1.yml
+++ b/data/in/people/Philip-GiaQuinta-d1e89034-ef4a-4a10-b16d-16dc617dcdf1.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_philip_giaquinta_879
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_philip_giaquinta_879
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_philip_giaquinta_879
-- url: https://api.iga.in.gov/2018ss1/legislators/philip_giaquinta_879
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_philip_giaquinta_879
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_philip_giaquinta_879
+- url: https://api.iga.in.gov/2019/legislators/philip_giaquinta_879
+image: http://iga.in.gov/legislative/2019/portraits/legislator_philip_giaquinta_879
 other_identifiers:
 - identifier: INL000088
   scheme: legacy_openstates

--- a/data/in/people/Ragen-Hatcher-4c9685ab-f2a4-46e0-980a-699bb01d26cf.yml
+++ b/data/in/people/Ragen-Hatcher-4c9685ab-f2a4-46e0-980a-699bb01d26cf.yml
@@ -1,0 +1,21 @@
+id: ocd-person/4c9685ab-f2a4-46e0-980a-699bb01d26cf
+name: Ragen Hatcher
+party:
+- name: Democratic
+roles:
+- district: '3'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ragen_hatcher_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ragen_hatcher_1
+- url: https://api.iga.in.gov/2019/legislators/ragen_hatcher_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ragen_hatcher_1
+given_name: Ragen
+family_name: Hatcher

--- a/data/in/people/Randall-Frye-df0cd4fe-e276-4381-9ad2-affd3bffc9e4.yml
+++ b/data/in/people/Randall-Frye-df0cd4fe-e276-4381-9ad2-affd3bffc9e4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randall_frye_1039
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randall_frye_1039
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randall_frye_1039
-- url: https://api.iga.in.gov/2018ss1/legislators/randall_frye_1039
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_randall_frye_1039
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randall_frye_1039
+- url: https://api.iga.in.gov/2019/legislators/randall_frye_1039
+image: http://iga.in.gov/legislative/2019/portraits/legislator_randall_frye_1039
 other_identifiers:
 - identifier: INL000087
   scheme: legacy_openstates

--- a/data/in/people/Randall-Head-e5238773-c2c9-4caf-9ddf-b2769c5944d1.yml
+++ b/data/in/people/Randall-Head-e5238773-c2c9-4caf-9ddf-b2769c5944d1.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randall_head_975
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randall_head_975
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randall_head_975
-- url: https://api.iga.in.gov/2018ss1/legislators/randall_head_975
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_randall_head_975
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randall_head_975
+- url: https://api.iga.in.gov/2019/legislators/randall_head_975
+image: http://iga.in.gov/legislative/2019/portraits/legislator_randall_head_975
 other_identifiers:
 - identifier: INL000016
   scheme: legacy_openstates

--- a/data/in/people/Randy-Lyness-96c8ce73-904d-45f9-a2e1-cb9c72596e40.yml
+++ b/data/in/people/Randy-Lyness-96c8ce73-904d-45f9-a2e1-cb9c72596e40.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randy_lyness_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randy_lyness_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_randy_lyness_1
-- url: https://api.iga.in.gov/2018ss1/legislators/randy_lyness_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_randy_lyness_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_randy_lyness_1
+- url: https://api.iga.in.gov/2019/legislators/randy_lyness_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_randy_lyness_1
 other_identifiers:
 - identifier: INL000280
   scheme: legacy_openstates

--- a/data/in/people/Rick-Niemeyer-0b243d61-c607-4711-bc54-aecc21281540.yml
+++ b/data/in/people/Rick-Niemeyer-0b243d61-c607-4711-bc54-aecc21281540.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_rick_niemeyer_1109
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rick_niemeyer_1109
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_rick_niemeyer_1109
-- url: https://api.iga.in.gov/2018ss1/legislators/rick_niemeyer_1109
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_rick_niemeyer_1109
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rick_niemeyer_1109
+- url: https://api.iga.in.gov/2019/legislators/rick_niemeyer_1109
+image: http://iga.in.gov/legislative/2019/portraits/legislator_rick_niemeyer_1109
 other_identifiers:
 - identifier: INL000174
   scheme: legacy_openstates

--- a/data/in/people/Rita-Fleming-03416080-75a4-4eb2-acde-6d59f0967666.yml
+++ b/data/in/people/Rita-Fleming-03416080-75a4-4eb2-acde-6d59f0967666.yml
@@ -1,0 +1,21 @@
+id: ocd-person/03416080-75a4-4eb2-acde-6d59f0967666
+name: Rita Fleming
+party:
+- name: Democratic
+roles:
+- district: '71'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rita_fleming_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rita_fleming_1
+- url: https://api.iga.in.gov/2019/legislators/rita_fleming_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_rita_fleming_1
+given_name: Rita
+family_name: Fleming

--- a/data/in/people/Robert-Behning-3d215bfb-c08a-47f0-91d3-eb114b33c56d.yml
+++ b/data/in/people/Robert-Behning-3d215bfb-c08a-47f0-91d3-eb114b33c56d.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_behning_187
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_behning_187
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_behning_187
-- url: https://api.iga.in.gov/2018ss1/legislators/robert_behning_187
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_robert_behning_187
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_behning_187
+- url: https://api.iga.in.gov/2019/legislators/robert_behning_187
+image: http://iga.in.gov/legislative/2019/portraits/legislator_robert_behning_187
 other_identifiers:
 - identifier: INL000058
   scheme: legacy_openstates

--- a/data/in/people/Robert-Cherry-c0e3527e-b990-4190-8ffe-43258158ac58.yml
+++ b/data/in/people/Robert-Cherry-c0e3527e-b990-4190-8ffe-43258158ac58.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_cherry_395
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_cherry_395
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_cherry_395
-- url: https://api.iga.in.gov/2018ss1/legislators/robert_cherry_395
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_robert_cherry_395
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_cherry_395
+- url: https://api.iga.in.gov/2019/legislators/robert_cherry_395
+image: http://iga.in.gov/legislative/2019/portraits/legislator_robert_cherry_395
 other_identifiers:
 - identifier: INL000066
   scheme: legacy_openstates

--- a/data/in/people/Robert-Heaton-791928fe-00bb-46bf-9b57-36b7a40e0250.yml
+++ b/data/in/people/Robert-Heaton-791928fe-00bb-46bf-9b57-36b7a40e0250.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_heaton_1030
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_heaton_1030
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_heaton_1030
-- url: https://api.iga.in.gov/2018ss1/legislators/robert_heaton_1030
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_robert_heaton_1030
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_heaton_1030
+- url: https://api.iga.in.gov/2019/legislators/robert_heaton_1030
+image: http://iga.in.gov/legislative/2019/portraits/legislator_robert_heaton_1030
 other_identifiers:
 - identifier: INL000093
   scheme: legacy_openstates

--- a/data/in/people/Robert-Morris-20851625-bc7c-41ed-841e-27af062bc03e.yml
+++ b/data/in/people/Robert-Morris-20851625-bc7c-41ed-841e-27af062bc03e.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_morris_1021
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_morris_1021
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robert_morris_1021
-- url: https://api.iga.in.gov/2018ss1/legislators/robert_morris_1021
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_robert_morris_1021
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robert_morris_1021
+- url: https://api.iga.in.gov/2019/legislators/robert_morris_1021
+image: http://iga.in.gov/legislative/2019/portraits/legislator_robert_morris_1021
 other_identifiers:
 - identifier: INL000113
   scheme: legacy_openstates

--- a/data/in/people/Robin-Shackleford-d15f8f7e-148b-47fc-858d-84ad23347f64.yml
+++ b/data/in/people/Robin-Shackleford-d15f8f7e-148b-47fc-858d-84ad23347f64.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robin_shackleford_1128
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robin_shackleford_1128
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_robin_shackleford_1128
-- url: https://api.iga.in.gov/2018ss1/legislators/robin_shackleford_1128
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_robin_shackleford_1128
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_robin_shackleford_1128
+- url: https://api.iga.in.gov/2019/legislators/robin_shackleford_1128
+image: http://iga.in.gov/legislative/2019/portraits/legislator_robin_shackleford_1128
 other_identifiers:
 - identifier: INL000177
   scheme: legacy_openstates

--- a/data/in/people/Rodric-Bray-766cf9c2-a001-49a1-8fba-075a0510767d.yml
+++ b/data/in/people/Rodric-Bray-766cf9c2-a001-49a1-8fba-075a0510767d.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_rodric_bray_1106
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rodric_bray_1106
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_rodric_bray_1106
-- url: https://api.iga.in.gov/2018ss1/legislators/rodric_bray_1106
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_rodric_bray_1106
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_rodric_bray_1106
+- url: https://api.iga.in.gov/2019/legislators/rodric_bray_1106
+image: http://iga.in.gov/legislative/2019/portraits/legislator_rodric_bray_1106
 other_identifiers:
 - identifier: INL000153
   scheme: legacy_openstates

--- a/data/in/people/Ron-Alting-91572a47-dcdf-4be5-8fec-99630da33a39.yml
+++ b/data/in/people/Ron-Alting-91572a47-dcdf-4be5-8fec-99630da33a39.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ron_alting_538
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ron_alting_538
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ron_alting_538
-- url: https://api.iga.in.gov/2018ss1/legislators/ron_alting_538
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ron_alting_538
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ron_alting_538
+- url: https://api.iga.in.gov/2019/legislators/ron_alting_538
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ron_alting_538
 other_identifiers:
 - identifier: INL000001
   scheme: legacy_openstates

--- a/data/in/people/Ronald-Bacon-df43dec4-b355-43cc-a420-a3c162b3840f.yml
+++ b/data/in/people/Ronald-Bacon-df43dec4-b355-43cc-a420-a3c162b3840f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ronald_bacon_1044
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ronald_bacon_1044
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ronald_bacon_1044
-- url: https://api.iga.in.gov/2018ss1/legislators/ronald_bacon_1044
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ronald_bacon_1044
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ronald_bacon_1044
+- url: https://api.iga.in.gov/2019/legislators/ronald_bacon_1044
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ronald_bacon_1044
 other_identifiers:
 - identifier: INL000052
   scheme: legacy_openstates

--- a/data/in/people/Ronald-Grooms-2af033d5-2fa7-40c5-a01b-bb12bf909510.yml
+++ b/data/in/people/Ronald-Grooms-2af033d5-2fa7-40c5-a01b-bb12bf909510.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ronald_grooms_1024
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ronald_grooms_1024
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ronald_grooms_1024
-- url: https://api.iga.in.gov/2018ss1/legislators/ronald_grooms_1024
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ronald_grooms_1024
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ronald_grooms_1024
+- url: https://api.iga.in.gov/2019/legislators/ronald_grooms_1024
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ronald_grooms_1024
 other_identifiers:
 - identifier: INL000015
   scheme: legacy_openstates

--- a/data/in/people/Ryan-Dvorak-16b01fca-3a93-41a3-ad6a-f2bf9209ddf7.yml
+++ b/data/in/people/Ryan-Dvorak-16b01fca-3a93-41a3-ad6a-f2bf9209ddf7.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_dvorak_697
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_dvorak_697
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_dvorak_697
-- url: https://api.iga.in.gov/2018ss1/legislators/ryan_dvorak_697
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ryan_dvorak_697
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_dvorak_697
+- url: https://api.iga.in.gov/2019/legislators/ryan_dvorak_697
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ryan_dvorak_697
 other_identifiers:
 - identifier: INL000079
   scheme: legacy_openstates

--- a/data/in/people/Ryan-Hatfield-58bbda21-7c3e-4189-9d02-0ba7f95a6471.yml
+++ b/data/in/people/Ryan-Hatfield-58bbda21-7c3e-4189-9d02-0ba7f95a6471.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_hatfield_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_hatfield_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_hatfield_1
-- url: https://api.iga.in.gov/2018ss1/legislators/ryan_hatfield_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ryan_hatfield_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_hatfield_1
+- url: https://api.iga.in.gov/2019/legislators/ryan_hatfield_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ryan_hatfield_1
 other_identifiers:
 - identifier: INL000283
   scheme: legacy_openstates

--- a/data/in/people/Ryan-Lauer-d96c807a-9e72-4861-bca4-67d787cbf49f.yml
+++ b/data/in/people/Ryan-Lauer-d96c807a-9e72-4861-bca4-67d787cbf49f.yml
@@ -1,0 +1,21 @@
+id: ocd-person/d96c807a-9e72-4861-bca4-67d787cbf49f
+name: Ryan Lauer
+party:
+- name: Republican
+roles:
+- district: '59'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9841
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_lauer_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_lauer_1
+- url: https://api.iga.in.gov/2019/legislators/ryan_lauer_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ryan_lauer_1
+given_name: Ryan
+family_name: Lauer

--- a/data/in/people/Ryan-Mishler-010e5ebe-683c-4fe2-9696-46f7f0b4bea6.yml
+++ b/data/in/people/Ryan-Mishler-010e5ebe-683c-4fe2-9696-46f7f0b4bea6.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_mishler_801
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_mishler_801
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_ryan_mishler_801
-- url: https://api.iga.in.gov/2018ss1/legislators/ryan_mishler_801
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_ryan_mishler_801
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_ryan_mishler_801
+- url: https://api.iga.in.gov/2019/legislators/ryan_mishler_801
+image: http://iga.in.gov/legislative/2019/portraits/legislator_ryan_mishler_801
 other_identifiers:
 - identifier: INL000029
   scheme: legacy_openstates

--- a/data/in/people/Sean-Eberhart-48ceb261-5010-477c-a0e6-9d331b10054a.yml
+++ b/data/in/people/Sean-Eberhart-48ceb261-5010-477c-a0e6-9d331b10054a.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sean_eberhart_875
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sean_eberhart_875
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sean_eberhart_875
-- url: https://api.iga.in.gov/2018ss1/legislators/sean_eberhart_875
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_sean_eberhart_875
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sean_eberhart_875
+- url: https://api.iga.in.gov/2019/legislators/sean_eberhart_875
+image: http://iga.in.gov/legislative/2019/portraits/legislator_sean_eberhart_875
 other_identifiers:
 - identifier: INL000080
   scheme: legacy_openstates

--- a/data/in/people/Shane-Lindauer-2a0b391a-a59d-4b7f-907b-87980c2714d8.yml
+++ b/data/in/people/Shane-Lindauer-2a0b391a-a59d-4b7f-907b-87980c2714d8.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_shane_lindauer_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_shane_lindauer_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_shane_lindauer_1
-- url: https://api.iga.in.gov/2018ss1/legislators/shane_lindauer_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_shane_lindauer_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_shane_lindauer_1
+- url: https://api.iga.in.gov/2019/legislators/shane_lindauer_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_shane_lindauer_1
 other_identifiers:
 - identifier: INL000307
   scheme: legacy_openstates

--- a/data/in/people/Sharon-Negele-5df40faa-22e6-4300-b749-89abfdc2e554.yml
+++ b/data/in/people/Sharon-Negele-5df40faa-22e6-4300-b749-89abfdc2e554.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sharon_negele_1110
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sharon_negele_1110
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sharon_negele_1110
-- url: https://api.iga.in.gov/2018ss1/legislators/sharon_negele_1110
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_sharon_negele_1110
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sharon_negele_1110
+- url: https://api.iga.in.gov/2019/legislators/sharon_negele_1110
+image: http://iga.in.gov/legislative/2019/portraits/legislator_sharon_negele_1110
 other_identifiers:
 - identifier: INL000173
   scheme: legacy_openstates

--- a/data/in/people/Sheila-Klinker-68f44f31-ba0b-4641-a656-f05e91c02cd8.yml
+++ b/data/in/people/Sheila-Klinker-68f44f31-ba0b-4641-a656-f05e91c02cd8.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sheila_klinker_212
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sheila_klinker_212
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sheila_klinker_212
-- url: https://api.iga.in.gov/2018ss1/legislators/sheila_klinker_212
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_sheila_klinker_212
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sheila_klinker_212
+- url: https://api.iga.in.gov/2019/legislators/sheila_klinker_212
+image: http://iga.in.gov/legislative/2019/portraits/legislator_sheila_klinker_212
 other_identifiers:
 - identifier: INL000099
   scheme: legacy_openstates

--- a/data/in/people/Steve-Bartels-df749cfb-56e8-482f-bf4b-183a1fb52594.yml
+++ b/data/in/people/Steve-Bartels-df749cfb-56e8-482f-bf4b-183a1fb52594.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_stephen_bartels_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_stephen_bartels_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_stephen_bartels_1
-- url: https://api.iga.in.gov/2018ss1/legislators/stephen_bartels_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_stephen_bartels_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_stephen_bartels_1
+- url: https://api.iga.in.gov/2019/legislators/stephen_bartels_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_stephen_bartels_1
 other_identifiers:
 - identifier: INL000308
   scheme: legacy_openstates

--- a/data/in/people/Steven-Davisson-77a93fc3-bbc5-41b6-b1af-0069670dd5af.yml
+++ b/data/in/people/Steven-Davisson-77a93fc3-bbc5-41b6-b1af-0069670dd5af.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_steven_davisson_1034
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_steven_davisson_1034
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_steven_davisson_1034
-- url: https://api.iga.in.gov/2018ss1/legislators/steven_davisson_1034
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_steven_davisson_1034
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_steven_davisson_1034
+- url: https://api.iga.in.gov/2019/legislators/steven_davisson_1034
+image: http://iga.in.gov/legislative/2019/portraits/legislator_steven_davisson_1034
 other_identifiers:
 - identifier: INL000072
   scheme: legacy_openstates

--- a/data/in/people/Sue-Errington-98feacbe-3be5-407e-a437-66d65a836a5e.yml
+++ b/data/in/people/Sue-Errington-98feacbe-3be5-407e-a437-66d65a836a5e.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sue_errington_866
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sue_errington_866
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_sue_errington_866
-- url: https://api.iga.in.gov/2018ss1/legislators/sue_errington_866
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_sue_errington_866
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_sue_errington_866
+- url: https://api.iga.in.gov/2019/legislators/sue_errington_866
+image: http://iga.in.gov/legislative/2019/portraits/legislator_sue_errington_866
 other_identifiers:
 - identifier: INL000161
   scheme: legacy_openstates

--- a/data/in/people/Susan-Glick-a0b2ce58-2c2d-4b71-a9e2-7b8ae153d53f.yml
+++ b/data/in/people/Susan-Glick-a0b2ce58-2c2d-4b71-a9e2-7b8ae153d53f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_susan_glick_1048
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_susan_glick_1048
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_susan_glick_1048
-- url: https://api.iga.in.gov/2018ss1/legislators/susan_glick_1048
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_susan_glick_1048
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_susan_glick_1048
+- url: https://api.iga.in.gov/2019/legislators/susan_glick_1048
+image: http://iga.in.gov/legislative/2019/portraits/legislator_susan_glick_1048
 other_identifiers:
 - identifier: INL000014
   scheme: legacy_openstates

--- a/data/in/people/Terri-Jo-Austin-cc8462eb-3089-4961-816f-fe3b0e1986f5.yml
+++ b/data/in/people/Terri-Jo-Austin-cc8462eb-3089-4961-816f-fe3b0e1986f5.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_terri_jo_austin_700
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_terri_jo_austin_700
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_terri_jo_austin_700
-- url: https://api.iga.in.gov/2018ss1/legislators/terri_jo_austin_700
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_terri_jo_austin_700
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_terri_jo_austin_700
+- url: https://api.iga.in.gov/2019/legislators/terri_jo_austin_700
+image: http://iga.in.gov/legislative/2019/portraits/legislator_terri_jo_austin_700
 other_identifiers:
 - identifier: INL000051
   scheme: legacy_openstates

--- a/data/in/people/Terry-Goodin-17a999cc-8bc7-4ecd-8e82-c741fa8ac1be.yml
+++ b/data/in/people/Terry-Goodin-17a999cc-8bc7-4ecd-8e82-c741fa8ac1be.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_terry_goodin_642
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_terry_goodin_642
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_terry_goodin_642
-- url: https://api.iga.in.gov/2018ss1/legislators/terry_goodin_642
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_terry_goodin_642
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_terry_goodin_642
+- url: https://api.iga.in.gov/2019/legislators/terry_goodin_642
+image: http://iga.in.gov/legislative/2019/portraits/legislator_terry_goodin_642
 other_identifiers:
 - identifier: INL000089
   scheme: legacy_openstates

--- a/data/in/people/Thomas-Saunders-e9b068a4-93fc-42c1-937a-584445fa46d4.yml
+++ b/data/in/people/Thomas-Saunders-e9b068a4-93fc-42c1-937a-584445fa46d4.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_thomas_saunders_225
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_thomas_saunders_225
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_thomas_saunders_225
-- url: https://api.iga.in.gov/2018ss1/legislators/thomas_saunders_225
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_thomas_saunders_225
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_thomas_saunders_225
+- url: https://api.iga.in.gov/2019/legislators/thomas_saunders_225
+image: http://iga.in.gov/legislative/2019/portraits/legislator_thomas_saunders_225
 other_identifiers:
 - identifier: INL000129
   scheme: legacy_openstates

--- a/data/in/people/Timothy-Brown-a0c6af20-56b0-41be-abf7-9d2265988a48.yml
+++ b/data/in/people/Timothy-Brown-a0c6af20-56b0-41be-abf7-9d2265988a48.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_brown_220
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_brown_220
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_brown_220
-- url: https://api.iga.in.gov/2018ss1/legislators/timothy_brown_220
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_timothy_brown_220
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_brown_220
+- url: https://api.iga.in.gov/2019/legislators/timothy_brown_220
+image: http://iga.in.gov/legislative/2019/portraits/legislator_timothy_brown_220
 other_identifiers:
 - identifier: INL000062
   scheme: legacy_openstates

--- a/data/in/people/Timothy-Lanane-cf84a4e4-8c27-420d-a69d-af4bb78a5f72.yml
+++ b/data/in/people/Timothy-Lanane-cf84a4e4-8c27-420d-a69d-af4bb78a5f72.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_lanane_223
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_lanane_223
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_lanane_223
-- url: https://api.iga.in.gov/2018ss1/legislators/timothy_lanane_223
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_timothy_lanane_223
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_lanane_223
+- url: https://api.iga.in.gov/2019/legislators/timothy_lanane_223
+image: http://iga.in.gov/legislative/2019/portraits/legislator_timothy_lanane_223
 other_identifiers:
 - identifier: INL000022
   scheme: legacy_openstates

--- a/data/in/people/Timothy-Wesco-fbcd4d2c-32c6-4c97-837b-4e4ed80c43df.yml
+++ b/data/in/people/Timothy-Wesco-fbcd4d2c-32c6-4c97-837b-4e4ed80c43df.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_wesco_1025
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_wesco_1025
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_timothy_wesco_1025
-- url: https://api.iga.in.gov/2018ss1/legislators/timothy_wesco_1025
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_timothy_wesco_1025
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_timothy_wesco_1025
+- url: https://api.iga.in.gov/2019/legislators/timothy_wesco_1025
+image: http://iga.in.gov/legislative/2019/portraits/legislator_timothy_wesco_1025
 other_identifiers:
 - identifier: INL000148
   scheme: legacy_openstates

--- a/data/in/people/Todd-Huston-d2667b82-c381-495d-b533-c70a9ae92ec0.yml
+++ b/data/in/people/Todd-Huston-d2667b82-c381-495d-b533-c70a9ae92ec0.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_todd_huston_1114
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_todd_huston_1114
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_todd_huston_1114
-- url: https://api.iga.in.gov/2018ss1/legislators/todd_huston_1114
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_todd_huston_1114
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_todd_huston_1114
+- url: https://api.iga.in.gov/2019/legislators/todd_huston_1114
+image: http://iga.in.gov/legislative/2019/portraits/legislator_todd_huston_1114
 other_identifiers:
 - identifier: INL000166
   scheme: legacy_openstates

--- a/data/in/people/Tonya-Pfaff-0f97a586-0089-4eb8-86c1-40f42bc1f594.yml
+++ b/data/in/people/Tonya-Pfaff-0f97a586-0089-4eb8-86c1-40f42bc1f594.yml
@@ -1,0 +1,21 @@
+id: ocd-person/0f97a586-0089-4eb8-86c1-40f42bc1f594
+name: Tonya Pfaff
+party:
+- name: Democratic
+roles:
+- district: '43'
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+  type: lower
+  start_date: '2018-11-07'
+contact_details:
+- address: 200 W. Washington Street;Indianapolis, IN 46204
+  note: Capitol Office
+  voice: 800-382-9842
+links:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_tonya_pfaff_1
+sources:
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_tonya_pfaff_1
+- url: https://api.iga.in.gov/2019/legislators/tonya_pfaff_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_tonya_pfaff_1
+given_name: Tonya
+family_name: Pfaff

--- a/data/in/people/Travis-Holdman-aa948d0d-f7d1-4a11-a58b-986b0d61ebf7.yml
+++ b/data/in/people/Travis-Holdman-aa948d0d-f7d1-4a11-a58b-986b0d61ebf7.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_travis_holdman_955
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_travis_holdman_955
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_travis_holdman_955
-- url: https://api.iga.in.gov/2018ss1/legislators/travis_holdman_955
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_travis_holdman_955
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_travis_holdman_955
+- url: https://api.iga.in.gov/2019/legislators/travis_holdman_955
+image: http://iga.in.gov/legislative/2019/portraits/legislator_travis_holdman_955
 other_identifiers:
 - identifier: INL000018
   scheme: legacy_openstates

--- a/data/in/people/Vanessa-Summers-51d00dd2-d18c-4d77-9ad1-710016d30448.yml
+++ b/data/in/people/Vanessa-Summers-51d00dd2-d18c-4d77-9ad1-710016d30448.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vanessa_summers_231
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vanessa_summers_231
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vanessa_summers_231
-- url: https://api.iga.in.gov/2018ss1/legislators/vanessa_summers_231
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_vanessa_summers_231
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vanessa_summers_231
+- url: https://api.iga.in.gov/2019/legislators/vanessa_summers_231
+image: http://iga.in.gov/legislative/2019/portraits/legislator_vanessa_summers_231
 other_identifiers:
 - identifier: INL000138
   scheme: legacy_openstates

--- a/data/in/people/Vaneta-Becker-b6be97c1-d574-443d-b493-224dcb6e2a7f.yml
+++ b/data/in/people/Vaneta-Becker-b6be97c1-d574-443d-b493-224dcb6e2a7f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vaneta_becker_228
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vaneta_becker_228
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vaneta_becker_228
-- url: https://api.iga.in.gov/2018ss1/legislators/vaneta_becker_228
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_vaneta_becker_228
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vaneta_becker_228
+- url: https://api.iga.in.gov/2019/legislators/vaneta_becker_228
+image: http://iga.in.gov/legislative/2019/portraits/legislator_vaneta_becker_228
 other_identifiers:
 - identifier: INL000004
   scheme: legacy_openstates

--- a/data/in/people/Vernon-Smith-86b7914b-08e6-4ac7-bcd6-b4afa4dceb09.yml
+++ b/data/in/people/Vernon-Smith-86b7914b-08e6-4ac7-bcd6-b4afa4dceb09.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9842
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vernon_smith_230
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vernon_smith_230
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_vernon_smith_230
-- url: https://api.iga.in.gov/2018ss1/legislators/vernon_smith_230
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_vernon_smith_230
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_vernon_smith_230
+- url: https://api.iga.in.gov/2019/legislators/vernon_smith_230
+image: http://iga.in.gov/legislative/2019/portraits/legislator_vernon_smith_230
 other_identifiers:
 - identifier: INL000131
   scheme: legacy_openstates

--- a/data/in/people/Victoria-Spartz-b5faa5ff-e642-457b-a54d-4ba21daf626b.yml
+++ b/data/in/people/Victoria-Spartz-b5faa5ff-e642-457b-a54d-4ba21daf626b.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9467
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_victoria_spartz_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_victoria_spartz_1
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_victoria_spartz_1
-- url: https://api.iga.in.gov/2018ss1/legislators/victoria_spartz_1
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_victoria_spartz_1
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_victoria_spartz_1
+- url: https://api.iga.in.gov/2019/legislators/victoria_spartz_1
+image: http://iga.in.gov/legislative/2019/portraits/legislator_victoria_spartz_1
 other_identifiers:
 - identifier: INL000306
   scheme: legacy_openstates

--- a/data/in/people/Wendy-McNamara-ac2c89af-df39-4057-bdeb-15ca57b7ef9f.yml
+++ b/data/in/people/Wendy-McNamara-ac2c89af-df39-4057-bdeb-15ca57b7ef9f.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_wendy_mcnamara_1046
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_wendy_mcnamara_1046
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_wendy_mcnamara_1046
-- url: https://api.iga.in.gov/2018ss1/legislators/wendy_mcnamara_1046
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_wendy_mcnamara_1046
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_wendy_mcnamara_1046
+- url: https://api.iga.in.gov/2019/legislators/wendy_mcnamara_1046
+image: http://iga.in.gov/legislative/2019/portraits/legislator_wendy_mcnamara_1046
 other_identifiers:
 - identifier: INL000111
   scheme: legacy_openstates

--- a/data/in/people/Woody-Burton-8c51d564-ae76-46c4-90a7-ff9e79ab1f2c.yml
+++ b/data/in/people/Woody-Burton-8c51d564-ae76-46c4-90a7-ff9e79ab1f2c.yml
@@ -11,11 +11,11 @@ contact_details:
   note: Capitol Office
   voice: 800-382-9841
 links:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_woody_burton_235
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_woody_burton_235
 sources:
-- url: http://iga.in.gov/legislative/2018ss1/legislators/legislator_woody_burton_235
-- url: https://api.iga.in.gov/2018ss1/legislators/woody_burton_235
-image: http://iga.in.gov/legislative/2018ss1/portraits/legislator_woody_burton_235
+- url: http://iga.in.gov/legislative/2019/legislators/legislator_woody_burton_235
+- url: https://api.iga.in.gov/2019/legislators/woody_burton_235
+image: http://iga.in.gov/legislative/2019/portraits/legislator_woody_burton_235
 other_identifiers:
 - identifier: INL000063
   scheme: legacy_openstates

--- a/data/in/retired/Charlie-Brown-4b96e94b-2384-4bff-b54d-9b6587d19a17.yml
+++ b/data/in/retired/Charlie-Brown-4b96e94b-2384-4bff-b54d-9b6587d19a17.yml
@@ -6,6 +6,7 @@ roles:
 - district: '3'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Clyde-Kersey-7081abcc-348a-4eff-84a1-74f6a2c7ef01.yml
+++ b/data/in/retired/Clyde-Kersey-7081abcc-348a-4eff-84a1-74f6a2c7ef01.yml
@@ -6,6 +6,7 @@ roles:
 - district: '43'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/David-Long-c22c2b28-d509-4891-a325-cc06e73e788e.yml
+++ b/data/in/retired/David-Long-c22c2b28-d509-4891-a325-cc06e73e788e.yml
@@ -6,6 +6,7 @@ roles:
 - district: '16'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: upper
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Douglas-Eckerty-2ac8fe4a-56d1-4781-8a6f-837174ce4265.yml
+++ b/data/in/retired/Douglas-Eckerty-2ac8fe4a-56d1-4781-8a6f-837174ce4265.yml
@@ -6,6 +6,7 @@ roles:
 - district: '26'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: upper
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Greg-Beumer-0a4c7269-3039-425c-8acb-d428c88e6a8a.yml
+++ b/data/in/retired/Greg-Beumer-0a4c7269-3039-425c-8acb-d428c88e6a8a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '33'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Harold-Slager-b71e9f3a-2c59-4e18-80e6-da0a7cc51648.yml
+++ b/data/in/retired/Harold-Slager-b71e9f3a-2c59-4e18-80e6-da0a7cc51648.yml
@@ -6,6 +6,7 @@ roles:
 - district: '15'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/James-Baird-650c6338-9a20-44df-82e3-5f0d372bc415.yml
+++ b/data/in/retired/James-Baird-650c6338-9a20-44df-82e3-5f0d372bc415.yml
@@ -6,6 +6,7 @@ roles:
 - district: '44'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/James-Smith-b961beb9-b315-481d-840a-a727c52783c9.yml
+++ b/data/in/retired/James-Smith-b961beb9-b315-481d-840a-a727c52783c9.yml
@@ -6,6 +6,7 @@ roles:
 - district: '45'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: upper
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Joe-Taylor-5b9af417-d7e1-4a3d-96bb-647e8fd734d5.yml
+++ b/data/in/retired/Joe-Taylor-5b9af417-d7e1-4a3d-96bb-647e8fd734d5.yml
@@ -6,6 +6,8 @@ roles:
 - district: '7'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-12-03'
+  end_reason: 'Resignation'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Joseph-Zakas-80a66e08-e30e-4828-b3d7-85a952af56e8.yml
+++ b/data/in/retired/Joseph-Zakas-80a66e08-e30e-4828-b3d7-85a952af56e8.yml
@@ -6,6 +6,7 @@ roles:
 - district: '11'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: upper
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Julie-Olthoff-df8a1659-63b2-4e11-8dce-17bce11f8162.yml
+++ b/data/in/retired/Julie-Olthoff-df8a1659-63b2-4e11-8dce-17bce11f8162.yml
@@ -6,6 +6,7 @@ roles:
 - district: '19'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Kathy-Richardson-78e2597b-60d2-4902-af7c-a98e84b71b9a.yml
+++ b/data/in/retired/Kathy-Richardson-78e2597b-60d2-4902-af7c-a98e84b71b9a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '29'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Linda-Lawson-512b492f-8d12-48f6-a509-f0a4a12ee11a.yml
+++ b/data/in/retired/Linda-Lawson-512b492f-8d12-48f6-a509-f0a4a12ee11a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '1'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Michael-Delph-c44e058d-5b65-48bd-8994-431e624f43cf.yml
+++ b/data/in/retired/Michael-Delph-c44e058d-5b65-48bd-8994-431e624f43cf.yml
@@ -6,6 +6,7 @@ roles:
 - district: '29'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: upper
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Milo-Smith-a3cca3aa-1783-4eae-b3e7-2ee7832dfcb6.yml
+++ b/data/in/retired/Milo-Smith-a3cca3aa-1783-4eae-b3e7-2ee7832dfcb6.yml
@@ -6,6 +6,7 @@ roles:
 - district: '59'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Richard-Hamm-70b18ef2-1df3-494e-a9ac-dac5b71a3b4f.yml
+++ b/data/in/retired/Richard-Hamm-70b18ef2-1df3-494e-a9ac-dac5b71a3b4f.yml
@@ -6,6 +6,7 @@ roles:
 - district: '56'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Sally-Siegrist-a90c6c3f-a4c0-4bbe-a1a6-6d1c82345769.yml
+++ b/data/in/retired/Sally-Siegrist-a90c6c3f-a4c0-4bbe-a1a6-6d1c82345769.yml
@@ -6,6 +6,7 @@ roles:
 - district: '26'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Scott-Pelath-61f57248-4172-4ac6-b075-df82cff344cf.yml
+++ b/data/in/retired/Scott-Pelath-61f57248-4172-4ac6-b075-df82cff344cf.yml
@@ -6,6 +6,7 @@ roles:
 - district: '9'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Steven-Stemler-f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf.yml
+++ b/data/in/retired/Steven-Stemler-f27c1c1e-8e8c-40d6-bfd3-8efd6c10a9bf.yml
@@ -6,6 +6,7 @@ roles:
 - district: '71'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Thomas-Washburne-0c49328e-c3a6-4d21-988c-ceb32e2179e3.yml
+++ b/data/in/retired/Thomas-Washburne-0c49328e-c3a6-4d21-988c-ceb32e2179e3.yml
@@ -6,6 +6,7 @@ roles:
 - district: '64'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/Wes-Culver-731524ef-ec61-42c8-af9c-61411d9592f1.yml
+++ b/data/in/retired/Wes-Culver-731524ef-ec61-42c8-af9c-61411d9592f1.yml
@@ -6,6 +6,7 @@ roles:
 - district: '49'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/data/in/retired/William-Friend-0f2d19a6-7ae8-4e2c-8111-6b8965284a01.yml
+++ b/data/in/retired/William-Friend-0f2d19a6-7ae8-4e2c-8111-6b8965284a01.yml
@@ -6,6 +6,7 @@ roles:
 - district: '23'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   type: lower
+  end_date: '2018-11-06'
 contact_details:
 - address: 200 W. Washington Street;Indianapolis, IN 46204
   note: Capitol Office

--- a/settings.yml
+++ b/settings.yml
@@ -103,6 +103,10 @@ in:
   legislature_name: Indiana General Assembly
   lower_seats: 100
   upper_seats: 50
+  vacancies:
+    - chamber: lower
+      district: 7
+      vacant_until: 2019-01-01
 ks:
   legislature_name: Kansas State Legislature
   lower_seats: 125


### PR DESCRIPTION
One seat is vacant (Joe Taylor resigned effective 12/3 and his replacement has not been sworn in yet). The Civil Law committee might be disbanded, as it doesn't show up in the data, but it's unclear so I didn't mark it as disbanded.

Part of #38.