### PR TITLE
Update contact information for IA legislators

### DIFF
--- a/data/ia/people/Ann-Meyer-f8bf5332-b8b7-4d55-8652-e9b883cae35e.yml
+++ b/data/ia/people/Ann-Meyer-f8bf5332-b8b7-4d55-8652-e9b883cae35e.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 2908 S. Soldier Creek Dr., Fort Dodge, IA 50501
+- address: 2908 S Soldier Creek Dr, Fort Dodge, IA 50501
   note: District Office
+- email: Ann.Meyer@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27019
 sources:

--- a/data/ia/people/Anne-Osmundson-f7c967d7-bd1b-4cd6-aa35-dfbf0966b382.yml
+++ b/data/ia/people/Anne-Osmundson-f7c967d7-bd1b-4cd6-aa35-dfbf0966b382.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 11663 Bell Road, Volga, IA 52077
   note: District Office
+- email: Anne.Osmundson@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27029
 sources:

--- a/data/ia/people/Brian-Best-4dfe4566-e567-4f5f-bc1d-f6dd3febe2ea.yml
+++ b/data/ia/people/Brian-Best-4dfe4566-e567-4f5f-bc1d-f6dd3febe2ea.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: P.O. Box 491, Glidden, IA 51443
+- address: PO Box 491, Glidden, IA 51443
   note: District Office
 - email: Brian.Best@legis.iowa.gov
   note: Capitol Office

--- a/data/ia/people/Brian-K-Lohse-076d9aaa-b357-4f27-aa57-05bb3c8f2075.yml
+++ b/data/ia/people/Brian-K-Lohse-076d9aaa-b357-4f27-aa57-05bb3c8f2075.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 1500 NE Morgan Drive, Bondurant, IA 50035
+- address: PO Box 67, Bondurant, IA 50035
   note: District Office
+- email: Brian.Lohse@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27022
 sources:

--- a/data/ia/people/Carrie-Koelker-9b68d2a2-ead2-401e-a225-1edae68f6099.yml
+++ b/data/ia/people/Carrie-Koelker-9b68d2a2-ead2-401e-a225-1edae68f6099.yml
@@ -9,7 +9,6 @@ roles:
 contact_details:
 - address: 807 Third St NW, Dyersville, IA 52040
   note: District Office
-  voice: 563-875-7530
 - email: carrie.koelker@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3371

--- a/data/ia/people/Dave-Jacoby-4c535bc4-4b3c-4def-9332-700a1ebb5c6a.yml
+++ b/data/ia/people/Dave-Jacoby-4c535bc4-4b3c-4def-9332-700a1ebb5c6a.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 2308 Northridge Dr, Coralville, IA 52241
+- address: 2308 N Ridge Dr, Coralville, IA 52241
   note: District Office
   voice: 319-358-8538
 - email: david.jacoby@legis.iowa.gov

--- a/data/ia/people/Dave-Maxwell-7a4fb824-66ee-4460-80ca-1ea45f6687fa.yml
+++ b/data/ia/people/Dave-Maxwell-7a4fb824-66ee-4460-80ca-1ea45f6687fa.yml
@@ -1,5 +1,5 @@
 id: ocd-person/7a4fb824-66ee-4460-80ca-1ea45f6687fa
-name: Dave E. Maxwell
+name: David E. Maxwell
 party:
 - name: Republican
 roles:
@@ -20,5 +20,5 @@ image: https://www.legis.iowa.gov/photo?action=getPhoto&ga=2019-2020&pid=10757
 other_identifiers:
 - identifier: IAL000277
   scheme: legacy_openstates
-given_name: Dave
+given_name: David
 family_name: Maxwell

--- a/data/ia/people/Dave-Williams-ff29e7b3-807b-4ab4-9c74-12c193b25452.yml
+++ b/data/ia/people/Dave-Williams-ff29e7b3-807b-4ab4-9c74-12c193b25452.yml
@@ -6,7 +6,9 @@ roles:
 - district: '60'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Dave.Williams@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27030
 sources:

--- a/data/ia/people/Dennis-M-Cohoon-41457caf-683d-4551-8158-02ab4b6bdc7f.yml
+++ b/data/ia/people/Dennis-M-Cohoon-41457caf-683d-4551-8158-02ab4b6bdc7f.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 8151 138th St, Burlington, IA 52601
-  note: District Office
 - email: dennis.cohoon@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Dustin-D-Hite-d03ae1ca-5d65-4007-b3be-222f40451bd7.yml
+++ b/data/ia/people/Dustin-D-Hite-d03ae1ca-5d65-4007-b3be-222f40451bd7.yml
@@ -6,7 +6,9 @@ roles:
 - district: '79'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Dustin.Hite@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27034
 sources:

--- a/data/ia/people/Gary-Carlson-ac372eee-b649-4017-a949-ed6d0b6334da.yml
+++ b/data/ia/people/Gary-Carlson-ac372eee-b649-4017-a949-ed6d0b6334da.yml
@@ -9,7 +9,6 @@ roles:
 contact_details:
 - address: 104 Deerpath Ln, Muscatine, IA 52761
   note: District Office
-  voice: 563-299-7021
 - email: Gary.Carlson@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Heather-Matson-79d03429-b53d-472b-bd89-18b4b273a973.yml
+++ b/data/ia/people/Heather-Matson-79d03429-b53d-472b-bd89-18b4b273a973.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 1802 SW Prairie Trail Pkwy, Ankeny, IA 50023
   note: District Office
+- email: Heather.Matson@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27023
 sources:

--- a/data/ia/people/Holly-Brink-0e5d51f0-3a19-4290-a8db-468c17b5a0e9.yml
+++ b/data/ia/people/Holly-Brink-0e5d51f0-3a19-4290-a8db-468c17b5a0e9.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 2199 Oxford Avenue, Oskaloosa, IA 52577
   note: District Office
+- email: Holly.Brink@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27035
 sources:

--- a/data/ia/people/Jacob-Bossman-9c6428d6-af30-4a4f-bb9c-666d3d6d84c5.yml
+++ b/data/ia/people/Jacob-Bossman-9c6428d6-af30-4a4f-bb9c-666d3d6d84c5.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 2650 S Cedar St, Sioux City, IA 51106
   note: District Office
+- email: Jacob.Bossman@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=25497
 sources:

--- a/data/ia/people/Jarad-J-Klein-f047b23b-e942-4491-915b-38a1dc602827.yml
+++ b/data/ia/people/Jarad-J-Klein-f047b23b-e942-4491-915b-38a1dc602827.yml
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000325
   scheme: legacy_openstates
-given_name: Jarad J.
+given_name: Jarad
 family_name: Klein

--- a/data/ia/people/Jeff-Kurtz-6b6c7e53-fc33-4e07-bf81-c03b4fc7b0b9.yml
+++ b/data/ia/people/Jeff-Kurtz-6b6c7e53-fc33-4e07-bf81-c03b4fc7b0b9.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 6 Klesner Court, Fort Madison, IA 52627
   note: District Office
+- email: Jeff.Kurtz@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27037
 sources:

--- a/data/ia/people/Jeff-Shipley-11ceb3de-a680-4dc0-b140-edd37f04e75b.yml
+++ b/data/ia/people/Jeff-Shipley-11ceb3de-a680-4dc0-b140-edd37f04e75b.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 101 E. Hempstead Ave., Fairfield, IA 52556
   note: District Office
+- email: Jeff.Shipley@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27036
 sources:

--- a/data/ia/people/Jennifer-Konfrst-f8a5dfc0-e8e0-4f38-a29f-4e3d3ddf87cb.yml
+++ b/data/ia/people/Jennifer-Konfrst-f8a5dfc0-e8e0-4f38-a29f-4e3d3ddf87cb.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 6518 Northwest Dr, Windsor Heights, IA 50324
   note: District Office
+- email: Jennifer.Konfrst@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27026
 sources:

--- a/data/ia/people/Joe-Mitchell-ba7f1d9b-029b-40ff-98d5-7aab995d259e.yml
+++ b/data/ia/people/Joe-Mitchell-ba7f1d9b-029b-40ff-98d5-7aab995d259e.yml
@@ -6,7 +6,9 @@ roles:
 - district: '84'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Joe.Mitchell@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27038
 sources:

--- a/data/ia/people/John-H-Wills-955a4d7c-a378-4bd2-8a74-dac94f74ba52.yml
+++ b/data/ia/people/John-H-Wills-955a4d7c-a378-4bd2-8a74-dac94f74ba52.yml
@@ -20,5 +20,5 @@ image: https://www.legis.iowa.gov/photo?action=getPhoto&ga=2019-2020&pid=13794
 other_identifiers:
 - identifier: IAL000507
   scheme: legacy_openstates
-given_name: John H.
+given_name: John
 family_name: Wills

--- a/data/ia/people/Jon-A-Jacobsen-b207b3dd-c8bf-41f1-8809-374c8f91f5ef.yml
+++ b/data/ia/people/Jon-A-Jacobsen-b207b3dd-c8bf-41f1-8809-374c8f91f5ef.yml
@@ -22,5 +22,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000553
   scheme: legacy_openstates
-given_name: Jon A.
+given_name: Jon
 family_name: Jacobsen

--- a/data/ia/people/Jon-Thorup-5ce342a3-9018-4a9b-a06d-2c4ad7270d14.yml
+++ b/data/ia/people/Jon-Thorup-5ce342a3-9018-4a9b-a06d-2c4ad7270d14.yml
@@ -7,9 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 1630 Lucas Drive, Knoxville, IA 50138
+- address: 1630 Lucas Dr, Knoxville, IA 50138
   note: District Office
   voice: 641-891-9357
+- email: Jon.Thorup@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27021
 sources:

--- a/data/ia/people/Julian-B-Garrett-67f25420-8ea1-49d1-aa86-488136b5f9f5.yml
+++ b/data/ia/people/Julian-B-Garrett-67f25420-8ea1-49d1-aa86-488136b5f9f5.yml
@@ -30,5 +30,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000479
   scheme: legacy_openstates
-given_name: Julian B.
+given_name: Julian
 family_name: Garrett

--- a/data/ia/people/Karin-Derry-841c757d-37ec-43e7-b1e2-e54795b2e95e.yml
+++ b/data/ia/people/Karin-Derry-841c757d-37ec-43e7-b1e2-e54795b2e95e.yml
@@ -9,6 +9,9 @@ roles:
 contact_details:
 - address: 6689 River Bend Dr, Johnston, IA 50131
   note: District Office
+- email: Karin.Derry@legis.iowa.gov
+  note: Capitol Office
+  voice: 515-281-3221
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27024
 sources:

--- a/data/ia/people/Kenan-Judge-1b7d56b0-f635-423c-9c09-5617322b1518.yml
+++ b/data/ia/people/Kenan-Judge-1b7d56b0-f635-423c-9c09-5617322b1518.yml
@@ -6,7 +6,9 @@ roles:
 - district: '44'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Kenan.Judge@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27027
 sources:

--- a/data/ia/people/Kristin-Sunde-87ecc902-b632-4117-a494-5b8b5962423b.yml
+++ b/data/ia/people/Kristin-Sunde-87ecc902-b632-4117-a494-5b8b5962423b.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 1629 S. 50th Place, West Des Moines, IA 50265
+- address: 1629 S 50th Place, West Des Moines, IA 50265
   note: District Office
+- email: Kristin.Sunde@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27025
 sources:

--- a/data/ia/people/Lindsay-James-5d24f3bc-b000-4283-bf2d-4b279610da00.yml
+++ b/data/ia/people/Lindsay-James-5d24f3bc-b000-4283-bf2d-4b279610da00.yml
@@ -6,7 +6,9 @@ roles:
 - district: '99'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Lindsay.James@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27039
 sources:

--- a/data/ia/people/Mark-S-Lofgren-b1110000-b6c3-4348-8655-8a7b51c8a9db.yml
+++ b/data/ia/people/Mark-S-Lofgren-b1110000-b6c3-4348-8655-8a7b51c8a9db.yml
@@ -21,5 +21,5 @@ image: https://www.legis.iowa.gov/photo?action=getPhoto&ga=2019-2020&pid=9406
 other_identifiers:
 - identifier: IAL000548
   scheme: legacy_openstates
-given_name: Mark S.
+given_name: Mark
 family_name: Lofgren

--- a/data/ia/people/Mary-Lynn-Wolfe-92e913f1-c580-49e1-be13-d5a8a31f503e.yml
+++ b/data/ia/people/Mary-Lynn-Wolfe-92e913f1-c580-49e1-be13-d5a8a31f503e.yml
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000321
   scheme: legacy_openstates
-given_name: Mary Lynn
+given_name: Mary
 family_name: Wolfe

--- a/data/ia/people/Megan-Jones-65c3efb9-452e-4aae-a390-15db3f3ba707.yml
+++ b/data/ia/people/Megan-Jones-65c3efb9-452e-4aae-a390-15db3f3ba707.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 4470 Hwy 71, Sioux Rapids, IA 50585
-  note: District Office
 - email: megan.jones@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Molly-Erin-Donahue-d675a03b-f474-4e1c-b48a-b78b399488c4.yml
+++ b/data/ia/people/Molly-Erin-Donahue-d675a03b-f474-4e1c-b48a-b78b399488c4.yml
@@ -6,7 +6,9 @@ roles:
 - district: '68'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Molly.Donahue@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27031
 sources:

--- a/data/ia/people/Norlin-Mommsen-8b71a0ba-b73f-4ce9-bb88-3ff7bbdb8d1d.yml
+++ b/data/ia/people/Norlin-Mommsen-8b71a0ba-b73f-4ce9-bb88-3ff7bbdb8d1d.yml
@@ -9,7 +9,7 @@ roles:
 contact_details:
 - address: 2308 15th St Ct, DeWitt, IA 52742
   note: District Office
-  voice: 563-659-9322
+  voice: 563-659-8322
 - email: Norlin.Mommsen@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Phil-Thompson-9eddb157-fee7-4b49-a7da-0f791731afcc.yml
+++ b/data/ia/people/Phil-Thompson-9eddb157-fee7-4b49-a7da-0f791731afcc.yml
@@ -6,7 +6,9 @@ roles:
 - district: '47'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Phil.Thompson@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27028
 sources:

--- a/data/ia/people/Ray-Sorensen-49acd6a0-9b64-494d-91a2-21d7fd28f8f4.yml
+++ b/data/ia/people/Ray-Sorensen-49acd6a0-9b64-494d-91a2-21d7fd28f8f4.yml
@@ -6,7 +6,9 @@ roles:
 - district: '20'
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
-contact_details: []
+contact_details:
+- email: Ray.Sorensen@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27020
 sources:

--- a/data/ia/people/Rick-Olson-8ef407a5-2d80-4190-a656-a23d13fb5cb4.yml
+++ b/data/ia/people/Rick-Olson-8ef407a5-2d80-4190-a656-a23d13fb5cb4.yml
@@ -7,8 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 3012 E 31st Court, Des Moines, IA 50317
-  note: District Office
+- note: District Office
   voice: 515-265-4521
 - email: rick.olson@legis.iowa.gov
   note: Capitol Office

--- a/data/ia/people/Rob-Bacon-66b380fc-a043-4b53-9f9d-d41ad4706df8.yml
+++ b/data/ia/people/Rob-Bacon-66b380fc-a043-4b53-9f9d-d41ad4706df8.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 104 N Tama St, PO Box 485, Slater, IA 50244
-  note: District Office
 - email: rob.bacon@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221
@@ -22,5 +20,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000226
   scheme: legacy_openstates
-given_name: Rob
+given_name: Robert
 family_name: Bacon

--- a/data/ia/people/Shannon-Lundgren-076719e5-94aa-40b6-8658-70fa69a10e38.yml
+++ b/data/ia/people/Shannon-Lundgren-076719e5-94aa-40b6-8658-70fa69a10e38.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 918 Heather Dr, Peosta, IA 52068
-  note: District Office
 - email: Shannon.Lundgren@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Skyler-Wheeler-9d60676d-f50e-4117-8d22-681927e43a01.yml
+++ b/data/ia/people/Skyler-Wheeler-9d60676d-f50e-4117-8d22-681927e43a01.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: '602 2nd St SE #4, Orange City, IA 51041'
-  note: District Office
 - email: Skyler.Wheeler@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221

--- a/data/ia/people/Terry-C-Baxter-f37d7cfd-f30b-450f-8bfd-40ab1ccf4b94.yml
+++ b/data/ia/people/Terry-C-Baxter-f37d7cfd-f30b-450f-8bfd-40ab1ccf4b94.yml
@@ -21,5 +21,5 @@ image: https://www.legis.iowa.gov/photo?action=getPhoto&ga=2019-2020&pid=13796
 other_identifiers:
 - identifier: IAL000513
   scheme: legacy_openstates
-given_name: Terry C.
+given_name: Terry
 family_name: Baxter

--- a/data/ia/people/Thomas-A-Greene-79d48a0c-fdd7-49b1-9629-720a186f494a.yml
+++ b/data/ia/people/Thomas-A-Greene-79d48a0c-fdd7-49b1-9629-720a186f494a.yml
@@ -21,5 +21,5 @@ image: https://www.legis.iowa.gov/photo?action=getPhoto&ga=2019-2020&pid=18077
 other_identifiers:
 - identifier: IAL000540
   scheme: legacy_openstates
-given_name: Thomas A.
+given_name: Thomas
 family_name: Greene

--- a/data/ia/people/Thomas-D-Gerhold-ed333b61-6734-49a2-b37d-a167f330bf09.yml
+++ b/data/ia/people/Thomas-D-Gerhold-ed333b61-6734-49a2-b37d-a167f330bf09.yml
@@ -9,6 +9,8 @@ roles:
 contact_details:
 - address: 3326 71st Street, Atkins, IA 52206
   note: District Office
+- email: Thomas.Gerhold@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27033
 sources:

--- a/data/ia/people/Tom-Jeneary-49fc2a54-b290-4f92-9fda-64893f09d29c.yml
+++ b/data/ia/people/Tom-Jeneary-49fc2a54-b290-4f92-9fda-64893f09d29c.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 1501 Schafer Ave. SE, LeMars, IA 51031
+- address: 1501 Schafer Ave SE, Le Mars, IA 51031
   note: District Office
+- email: Tom.Jeneary@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27018
 sources:

--- a/data/ia/people/Tracy-Ehlert-0a7675f8-869f-4d49-9a14-c44201e8a8dc.yml
+++ b/data/ia/people/Tracy-Ehlert-0a7675f8-869f-4d49-9a14-c44201e8a8dc.yml
@@ -7,9 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 411 Hanover Rd. SW, Cedar Rapids, IA 52404
+- address: 411 Hanover Rd SW, Cedar Rapids, IA 52404
   note: District Office
   voice: 319-899-2980
+- email: Tracy.Ehlert@legis.iowa.gov
+  note: Capitol Office
 links:
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=88&personID=27032
 sources:

--- a/data/ia/people/Wes-Breckenridge-3a5ba7c4-1272-4432-856a-efdce220c3a8.yml
+++ b/data/ia/people/Wes-Breckenridge-3a5ba7c4-1272-4432-856a-efdce220c3a8.yml
@@ -7,8 +7,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ia/government
   type: lower
 contact_details:
-- address: 1419 N 23rd Ave W, Newton, IA 50208
-  note: District Office
 - email: Wes.Breckenridge@legis.iowa.gov
   note: Capitol Office
   voice: 515-281-3221


### PR DESCRIPTION
It seems that contact information for some IA legislators has changed since the last time it was scraped, so update the YAML with these changes. Also a few changes to given_names to remove middle names/initials.