### PR TITLE
Fix jurisdiction names with capital letters

### DIFF
--- a/data/pr/people/Reinaldo-Vargas-Rodrguez-995de1a6-47d2-44f1-b6f9-a805c43f69b9.yml
+++ b/data/pr/people/Reinaldo-Vargas-Rodrguez-995de1a6-47d2-44f1-b6f9-a805c43f69b9.yml
@@ -7,7 +7,7 @@ party:
 - name: Partido Nuevo Progresista
 roles:
 - district: '35'
-  jurisdiction: ocd-jurisdiction/country:us/state:PR/government
+  jurisdiction: ocd-jurisdiction/country:us/state:pr/government
   start_date: '2018-08-21'
   type: lower
 links:

--- a/data/pr/people/Wilson-Romn-Lpez-a8c74dd2-a9e8-44f3-9398-4b8b08f2f064.yml
+++ b/data/pr/people/Wilson-Romn-Lpez-a8c74dd2-a9e8-44f3-9398-4b8b08f2f064.yml
@@ -7,7 +7,7 @@ party:
 - name: Partido Nuevo Progresista
 roles:
 - district: '17'
-  jurisdiction: ocd-jurisdiction/country:us/state:PR/government
+  jurisdiction: ocd-jurisdiction/country:us/state:pr/government
   start_date: '2018-10-31'
   type: lower
 links:

--- a/data/vt/people/Harold-Colston-7fae5f96-31f0-4dba-af52-f14537de5263.yml
+++ b/data/vt/people/Harold-Colston-7fae5f96-31f0-4dba-af52-f14537de5263.yml
@@ -7,7 +7,7 @@ party:
 - name: Democratic
 roles:
 - district: Chittenden-6-7
-  jurisdiction: ocd-jurisdiction/country:us/state:VT/government
+  jurisdiction: ocd-jurisdiction/country:us/state:vt/government
   start_date: '2019-01-23'
   type: lower
 contact_details:

--- a/data/wa/people/Liz-Lovelett-f82a6162-120e-4bf2-90c4-02e22278d96e.yml
+++ b/data/wa/people/Liz-Lovelett-f82a6162-120e-4bf2-90c4-02e22278d96e.yml
@@ -6,6 +6,6 @@ party:
 - name: Democratic
 roles:
 - district: '40'
-  jurisdiction: ocd-jurisdiction/country:us/state:WA/government
+  jurisdiction: ocd-jurisdiction/country:us/state:wa/government
   start_date: '2019-02-05'
   type: upper


### PR DESCRIPTION
Some jurisidiction names ended up with capital letters, which doesn't match their official names. Fix these by changing the state names to lower case.