### PR TITLE
Fix data for past legislators

### DIFF
--- a/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
+++ b/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
@@ -24,6 +24,7 @@ memberships:
 - id: ocd-person/c1ce8b3f-ea56-4c8f-ab74-2a02b8d10063
   name: Donnie Chesteen
   role: Vice Chair
+  end_date: '2018-11-07'
 - id: ocd-person/474c3552-b3cd-4015-ac15-3c6301a0ce0e
   name: Artis Mccampbell
   role: Member

--- a/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
+++ b/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
@@ -13,6 +13,7 @@ memberships:
 - id: ocd-person/fa2c59ea-1a07-429d-85e4-9c60652919aa
   name: David Sessions
   role: Chair
+  end_date: '2018-11-07'
 - id: ocd-person/cb01dcb8-b382-48af-a781-d4019eb3dfa6
   name: Will Ainsworth
   role: Member

--- a/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
+++ b/data/al/organizations/Agriculture-and-Forestry-6cd9a311-5c34-4937-b3e5-420fff3bc342.yml
@@ -46,6 +46,7 @@ memberships:
 - id: ocd-person/a7e333c5-03f2-4343-9981-956bcc1ea38e
   name: Jack W. Williams
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/bd08d7a5-b1f3-484f-80c1-bddf2d636413
   name: Reed Ingram
   role: Member

--- a/data/al/organizations/County-and-Municipal-Government-34b948fc-188f-49e1-82f0-ef4f597a759a.yml
+++ b/data/al/organizations/County-and-Municipal-Government-34b948fc-188f-49e1-82f0-ef4f597a759a.yml
@@ -63,6 +63,7 @@ memberships:
 - id: ocd-person/a7e333c5-03f2-4343-9981-956bcc1ea38e
   name: Jack W. Williams
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/4f0a4d5d-b27a-4f33-b394-f27d306f8a42
   name: Steve Hurst
   role: Member

--- a/data/al/organizations/Ethics-and-Campaign-Finance-7ebfafb8-73ce-46cf-b8ca-b8e37ea76461.yml
+++ b/data/al/organizations/Ethics-and-Campaign-Finance-7ebfafb8-73ce-46cf-b8ca-b8e37ea76461.yml
@@ -40,6 +40,7 @@ memberships:
 - id: ocd-person/fa2c59ea-1a07-429d-85e4-9c60652919aa
   name: David Sessions
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/0c7c330a-17dd-46a8-abcc-ea773ba0ffa3
   name: Marcel Black
   role: Ranking Minority Member

--- a/data/al/organizations/Health-8374da44-b0ce-48a1-9c91-d7b670b11bbf.yml
+++ b/data/al/organizations/Health-8374da44-b0ce-48a1-9c91-d7b670b11bbf.yml
@@ -39,6 +39,7 @@ memberships:
 - id: ocd-person/a7e333c5-03f2-4343-9981-956bcc1ea38e
   name: Jack W. Williams
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/a08f605d-221f-4d26-8e13-4bcfa964cd8e
   name: Becky Nordgren
   role: Member

--- a/data/al/organizations/Mobile-County-Legislation-f6eb9877-616a-415d-8949-3304ea5ba7a7.yml
+++ b/data/al/organizations/Mobile-County-Legislation-f6eb9877-616a-415d-8949-3304ea5ba7a7.yml
@@ -14,6 +14,7 @@ memberships:
 - id: ocd-person/a7e333c5-03f2-4343-9981-956bcc1ea38e
   name: Jack W. Williams
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/f4133b43-f822-4d95-b1e0-a0a524de56f6
   name: Chris Pringle
   role: Member

--- a/data/al/organizations/Mobile-County-Legislation-f6eb9877-616a-415d-8949-3304ea5ba7a7.yml
+++ b/data/al/organizations/Mobile-County-Legislation-f6eb9877-616a-415d-8949-3304ea5ba7a7.yml
@@ -27,6 +27,7 @@ memberships:
 - id: ocd-person/fa2c59ea-1a07-429d-85e4-9c60652919aa
   name: David Sessions
   role: Chair
+  end_date: '2018-11-07'
 - id: ocd-person/947c7906-7825-442f-9241-d777b9bbe999
   name: Napoleon Bracy
   role: Member

--- a/data/al/organizations/State-Government-4748fd62-1894-45b3-9317-b9b9c5d25b97.yml
+++ b/data/al/organizations/State-Government-4748fd62-1894-45b3-9317-b9b9c5d25b97.yml
@@ -48,6 +48,7 @@ memberships:
 - id: ocd-person/a7e333c5-03f2-4343-9981-956bcc1ea38e
   name: Jack W. Williams
   role: Vice Chair
+  end_date: '2018-11-07'
 - id: ocd-person/76f9d6ad-f147-4913-b011-3f52e1105f77
   name: Mack Butler
   role: Member

--- a/data/al/organizations/Technology-and-Research-51cfd990-c01b-41cc-94da-368ac11f42dd.yml
+++ b/data/al/organizations/Technology-and-Research-51cfd990-c01b-41cc-94da-368ac11f42dd.yml
@@ -16,6 +16,7 @@ memberships:
 - id: ocd-person/c1ce8b3f-ea56-4c8f-ab74-2a02b8d10063
   name: Donnie Chesteen
   role: Chair
+  end_date: '2018-11-07'
 - id: ocd-person/4b1e7b36-b0cb-40f2-9042-39724f7816d8
   name: Alan Harper
   role: Member

--- a/data/al/organizations/Ways-and-Means-Education-010a25d3-70f8-401a-8338-00d4e137aa3a.yml
+++ b/data/al/organizations/Ways-and-Means-Education-010a25d3-70f8-401a-8338-00d4e137aa3a.yml
@@ -30,6 +30,7 @@ memberships:
 - id: ocd-person/c1ce8b3f-ea56-4c8f-ab74-2a02b8d10063
   name: Donnie Chesteen
   role: Member
+  end_date: '2018-11-07'
 - id: ocd-person/7e37884b-f6c9-4bd3-b4e9-ac185fd25e0e
   name: James E. Buskey
   role: Ranking Minority Member

--- a/data/al/people/David-Sessions-fa2c59ea-1a07-429d-85e4-9c60652919aa.yml
+++ b/data/al/people/David-Sessions-fa2c59ea-1a07-429d-85e4-9c60652919aa.yml
@@ -3,9 +3,14 @@ name: David Sessions
 party:
 - name: Republican
 roles:
+- district: '105'
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+  type: lower
+  end_date: '2018-11-07'
 - district: '35'
   jurisdiction: ocd-jurisdiction/country:us/state:al/government
   type: upper
+  start_date: '2018-11-07'
 links:
 - url: http://www.legislature.state.al.us/aliswww/ISD/ALSenator.aspx?OID_SPONSOR=100478&OID_PERSON=6832
 contact_details:

--- a/data/al/people/Donnie-Chesteen-c1ce8b3f-ea56-4c8f-ab74-2a02b8d10063.yml
+++ b/data/al/people/Donnie-Chesteen-c1ce8b3f-ea56-4c8f-ab74-2a02b8d10063.yml
@@ -3,9 +3,14 @@ name: Donnie Chesteen
 party:
 - name: Republican
 roles:
+- district: '87'
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+  type: lower
+  end_date: '2018-11-07'
 - district: '29'
   jurisdiction: ocd-jurisdiction/country:us/state:al/government
   type: upper
+  start_date: '2018-11-07'
 links:
 - url: http://www.legislature.state.al.us/aliswww/ISD/ALSenator.aspx?OID_SPONSOR=100472&OID_PERSON=6660
 contact_details:

--- a/data/al/people/Jack-W-Williams-a7e333c5-03f2-4343-9981-956bcc1ea38e.yml
+++ b/data/al/people/Jack-W-Williams-a7e333c5-03f2-4343-9981-956bcc1ea38e.yml
@@ -10,6 +10,7 @@ roles:
 - district: '34'
   jurisdiction: ocd-jurisdiction/country:us/state:al/government
   type: upper
+  start_date: '2018-11-07'
 links:
 - url: http://www.legislature.state.al.us/aliswww/ISD/ALSenator.aspx?OID_SPONSOR=100477&OID_PERSON=7707
 contact_details:

--- a/data/al/people/Jack-W-Williams-a7e333c5-03f2-4343-9981-956bcc1ea38e.yml
+++ b/data/al/people/Jack-W-Williams-a7e333c5-03f2-4343-9981-956bcc1ea38e.yml
@@ -3,6 +3,10 @@ name: Jack W. Williams
 party:
 - name: Republican
 roles:
+- district: '102'
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+  type: lower
+  end_date: '2018-11-07'
 - district: '34'
   jurisdiction: ocd-jurisdiction/country:us/state:al/government
   type: upper

--- a/data/ca/organizations/Aging-and-Long-Term-Care-44b1b005-8336-412c-82d0-438df8dfd12a.yml
+++ b/data/ca/organizations/Aging-and-Long-Term-Care-44b1b005-8336-412c-82d0-438df8dfd12a.yml
@@ -20,6 +20,7 @@ memberships:
   end_date: '2018-11-30'
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/1465de6a-ec39-4986-b3e4-e30ef7a47c20
   name: Todd Gloria
 - id: ocd-person/93b85e3f-af14-4792-ae2e-06bcdaf04aa1

--- a/data/ca/organizations/Agriculture-7583a023-a98d-4244-9674-86f314c5f92a.yml
+++ b/data/ca/organizations/Agriculture-7583a023-a98d-4244-9674-86f314c5f92a.yml
@@ -12,6 +12,7 @@ memberships:
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
   role: Chair
+  end_date: '2018-11-30'
 - id: ocd-person/3ffead8c-6856-4592-8594-182e295b8e87
   name: Devon J. Mathis
   role: Vice Chair

--- a/data/ca/organizations/Budget-28294af2-621f-4a09-8b24-acbfa48dd324.yml
+++ b/data/ca/organizations/Budget-28294af2-621f-4a09-8b24-acbfa48dd324.yml
@@ -21,6 +21,7 @@ memberships:
   name: William P. Brough
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/bd1120b7-407b-4452-8866-39b1bb60e826
   name: "Rocky J. Ch\xE1vez"
   end_date: '2018-11-30'

--- a/data/ca/organizations/Economic-Development-and-Investment-in-Rural-California-e50036eb-c5a4-4c55-968f-f62f5196dbf0.yml
+++ b/data/ca/organizations/Economic-Development-and-Investment-in-Rural-California-e50036eb-c5a4-4c55-968f-f62f5196dbf0.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
   role: Chair
+  end_date: '2018-11-30'
 - id: ocd-person/434bcfb4-1279-40cc-916b-f89af5805a9c
   name: Cecilia M. Aguiar-Curry
 - name: Dr. Joaquin Arambula

--- a/data/ca/organizations/Insurance-4da0a7ca-6c93-465a-90e1-73edd3dd48e7.yml
+++ b/data/ca/organizations/Insurance-4da0a7ca-6c93-465a-90e1-73edd3dd48e7.yml
@@ -19,6 +19,7 @@ memberships:
   name: Frank Bigelow
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/3e08c682-6d05-495e-87b4-e546b5f005e8
   name: Ian C. Calderon
 - id: ocd-person/6ba768a4-2756-42b5-a5c5-f6b8b5db0491

--- a/data/ca/organizations/Local-Government-2b44dba4-749c-409b-86d0-663c482dc5b0.yml
+++ b/data/ca/organizations/Local-Government-2b44dba4-749c-409b-86d0-663c482dc5b0.yml
@@ -19,6 +19,7 @@ memberships:
   name: Richard Bloom
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/407f6fda-8638-4cca-9704-7aa8df7de26e
   name: Jesse Gabriel
 - id: ocd-person/972cffb0-32a6-4cef-8a0f-a8cd901395b0

--- a/data/ca/organizations/Rail-af4ccbfc-956a-496b-967a-b39290621bba.yml
+++ b/data/ca/organizations/Rail-af4ccbfc-956a-496b-967a-b39290621bba.yml
@@ -15,6 +15,7 @@ memberships:
   name: Marc Berman
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/16d16f4a-1551-4546-bec2-e7f336a3e90f
   name: Jordan Cunningham
 - id: ocd-person/6e15bad0-0813-443e-bc20-83d70860b9b9

--- a/data/ca/organizations/Small-Business-and-Entrepreneurship-f5117af4-ffcf-49b4-8682-a27d199f956b.yml
+++ b/data/ca/organizations/Small-Business-and-Entrepreneurship-f5117af4-ffcf-49b4-8682-a27d199f956b.yml
@@ -16,6 +16,7 @@ memberships:
   end_date: '2018-11-30'
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/3e08c682-6d05-495e-87b4-e546b5f005e8
   name: Ian C. Calderon
 - name: Steven S. Choi, PhD.

--- a/data/ca/organizations/Wine-d2aeb66b-d9d1-48ba-9c54-aab0215252f4.yml
+++ b/data/ca/organizations/Wine-d2aeb66b-d9d1-48ba-9c54-aab0215252f4.yml
@@ -15,6 +15,7 @@ memberships:
   name: Frank Bigelow
 - id: ocd-person/fe462917-df55-4a43-9fd8-970541544ca6
   name: Anna M. Caballero
+  end_date: '2018-11-30'
 - id: ocd-person/9629be48-b082-4880-85a8-d2e14a4ad1a8
   name: Jim Cooper
 - id: ocd-person/91915f3b-c93f-4f55-a164-58b8c1587d6d

--- a/data/ca/people/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
+++ b/data/ca/people/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
@@ -3,6 +3,11 @@ name: Anna M. Caballero
 party:
 - name: Democratic
 roles:
+- district: '30'
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/government
+  type: lower
+  start_date: '2016-12-05'
+  end_date: '2018-11-30'
 - district: '12'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/government
   type: upper

--- a/data/ca/people/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
+++ b/data/ca/people/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
@@ -11,6 +11,7 @@ roles:
 - district: '12'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/government
   type: upper
+  start_date: '2018-12-03'
 contact_details:
 - address: State Capitol, Room 5052, Sacramento, CA 95814-4900
   email: senator.caballero@sen.ca.gov

--- a/data/mt/retired/Austin-Knudsen-6932f017-6867-409a-8321-6cf9dce312ef.yml
+++ b/data/mt/retired/Austin-Knudsen-6932f017-6867-409a-8321-6cf9dce312ef.yml
@@ -3,7 +3,7 @@ name: Austin Knudsen
 party:
 - name: Republican
 roles:
-- district: '33'
+- district: '34'
   jurisdiction: ocd-jurisdiction/country:us/state:mt/government
   type: lower
   end_date: 2018-12-31


### PR DESCRIPTION
- Some of the updates removed past roles for legislators who had new roles.
- A random mistake occurred in the update of Austin Knudsen's record changing the district to something incorrect

I imagine that, if we want to keep past data (i.e. retired legislators), we probably also want to add end dates to previous roles. Ideally we probably have a script to mark a legislator as being done with a role, similar to the retiring one.