### PR TITLE
Attempt to improve performance of to_database

### DIFF
--- a/scripts/to_database.py
+++ b/scripts/to_database.py
@@ -38,10 +38,12 @@ def update_subobjects(person, fieldname, objects, read_manager=None):
         updated = True
 
     # check if all objects exist
-    for obj in objects:
-        if updated:
-            break
-        if not read_manager.filter(**obj).count():
+    if not updated:
+        qs = read_manager
+        for obj in objects:
+            qs = qs.exclude(**obj)
+
+        if qs.exists():
             updated = True
 
     # if there's been an update, wipe the old & insert the new


### PR DESCRIPTION
to_database spends a lot of time in `update_subobjects`. By making a fewer number of queries through testing in an exclusionary way for updates (if no objects are returned that differ vs. if all objects are the same), we should be able to improve performance.

Hopefully this will help with #55.