### PR TITLE
Update contact information for Georgia legislators

### DIFF
--- a/data/ga/organizations/Appropriations-107fab84-ceaa-44d6-9554-dfe835a0aa04.yml
+++ b/data/ga/organizations/Appropriations-107fab84-ceaa-44d6-9554-dfe835a0aa04.yml
@@ -33,6 +33,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Chairman of Subcommittee
+  end_date: '2019-01-03'
 - name: Andrew Welch
   role: Chairman of Subcommittee
 - id: ocd-person/713cac52-0a57-4baa-8273-6eeca5b491df

--- a/data/ga/organizations/Economic-Development--Tourism-89eae15e-13a6-4766-9282-e0ba92424303.yml
+++ b/data/ga/organizations/Economic-Development--Tourism-89eae15e-13a6-4766-9282-e0ba92424303.yml
@@ -110,6 +110,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Member
+  end_date: '2019-01-03'
 - id: ocd-person/2844fe75-8c80-47ef-b75b-5e48b397b9b2
   name: Valencia Stovall
   role: Member

--- a/data/ga/organizations/Game-Fish--Parks-a84a3838-2d4d-4bca-a7a9-e15733ea7fc6.yml
+++ b/data/ga/organizations/Game-Fish--Parks-a84a3838-2d4d-4bca-a7a9-e15733ea7fc6.yml
@@ -60,6 +60,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Member
+  end_date: '2019-01-03'
 - name: Jason Spencer
   role: Member
 - id: ocd-person/80f4bbdf-02f3-4233-8456-e550e7e745af

--- a/data/ga/organizations/Industry-and-Labor-ca40b2c6-5685-43e5-9e7a-4f29c8a15675.yml
+++ b/data/ga/organizations/Industry-and-Labor-ca40b2c6-5685-43e5-9e7a-4f29c8a15675.yml
@@ -52,6 +52,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Member
+  end_date: '2019-01-03'
 - id: ocd-person/3a5721a0-d848-40d0-a48a-66b797e7d7d9
   name: Brian Strickland
   role: Member

--- a/data/ga/organizations/Insurance-8e66e3e2-71c1-42da-8390-7cc13cc180f3.yml
+++ b/data/ga/organizations/Insurance-8e66e3e2-71c1-42da-8390-7cc13cc180f3.yml
@@ -79,6 +79,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Member
+  end_date: '2019-01-03'
 - id: ocd-person/ce7cb314-aa41-43a3-a875-9204f3a10beb
   name: Mickey Stephens
   role: Member

--- a/data/ga/organizations/Small-Business-Development-13c268cf-57af-4fb6-b821-f31eba4321e2.yml
+++ b/data/ga/organizations/Small-Business-Development-13c268cf-57af-4fb6-b821-f31eba4321e2.yml
@@ -98,6 +98,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Member
+  end_date: '2019-01-03'
 - id: ocd-person/2844fe75-8c80-47ef-b75b-5e48b397b9b2
   name: Valencia Stovall
   role: Member

--- a/data/ga/organizations/Transportation-07988227-7ee3-4aee-98f5-e74ee8120486.yml
+++ b/data/ga/organizations/Transportation-07988227-7ee3-4aee-98f5-e74ee8120486.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Chairman of Subcommittee
+  end_date: '2019-01-03'
 - id: ocd-person/3ff894cb-f2e4-47d0-9f67-b125245a10c3
   name: Chuck Efstration
   role: Vice-Chairman of Subcommittee

--- a/data/ga/organizations/Transportation-c751df62-b868-4288-8667-1abb09b9a973.yml
+++ b/data/ga/organizations/Transportation-c751df62-b868-4288-8667-1abb09b9a973.yml
@@ -98,6 +98,7 @@ memberships:
 - id: ocd-person/1ae9453d-dbed-48a1-a848-875745f8991a
   name: Jason Shaw
   role: Ex-Officio
+  end_date: '2019-01-03'
 - name: Darlene Taylor
   role: Member
 - id: ocd-person/0cefc562-a4a4-4f82-b647-9932b2bb78aa

--- a/data/ga/people/Able-Mable-Thomas-78d8937f-740a-4f3a-a6a4-5a2884d7997e.yml
+++ b/data/ga/people/Able-Mable-Thomas-78d8937f-740a-4f3a-a6a4-5a2884d7997e.yml
@@ -18,7 +18,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=224&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/ThomasMable224.jpg
 family_name: Thomas
-given_name: '"Able" Mable'
+given_name: Mable
 extras:
   guid: 224
 other_identifiers:

--- a/data/ga/people/Andrew-J-Welch-4ffa6984-145b-49bc-bdc2-988d3475470e.yml
+++ b/data/ga/people/Andrew-J-Welch-4ffa6984-145b-49bc-bdc2-988d3475470e.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 220 State Capitol;Atlanta, GA 30334
+- address: 220-B State Capitol;Atlanta, GA 30334
   email: awelch@smithwelchlaw.com
   note: Capitol Address
   voice: 404-656-5912

--- a/data/ga/people/Angelika-Kausche-d2565b12-22ac-4100-a657-2cdaaca7c7ac.yml
+++ b/data/ga/people/Angelika-Kausche-d2565b12-22ac-4100-a657-2cdaaca7c7ac.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 409-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: angelika.kausche@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0116
 - address: 5805 State Bridge Rd, Suite G518;Johns Creek, GA 30097
   note: District Address
 links:

--- a/data/ga/people/Barry-Fleming-7ea227b9-339a-485a-bfc8-467206ad2457.yml
+++ b/data/ga/people/Barry-Fleming-7ea227b9-339a-485a-bfc8-467206ad2457.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-H Coverdell Legislative Office Bldg;Atlanta, GA 30334
+- address: 132 State Capitol;Atlanta, GA 30334
   email: barry.fleming@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0152
+  voice: 404-656-5125
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=101&Session=27
 sources:

--- a/data/ga/people/Becky-Evans-f9d51075-c77f-4c05-88b9-ed716fd3b964.yml
+++ b/data/ga/people/Becky-Evans-f9d51075-c77f-4c05-88b9-ed716fd3b964.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: becky@beckyevans.com
+- address: 404-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: becky.evans@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0109
 - address: P.O. Box 15074;Atlanta, GA 30333
   note: District Address
 links:

--- a/data/ga/people/Bert-Reeves-c73ad247-c75b-454e-a317-6c285e4b3cd5.yml
+++ b/data/ga/people/Bert-Reeves-c73ad247-c75b-454e-a317-6c285e4b3cd5.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 608-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 109 State Capitol;Atlanta, GA 30334
   email: bert.reeves@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0298
+  voice: 404-651-7737
 - address: 890 Crossfire Ridge;Marietta, GA 30064
   note: District Address
   voice: 770-427-1605

--- a/data/ga/people/Beth-Moore-d4386045-ecfa-43cf-8c52-ef8ddd74158e.yml
+++ b/data/ga/people/Beth-Moore-d4386045-ecfa-43cf-8c52-ef8ddd74158e.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 507-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: beth.moore@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0202
 - address: 107 Technology Parkway;Peachtree Corners, GA 30092
   note: District Address
   voice: 404-381-8311

--- a/data/ga/people/Betsy-Holland-c2c81ffc-f4b1-40f4-96b0-6309f89902ee.yml
+++ b/data/ga/people/Betsy-Holland-c2c81ffc-f4b1-40f4-96b0-6309f89902ee.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: betsy@betsyforgeorgia.com
+- address: 409-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: betsy.holland@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0116
 - address: 535 Pine Tree Drive NE;Atlanta, GA 30305
   note: District Address
   voice: 331-303-0507

--- a/data/ga/people/Bill-Heath-cce8b007-6fec-4947-b919-2c4d5ed77bd6.yml
+++ b/data/ga/people/Bill-Heath-cce8b007-6fec-4947-b919-2c4d5ed77bd6.yml
@@ -8,7 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: 110-C State Capitol;Atlanta, GA 30334
-  email: bill.heath@senate.ga.gov
+  email: billheath@billheath.net
   fax: 404-463-2279
   note: Capitol Address
   voice: 404-656-3943

--- a/data/ga/people/Bill-Hitchens-4a9ef816-9130-4510-a19e-3124e3f2aeed.yml
+++ b/data/ga/people/Bill-Hitchens-4a9ef816-9130-4510-a19e-3124e3f2aeed.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-D State Capitol;Atlanta, GA 30334
   email: bill.hitchens@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0152
+  voice: 404-463-7855
 - address: 2440 Rincon-Stillwell Rd.;Rincon, GA 31326
   note: District Address
 links:

--- a/data/ga/people/Bill-Werkheiser-adefd0ba-43cd-4aae-9321-12f67e57ac8a.yml
+++ b/data/ga/people/Bill-Werkheiser-adefd0ba-43cd-4aae-9321-12f67e57ac8a.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 608-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-J State Capitol;Atlanta, GA 30334
   email: bill.werkheiser@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0298
+  voice: 404-463-7857
 - address: P.O. Box 27;Glennville, GA 30427
   note: District Address
   voice: 912-237-0145

--- a/data/ga/people/Bonnie-Rich-08452f85-2530-4c39-8309-22ca020b848e.yml
+++ b/data/ga/people/Bonnie-Rich-08452f85-2530-4c39-8309-22ca020b848e.yml
@@ -7,7 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: P.O. Box 663;Suwannee, GA 30024
+- address: 601-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: bonnie.rich@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0254
+- address: P.O. Box 663;Suwanee, GA 30024
   note: District Address
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4949&Session=27

--- a/data/ga/people/Brenda-Lopez-d68d535c-67eb-4c96-a1a4-96a4d78c3709.yml
+++ b/data/ga/people/Brenda-Lopez-d68d535c-67eb-4c96-a1a4-96a4d78c3709.yml
@@ -19,7 +19,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4900&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/Lopez RomeroBrenda4900.jpg
-family_name: Lopez Romero
+family_name: Lopez
 given_name: Brenda
 extras:
   guid: 4900

--- a/data/ga/people/Brett-Harrell-347e0bf4-a87b-4474-bfd5-6e88633a6d10.yml
+++ b/data/ga/people/Brett-Harrell-347e0bf4-a87b-4474-bfd5-6e88633a6d10.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 613-D Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: brett@voteharrell.com
+- address: 133 State Capitol;Atlanta, GA 30334
+  email: brett.harrell@house.ga.gov
   note: Capitol Address
-  voice: 404-463-3793
+  voice: 404-656-5103
 - address: PO Box 1135;Snellville, GA 30078
   note: District Address
   voice: 404-966-5804

--- a/data/ga/people/Butch-Parrish-842218b5-88ae-4ba8-8395-756bf3340e16.yml
+++ b/data/ga/people/Butch-Parrish-842218b5-88ae-4ba8-8395-756bf3340e16.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 245 State Capitol;Atlanta, GA 30334
   email: butch.parrish@house.ga.gov
   note: Capitol Address
-  voice: 404-463-2247
+  voice: 404-463-2246
 - address: 132 Victory Drive;Swainsboro, GA 30401
   note: District Address
   voice: 478-237-3838

--- a/data/ga/people/CaMia-Hopson-7df3b776-3c59-4274-9459-7d3b284be2c4.yml
+++ b/data/ga/people/CaMia-Hopson-7df3b776-3c59-4274-9459-7d3b284be2c4.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: info@camiahopson.com
+- address: 607-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: camia.hopson@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0287
 - address: 1201 Rawson Dr.;Albany, GA 31701
   note: District Address
   voice: 229-513-1900

--- a/data/ga/people/Carolyn-Hugley-0f5a9273-2fc6-458f-af59-b75070a1dc76.yml
+++ b/data/ga/people/Carolyn-Hugley-0f5a9273-2fc6-458f-af59-b75070a1dc76.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 609-A Coverdell Legislative Office Building;Atlanta, GA 30334
+- address: 404-G Coverdell Legislative Office Building;Atlanta, GA 30334
   email: carolyn.hugley@house.ga.gov
   note: Capitol Address
-  voice: 404-656-5058
+  voice: 404-656-0109
 - address: PO Box 6342;Columbus, GA 319176342
   note: District Address
 links:

--- a/data/ga/people/Chris-Erwin-d79c3e9b-b73d-416b-9bfd-8a0338d8256c.yml
+++ b/data/ga/people/Chris-Erwin-d79c3e9b-b73d-416b-9bfd-8a0338d8256c.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: erwin4georgia@gmail.com
+- address: 504-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: chris.erwin@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0188
 - address: P.O. Box 501029;Atlanta, GA 31150
   note: District Address
 links:

--- a/data/ga/people/Chuck-E-Martin-42517dd7-eccb-4d22-a795-cbd010b69ee6.yml
+++ b/data/ga/people/Chuck-E-Martin-42517dd7-eccb-4d22-a795-cbd010b69ee6.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 417-B State Capitol;Atlanta, GA 30334
+- address: 417-A State Capitol;Atlanta, GA 30334
   email: chuck@martinforgeorgia.com
   note: Capitol Address
   voice: 404-656-5064

--- a/data/ga/people/Chuck-Efstration-3ff894cb-f2e4-47d0-9f67-b125245a10c3.yml
+++ b/data/ga/people/Chuck-Efstration-3ff894cb-f2e4-47d0-9f67-b125245a10c3.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 113 State Capitol;Atlanta, GA 30334
+- address: 131 State Capitol;Atlanta, GA 30334
   email: chuck.efstration@house.ga.gov
   note: Capitol Address
-  voice: 404-651-7737
+  voice: 404-656-5105
 - address: P.O. Box 1656;Dacula, GA 30019
   note: District Address
 links:

--- a/data/ga/people/Chuck-Payne--1ac93f89-f367-4de3-82ba-79fa78d4d134.yml
+++ b/data/ga/people/Chuck-Payne--1ac93f89-f367-4de3-82ba-79fa78d4d134.yml
@@ -21,8 +21,8 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4909&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/Payne Chuck 4909.jpg
-family_name: 'Payne '
-given_name: 'Chuck '
+family_name: Payne
+given_name: Chuck
 extras:
   guid: 4909
 other_identifiers:

--- a/data/ga/people/Clay-Pirkle-cdd385ef-1b37-49e6-a8d7-a2b8087bef4e.yml
+++ b/data/ga/people/Clay-Pirkle-cdd385ef-1b37-49e6-a8d7-a2b8087bef4e.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 504-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 504-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: clay.pirkle@house.ga.gov
   note: Capitol Address
   voice: 404-656-0188

--- a/data/ga/people/Colton-Moore-6ebda9ee-2203-4b66-9bb3-64d2307157a0.yml
+++ b/data/ga/people/Colton-Moore-6ebda9ee-2203-4b66-9bb3-64d2307157a0.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: colton@coltonmoore.com
+- address: 612-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: colton.moore@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0325
 - address: P.O. Box 1516;Trenton, GA 30752
   note: District Address
 links:

--- a/data/ga/people/Dale-Washburn-ec6cf250-ebcc-4dda-89a5-12da9ebbe51a.yml
+++ b/data/ga/people/Dale-Washburn-ec6cf250-ebcc-4dda-89a5-12da9ebbe51a.yml
@@ -7,6 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 401-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  note: Capitol Address
+  voice: 404-656-0152
 - address: 3040 Riverside Dr, Suite C-2;Macon, GA 31210
   note: District Address
 links:

--- a/data/ga/people/Danny-Mathis-1a9598cc-056f-4725-a3fb-64c3f0fd26ed.yml
+++ b/data/ga/people/Danny-Mathis-1a9598cc-056f-4725-a3fb-64c3f0fd26ed.yml
@@ -7,6 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 401-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  note: Capitol Address
+  voice: 404-656-0152
 - address: P.O. Box 531;Cochran, GA 31014
   note: District Address
 links:

--- a/data/ga/people/Darlene-K-Taylor-d00eb950-0fb6-41ab-ae22-8e9ce84d7cf0.yml
+++ b/data/ga/people/Darlene-K-Taylor-d00eb950-0fb6-41ab-ae22-8e9ce84d7cf0.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-J State Capitol;Atlanta, GA 30334
+- address: 401-H State Capitol;Atlanta, GA 30334
   email: darlene.taylor@house.ga.gov
   note: Capitol Address
   voice: 404-656-7857

--- a/data/ga/people/Darshun-Kendrick-1f94316e-fb58-401f-bbfc-5ada0a717b6b.yml
+++ b/data/ga/people/Darshun-Kendrick-1f94316e-fb58-401f-bbfc-5ada0a717b6b.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 409-E Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: dkendrick@kendrickforgeorgia.com
+- address: 404-F Coverdell Legislative Office Building;Atlanta, GA 30334
+  email: darshun.kendrick@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0116
+  voice: 404-656-0109
 - address: PO Box 630;Lithonia, GA 30058
   note: District Address
 links:

--- a/data/ga/people/Dave-Belton-beada68c-a23f-476c-83bf-a6c004a11e0e.yml
+++ b/data/ga/people/Dave-Belton-beada68c-a23f-476c-83bf-a6c004a11e0e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 614-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: dave.belton@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0152
+  voice: 404-656-3947
 - address: 1471 Morgan Dr.;Buckhead, GA 30625
   note: District Address
 links:

--- a/data/ga/people/David-Clark-ad18dba4-9247-4542-95b1-2ccef815dbc7.yml
+++ b/data/ga/people/David-Clark-ad18dba4-9247-4542-95b1-2ccef815dbc7.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 608-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 608-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: david.clark@house.ga.gov
   note: Capitol Address
   voice: 404-656-0298

--- a/data/ga/people/David-Knight-1871260f-8daf-43e1-a9ec-09ebcfdbb6a4.yml
+++ b/data/ga/people/David-Knight-1871260f-8daf-43e1-a9ec-09ebcfdbb6a4.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 228-A State Capitol;Atlanta, GA 30334
+- address: 245 State Capitol;Atlanta, GA 30334
   email: david.knight@house.ga.gov
   note: Capitol Address
-  voice: 404-656-5099
+  voice: 404-463-2248
 - address: 1003 East College Street;Griffin, GA 30224
   note: District Address
 links:

--- a/data/ga/people/Deborah-Silcox-b824f8fd-7343-449d-8027-fcd0afaf1949.yml
+++ b/data/ga/people/Deborah-Silcox-b824f8fd-7343-449d-8027-fcd0afaf1949.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 404-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 614-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: deborah.silcox@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0109
+  voice: 404-656-3949
 - address: '6300 Powers Ferry Rd, Ste. 600, # 177;Atlanta, GA 30339'
   note: District Address
 links:

--- a/data/ga/people/Debra-Bazemore-1bb8d14b-9d5d-4edd-8c93-37e95991a8e4.yml
+++ b/data/ga/people/Debra-Bazemore-1bb8d14b-9d5d-4edd-8c93-37e95991a8e4.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 411-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 507-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: debra.bazemore@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0126
+  voice: 404-656-0202
 - address: 7042 Galloway Pointe;Riverdale, GA 30296
   note: District Address
 links:

--- a/data/ga/people/Derrick-Jackson-9c6d1032-c14f-4b57-90df-eaa1273cc336.yml
+++ b/data/ga/people/Derrick-Jackson-9c6d1032-c14f-4b57-90df-eaa1273cc336.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 509-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 509-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: derrick.jackson@house.ga.gov
   note: Capitol Address
   voice: 404-656-0220

--- a/data/ga/people/Dominic-LaRiccia-d8a23bbd-ee89-4976-b859-421fa66d7fde.yml
+++ b/data/ga/people/Dominic-LaRiccia-d8a23bbd-ee89-4976-b859-421fa66d7fde.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 508-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 109 State Capitol;Atlanta, GA 30334
   email: dominic.lariccia@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0213
+  voice: 404-651-7737
 - address: P.O. Box 1156;Douglas, GA 31534
   note: District Address
 links:

--- a/data/ga/people/Don-Hogan-ca34bbde-7f53-44eb-abdd-c5c12aebe591.yml
+++ b/data/ga/people/Don-Hogan-ca34bbde-7f53-44eb-abdd-c5c12aebe591.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 404-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 501-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: don.hogan@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0109
+  voice: 404-656-0177
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4906&Session=27
 sources:

--- a/data/ga/people/Don-Parsons-81dde544-49e9-4fb0-9313-32eacaf6194b.yml
+++ b/data/ga/people/Don-Parsons-81dde544-49e9-4fb0-9313-32eacaf6194b.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401 State Capitol;Atlanta, GA 30334
+- address: 401-F State Capitol;Atlanta, GA 30334
   email: repdon@donparsons.org
   note: Capitol Address
-  voice: 404-656-9198
+  voice: 404-463-7853
 - address: 3167 Sycamore Lane;Marietta, GA 30066
   note: District Address
   voice: 770-977-4426

--- a/data/ga/people/Donna-McLeod-b9fdcb93-e797-4ac7-974d-d96b8e963b21.yml
+++ b/data/ga/people/Donna-McLeod-b9fdcb93-e797-4ac7-974d-d96b8e963b21.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 509-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: donna.mcleod@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0220
 - address: P.O. Box 1021;Lawrenceville, GA 30046
   note: District Address
 links:

--- a/data/ga/people/Ed-Setzler-777f58bb-9d6b-4755-ab7b-b94d11629cb5.yml
+++ b/data/ga/people/Ed-Setzler-777f58bb-9d6b-4755-ab7b-b94d11629cb5.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401 State Capitol;Atlanta, GA 30334
+- address: 401-I State Capitol;Atlanta, GA 30334
   email: ed.setzler@house.ga.gov
   note: Capitol Address
   voice: 404-656-7857

--- a/data/ga/people/Eddie-Lumsden-f33d979c-554c-433e-ad0f-837eef1da589.yml
+++ b/data/ga/people/Eddie-Lumsden-f33d979c-554c-433e-ad0f-837eef1da589.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 612-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 402 Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: eddie.lumsden@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0325
+  voice: 404-656-5087
 - address: PO Box 122;Armuchee, GA 30105
   note: District Address
 links:

--- a/data/ga/people/El-Mahdi-Holly-4615e308-db74-408f-89df-02be56b5013b.yml
+++ b/data/ga/people/El-Mahdi-Holly-4615e308-db74-408f-89df-02be56b5013b.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: EL@ELforStateRep.com
+- address: 607-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: el-mahdi.holly@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0287
 - address: 1740 Hudson Bridge Rd, Ste 1221;Stockbridge, GA 30253
   note: District Address
   voice: 770-284-8146

--- a/data/ga/people/Emory-Dunahoo-3b2b9f31-6859-4582-8d82-581597c0c178.yml
+++ b/data/ga/people/Emory-Dunahoo-3b2b9f31-6859-4582-8d82-581597c0c178.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-D Coverdell Legislative Office Building;Atlanta, GA 30334
+- address: 401-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: emory.dunahoo@house.ga.gov
   note: Capitol Address
   voice: 404-656-0152

--- a/data/ga/people/Erick-E-Allen-7e50f680-943e-4952-b92b-bb8913f81f30.yml
+++ b/data/ga/people/Erick-E-Allen-7e50f680-943e-4952-b92b-bb8913f81f30.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 404-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: erick.allen@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0109
 - address: 2690 Cobb Parkway SE, AS-578;Smyrna, GA 30080
   note: District Address
   voice: 678-310-9650

--- a/data/ga/people/Ginny-Ehrhart-be05ace3-ea73-4f3f-85ae-c5ed313d4cbe.yml
+++ b/data/ga/people/Ginny-Ehrhart-be05ace3-ea73-4f3f-85ae-c5ed313d4cbe.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 401-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: ginny.ehrhart@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0152
 - address: P.O. Box 1206;Marietta, GA 30061
   note: District Address
 links:

--- a/data/ga/people/Greg-Dolezal-1f7d013a-8861-4e08-b6bf-7c8d36f8107c.yml
+++ b/data/ga/people/Greg-Dolezal-1f7d013a-8861-4e08-b6bf-7c8d36f8107c.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 305-B Coverdell Legislative Office Building;Atlanta, GA 30334
   email: greg.dolezal@senate.ga.gov
   note: Capitol Address
+  voice: 404-656-7127
 - address: 5255 Harris Springs Dr;Cumming, GA 30040
   note: District Address
 links:

--- a/data/ga/people/Greg-Morris-8daf8850-68d4-4027-87f9-595c055ae96a.yml
+++ b/data/ga/people/Greg-Morris-8daf8850-68d4-4027-87f9-595c055ae96a.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 226 State Capitol;Atlanta, GA 30334
+- address: 226-B State Capitol;Atlanta, GA 30334
   email: greg.morris@house.ga.gov
   fax: 404-463-4122
   note: Capitol Address

--- a/data/ga/people/Gregg-Kennard-f936e87a-99f0-45a7-915b-496bc7574728.yml
+++ b/data/ga/people/Gregg-Kennard-f936e87a-99f0-45a7-915b-496bc7574728.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 507-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: gregg.kennard@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0202
 - address: P.O. Box 490723;Lawrenceville, GA 30049
   note: District Address
 links:

--- a/data/ga/people/Harold-V-Jones-II-d7bfd125-d343-4acd-a4dc-480daf241af3.yml
+++ b/data/ga/people/Harold-V-Jones-II-d7bfd125-d343-4acd-a4dc-480daf241af3.yml
@@ -21,7 +21,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=851&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/Jones IIHarold851.jpg
-family_name: Jones II
+family_name: Jones
 given_name: Harold
 extras:
   guid: 851

--- a/data/ga/people/Heath-Clark-184a243c-6357-4a30-a072-5ed3e0ea5ac0.yml
+++ b/data/ga/people/Heath-Clark-184a243c-6357-4a30-a072-5ed3e0ea5ac0.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 408-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 508-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: heath.clark@house.ga.gov
   note: Capitol Address
-  voice: 404-657-1803
+  voice: 404-656-0213
 - address: 305 Tarrasa Dr.;Warner Robins, GA 30188
   note: District Address
 links:

--- a/data/ga/people/Henry-Wayne-Howard-dcd39a01-0e57-4181-9c51-21dd56d60e9c.yml
+++ b/data/ga/people/Henry-Wayne-Howard-dcd39a01-0e57-4181-9c51-21dd56d60e9c.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 511-H Coverdell Legislative Office Building;Atlanta, GA 30334
+- address: 511-I Coverdell Legislative Office Building;Atlanta, GA 30334
   email: wayne.howard@house.ga.gov
   note: Capitol Address
   voice: 404-656-6372
@@ -21,7 +21,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=131&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/HowardWayne131.jpg
 family_name: Howard
-given_name: Henry "Wayne"
+given_name: Henry
 extras:
   guid: 131
 other_identifiers:

--- a/data/ga/people/Houston-Gaines-e73cb2a6-bf3e-4211-a386-142c18a4f607.yml
+++ b/data/ga/people/Houston-Gaines-e73cb2a6-bf3e-4211-a386-142c18a4f607.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 612-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: houston.gaines@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0325
 - address: P.O. Box 1203;Athens, GA 30603
   note: District Address
 links:

--- a/data/ga/people/J-Collins-bda95ef9-7054-4100-ab95-498abe8b892f.yml
+++ b/data/ga/people/J-Collins-bda95ef9-7054-4100-ab95-498abe8b892f.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 404-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 408-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: j.collins@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0109
+  voice: 404-656-1803
 - address: 206 South Carroll Rd.;Villa Rica, GA 30180
   note: District Address
 links:

--- a/data/ga/people/James-Beverly-5e6ceaa7-8c7a-4e9b-95fa-304041daaab0.yml
+++ b/data/ga/people/James-Beverly-5e6ceaa7-8c7a-4e9b-95fa-304041daaab0.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 509-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 509-H Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: james.beverly@house.ga.gov
   note: Capitol Address
   voice: 404-656-0220

--- a/data/ga/people/Jasmine-Clark-0461f02b-df18-4984-8b3b-ada287879d0a.yml
+++ b/data/ga/people/Jasmine-Clark-0461f02b-df18-4984-8b3b-ada287879d0a.yml
@@ -6,7 +6,11 @@ roles:
 - district: '108'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
-contact_details: []
+contact_details:
+- address: 607-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: jasmine.clark@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0287
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4953&Session=27
 sources:

--- a/data/ga/people/Jay-Powell-fa8116dd-1638-4a0c-86d2-f0d70d4a284c.yml
+++ b/data/ga/people/Jay-Powell-fa8116dd-1638-4a0c-86d2-f0d70d4a284c.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 133 State Capitol;Atlanta, GA 30334
+- address: HM-1 State Capitol;Atlanta, GA 30334
   email: jay.powell@house.ga.gov
   note: Capitol Address
-  voice: 404-656-5103
+  voice: 404-656-5141
 - address: PO Box 188;Camilla, Ga 31730
   note: District Address
   voice: 229-336-3962

--- a/data/ga/people/Jeff-Jones-7c54f126-a624-4ac2-939b-87a09f59585d.yml
+++ b/data/ga/people/Jeff-Jones-7c54f126-a624-4ac2-939b-87a09f59585d.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 501-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 501-H Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: jeff.jones@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0178
+  voice: 404-656-0177
 - address: 139-358 Altama Connector;Brunswick, GA 31525
   note: District Address
 links:

--- a/data/ga/people/Jesse-Petrea-38c596a4-df69-4a56-9329-be73f26bc7d5.yml
+++ b/data/ga/people/Jesse-Petrea-38c596a4-df69-4a56-9329-be73f26bc7d5.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 408-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 408-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: jesse.petrea@house.ga.gov
   note: Capitol Address
   voice: 404-657-1803

--- a/data/ga/people/Jimmy-Pruett-0c45cc6b-8368-4ed0-a450-840309900a7d.yml
+++ b/data/ga/people/Jimmy-Pruett-0c45cc6b-8368-4ed0-a450-840309900a7d.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-D State Capitol;Atlanta, GA 30334
+- address: 402 State Capitol;Atlanta, GA 30334
   email: jimmy.pruett@house.ga.gov
   note: Capitol Address
-  voice: 404-656-7855
+  voice: 404-656-5143
 - address: PO Box 459;Eastman, GA 31023
   fax: 478-374-5114
   note: District Address

--- a/data/ga/people/Jodi-Lott-be736ffd-fffe-4bf0-8bd4-8b2c594f8bf6.yml
+++ b/data/ga/people/Jodi-Lott-be736ffd-fffe-4bf0-8bd4-8b2c594f8bf6.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 501-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 109 State Capitol;Atlanta, GA 30334
   email: jodi.lott@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0177
+  voice: 404-651-7737
 - address: P.O. Box 86;Evans, GA 30809
   note: District Address
 links:

--- a/data/ga/people/John-Carson-713cac52-0a57-4baa-8273-6eeca5b491df.yml
+++ b/data/ga/people/John-Carson-713cac52-0a57-4baa-8273-6eeca5b491df.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-E State Capitol;Atlanta, GA 30334
   email: john.carson@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0287
+  voice: 404-463-7855
 - address: 3605 Sandy Plains Road, Suite 240-123;Marietta, GA 30066
   note: District Address
   voice: 404-520-8826

--- a/data/ga/people/John-Corbett-a34c9a5a-f307-4c07-b766-3b3b1148d7b1.yml
+++ b/data/ga/people/John-Corbett-a34c9a5a-f307-4c07-b766-3b3b1148d7b1.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 508-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 508-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: john.corbett@house.ga.gov
   note: Capitol Address
   voice: 404-656-0213

--- a/data/ga/people/Joseph-Gullett-f36d2507-b19a-4ee5-b4f9-5c06df761edf.yml
+++ b/data/ga/people/Joseph-Gullett-f36d2507-b19a-4ee5-b4f9-5c06df761edf.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 501-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: joseph.gullett@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0177
 - address: 290 Hope Drive;Dallas, GA 30157
   note: District Address
 links:

--- a/data/ga/people/Josh-Bonner-0e45048c-c1a4-415f-9ee4-5d09ea857e2e.yml
+++ b/data/ga/people/Josh-Bonner-0e45048c-c1a4-415f-9ee4-5d09ea857e2e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 507-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 601-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: josh.bonner@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0202
+  voice: 404-656-0254
 - address: P.O. Box 3457;Peachtree City, GA 30269
   note: District Address
 links:

--- a/data/ga/people/Josh-McLaurin-b83b0486-773f-4979-a1ce-e2f7f3e6d7e1.yml
+++ b/data/ga/people/Josh-McLaurin-b83b0486-773f-4979-a1ce-e2f7f3e6d7e1.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 507-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: josh.mclaurin@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0202
 - address: P.O. Box 567297;Atlanta, GA 31156
   note: District Address
 links:

--- a/data/ga/people/Karen-Mathiak-f8db50e0-08ab-406c-ac8b-39c7038ef5ca.yml
+++ b/data/ga/people/Karen-Mathiak-f8db50e0-08ab-406c-ac8b-39c7038ef5ca.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 608-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: karen.mathiak@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0287
+  voice: 404-656-0298
 - address: 127 Dunwoody Circle;Griffin, GA 30223
   note: District Address
 links:

--- a/data/ga/people/Karla-Drenner-27365f19-a138-4a9e-9f6e-11352932e5d5.yml
+++ b/data/ga/people/Karla-Drenner-27365f19-a138-4a9e-9f6e-11352932e5d5.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 507-H Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: dren16999@aol.com
+  email: karla.drenner@house.ga.gov
   fax: 404-651-8086
   note: Capitol Address
   voice: 404-656-0202

--- a/data/ga/people/Kasey-Carpenter-97a40ea4-674f-4b84-8fd3-8bc2f3b4a35d.yml
+++ b/data/ga/people/Kasey-Carpenter-97a40ea4-674f-4b84-8fd3-8bc2f3b4a35d.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 601-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 408-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: kasey.carpenter@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0254
+  voice: 404-656-1803
 - address: 1301 W. Morton Drive;Dalton, GA 30720
   note: District Address
 links:

--- a/data/ga/people/Katie-M-Dempsey-bf68b3dc-ca81-49f9-8e33-fe27317183d3.yml
+++ b/data/ga/people/Katie-M-Dempsey-bf68b3dc-ca81-49f9-8e33-fe27317183d3.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 245 State Capitol;Atlanta, GA 30334
   email: katie.dempsey@house.ga.gov
   note: Capitol Address
-  voice: 404-463-2247
+  voice: 404-463-2248
 - address: '3 Central Plaza, #360;Rome, GA 30161'
   note: District Address
 links:

--- a/data/ga/people/Kay-Kirkpatrick-fc31ab02-026c-4173-86db-570c0b297c64.yml
+++ b/data/ga/people/Kay-Kirkpatrick-fc31ab02-026c-4173-86db-570c0b297c64.yml
@@ -11,6 +11,8 @@ contact_details:
   email: kay.kirkpatrick@senate.ga.gov
   note: Capitol Address
   voice: 404-656-3932
+- note: District Address
+  voice: 404-822-4719
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4910&Session=27
 sources:

--- a/data/ga/people/Ken-Pullin-3159bddc-29e9-4beb-a88b-e1a726ba48c0.yml
+++ b/data/ga/people/Ken-Pullin-3159bddc-29e9-4beb-a88b-e1a726ba48c0.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: ken.pullin@house.ga.gov
+- address: 504-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: ken.pullin@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0188
 - address: P.O. Box 295;Zebulon, GA 30295
   note: District Address
 links:

--- a/data/ga/people/Kevin-Tanner-2e2585e3-ffcc-4666-be79-b52f3d980855.yml
+++ b/data/ga/people/Kevin-Tanner-2e2585e3-ffcc-4666-be79-b52f3d980855.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 614-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 416 State Capitol;Atlanta, GA 30334
   email: kevin.tanner@house.ga.gov
   note: Capitol Address
-  voice: 404-656-3947
+  voice: 404-656-9210
 - address: P.O. Box 1885;Dawsonville, GA 30534
   note: District Address
 links:

--- a/data/ga/people/Larry-Walker-III-44a51125-9e82-41f6-8d4f-a646895b5994.yml
+++ b/data/ga/people/Larry-Walker-III-44a51125-9e82-41f6-8d4f-a646895b5994.yml
@@ -9,18 +9,18 @@ roles:
 contact_details:
 - address: 421-B State Capitol;Atlanta, GA 30334
   email: larry.walker@senate.ga.gov
-  fax: 404-651-5795
   note: Capitol Address
-  voice: 404-656-7454
+  voice: 404-656-0095
 - address: 1110 Washington Street;Perry, GA 31069
   note: District Address
+  voice: 404-656-0095
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4878&Session=27
 sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4878&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/Walker IIILawrence4878.jpg
-family_name: Walker III
+family_name: Walker
 given_name: Larry
 extras:
   guid: 4878

--- a/data/ga/people/Lee-Hawkins-69493144-3e3e-49a8-9e1f-f9a948fd0ff3.yml
+++ b/data/ga/people/Lee-Hawkins-69493144-3e3e-49a8-9e1f-f9a948fd0ff3.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 508-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-B State Capitol;Atlanta, GA 30334
   email: lee.hawkins@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0213
+  voice: 404-656-7855
 - address: 4317 Tall Hickory Trail;Gainesville, GA 30506
   note: District Address
 links:

--- a/data/ga/people/Lynn-Smith-945875f7-f3c5-4c75-acd6-a195a0f76b12.yml
+++ b/data/ga/people/Lynn-Smith-945875f7-f3c5-4c75-acd6-a195a0f76b12.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 228 State Capitol;Atlanta, GA 30334
+- address: 228-C State Capitol;Atlanta, GA 30334
   email: lynn.smith@house.ga.gov
   note: Capitol Address
   voice: 404-656-7149

--- a/data/ga/people/Mandi-L-Ballinger-d6a8848d-a637-4c2e-ae37-84440c614400.yml
+++ b/data/ga/people/Mandi-L-Ballinger-d6a8848d-a637-4c2e-ae37-84440c614400.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 131-B State Capitol;Atlanta, GA 30334
+- address: 218-B State Capitol;Atlanta, GA 30334
   email: mandi.ballinger@house.ga.gov
   note: Capitol Address
-  voice: 404-656-5105
+  voice: 404-656-7153
 - address: P.O. Box 5123;Canton, GA 30114
   note: District Address
 links:

--- a/data/ga/people/Marc-Morris-fb3652ce-0a13-403a-adca-60ac18ca2756.yml
+++ b/data/ga/people/Marc-Morris-fb3652ce-0a13-403a-adca-60ac18ca2756.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 601-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 608-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: marc.morris@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0254
+  voice: 404-656-0298
 - address: 343-A Dahlonega St.;Cumming, GA 30040
   note: District Address
 links:

--- a/data/ga/people/Marcus-A-Wiedower-ff24cea3-8582-4cfe-b015-74ee7c5ebeef.yml
+++ b/data/ga/people/Marcus-A-Wiedower-ff24cea3-8582-4cfe-b015-74ee7c5ebeef.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 612-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: marcus.wiedower@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0325
 - address: P.O. Box 623;Watkinsville, GA 30677
   note: District Address
 links:

--- a/data/ga/people/Mark-Newton-5e12fb82-1f69-46df-9ac5-a09ce51dd95b.yml
+++ b/data/ga/people/Mark-Newton-5e12fb82-1f69-46df-9ac5-a09ce51dd95b.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 612-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 601-H Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: mark.newton@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0325
+  voice: 404-656-0254
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4902&Session=27
 sources:

--- a/data/ga/people/Martin-Momtahan-6552dd8d-1020-4bbb-abfc-88975573ebd4.yml
+++ b/data/ga/people/Martin-Momtahan-6552dd8d-1020-4bbb-abfc-88975573ebd4.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 501-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: martin.momtahan@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0177
 - address: 215 Postell Rd;Dallas, GA 30157
   note: District Address
 links:

--- a/data/ga/people/Mary-Frances-Williams-4aec761f-5117-4f43-a487-9d77418f0bfa.yml
+++ b/data/ga/people/Mary-Frances-Williams-4aec761f-5117-4f43-a487-9d77418f0bfa.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 607-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: maryfrances.williams@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0287
 - address: '1000 Whitlock Ave, Ste 320, PMB #249;Marietta, GA 30064'
   note: District Address
   voice: 770-424-9084

--- a/data/ga/people/Mary-Margaret-Margaret-Oliver-1eac4f46-2c61-4f92-a18c-70bfdeb7fec1.yml
+++ b/data/ga/people/Mary-Margaret-Margaret-Oliver-1eac4f46-2c61-4f92-a18c-70bfdeb7fec1.yml
@@ -1,5 +1,5 @@
 id: ocd-person/1eac4f46-2c61-4f92-a18c-70bfdeb7fec1
-name: Mary Margaret Margaret Oliver
+name: Mary Margaret Oliver
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Mary-Robichaux-b1b3ded9-8ddc-4160-abe1-9b22d4f23527.yml
+++ b/data/ga/people/Mary-Robichaux-b1b3ded9-8ddc-4160-abe1-9b22d4f23527.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: mary@electmaryrobichaux.com
+- address: 507-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: mary.robichaux@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0202
 - address: P.O. Box 1001;Roswell, GA 30077
   note: District Address
 links:

--- a/data/ga/people/Matt-Dollar-f1db7c7d-cf44-4a58-aaab-5c75ad4bc76e.yml
+++ b/data/ga/people/Matt-Dollar-f1db7c7d-cf44-4a58-aaab-5c75ad4bc76e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-K State Capitol;Atlanta, GA 30334
+- address: 401-G State Capitol;Atlanta, GA 30334
   email: matt.dollar@house.ga.gov
   note: Capitol Address
-  voice: 404-656-5138
+  voice: 404-463-7853
 - address: PO Box 681746;Marietta, GA 30068
   note: District Address
 links:

--- a/data/ga/people/Matt-Dubnik-99f0a2a7-8817-4756-a40e-575e259890e7.yml
+++ b/data/ga/people/Matt-Dubnik-99f0a2a7-8817-4756-a40e-575e259890e7.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 504-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 508-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: matt.dubnik@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0188
+  voice: 404-656-0213
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4886&Session=27
 sources:

--- a/data/ga/people/Matthew-Gambill-909e9026-e549-494b-be99-e8562a389e0c.yml
+++ b/data/ga/people/Matthew-Gambill-909e9026-e549-494b-be99-e8562a389e0c.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 601-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: matthew.gambill@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0254
 - address: P.O. Box 487;Cartersville, GA 30120
   note: District Address
 links:

--- a/data/ga/people/Matthew-Wilson-6b245346-1f6b-4c5e-8955-150a6b1e0a45.yml
+++ b/data/ga/people/Matthew-Wilson-6b245346-1f6b-4c5e-8955-150a6b1e0a45.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: matthew.wilson@house.ga.gov
+- address: 511-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: matthew.wilson@house.ga.gov
   note: Capitol Address
+  voice: 404-656-6372
 - address: 2719 Buford Hwy NE;Atlanta, GA 30324
   note: District Address
   voice: 678-631-8820

--- a/data/ga/people/Micah-Gravley-b2f6bc11-2b2f-4b49-9d44-d07a89432688.yml
+++ b/data/ga/people/Micah-Gravley-b2f6bc11-2b2f-4b49-9d44-d07a89432688.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 415 State Capitol;Atlanta, GA 30334
   email: micah.gravley@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0152
+  voice: 404-463-8143
 - address: 94 Bridge Place;Douglasville, GA 30134
   note: District Address
 links:

--- a/data/ga/people/Michael-Doc-Rhett-efb9168c-b45a-4f43-bba5-d6f05e7d9cbe.yml
+++ b/data/ga/people/Michael-Doc-Rhett-efb9168c-b45a-4f43-bba5-d6f05e7d9cbe.yml
@@ -20,7 +20,7 @@ sources:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=855&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/RhettMichael 'Doc'855.jpg
 family_name: Rhett
-given_name: Michael 'Doc'
+given_name: Michael
 extras:
   guid: 855
 other_identifiers:

--- a/data/ga/people/Mike-Cheokas-1831cc73-e694-4cea-83a4-b55c3495f76a.yml
+++ b/data/ga/people/Mike-Cheokas-1831cc73-e694-4cea-83a4-b55c3495f76a.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-H State Capitol;Atlanta, GA 30334
+- address: 401-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: mike.cheokas@house.ga.gov
   note: Capitol Address
-  voice: 404-656-7857
+  voice: 404-656-0152
 - address: PO Box 824;Americus, GA 31709
   fax: 229-924-7893
   note: District Address

--- a/data/ga/people/Mike-Wilensky-c81dd3da-4794-4b65-ba9d-dd311bbcda3a.yml
+++ b/data/ga/people/Mike-Wilensky-c81dd3da-4794-4b65-ba9d-dd311bbcda3a.yml
@@ -7,8 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 115 Perimeter Center Place NE, Suite 725;Dunwoody, GA 30346
-  fax: 770-407-7310
+- address: 507-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: mike.wilensky@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0202
+- address: P.O. Box 88533;Dunwoody, GA 30356
+  fax: 404-463-6381
   note: District Address
   voice: 678-791-1725
 links:

--- a/data/ga/people/Mitchell-Scoggins-7ac30a66-1649-4a8c-a72f-a4b9a7ab1534.yml
+++ b/data/ga/people/Mitchell-Scoggins-7ac30a66-1649-4a8c-a72f-a4b9a7ab1534.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 612-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: mitchell.scoggins@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0325
 - address: P.O. Box 1051;Cartersville, GA 30120
   note: District Address
 links:

--- a/data/ga/people/Nikema-Williams-dc77cfbd-4ba3-40fb-8c33-50715c502f97.yml
+++ b/data/ga/people/Nikema-Williams-dc77cfbd-4ba3-40fb-8c33-50715c502f97.yml
@@ -20,7 +20,7 @@ sources:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4919&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/WilliamsNikema 4919.jpg
 family_name: Williams
-given_name: 'Nikema '
+given_name: Nikema
 extras:
   guid: 4919
 other_identifiers:

--- a/data/ga/people/Noel-Williams-Jr-3252da04-a17e-4298-b19d-9dd2fbf29ded.yml
+++ b/data/ga/people/Noel-Williams-Jr-3252da04-a17e-4298-b19d-9dd2fbf29ded.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 601-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: noel.williams@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0254
 - address: 1308 Ogburn Rd;Cordele, GA 31015
   note: District Address
 links:
@@ -15,7 +19,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4960&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/Williams, Jr.Noel4960.jpg
-family_name: Williams, Jr.
+family_name: Williams
 given_name: Noel
 extras:
   guid: 4960

--- a/data/ga/people/P-K-Martin-IV-90751b67-4684-4528-a9a2-9d10b884ab78.yml
+++ b/data/ga/people/P-K-Martin-IV-90751b67-4684-4528-a9a2-9d10b884ab78.yml
@@ -9,9 +9,8 @@ roles:
 contact_details:
 - address: 324-B Coverdell Legislative Office Building;Atlanta, GA 30334
   email: p.k.martin@senate.ga.gov
-  fax: 404-651-5795
   note: Capitol Address
-  voice: 404-656-7454
+  voice: 404-463-6598
 - address: 455 Pine Forest Dr;Lawrenceville, GA 30046
   note: District Address
   voice: 770-378-2102
@@ -21,7 +20,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=854&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/Martin IVP. K.854.jpg
-family_name: Martin IV
+family_name: Martin
 given_name: P. K.
 extras:
   guid: 854

--- a/data/ga/people/Patty-Bentley-af51c2db-8871-45a4-803d-314fa2b9d18d.yml
+++ b/data/ga/people/Patty-Bentley-af51c2db-8871-45a4-803d-314fa2b9d18d.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 607-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: patty.bentley@house.ga.gov
   note: Capitol Address
   voice: 404-656-0287

--- a/data/ga/people/Pedro-Pete-Marin-90ad4502-efa3-4e77-9aed-4ec3667f4352.yml
+++ b/data/ga/people/Pedro-Pete-Marin-90ad4502-efa3-4e77-9aed-4ec3667f4352.yml
@@ -21,7 +21,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=163&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/MarinPedro163.jpg
 family_name: Marin
-given_name: Pedro "Pete"
+given_name: Pedro
 extras:
   guid: 163
 other_identifiers:

--- a/data/ga/people/Penny-Houston-baf8f67a-639f-4f5e-8f6e-a20c7bfdeac8.yml
+++ b/data/ga/people/Penny-Houston-baf8f67a-639f-4f5e-8f6e-a20c7bfdeac8.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 245 State Capitol;Atlanta, GA 30334
   email: penny.houston@house.ga.gov
   note: Capitol Address
-  voice: 404-463-2247
+  voice: 404-463-2248
 - address: 8395 Highway 129;Nashville, GA 31639
   note: District Address
 links:

--- a/data/ga/people/Randy-Robertson-6da7fe11-4436-4854-8e1b-4c45dc4cdaac.yml
+++ b/data/ga/people/Randy-Robertson-6da7fe11-4436-4854-8e1b-4c45dc4cdaac.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 305-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: randy.robertson@senate.ga.gov
   note: Capitol Address
+  voice: 404-463-3931
 - address: P.O. Box 62;Cataula, GA 31804
   note: District Address
 links:

--- a/data/ga/people/Richard-H-Smith-fa84bdc1-e9c1-4794-b6ad-b8e0564efd9d.yml
+++ b/data/ga/people/Richard-H-Smith-fa84bdc1-e9c1-4794-b6ad-b8e0564efd9d.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 220 State Capitol;Atlanta, GA 30334
+- address: 220-A State Capitol;Atlanta, GA 30334
   email: richard.smith@house.ga.gov
   fax: 404-463-4221
   note: Capitol Address

--- a/data/ga/people/Rick-Jasperse-4d1f5379-01e9-4f58-9868-42acc07ec7a8.yml
+++ b/data/ga/people/Rick-Jasperse-4d1f5379-01e9-4f58-9868-42acc07ec7a8.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-H State Capitol;Atlanta, GA 30334
+- address: 218-A State Capitol;Atlanta, GA 30334
   email: rick.jasperse@house.ga.gov
   note: Capitol Address
-  voice: 404-656-7857
+  voice: 404-656-5943
 - address: 89 Apple Valley Farm Lane;Jasper, GA 30143
   note: District Address
 links:

--- a/data/ga/people/Rick-Williams-c7860bae-9d9c-449c-9903-20230eec50ac.yml
+++ b/data/ga/people/Rick-Williams-c7860bae-9d9c-449c-9903-20230eec50ac.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 601-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: rick.williams@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0287
+  voice: 404-656-0254
 - address: 1670 N. Jefferson Street;Milledgeville, GA 31061
   note: District Address
 links:

--- a/data/ga/people/Sally-Harrell-218a4fc4-a568-4b78-b350-0d60c6b12d4c.yml
+++ b/data/ga/people/Sally-Harrell-218a4fc4-a568-4b78-b350-0d60c6b12d4c.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 319-B Coverdell Legislative Office Building;Atlanta, GA 30334
   email: sally.harrell@senate.ga.gov
   note: Capitol Address
+  voice: 404-463-2260
 - address: P.O. Box 941365;Atlanta, GA 31141
   note: District Address
 links:

--- a/data/ga/people/Sam-Watson-cbcdfca3-e47d-4b32-9164-ec0709a134bf.yml
+++ b/data/ga/people/Sam-Watson-cbcdfca3-e47d-4b32-9164-ec0709a134bf.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 508-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 245 State Capitol;Atlanta, GA 30334
   email: sam.watson@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0213
+  voice: 404-463-2246
 - address: P.O. Box 3914;Moultrie, GA 31776
   note: District Address
 links:

--- a/data/ga/people/Sharon-Beasley-Teague-32f44be5-9a18-4b88-83f0-75cfff44ef42.yml
+++ b/data/ga/people/Sharon-Beasley-Teague-32f44be5-9a18-4b88-83f0-75cfff44ef42.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 509-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: sharon.beasley-teague@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0221
+  voice: 404-656-0220
 - address: PO Box 488;Red Oak, GA 30272
   note: District Address
 links:

--- a/data/ga/people/Shaw-Blackmon-ee145624-3295-4db4-b3ce-9d1583e4ef6e.yml
+++ b/data/ga/people/Shaw-Blackmon-ee145624-3295-4db4-b3ce-9d1583e4ef6e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 501-E Coverdell Legislative Office Bldg;Atlanta, GA 30334
+- address: 401-K State Capitol;Atlanta, GA 30334
   email: shaw.blackmon@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0177
+  voice: 404-463-7853
 - address: P. O. Box 729;Bonaire, GA 31005
   note: District Address
 links:

--- a/data/ga/people/Sheikh-Rahman-5b6e0e37-802b-4103-b401-551532aba2e7.yml
+++ b/data/ga/people/Sheikh-Rahman-5b6e0e37-802b-4103-b401-551532aba2e7.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 323-B Coverdell Legislative Office Building;Atlanta, GA 30334
   email: sheikh.rahman@senate.ga.gov
   note: Capitol Address
+  voice: 404-463-1318
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4924&Session=27
 sources:

--- a/data/ga/people/Shelly-Hutchinson-4161e949-6ea2-4df9-8248-cabcf40286ae.yml
+++ b/data/ga/people/Shelly-Hutchinson-4161e949-6ea2-4df9-8248-cabcf40286ae.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: shelly@shellyforgeorgia.com
+- address: 607-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: shelly.hutchinson@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0287
 - address: 2483 Heritage Village, Ste 16166;Snellville, GA 30078
   note: District Address
   voice: 470-440-1795

--- a/data/ga/people/Sheri-Gilligan-11b76460-b10e-4182-a052-0b2db5b60fce.yml
+++ b/data/ga/people/Sheri-Gilligan-11b76460-b10e-4182-a052-0b2db5b60fce.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 612-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 612-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: sheri.gilligan@house.ga.gov
   note: Capitol Address
   voice: 404-656-0325

--- a/data/ga/people/Steve-Tarvin-80f4bbdf-02f3-4233-8456-e550e7e745af.yml
+++ b/data/ga/people/Steve-Tarvin-80f4bbdf-02f3-4233-8456-e550e7e745af.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 601-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 613-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: steve.tarvin@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0254
+  voice: 404-463-3793
 - address: P.O. Box 750;Chickamauga, GA 30707
   note: District Address
   voice: 423-605-7328

--- a/data/ga/people/Steven-Meeks-3194a8e0-aaf8-4686-b2c9-a22521f85fff.yml
+++ b/data/ga/people/Steven-Meeks-3194a8e0-aaf8-4686-b2c9-a22521f85fff.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: meekss@me.com
+- address: 501-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: meekss@me.com
   note: Capitol Address
+  voice: 404-656-0177
 - address: P.O. Box 178;Screven, GA 31560
   note: District Address
 links:

--- a/data/ga/people/Steven-Sainz-99082062-acd6-4c6b-bb45-2cfa071f19fc.yml
+++ b/data/ga/people/Steven-Sainz-99082062-acd6-4c6b-bb45-2cfa071f19fc.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 501-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: steven.sainz@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0177
 - address: 203 E 5th St;Woodbine, GA 31569
   note: District Address
 links:

--- a/data/ga/people/Susan-Holmes-aaa374c2-a584-4e78-b2f3-f899efb2d568.yml
+++ b/data/ga/people/Susan-Holmes-aaa374c2-a584-4e78-b2f3-f899efb2d568.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 501-F Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: sdholmes@bellsouth.net
+- address: 218-C State Capitol;Atlanta, GA 30334
+  email: susan.holmes@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0178
+  voice: 404-656-5132
 - address: PO Box 151;Monticello, GA 31064
   note: District Address
 links:

--- a/data/ga/people/Teri-Anulewicz-06eaa836-9c03-4dc0-800d-e08f57333d19.yml
+++ b/data/ga/people/Teri-Anulewicz-06eaa836-9c03-4dc0-800d-e08f57333d19.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 409-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: teri.anulewicz@house.ga.gov
   note: Capitol Address
   voice: 404-656-0116
 - address: P.O. Box 1385;Smyrna, GA 30081

--- a/data/ga/people/Terry-Rogers-481b74d1-e0d8-4282-b768-98b660bb13c1.yml
+++ b/data/ga/people/Terry-Rogers-481b74d1-e0d8-4282-b768-98b660bb13c1.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 113 State Capitol;Atlanta, GA 30334
+- address: 109 State Capitol;Atlanta, GA 30334
   email: terry.rogers@house.ga.gov
   note: Capitol Address
   voice: 404-651-7737

--- a/data/ga/people/Todd-Jones-45567c87-3ba6-49ec-9ea2-5ebb880aa94c.yml
+++ b/data/ga/people/Todd-Jones-45567c87-3ba6-49ec-9ea2-5ebb880aa94c.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 508-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: todd.jones@house.ga.gov
   note: Capitol Address
-  voice: 404-656-0287
+  voice: 404-656-0213
 - address: 2435 Concord Creek Trail;Cumming, GA 30041
   note: District Address
 links:

--- a/data/ga/people/Tom-McCall-2669fed9-8f5d-4dba-822f-eac73162c9b9.yml
+++ b/data/ga/people/Tom-McCall-2669fed9-8f5d-4dba-822f-eac73162c9b9.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 228 State Capitol;Atlanta, GA 30334
+- address: 228-B State Capitol;Atlanta, GA 30334
   email: tom.mccall@house.ga.gov
   fax: 404-656-6897
   note: Capitol Address

--- a/data/ga/people/Trey-Rhodes-9dfc8ec3-0935-4d1d-877d-e05cf7a5dca5.yml
+++ b/data/ga/people/Trey-Rhodes-9dfc8ec3-0935-4d1d-877d-e05cf7a5dca5.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 113 State Capitol;Atlanta, GA 30334
+- address: 228-A State Capitol;Atlanta, GA 30334
   email: trey.rhodes@house.ga.gov
   note: Capitol Address
-  voice: 404-651-7737
+  voice: 404-656-5099
 - address: 1051 Ben Hammond Drive;Greensboro, GA 30642
   note: District Address
 links:

--- a/data/ga/people/Vance-Smith-9deeb60b-4d1e-42b8-8052-d2808a30ea9a.yml
+++ b/data/ga/people/Vance-Smith-9deeb60b-4d1e-42b8-8052-d2808a30ea9a.yml
@@ -7,8 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- email: vancecsmithjr@gmail.com
+- address: 601-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: vance.smith@house.ga.gov
   note: Capitol Address
+  voice: 404-656-0254
 - address: P.O. Box 171;Pine Mountain, GA 31822
   note: District Address
 links:

--- a/data/ga/people/Vernon-Jones-e50e3f0d-4388-44c7-9d40-a726b43130d1.yml
+++ b/data/ga/people/Vernon-Jones-e50e3f0d-4388-44c7-9d40-a726b43130d1.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 607-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 607-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: vernon.jones@house.ga.gov
   note: Capitol Address
   voice: 404-656-0287

--- a/data/ga/people/Viola-Davis-e3b1be9c-b244-4466-9192-adc365a31cfb.yml
+++ b/data/ga/people/Viola-Davis-e3b1be9c-b244-4466-9192-adc365a31cfb.yml
@@ -7,6 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
+- address: 404-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: viola.davis@house.ga.gov
+  note: Capitol Address
+  voice: 404-656-0109
 - address: P.O. Box 831592;Stone Mountain, GA 30083
   note: District Address
 links:

--- a/data/ga/people/Wes-Cantrell-8a651023-0e57-41c8-b5fb-aeaa48ec152f.yml
+++ b/data/ga/people/Wes-Cantrell-8a651023-0e57-41c8-b5fb-aeaa48ec152f.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-H Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: wes.cantrell@house.ga.gov
   note: Capitol Address
   voice: 404-656-0152

--- a/data/ga/people/William-Boddie-91d76496-2642-49d5-ac8f-1fd3cf187d9f.yml
+++ b/data/ga/people/William-Boddie-91d76496-2642-49d5-ac8f-1fd3cf187d9f.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 404-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 609 Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: william.boddie@house.ga.gov
   note: Capitol Address
   voice: 404-656-0109

--- a/data/ga/people/William-T-Ligon-Jr-cb9e65cd-936b-4eef-b504-4e80c4512fec.yml
+++ b/data/ga/people/William-T-Ligon-Jr-cb9e65cd-936b-4eef-b504-4e80c4512fec.yml
@@ -21,7 +21,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=746&Session=27
 image: http://www.senate.ga.gov/SiteCollectionImages/Ligon, Jr.William746.jpg
-family_name: Ligon, Jr.
+family_name: Ligon
 given_name: William
 extras:
   guid: 746

--- a/data/ga/people/Winfred-J-Dukes-15e1c977-35f5-4e57-a3bd-b904fba74def.yml
+++ b/data/ga/people/Winfred-J-Dukes-15e1c977-35f5-4e57-a3bd-b904fba74def.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 411-H Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: wdukes_2000@yahoo.com
+  email: winfred.dukes@house.ga.gov
   note: Capitol Address
   voice: 404-656-0126
 - address: 407 S. Slappey Blvd.;Albany, GA 31701

--- a/data/ga/people/Zahra-Karinshak-932f345f-19a2-4c24-9c77-b81ef894084b.yml
+++ b/data/ga/people/Zahra-Karinshak-932f345f-19a2-4c24-9c77-b81ef894084b.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 314-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: zahra.karinshak@senate.ga.gov
   note: Capitol Address
+  voice: 404-656-0048
 - address: P.O. Box 956034;Duluth, GA 30095
   note: District Address
 links:

--- a/data/ga/retired/Jason-Shaw-1ae9453d-dbed-48a1-a848-875745f8991a.yml
+++ b/data/ga/retired/Jason-Shaw-1ae9453d-dbed-48a1-a848-875745f8991a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '176'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
+  end_date: '2019-01-03'
 contact_details:
 - address: 218-B State Capitol;Atlanta, GA 30334
   email: jason.shaw@house.ga.gov

--- a/settings.yml
+++ b/settings.yml
@@ -86,6 +86,9 @@ ga:
     - chamber: lower
       district: 5
       vacant_until: 2021-02-01
+    - chamber: lower
+      district: 176
+      vacant_until: 2019-03-15
 hi:
   legislature_name: Hawaii State Legislature
   lower_seats: 51


### PR DESCRIPTION
Some changes here since scraping, so update with the latest information. Also mark Jason Shaw as retired, the special election will be held in February to replace him.