### PR TITLE
Correct URL for UT House Representative Derek Kitchen.

### DIFF
--- a/data/ut/people/Derek-Kitchen-8b1630fd-d86e-4c72-a6be-584d65bb8de0.yml
+++ b/data/ut/people/Derek-Kitchen-8b1630fd-d86e-4c72-a6be-584d65bb8de0.yml
@@ -12,7 +12,7 @@ contact_details:
   email: dkitchen@le.utah.gov
   note: District Office
 links:
-- url: https://senate.utah.gov/Derek-kitchen
+- url: https://senate.utah.gov/derek-kitchen
 sources:
 - url: http://le.utah.gov/data/legislators.json
 image: https://le.utah.gov/images/legislator/KITCHDL.jpg


### PR DESCRIPTION
Reference: https://senate.utah.gov/senate-roster/

The link does not work with a capital 'P'.