### PR TITLE
KY: people updates from new website

### DIFF
--- a/data/ky/organizations/Committee-On-Committees-b7c58d6c-ab92-4df7-833c-c1675f08eaf5.yml
+++ b/data/ky/organizations/Committee-On-Committees-b7c58d6c-ab92-4df7-833c-c1675f08eaf5.yml
@@ -15,6 +15,7 @@ memberships:
   name: Jimmy Higdon
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/f8c1bb0f-3e7e-4aa6-a2c2-d891d903fc71
   name: Dennis Parrett
 - id: ocd-person/0ba38857-4bea-4471-8462-2db7677012b9

--- a/data/ky/organizations/Judiciary-76c0668b-de85-4ae6-8854-95af2cfe0aaa.yml
+++ b/data/ky/organizations/Judiciary-76c0668b-de85-4ae6-8854-95af2cfe0aaa.yml
@@ -23,6 +23,7 @@ memberships:
   name: Perry B. Clark
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/ab143215-1511-4d9b-bdd8-dfb298768770
   name: Alice Forgy Kerr
 - id: ocd-person/1bca305e-0f8d-4ce6-849a-322f7dbecb4b

--- a/data/ky/organizations/Justice-And-Judiciary-f1302b17-f8ec-4f36-b0fc-16e30e3ecbd8.yml
+++ b/data/ky/organizations/Justice-And-Judiciary-f1302b17-f8ec-4f36-b0fc-16e30e3ecbd8.yml
@@ -17,6 +17,7 @@ memberships:
   name: Christian McDaniel
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/1bca305e-0f8d-4ce6-849a-322f7dbecb4b
   name: John Schickel
 - id: ocd-person/42990da5-7020-4327-bbd8-496955b00040

--- a/data/ky/organizations/Legislative-Research-Commission-32983c75-cce1-4cf2-b8ca-5d3b7784f90c.yml
+++ b/data/ky/organizations/Legislative-Research-Commission-32983c75-cce1-4cf2-b8ca-5d3b7784f90c.yml
@@ -15,6 +15,7 @@ memberships:
   name: Jimmy Higdon
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/f8c1bb0f-3e7e-4aa6-a2c2-d891d903fc71
   name: Dennis Parrett
 - id: ocd-person/0ba38857-4bea-4471-8462-2db7677012b9

--- a/data/ky/organizations/Licensing-Occupations--Administrative-Regulations-294cc86c-b945-4e2b-bf46-b485959c68bb.yml
+++ b/data/ky/organizations/Licensing-Occupations--Administrative-Regulations-294cc86c-b945-4e2b-bf46-b485959c68bb.yml
@@ -27,6 +27,7 @@ memberships:
   name: Jimmy Higdon
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/b32a95c9-42ba-449b-8581-97b9cef73c6a
   name: Christian McDaniel
 - id: ocd-person/09938275-7282-4f47-b4f5-a555eb809004

--- a/data/ky/organizations/Natural-Resources--Energy-85b14f4d-99a1-4126-8507-b4fafa7c3449.yml
+++ b/data/ky/organizations/Natural-Resources--Energy-85b14f4d-99a1-4126-8507-b4fafa7c3449.yml
@@ -22,6 +22,7 @@ memberships:
   name: Paul Hornback
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/b32a95c9-42ba-449b-8581-97b9cef73c6a
   name: Christian McDaniel
 - id: ocd-person/1bca305e-0f8d-4ce6-849a-322f7dbecb4b

--- a/data/ky/organizations/Rules-81aff290-2637-4f3c-972e-ae45466ce579.yml
+++ b/data/ky/organizations/Rules-81aff290-2637-4f3c-972e-ae45466ce579.yml
@@ -15,6 +15,7 @@ memberships:
   name: Jimmy Higdon
 - id: ocd-person/a6366782-145a-433a-ac96-d20ed09c0050
   name: Ray S. Jones II
+  end_date: '2018-12-31'
 - id: ocd-person/f8c1bb0f-3e7e-4aa6-a2c2-d891d903fc71
   name: Dennis Parrett
 - id: ocd-person/0ba38857-4bea-4471-8462-2db7677012b9

--- a/data/ky/people/Adam-Bowling-e7f7a316-4eb0-4be9-adf9-e7067b20dcfc.yml
+++ b/data/ky/people/Adam-Bowling-e7f7a316-4eb0-4be9-adf9-e7067b20dcfc.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 416B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 416B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 664
+  email: adam.bowling@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H087.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=87
 sources:
-- url: http://www.lrc.ky.gov/legislator/H087.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House87.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=87
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house87.jpg

--- a/data/ky/people/Adam-Koenig-3414197e-5823-4606-8bda-85a7d2b30895.yml
+++ b/data/ky/people/Adam-Koenig-3414197e-5823-4606-8bda-85a7d2b30895.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 367A;Frankfort, KY 40601
   email: Adam.Koenig@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 689
 links:
-- url: http://www.lrc.ky.gov/legislator/H069.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=69
 sources:
-- url: http://www.lrc.ky.gov/legislator/H069.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House69.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=69
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house69.jpg
 other_identifiers:
 - identifier: KYL000089
   scheme: legacy_openstates

--- a/data/ky/people/Al-Gentry-dfaa3769-decc-4c1c-9c0b-7195153ab6c8.yml
+++ b/data/ky/people/Al-Gentry-dfaa3769-decc-4c1c-9c0b-7195153ab6c8.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432D;Frankfort, KY 40601
   email: Al.Gentry@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 699
 links:
-- url: http://www.lrc.ky.gov/legislator/H046.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=46
 sources:
-- url: http://www.lrc.ky.gov/legislator/H046.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House46.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=46
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house46.jpg
 other_identifiers:
 - identifier: KYL000249
   scheme: legacy_openstates

--- a/data/ky/people/Albert-Robinson-20725674-e107-443e-801f-858e40407e85.yml
+++ b/data/ky/people/Albert-Robinson-20725674-e107-443e-801f-858e40407e85.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 228;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 228;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 604
+  email: Albert.Robinson@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S021.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=121
 sources:
-- url: http://www.lrc.ky.gov/legislator/S021.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate21.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=121
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate121.jpg
 other_identifiers:
 - identifier: KYL000151
   scheme: legacy_openstates

--- a/data/ky/people/Alice-Forgy-Kerr-ab143215-1511-4d9b-bdd8-dfb298768770.yml
+++ b/data/ky/people/Alice-Forgy-Kerr-ab143215-1511-4d9b-bdd8-dfb298768770.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 203;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 203;Frankfort, KY 40601
   email: Alice.Kerr@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 625
 links:
-- url: http://www.lrc.ky.gov/legislator/S012.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=112
 sources:
-- url: http://www.lrc.ky.gov/legislator/S012.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate12.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=112
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate112.jpg
 other_identifiers:
 - identifier: KYL000016
   scheme: legacy_openstates

--- a/data/ky/people/Angie-Hatton-7fd1a63f-0224-4f73-93da-c13fb4121712.yml
+++ b/data/ky/people/Angie-Hatton-7fd1a63f-0224-4f73-93da-c13fb4121712.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429I;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429I;Frankfort, KY 40601
   email: Angie.Hatton@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 669
 links:
-- url: http://www.lrc.ky.gov/legislator/H094.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=94
 sources:
-- url: http://www.lrc.ky.gov/legislator/H094.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House94.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=94
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house94.jpg
 other_identifiers:
 - identifier: KYL000255
   scheme: legacy_openstates

--- a/data/ky/people/Ashley-Tackett-Laferty-6bc2a8c3-3370-4586-b0b7-a5028f336d12.yml
+++ b/data/ky/people/Ashley-Tackett-Laferty-6bc2a8c3-3370-4586-b0b7-a5028f336d12.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432F;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432F;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 636
+  email: ashley.tackettlaferty@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H095.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=95
 sources:
-- url: http://www.lrc.ky.gov/legislator/H095.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House95.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=95
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house95.jpg

--- a/data/ky/people/Attica-Scott-81cbf001-e7a3-4b42-a581-e4d8f3c2b524.yml
+++ b/data/ky/people/Attica-Scott-81cbf001-e7a3-4b42-a581-e4d8f3c2b524.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 606
+  email: Attica.Scott@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H041.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=41
 sources:
-- url: http://www.lrc.ky.gov/legislator/H041.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House41.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=41
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house41.jpg
 other_identifiers:
 - identifier: KYL000260
   scheme: legacy_openstates

--- a/data/ky/people/Bart-Rowland-610ebbad-7dee-4081-948f-775d82ce129b.yml
+++ b/data/ky/people/Bart-Rowland-610ebbad-7dee-4081-948f-775d82ce129b.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 416D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 416D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 613
+  email: bart.rowland@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H021.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=21
 sources:
-- url: http://www.lrc.ky.gov/legislator/H021.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House21.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=21
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house21.jpg
 other_identifiers:
 - identifier: KYL000143
   scheme: legacy_openstates

--- a/data/ky/people/Bobby-McCool-22e056d2-728a-425a-a0a1-19e0e5cc59cb.yml
+++ b/data/ky/people/Bobby-McCool-22e056d2-728a-425a-a0a1-19e0e5cc59cb.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 413C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 621
+  email: bobby.mccool@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H097.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=97
 sources:
-- url: http://www.lrc.ky.gov/legislator/H097.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House97.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=97
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house97.jpg

--- a/data/ky/people/Brandon-Reed-814b090c-4339-41fa-a869-975391d3bc82.yml
+++ b/data/ky/people/Brandon-Reed-814b090c-4339-41fa-a869-975391d3bc82.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 402;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 402;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 684
+  email: Brandon.Reed@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H024.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=24
 sources:
-- url: http://www.lrc.ky.gov/legislator/H024.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House24.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=24
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house24.jpg
 other_identifiers:
 - identifier: KYL000242
   scheme: legacy_openstates

--- a/data/ky/people/Brandon-Smith-209d5334-d4a2-45f3-b910-0cd52f96dd4e.yml
+++ b/data/ky/people/Brandon-Smith-209d5334-d4a2-45f3-b910-0cd52f96dd4e.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 252;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 252;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 646
+  email: Brandon.Smith@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S030.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=130
 sources:
-- url: http://www.lrc.ky.gov/legislator/S030.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate30.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=130
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate130.jpg
 other_identifiers:
 - identifier: KYL000028
   scheme: legacy_openstates

--- a/data/ky/people/Buddy-Wheatley-e89428e8-7f31-45aa-997c-ebcf44937ef2.yml
+++ b/data/ky/people/Buddy-Wheatley-e89428e8-7f31-45aa-997c-ebcf44937ef2.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 462A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 462A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 722
+  email: buddy.wheatley@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H065.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=65
 sources:
-- url: http://www.lrc.ky.gov/legislator/H065.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House65.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=65
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house65.jpg

--- a/data/ky/people/C-Ed-Massey-f34e6e8e-965b-4a71-bf36-115ba55a66e0.yml
+++ b/data/ky/people/C-Ed-Massey-f34e6e8e-965b-4a71-bf36-115ba55a66e0.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329I;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329I;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 632
+  email: ed.massey@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H066.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=66
 sources:
-- url: http://www.lrc.ky.gov/legislator/H066.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House66.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=66
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house66.jpg

--- a/data/ky/people/CB-Embry-Jr-3c502d9b-b08c-4a40-97e2-bda82c95e9c0.yml
+++ b/data/ky/people/CB-Embry-Jr-3c502d9b-b08c-4a40-97e2-bda82c95e9c0.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 252;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 252;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 710
+  email: cb.embry@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S006.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=106
 sources:
-- url: http://www.lrc.ky.gov/legislator/S006.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate06.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=106
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate106.jpg
 other_identifiers:
 - identifier: KYL000065
   scheme: legacy_openstates

--- a/data/ky/people/Chad-McCoy-b85d962e-d083-4352-8900-ac4e0ae87c0f.yml
+++ b/data/ky/people/Chad-McCoy-b85d962e-d083-4352-8900-ac4e0ae87c0f.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 416B;Frankfort KY 40601
-  email: Chad.McCoy@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 370;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 316;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 370;Frankfort, KY 40601
   email: Chad.McCoy@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-2217
 links:
-- url: http://www.lrc.ky.gov/legislator/H050.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=50
 sources:
-- url: http://www.lrc.ky.gov/legislator/H050.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House50.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=50
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house50.jpg
 other_identifiers:
 - identifier: KYL000237
   scheme: legacy_openstates

--- a/data/ky/people/Charles-Booker-b8e08787-d029-4f89-a7fb-febf83bac991.yml
+++ b/data/ky/people/Charles-Booker-b8e08787-d029-4f89-a7fb-febf83bac991.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 703
+  email: charles.booker@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H043.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=43
 sources:
-- url: http://www.lrc.ky.gov/legislator/H043.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House43.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=43
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house43.jpg

--- a/data/ky/people/Charles-Miller-45d2e575-8fdd-4b9b-b535-f0cbc5114cdd.yml
+++ b/data/ky/people/Charles-Miller-45d2e575-8fdd-4b9b-b535-f0cbc5114cdd.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 457D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 457D;Frankfort, KY 40601
   email: Charlie.Miller@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 631
 links:
-- url: http://www.lrc.ky.gov/legislator/H028.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=28
 sources:
-- url: http://www.lrc.ky.gov/legislator/H028.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House28.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=28
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house28.jpg
 other_identifiers:
 - identifier: KYL000097
   scheme: legacy_openstates

--- a/data/ky/people/Cherlynn-Stevenson-21df94f4-75d3-45c3-a9bf-224a8278675b.yml
+++ b/data/ky/people/Cherlynn-Stevenson-21df94f4-75d3-45c3-a9bf-224a8278675b.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424G;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 707
+  email: cherlynn.stevenson@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H088.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=88
 sources:
-- url: http://www.lrc.ky.gov/legislator/H088.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House88.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=88
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house88.jpg

--- a/data/ky/people/Chris-Freeland-db36edd8-6c2f-4441-aa30-5b4dc48b3357.yml
+++ b/data/ky/people/Chris-Freeland-db36edd8-6c2f-4441-aa30-5b4dc48b3357.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 413E;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 611
+  email: chris.freeland@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H006.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=6
 sources:
-- url: http://www.lrc.ky.gov/legislator/H006.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House06.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=6
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house6.jpg

--- a/data/ky/people/Chris-Fugate-6843e90b-a30a-4dbf-885c-7321ccc8f73f.yml
+++ b/data/ky/people/Chris-Fugate-6843e90b-a30a-4dbf-885c-7321ccc8f73f.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 324A;Frankfort, KY 40601
   email: Chris.Fugate@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 697
 links:
-- url: http://www.lrc.ky.gov/legislator/H084.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=84
 sources:
-- url: http://www.lrc.ky.gov/legislator/H084.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House84.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=84
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house84.jpg
 other_identifiers:
 - identifier: KYL000245
   scheme: legacy_openstates

--- a/data/ky/people/Chris-Harris-8c9366c3-0ef4-48c4-9292-490a216a1815.yml
+++ b/data/ky/people/Chris-Harris-8c9366c3-0ef4-48c4-9292-490a216a1815.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 457C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 457C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 635
+  email: chris.harris@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H093.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=93
 sources:
-- url: http://www.lrc.ky.gov/legislator/H093.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House93.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=93
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house93.jpg
 other_identifiers:
 - identifier: KYL000226
   scheme: legacy_openstates

--- a/data/ky/people/Christian-McDaniel-b32a95c9-42ba-449b-8581-97b9cef73c6a.yml
+++ b/data/ky/people/Christian-McDaniel-b32a95c9-42ba-449b-8581-97b9cef73c6a.yml
@@ -7,17 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 204;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 204;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 228;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 615
+  email: Chris.McDaniel@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S023.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=123
 sources:
-- url: http://www.lrc.ky.gov/legislator/S023.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate23.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=123
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate123.jpg
 other_identifiers:
 - identifier: KYL000149
   scheme: legacy_openstates

--- a/data/ky/people/Cluster-Howard-36b01740-6f38-4f87-b007-763e45ef1eb1.yml
+++ b/data/ky/people/Cluster-Howard-36b01740-6f38-4f87-b007-763e45ef1eb1.yml
@@ -7,12 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 467;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 467;Frankfort, KY 40601
   email: cluster.howard@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 794
 links:
-- url: http://www.lrc.ky.gov/legislator/H091.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=91
 sources:
-- url: http://www.lrc.ky.gov/legislator/H091.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House91.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=91
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house91.jpg

--- a/data/ky/people/Damon-Thayer-bb250cb3-f9ac-4d33-bdde-36c4e3bca9d4.yml
+++ b/data/ky/people/Damon-Thayer-bb250cb3-f9ac-4d33-bdde-36c4e3bca9d4.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 242;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 242;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2450
+  email: Damon.Thayer@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S017.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=117
 sources:
-- url: http://www.lrc.ky.gov/legislator/S017.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate17.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=117
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate117.jpg
 other_identifiers:
 - identifier: KYL000032
   scheme: legacy_openstates

--- a/data/ky/people/Dan-Malano-Seum-09938275-7282-4f47-b4f5-a555eb809004.yml
+++ b/data/ky/people/Dan-Malano-Seum-09938275-7282-4f47-b4f5-a555eb809004.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 242;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 228;Frankfort, KY 40601
   email: Dan.Seum@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-2450
-- address: 702 Capitol Ave;Annex Room 228;Frankfort KY 40601
-  email: Dan.Seum@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 662
 links:
-- url: http://www.lrc.ky.gov/legislator/S038.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=138
 sources:
-- url: http://www.lrc.ky.gov/legislator/S038.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate38.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=138
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate138.jpg
 other_identifiers:
 - identifier: KYL000026
   scheme: legacy_openstates

--- a/data/ky/people/Daniel-Elliott-d93e2493-49a8-4395-b7e0-5842893344e1.yml
+++ b/data/ky/people/Daniel-Elliott-d93e2493-49a8-4395-b7e0-5842893344e1.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329F;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329F;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 677
+  email: Daniel.Elliott@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H054.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=54
 sources:
-- url: http://www.lrc.ky.gov/legislator/H054.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House54.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=54
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house54.jpg
 other_identifiers:
 - identifier: KYL000236
   scheme: legacy_openstates

--- a/data/ky/people/Danny-Bentley-f56d6e0d-20b2-4cf4-aa7a-fd1d5c591d60.yml
+++ b/data/ky/people/Danny-Bentley-f56d6e0d-20b2-4cf4-aa7a-fd1d5c591d60.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329J;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 367C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 678
+  email: Danny.Bentley@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H098.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=98
 sources:
-- url: http://www.lrc.ky.gov/legislator/H098.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House98.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=98
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house98.jpg
 other_identifiers:
 - identifier: KYL000246
   scheme: legacy_openstates

--- a/data/ky/people/Danny-Carroll-0ec7d376-4235-44e7-a6d7-d63962dff167.yml
+++ b/data/ky/people/Danny-Carroll-0ec7d376-4235-44e7-a6d7-d63962dff167.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: Annex;Room 229;Frankfort KY 40601
+- address: 702 Capital Ave;Room 229;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 712
+  email: danny.carroll@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S002.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=102
 sources:
-- url: http://www.lrc.ky.gov/legislator/S002.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate02.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=102
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate102.jpg
 other_identifiers:
 - identifier: KYL000214
   scheme: legacy_openstates

--- a/data/ky/people/David-Hale-ebd5f90d-e3cc-45ef-97ff-d51ff1685bcc.yml
+++ b/data/ky/people/David-Hale-ebd5f90d-e3cc-45ef-97ff-d51ff1685bcc.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 405B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 405B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 642
+  email: david.hale@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H074.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=74
 sources:
-- url: http://www.lrc.ky.gov/legislator/H074.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House74.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=74
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house74.jpg
 other_identifiers:
 - identifier: KYL000224
   scheme: legacy_openstates

--- a/data/ky/people/David-Meade-3643503c-1da8-4a57-90f1-54f063b1d25e.yml
+++ b/data/ky/people/David-Meade-3643503c-1da8-4a57-90f1-54f063b1d25e.yml
@@ -7,19 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 370;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 309;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-2217
-- address: 702 Capitol Ave;Annex Room 332C;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 309;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 332C;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-4334
+  email: David.Meade@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H080.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=80
 sources:
-- url: http://www.lrc.ky.gov/legislator/H080.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House80.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=80
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house80.jpg
 other_identifiers:
 - identifier: KYL000161
   scheme: legacy_openstates

--- a/data/ky/people/David-Osborne-bf8bfdc3-66f2-417c-8178-9ed16bf8843f.yml
+++ b/data/ky/people/David-Osborne-bf8bfdc3-66f2-417c-8178-9ed16bf8843f.yml
@@ -7,21 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 332C;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 309;Frankfort KY 40601
-  email: David.Osborne@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-4334
-- address: 702 Capitol Ave;Annex Room 332;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 309;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 332;Frankfort, KY 40601
   email: David.Osborne@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-4334
 links:
-- url: http://www.lrc.ky.gov/legislator/H059.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=59
 sources:
-- url: http://www.lrc.ky.gov/legislator/H059.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House59.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=59
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house59.jpg
 other_identifiers:
 - identifier: KYL000105
   scheme: legacy_openstates

--- a/data/ky/people/David-P-Givens-5594a97f-7358-427e-af84-43150a21c97e.yml
+++ b/data/ky/people/David-P-Givens-5594a97f-7358-427e-af84-43150a21c97e.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 204;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 204;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 236;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-3120
+  email: David.Givens@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S009.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=109
 sources:
-- url: http://www.lrc.ky.gov/legislator/S009.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate09.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=109
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate109.jpg
 other_identifiers:
 - identifier: KYL000009
   scheme: legacy_openstates

--- a/data/ky/people/Dean-Schamore-bbf9c478-bb34-4f51-ae0f-49dabe52c1ce.yml
+++ b/data/ky/people/Dean-Schamore-bbf9c478-bb34-4f51-ae0f-49dabe52c1ce.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424F;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 704
+  email: dean.schamore@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H010.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=10
 sources:
-- url: http://www.lrc.ky.gov/legislator/H010.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House10.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=10
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house10.jpg
 other_identifiers:
 - identifier: KYL000222
   scheme: legacy_openstates

--- a/data/ky/people/Deanna-Frazier-96ab59e2-44c2-4c3d-ac8a-1ee24acc5b55.yml
+++ b/data/ky/people/Deanna-Frazier-96ab59e2-44c2-4c3d-ac8a-1ee24acc5b55.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 405C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 405C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 820
+  email: deanna.frazier@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H081.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=81
 sources:
-- url: http://www.lrc.ky.gov/legislator/H081.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House81.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=81
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house81.jpg

--- a/data/ky/people/Denise-Harper-Angel-3b8491a7-53b7-4b69-aac5-110a09c930ad.yml
+++ b/data/ky/people/Denise-Harper-Angel-3b8491a7-53b7-4b69-aac5-110a09c930ad.yml
@@ -7,17 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 254;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-2470
+  voice: 502-564-2470 ext. 633
+  email: Denise.HarperAngel@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S035.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=135
 sources:
-- url: http://www.lrc.ky.gov/legislator/S035.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate35.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=135
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate135.jpg
 other_identifiers:
 - identifier: KYL000010
   scheme: legacy_openstates

--- a/data/ky/people/Dennis-Keene-5d8b296d-ee49-4958-ba3d-43c35b97fe71.yml
+++ b/data/ky/people/Dennis-Keene-5d8b296d-ee49-4958-ba3d-43c35b97fe71.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 305;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429G;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-5565
-- address: 702 Capitol Ave;Annex Room 429G;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 634
+  email: Dennis.Keene@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H067.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=67
 sources:
-- url: http://www.lrc.ky.gov/legislator/H067.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House67.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=67
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house67.jpg
 other_identifiers:
 - identifier: KYL000085
   scheme: legacy_openstates

--- a/data/ky/people/Dennis-Parrett-f8c1bb0f-3e7e-4aa6-a2c2-d891d903fc71.yml
+++ b/data/ky/people/Dennis-Parrett-f8c1bb0f-3e7e-4aa6-a2c2-d891d903fc71.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 330;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 254;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2470
+  email: dennis.parrett@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S010.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=110
 sources:
-- url: http://www.lrc.ky.gov/legislator/S010.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate10.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=110
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate110.jpg
 other_identifiers:
 - identifier: KYL000021
   scheme: legacy_openstates

--- a/data/ky/people/Derek-Lewis-60ef609e-8aed-4698-a626-664f536a6122.yml
+++ b/data/ky/people/Derek-Lewis-60ef609e-8aed-4698-a626-664f536a6122.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 413D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 654
+  email: derek.lewis@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H090.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=90
 sources:
-- url: http://www.lrc.ky.gov/legislator/H090.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House90.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=90
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house90.jpg

--- a/data/ky/people/Derrick-Graham-27334d5d-f890-4082-bfbb-3d11af8e3756.yml
+++ b/data/ky/people/Derrick-Graham-27334d5d-f890-4082-bfbb-3d11af8e3756.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429J;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 305;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 472;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-5565
+  email: Derrick.Graham@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H057.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=57
 sources:
-- url: http://www.lrc.ky.gov/legislator/H057.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House57.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=57
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house57.jpg
 other_identifiers:
 - identifier: KYL000073
   scheme: legacy_openstates

--- a/data/ky/people/Diane-St-Onge-64e82120-1faf-4774-b840-173585f8b2b8.yml
+++ b/data/ky/people/Diane-St-Onge-64e82120-1faf-4774-b840-173585f8b2b8.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 357B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 367B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 701
+  email: Diane.StOnge@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H063.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=63
 sources:
-- url: http://www.lrc.ky.gov/legislator/H063.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House63.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=63
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house63.jpg
 other_identifiers:
 - identifier: KYL000163
   scheme: legacy_openstates

--- a/data/ky/people/Ernie-Harris-dac2e4da-be62-43ad-9c95-215920b4d585.yml
+++ b/data/ky/people/Ernie-Harris-dac2e4da-be62-43ad-9c95-215920b4d585.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 204;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 204;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 605
+  email: Ernie.Harris@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S026.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=126
 sources:
-- url: http://www.lrc.ky.gov/legislator/S026.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate26.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=126
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate126.jpg
 other_identifiers:
 - identifier: KYL000011
   scheme: legacy_openstates

--- a/data/ky/people/George-Brown-Jr-bb3e5fee-3bda-4a5d-95ee-dc31ff9defed.yml
+++ b/data/ky/people/George-Brown-Jr-bb3e5fee-3bda-4a5d-95ee-dc31ff9defed.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429D;Frankfort, KY 40601
   email: george.brown@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 620
 links:
-- url: http://www.lrc.ky.gov/legislator/H077.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=77
 sources:
-- url: http://www.lrc.ky.gov/legislator/H077.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House77.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=77
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house77.jpg
 other_identifiers:
 - identifier: KYL000208
   scheme: legacy_openstates

--- a/data/ky/people/Gerald-A-Neal-0d92a09c-ce23-46cd-9582-b7d1b08d76dd.yml
+++ b/data/ky/people/Gerald-A-Neal-0d92a09c-ce23-46cd-9582-b7d1b08d76dd.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 655
+  email: Gerald.Neal@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S033.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=133
 sources:
-- url: http://www.lrc.ky.gov/legislator/S033.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate33.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=133
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate133.jpg
 other_identifiers:
 - identifier: KYL000019
   scheme: legacy_openstates

--- a/data/ky/people/James-Tipton-d6c9aa9b-3c6b-411a-bff1-fc1c38d4bce0.yml
+++ b/data/ky/people/James-Tipton-d6c9aa9b-3c6b-411a-bff1-fc1c38d4bce0.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 316B;Frankfort, KY 40601
   email: James.Tipton@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 793
 links:
-- url: http://www.lrc.ky.gov/legislator/H053.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=53
 sources:
-- url: http://www.lrc.ky.gov/legislator/H053.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House53.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=53
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house53.jpg
 other_identifiers:
 - identifier: KYL000219
   scheme: legacy_openstates

--- a/data/ky/people/Jared-Carpenter-b2299f51-c122-46ac-9937-3a6a7b682bb8.yml
+++ b/data/ky/people/Jared-Carpenter-b2299f51-c122-46ac-9937-3a6a7b682bb8.yml
@@ -7,17 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 203;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 209;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 730
+  email: jared.carpenter@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S034.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=134
 sources:
-- url: http://www.lrc.ky.gov/legislator/S034.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate34.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=134
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate134.jpg
 other_identifiers:
 - identifier: KYL000004
   scheme: legacy_openstates

--- a/data/ky/people/Jason-Nemes-c56fc398-975e-47b9-919a-fbdd0c9f721d.yml
+++ b/data/ky/people/Jason-Nemes-c56fc398-975e-47b9-919a-fbdd0c9f721d.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 416C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 416C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 706
+  email: Jason.Nemes@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H033.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=33
 sources:
-- url: http://www.lrc.ky.gov/legislator/H033.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House33.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=33
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house33.jpg
 other_identifiers:
 - identifier: KYL000262
   scheme: legacy_openstates

--- a/data/ky/people/Jason-Petrie-3fac3a9c-78ad-4b24-8483-f1786fac9c9e.yml
+++ b/data/ky/people/Jason-Petrie-3fac3a9c-78ad-4b24-8483-f1786fac9c9e.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 313;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 618
+  email: Jason.Petrie@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H016.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=16
 sources:
-- url: http://www.lrc.ky.gov/legislator/H016.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House16.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=16
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house16.jpg
 other_identifiers:
 - identifier: KYL000250
   scheme: legacy_openstates

--- a/data/ky/people/Jeff-Hoover-b42b9001-5603-4c72-9e7e-5f677ba7f263.yml
+++ b/data/ky/people/Jeff-Hoover-b42b9001-5603-4c72-9e7e-5f677ba7f263.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 373C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 373C;Frankfort, KY 40601
   email: Jeff.Hoover@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 614
 links:
-- url: http://www.lrc.ky.gov/legislator/H083.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=83
 sources:
-- url: http://www.lrc.ky.gov/legislator/H083.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House83.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=83
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house83.jpg
 other_identifiers:
 - identifier: KYL000080
   scheme: legacy_openstates

--- a/data/ky/people/Jeffery-Donohue-ab7f41e2-e305-48e8-9071-d96962e7df43.yml
+++ b/data/ky/people/Jeffery-Donohue-ab7f41e2-e305-48e8-9071-d96962e7df43.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 451C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 451C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 629
+  email: Jeff.Donahue@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H037.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=37
 sources:
-- url: http://www.lrc.ky.gov/legislator/H037.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House37.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=37
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house37.jpg
 other_identifiers:
 - identifier: KYL000156
   scheme: legacy_openstates

--- a/data/ky/people/Jerry-T-Miller-ddf30bed-6cd2-43be-88c6-a252410bf4d0.yml
+++ b/data/ky/people/Jerry-T-Miller-ddf30bed-6cd2-43be-88c6-a252410bf4d0.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 357C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 357C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 718
+  email: jerry.miller@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H036.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=36
 sources:
-- url: http://www.lrc.ky.gov/legislator/H036.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House36.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=36
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house36.jpg
 other_identifiers:
 - identifier: KYL000223
   scheme: legacy_openstates

--- a/data/ky/people/Jim-DuPlessis-31ac29a7-e44e-4c06-9ca8-cc60648af0d0.yml
+++ b/data/ky/people/Jim-DuPlessis-31ac29a7-e44e-4c06-9ca8-cc60648af0d0.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 376;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 376;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 650
+  email: jim.duplessis@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H025.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=25
 sources:
-- url: http://www.lrc.ky.gov/legislator/H025.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House25.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=25
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house25.jpg
 other_identifiers:
 - identifier: KYL000216
   scheme: legacy_openstates

--- a/data/ky/people/Jim-Glenn-e642c0f0-a3aa-485d-8f3a-9a6f05f5b606.yml
+++ b/data/ky/people/Jim-Glenn-e642c0f0-a3aa-485d-8f3a-9a6f05f5b606.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 467;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 462A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 720
+  email: jim.glenn@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H013.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=13
 sources:
-- url: http://www.lrc.ky.gov/legislator/H013.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House13.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=13
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house13.jpg

--- a/data/ky/people/Jim-Gooch-Jr-f40ed494-ce37-43f4-b323-1bc2b6197831.yml
+++ b/data/ky/people/Jim-Gooch-Jr-f40ed494-ce37-43f4-b323-1bc2b6197831.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 376;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 376;Frankfort, KY 40601
   email: Jim.Gooch@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 687
 links:
-- url: http://www.lrc.ky.gov/legislator/H012.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=12
 sources:
-- url: http://www.lrc.ky.gov/legislator/H012.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House12.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=12
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house12.jpg
 other_identifiers:
 - identifier: KYL000072
   scheme: legacy_openstates

--- a/data/ky/people/Jim-Stewart-III-deeadc90-7fa0-4600-acd6-32125d668243.yml
+++ b/data/ky/people/Jim-Stewart-III-deeadc90-7fa0-4600-acd6-32125d668243.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 358A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 358A;Frankfort, KY 40601
   email: Jim.Stewart@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 690
 links:
-- url: http://www.lrc.ky.gov/legislator/H086.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=86
 sources:
-- url: http://www.lrc.ky.gov/legislator/H086.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House86.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=86
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house86.jpg
 other_identifiers:
 - identifier: KYL000125
   scheme: legacy_openstates

--- a/data/ky/people/Jimmy-Higdon-4042b29b-c6bb-407e-856d-9197a03d55ff.yml
+++ b/data/ky/people/Jimmy-Higdon-4042b29b-c6bb-407e-856d-9197a03d55ff.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 236;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 204;Frankfort, KY 40601
   email: Jimmy.Higdon@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-3120
-- address: 702 Capitol Ave;Annex Room 236;Frankfort KY 40601
-  email: Jimmy.Higdon@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 717
 links:
-- url: http://www.lrc.ky.gov/legislator/S014.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=114
 sources:
-- url: http://www.lrc.ky.gov/legislator/S014.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate14.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=114
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate114.jpg
 other_identifiers:
 - identifier: KYL000012
   scheme: legacy_openstates

--- a/data/ky/people/Joe-Graviss-4a2f8113-8c3c-4e97-adad-ceca2bb73549.yml
+++ b/data/ky/people/Joe-Graviss-4a2f8113-8c3c-4e97-adad-ceca2bb73549.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429J;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429J;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 639
+  email: joe.graviss@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H056.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=56
 sources:
-- url: http://www.lrc.ky.gov/legislator/H056.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House56.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=56
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house56.jpg

--- a/data/ky/people/John-Blanton-7cda4251-f26b-4bab-bf88-ed61b947018e.yml
+++ b/data/ky/people/John-Blanton-7cda4251-f26b-4bab-bf88-ed61b947018e.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329H;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329H;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 668
+  email: John.Blanton@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H092.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=92
 sources:
-- url: http://www.lrc.ky.gov/legislator/H092.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House92.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=92
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house92.jpg
 other_identifiers:
 - identifier: KYL000240
   scheme: legacy_openstates

--- a/data/ky/people/John-Carney-80a7a928-7fbe-42d2-8795-d9bba9f84372.yml
+++ b/data/ky/people/John-Carney-80a7a928-7fbe-42d2-8795-d9bba9f84372.yml
@@ -1,5 +1,5 @@
 id: ocd-person/80a7a928-7fbe-42d2-8795-d9bba9f84372
-name: John Carney
+name: John Bam Carney
 other_names:
 - name: John Bam Carney
 party:
@@ -9,20 +9,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 309;Frankfort KY 40601
-  email: John.Carney@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 370D;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 314;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 370D;Frankfort, KY 40601
   email: John.Carney@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-2217
 links:
-- url: http://www.lrc.ky.gov/legislator/H051.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=51
 sources:
-- url: http://www.lrc.ky.gov/legislator/H051.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House51.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=51
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house51.jpg
 other_identifiers:
 - identifier: KYL000049
   scheme: legacy_openstates

--- a/data/ky/people/John-Schickel-1bca305e-0f8d-4ce6-849a-322f7dbecb4b.yml
+++ b/data/ky/people/John-Schickel-1bca305e-0f8d-4ce6-849a-322f7dbecb4b.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 209;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 617
+  email: John.Schickel@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S011.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=111
 sources:
-- url: http://www.lrc.ky.gov/legislator/S011.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate11.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=111
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate111.jpg
 other_identifiers:
 - identifier: KYL000025
   scheme: legacy_openstates

--- a/data/ky/people/John-Sims-Jr-13813bac-c1cf-4e1e-8295-30a0919f4ced.yml
+++ b/data/ky/people/John-Sims-Jr-13813bac-c1cf-4e1e-8295-30a0919f4ced.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429C;Frankfort, KY 40601
   email: John.Sims@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 696
 links:
-- url: http://www.lrc.ky.gov/legislator/H070.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=70
 sources:
-- url: http://www.lrc.ky.gov/legislator/H070.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House70.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=70
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house70.jpg
 other_identifiers:
 - identifier: KYL000248
   scheme: legacy_openstates

--- a/data/ky/people/Johnny-Ray-Turner-78f1da82-e9dd-47b7-b10a-fd81cbcb2011.yml
+++ b/data/ky/people/Johnny-Ray-Turner-78f1da82-e9dd-47b7-b10a-fd81cbcb2011.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 330;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 254;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2470
+  email: JohnnyRay.Turner@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S029.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=129
 sources:
-- url: http://www.lrc.ky.gov/legislator/S029.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate29.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=129
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate129.jpg
 other_identifiers:
 - identifier: KYL000033
   scheme: legacy_openstates

--- a/data/ky/people/Joni-L-Jenkins-f5095840-d06a-4faf-a7dd-76a07c2d709f.yml
+++ b/data/ky/people/Joni-L-Jenkins-f5095840-d06a-4faf-a7dd-76a07c2d709f.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432A;Frankfort KY 40601
-  email: Joni.Jenkins@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 305;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 472;Frankfort, KY 40601
   email: Joni.Jenkins@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-5565
 links:
-- url: http://www.lrc.ky.gov/legislator/H044.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=44
 sources:
-- url: http://www.lrc.ky.gov/legislator/H044.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House44.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=44
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house44.jpg
 other_identifiers:
 - identifier: KYL000084
   scheme: legacy_openstates

--- a/data/ky/people/Joseph-M-Fischer-7f62c255-aeee-4282-8219-efc56dba67c2.yml
+++ b/data/ky/people/Joseph-M-Fischer-7f62c255-aeee-4282-8219-efc56dba67c2.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 313;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329D;Frankfort, KY 40601
   email: Joe.Fischer@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 742
 links:
-- url: http://www.lrc.ky.gov/legislator/H068.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=68
 sources:
-- url: http://www.lrc.ky.gov/legislator/H068.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House68.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=68
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house68.jpg
 other_identifiers:
 - identifier: KYL000067
   scheme: legacy_openstates

--- a/data/ky/people/Josie-Raymond-2973d2c4-1ca8-4842-a3d9-d5444b212c00.yml
+++ b/data/ky/people/Josie-Raymond-2973d2c4-1ca8-4842-a3d9-d5444b212c00.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 451B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 451B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 616
+  email: josie.raymond@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H031.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=31
 sources:
-- url: http://www.lrc.ky.gov/legislator/H031.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House31.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=31
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house31.jpg

--- a/data/ky/people/Julian-M-Carroll-34272848-8144-4e75-a6a2-ab2072f0092f.yml
+++ b/data/ky/people/Julian-M-Carroll-34272848-8144-4e75-a6a2-ab2072f0092f.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
   email: Julian.Carroll@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 645
 links:
-- url: http://www.lrc.ky.gov/legislator/S007.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=107
 sources:
-- url: http://www.lrc.ky.gov/legislator/S007.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate07.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=107
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate107.jpg
 other_identifiers:
 - identifier: KYL000005
   scheme: legacy_openstates

--- a/data/ky/people/Julie-Raque-Adams-38ae421f-f4fa-40f6-b025-a75bc6b42f35.yml
+++ b/data/ky/people/Julie-Raque-Adams-38ae421f-f4fa-40f6-b025-a75bc6b42f35.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 242;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 242;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2450
+  email: julie.adams@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S036.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=136
 sources:
-- url: http://www.lrc.ky.gov/legislator/S036.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate36.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=136
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate136.jpg
 other_identifiers:
 - identifier: KYL000039
   scheme: legacy_openstates

--- a/data/ky/people/Kathy-Hinkle-514c3fb1-aac9-49aa-9ad4-2cb9f48704a7.yml
+++ b/data/ky/people/Kathy-Hinkle-514c3fb1-aac9-49aa-9ad4-2cb9f48704a7.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 612
+  email: kathy.hinkle@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H096.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=96
 sources:
-- url: http://www.lrc.ky.gov/legislator/H096.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House96.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=96
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house96.jpg

--- a/data/ky/people/Kelly-Flood-4314c1e2-d58c-434f-8de4-0a7a728aa75f.yml
+++ b/data/ky/people/Kelly-Flood-4314c1e2-d58c-434f-8de4-0a7a728aa75f.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424F;Frankfort, KY 40601
   email: Kelly.Flood@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 675
 links:
-- url: http://www.lrc.ky.gov/legislator/H075.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=75
 sources:
-- url: http://www.lrc.ky.gov/legislator/H075.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House75.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=75
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house75.jpg
 other_identifiers:
 - identifier: KYL000068
   scheme: legacy_openstates

--- a/data/ky/people/Ken-Upchurch-7aa13bf4-126a-4901-bfeb-2244bd2d3cc3.yml
+++ b/data/ky/people/Ken-Upchurch-7aa13bf4-126a-4901-bfeb-2244bd2d3cc3.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 307A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 307A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 784
+  email: Ken.Upchurch@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H052.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=52
 sources:
-- url: http://www.lrc.ky.gov/legislator/H052.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House52.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=52
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house52.jpg
 other_identifiers:
 - identifier: KYL000179
   scheme: legacy_openstates

--- a/data/ky/people/Kevin-D-Bratcher-035b1122-ff5d-4e14-ac67-60871c5e7fea.yml
+++ b/data/ky/people/Kevin-D-Bratcher-035b1122-ff5d-4e14-ac67-60871c5e7fea.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 370;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 316;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 357E;Frankfort, KY 40601
   email: Kevin.Bratcher@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-2217
-- address: 702 Capitol Ave;Annex Room 357E;Frankfort KY 40601
-  email: Kevin.Bratcher@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 708
 links:
-- url: http://www.lrc.ky.gov/legislator/H029.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=29
 sources:
-- url: http://www.lrc.ky.gov/legislator/H029.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House29.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=29
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house29.jpg
 other_identifiers:
 - identifier: KYL000045
   scheme: legacy_openstates

--- a/data/ky/people/Kim-King-cd95ada0-14f0-4b63-aeea-f4a92525eeaf.yml
+++ b/data/ky/people/Kim-King-cd95ada0-14f0-4b63-aeea-f4a92525eeaf.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 405C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 405A;Frankfort, KY 40601
   email: kim.king@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 763
 links:
-- url: http://www.lrc.ky.gov/legislator/H055.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=55
 sources:
-- url: http://www.lrc.ky.gov/legislator/H055.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House55.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=55
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house55.jpg
 other_identifiers:
 - identifier: KYL000087
   scheme: legacy_openstates

--- a/data/ky/people/Kimberly-Poore-Moser-92511255-ca06-4241-bd91-0cafd92e3d5c.yml
+++ b/data/ky/people/Kimberly-Poore-Moser-92511255-ca06-4241-bd91-0cafd92e3d5c.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 315;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 694
+  email: Kimberly.Moser@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H064.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=64
 sources:
-- url: http://www.lrc.ky.gov/legislator/H064.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House64.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=64
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house64.jpg
 other_identifiers:
 - identifier: KYL000239
   scheme: legacy_openstates

--- a/data/ky/people/Larry-Elkins-b64b73bc-6623-4953-b648-1ab39c466ac5.yml
+++ b/data/ky/people/Larry-Elkins-b64b73bc-6623-4953-b648-1ab39c466ac5.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 405D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 405D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 607
+  email: larry.elkins@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H005.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=5
 sources:
-- url: http://www.lrc.ky.gov/legislator/H005.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House05.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=5
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house5.jpg

--- a/data/ky/people/Les-Yates-24c69bb9-f9b1-484f-9165-1c3d14cbfbd2.yml
+++ b/data/ky/people/Les-Yates-24c69bb9-f9b1-484f-9165-1c3d14cbfbd2.yml
@@ -7,10 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 351C;Frankfort, KY 40601
   note: Capitol Office
+  email: les.yates@lrc.ky.gov
+  voice: 502-564-8100 ext. 709
 links:
-- url: http://www.lrc.ky.gov/legislator/H073.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=73
 sources:
-- url: http://www.lrc.ky.gov/legislator/H073.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House73.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=73
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house73.jpg

--- a/data/ky/people/Lisa-Willner-6dd815a4-fc3c-4e79-8cd5-a574d8cf0af8.yml
+++ b/data/ky/people/Lisa-Willner-6dd815a4-fc3c-4e79-8cd5-a574d8cf0af8.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 659
+  email: lisa.willner@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H035.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=35
 sources:
-- url: http://www.lrc.ky.gov/legislator/H035.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House35.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=35
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house35.jpg

--- a/data/ky/people/Lynn-Bechler-a061c4f7-4c57-471a-839d-1027098badef.yml
+++ b/data/ky/people/Lynn-Bechler-a061c4f7-4c57-471a-839d-1027098badef.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 316C;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 665
+  email: Lynn.Bechler@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H004.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=4
 sources:
-- url: http://www.lrc.ky.gov/legislator/H004.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House04.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=4
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house4.jpg
 other_identifiers:
 - identifier: KYL000153
   scheme: legacy_openstates

--- a/data/ky/people/Maria-Sorolis-709b11a0-a7e6-4bc4-a3e7-28459586806f.yml
+++ b/data/ky/people/Maria-Sorolis-709b11a0-a7e6-4bc4-a3e7-28459586806f.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 692
+  email: maria.sorolis@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H048.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=48
 sources:
-- url: http://www.lrc.ky.gov/legislator/H048.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House48.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=48
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house48.jpg

--- a/data/ky/people/Mark-Hart-b1a31b02-5d89-42be-97d4-7d08d99161d8.yml
+++ b/data/ky/people/Mark-Hart-b1a31b02-5d89-42be-97d4-7d08d99161d8.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 316D;Frankfort, KY 40601
   email: Mark.Hart@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 667
 links:
-- url: http://www.lrc.ky.gov/legislator/H078.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=78
 sources:
-- url: http://www.lrc.ky.gov/legislator/H078.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House78.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=78
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house78.jpg
 other_identifiers:
 - identifier: KYL000251
   scheme: legacy_openstates

--- a/data/ky/people/Mary-Lou-Marzian-86342422-7a28-4631-b3d7-3912eb444ffd.yml
+++ b/data/ky/people/Mary-Lou-Marzian-86342422-7a28-4631-b3d7-3912eb444ffd.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 451E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 451D;Frankfort, KY 40601
   email: MaryLou.Marzian@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 643
 links:
-- url: http://www.lrc.ky.gov/legislator/H034.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=34
 sources:
-- url: http://www.lrc.ky.gov/legislator/H034.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House34.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=34
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house34.jpg
 other_identifiers:
 - identifier: KYL000092
   scheme: legacy_openstates

--- a/data/ky/people/Matt-Castlen-49e35e02-51af-40b7-96c0-031bcc2040de.yml
+++ b/data/ky/people/Matt-Castlen-49e35e02-51af-40b7-96c0-031bcc2040de.yml
@@ -11,20 +11,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
+  note: Capitol Office
+  voice: 502-564-8100 ext. 688
   email: Matt.Castlen@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
 links:
-- url: http://www.lrc.ky.gov/legislator/H014.htm
-- url: http://www.lrc.ky.gov/legislator/S008.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=108
 sources:
-- url: http://www.lrc.ky.gov/legislator/H014.htm
-- url: http://www.lrc.ky.gov/legislator/S008.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate08.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=108
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate108.jpg
 other_identifiers:
 - identifier: KYL000243
   scheme: legacy_openstates

--- a/data/ky/people/Matthew-Koch-1b8bc567-b895-4fae-8b3f-7a7160ca5138.yml
+++ b/data/ky/people/Matthew-Koch-1b8bc567-b895-4fae-8b3f-7a7160ca5138.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329E;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 660
+  email: matthew.koch@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H072.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=72
 sources:
-- url: http://www.lrc.ky.gov/legislator/H072.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House72.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=72
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house72.jpg

--- a/data/ky/people/Max-Wise-32b5035e-6d1a-44b8-9f7a-4173a1cdb940.yml
+++ b/data/ky/people/Max-Wise-32b5035e-6d1a-44b8-9f7a-4173a1cdb940.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: Annex;Room 229;Frankfort KY 40601
+- address: 702 Capital Ave;Room 229;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 673
+  email: max.wise@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S016.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=116
 sources:
-- url: http://www.lrc.ky.gov/legislator/S016.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate16.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=116
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate116.jpg
 other_identifiers:
 - identifier: KYL000206
   scheme: legacy_openstates

--- a/data/ky/people/McKenzie-Cantrell-b3c48c61-39e6-4414-a07f-ceed047d99ec.yml
+++ b/data/ky/people/McKenzie-Cantrell-b3c48c61-39e6-4414-a07f-ceed047d99ec.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424A;Frankfort, KY 40601
   email: McKenzie.Cantrell@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 670
 links:
-- url: http://www.lrc.ky.gov/legislator/H038.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=38
 sources:
-- url: http://www.lrc.ky.gov/legislator/H038.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House38.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=38
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house38.jpg
 other_identifiers:
 - identifier: KYL000261
   scheme: legacy_openstates

--- a/data/ky/people/Melinda-Gibbons-Prunty-70c7ec69-7921-48f5-976d-0f5739ee5c14.yml
+++ b/data/ky/people/Melinda-Gibbons-Prunty-70c7ec69-7921-48f5-976d-0f5739ee5c14.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 373A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 686
+  email: Melinda.Prunty@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H015.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=15
 sources:
-- url: http://www.lrc.ky.gov/legislator/H015.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House15.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=15
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house15.jpg
 other_identifiers:
 - identifier: KYL000266
   scheme: legacy_openstates

--- a/data/ky/people/Michael-Meredith-f013115a-6bbc-48ac-aab4-7949dd902701.yml
+++ b/data/ky/people/Michael-Meredith-f013115a-6bbc-48ac-aab4-7949dd902701.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 416A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 416A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 719
+  email: michael.meredith@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H019.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=19
 sources:
-- url: http://www.lrc.ky.gov/legislator/H019.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House19.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=19
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house19.jpg
 other_identifiers:
 - identifier: KYL000096
   scheme: legacy_openstates

--- a/data/ky/people/Mike-Wilson-64af8584-1675-47fd-acfb-1cec59dfdda5.yml
+++ b/data/ky/people/Mike-Wilson-64af8584-1675-47fd-acfb-1cec59dfdda5.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 242;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 330;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 242;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2450
+  email: mike.wilson@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S032.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=132
 sources:
-- url: http://www.lrc.ky.gov/legislator/S032.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate32.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=132
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate132.jpg
 other_identifiers:
 - identifier: KYL000037
   scheme: legacy_openstates

--- a/data/ky/people/Morgan-McGarvey-9983a801-0a07-4d17-bca0-afb9576ebe69.yml
+++ b/data/ky/people/Morgan-McGarvey-9983a801-0a07-4d17-bca0-afb9576ebe69.yml
@@ -7,20 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
-  email: Morgan.McGarvey@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 331;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 254;Frankfort, KY 40601
   email: Morgan.McGarvey@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-2470
 links:
-- url: http://www.lrc.ky.gov/legislator/S019.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=119
 sources:
-- url: http://www.lrc.ky.gov/legislator/S019.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate19.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=119
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate119.jpg
 other_identifiers:
 - identifier: KYL000150
   scheme: legacy_openstates

--- a/data/ky/people/Myron-Dossett-c6904810-37a8-428d-8342-7831d7dc100c.yml
+++ b/data/ky/people/Myron-Dossett-c6904810-37a8-428d-8342-7831d7dc100c.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 401;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 401;Frankfort, KY 40601
   email: Myron.Dossett@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 657
 links:
-- url: http://www.lrc.ky.gov/legislator/H009.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=9
 sources:
-- url: http://www.lrc.ky.gov/legislator/H009.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House09.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=9
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house9.jpg
 other_identifiers:
 - identifier: KYL000063
   scheme: legacy_openstates

--- a/data/ky/people/Nancy-Tate-911af3e2-7435-4f82-a477-99cb078ea99b.yml
+++ b/data/ky/people/Nancy-Tate-911af3e2-7435-4f82-a477-99cb078ea99b.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 351D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 698
+  email: nancy.tate@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H027.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=27
 sources:
-- url: http://www.lrc.ky.gov/legislator/H027.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House27.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=27
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house27.jpg

--- a/data/ky/people/Nima-Kulkarni-bee3f0dd-450a-41a2-b9b9-e056d0a0f14d.yml
+++ b/data/ky/people/Nima-Kulkarni-bee3f0dd-450a-41a2-b9b9-e056d0a0f14d.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429E;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 603
+  email: nima.kulkarni@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H040.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=40
 sources:
-- url: http://www.lrc.ky.gov/legislator/H040.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House40.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=40
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house40.jpg

--- a/data/ky/people/Patti-Minter-86c48d8d-a98a-4580-8307-7e9b233d04f3.yml
+++ b/data/ky/people/Patti-Minter-86c48d8d-a98a-4580-8307-7e9b233d04f3.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 685
+  email: patti.minter@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H020.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=20
 sources:
-- url: http://www.lrc.ky.gov/legislator/H020.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House20.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=20
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house20.jpg

--- a/data/ky/people/Paul-Hornback-811a7e14-a322-4a51-90a5-8abf21e21e19.yml
+++ b/data/ky/people/Paul-Hornback-811a7e14-a322-4a51-90a5-8abf21e21e19.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 203;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 203;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 648
+  email: paul.hornback@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S020.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=120
 sources:
-- url: http://www.lrc.ky.gov/legislator/S020.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate20.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=120
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate120.jpg
 other_identifiers:
 - identifier: KYL000013
   scheme: legacy_openstates

--- a/data/ky/people/Perry-B-Clark-0bf69dc4-c762-4495-bff8-da9c84ecb022.yml
+++ b/data/ky/people/Perry-B-Clark-0bf69dc4-c762-4495-bff8-da9c84ecb022.yml
@@ -7,17 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 254;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-2470
+  voice: 502-564-2470 ext. 715
+  email: Perry.Clark@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S037.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=137
 sources:
-- url: http://www.lrc.ky.gov/legislator/S037.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate37.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=137
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate137.jpg
 other_identifiers:
 - identifier: KYL000006
   scheme: legacy_openstates

--- a/data/ky/people/Phillip-Pratt-91e57008-84f5-42ad-9f31-a2869bced4bb.yml
+++ b/data/ky/people/Phillip-Pratt-91e57008-84f5-42ad-9f31-a2869bced4bb.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 351;Frankfort, KY 40601
   email: Phillip.Pratt@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 671
 links:
-- url: http://www.lrc.ky.gov/legislator/H062.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=62
 sources:
-- url: http://www.lrc.ky.gov/legislator/H062.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House62.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=62
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house62.jpg
 other_identifiers:
 - identifier: KYL000247
   scheme: legacy_openstates

--- a/data/ky/people/R-Travis-Brenda-e4f9e8d5-582f-4a1c-9842-c521c685da33.yml
+++ b/data/ky/people/R-Travis-Brenda-e4f9e8d5-582f-4a1c-9842-c521c685da33.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 316E;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 651
+  email: travis.brenda@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H071.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=71
 sources:
-- url: http://www.lrc.ky.gov/legislator/H071.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House71.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=71
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house71.jpg

--- a/data/ky/people/Ralph-Alvarado-c2d18e4a-15c9-440c-9bec-f533a03b4235.yml
+++ b/data/ky/people/Ralph-Alvarado-c2d18e4a-15c9-440c-9bec-f533a03b4235.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: Annex;Room 229;Frankfort KY 40601
+- address: 702 Capital Ave;Room 229;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 681
+  email: ralph.alvarado@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S028.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=128
 sources:
-- url: http://www.lrc.ky.gov/legislator/S028.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate28.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=128
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate128.jpg
 other_identifiers:
 - identifier: KYL000220
   scheme: legacy_openstates

--- a/data/ky/people/Randy-Bridges-c033dd77-f8d7-4558-8582-9e0088ae5406.yml
+++ b/data/ky/people/Randy-Bridges-c033dd77-f8d7-4558-8582-9e0088ae5406.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 329G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329G;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 649
+  email: randy.bridges@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H003.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=3
 sources:
-- url: http://www.lrc.ky.gov/legislator/H003.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House03.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=3
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house3.jpg

--- a/data/ky/people/Regina-Huff-570cb11a-56be-4d07-92b7-6a76aaf79279.yml
+++ b/data/ky/people/Regina-Huff-570cb11a-56be-4d07-92b7-6a76aaf79279.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 367A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 309;Frankfort, KY 40601
   email: Regina.Huff@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 683
 links:
-- url: http://www.lrc.ky.gov/legislator/H082.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=82
 sources:
-- url: http://www.lrc.ky.gov/legislator/H082.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House82.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=82
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house82.jpg
 other_identifiers:
 - identifier: KYL000141
   scheme: legacy_openstates

--- a/data/ky/people/Reginald-Meeks-dad253cb-8663-4c0d-b09b-979d913ea226.yml
+++ b/data/ky/people/Reginald-Meeks-dad253cb-8663-4c0d-b09b-979d913ea226.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 653
+  email: Reginald.Meeks@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H042.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=42
 sources:
-- url: http://www.lrc.ky.gov/legislator/H042.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House42.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=42
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house42.jpg
 other_identifiers:
 - identifier: KYL000095
   scheme: legacy_openstates

--- a/data/ky/people/Reginald-Thomas-42b259db-9ddb-4588-a463-b1a38c944c66.yml
+++ b/data/ky/people/Reginald-Thomas-42b259db-9ddb-4588-a463-b1a38c944c66.yml
@@ -7,15 +7,16 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
   fax: 502-564-0777
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 608
+  email: Reginald.Thomas@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S013.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=113
 sources:
-- url: http://www.lrc.ky.gov/legislator/S013.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate13.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=113
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate113.jpg
 other_identifiers:
 - identifier: KYL000204
   scheme: legacy_openstates

--- a/data/ky/people/Richard-Heath-9e788295-a4ea-4572-aa06-d96aa9b0dc95.yml
+++ b/data/ky/people/Richard-Heath-9e788295-a4ea-4572-aa06-d96aa9b0dc95.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 405E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 405E;Frankfort, KY 40601
   email: Richard.Heath@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 638
 links:
-- url: http://www.lrc.ky.gov/legislator/H002.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=2
 sources:
-- url: http://www.lrc.ky.gov/legislator/H002.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House02.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=2
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house2.jpg
 other_identifiers:
 - identifier: KYL000157
   scheme: legacy_openstates

--- a/data/ky/people/Rick-Girdler-34ed9881-46b8-41ba-b625-3d350140d2b9.yml
+++ b/data/ky/people/Rick-Girdler-34ed9881-46b8-41ba-b625-3d350140d2b9.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 209;Frankfort, KY 40601
   email: Rick.Girdler@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 656
 links:
-- url: http://www.lrc.ky.gov/legislator/S015.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=115
 sources:
-- url: http://www.lrc.ky.gov/legislator/S015.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate15.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=115
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate115.jpg
 other_identifiers:
 - identifier: KYL000259
   scheme: legacy_openstates

--- a/data/ky/people/Rick-Rand-5d252767-24f1-4c6c-9bd9-00fb8084e84c.yml
+++ b/data/ky/people/Rick-Rand-5d252767-24f1-4c6c-9bd9-00fb8084e84c.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432F;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429H;Frankfort, KY 40601
   email: Rick.Rand@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 619
 links:
-- url: http://www.lrc.ky.gov/legislator/H047.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=47
 sources:
-- url: http://www.lrc.ky.gov/legislator/H047.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House47.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=47
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house47.jpg
 other_identifiers:
 - identifier: KYL000112
   scheme: legacy_openstates

--- a/data/ky/people/Rob-Rothenburger-460fe65d-7ae8-4467-9097-42ac5d631a44.yml
+++ b/data/ky/people/Rob-Rothenburger-460fe65d-7ae8-4467-9097-42ac5d631a44.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 373B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 373B;Frankfort, KY 40601
   email: Rob.Rothenburger@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 609
 links:
-- url: http://www.lrc.ky.gov/legislator/H058.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=58
 sources:
-- url: http://www.lrc.ky.gov/legislator/H058.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House58.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=58
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house58.jpg
 other_identifiers:
 - identifier: KYL000264
   scheme: legacy_openstates

--- a/data/ky/people/Rob-Wiederstein-d22917f5-2f7c-43c6-bc41-b919a078c092.yml
+++ b/data/ky/people/Rob-Wiederstein-d22917f5-2f7c-43c6-bc41-b919a078c092.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 451A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 736
+  email: rob.wiederstein@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H011.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=11
 sources:
-- url: http://www.lrc.ky.gov/legislator/H011.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House11.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=11
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house11.jpg

--- a/data/ky/people/Robby-Mills-366daab1-a877-49b9-86b8-e3c497143bf0.yml
+++ b/data/ky/people/Robby-Mills-366daab1-a877-49b9-86b8-e3c497143bf0.yml
@@ -11,20 +11,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
+  note: Capitol Office
+  voice: 502-564-8100 ext. 700
   email: Robby.Mills@lrc.ky.gov
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
 links:
-- url: http://www.lrc.ky.gov/legislator/H011.htm
-- url: http://www.lrc.ky.gov/legislator/S004.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=104
 sources:
-- url: http://www.lrc.ky.gov/legislator/H011.htm
-- url: http://www.lrc.ky.gov/legislator/S004.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate04.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=104
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate104.jpg
 other_identifiers:
 - identifier: KYL000244
   scheme: legacy_openstates

--- a/data/ky/people/Robert-Goforth-5fe1f4bd-b54a-4046-9bf0-adcb705ed7f1.yml
+++ b/data/ky/people/Robert-Goforth-5fe1f4bd-b54a-4046-9bf0-adcb705ed7f1.yml
@@ -7,21 +7,16 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 358B;Frankfort, KY 40601
   email: Robert.Goforth@lrc.ky.gov
   fax: 502-564-5640
   note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 358B;Frankfort KY 40601
-  email: Robert.Goforth@lrc.ky.gov
-  fax: 502-564-5640
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 630
 links:
-- url: http://www.lrc.ky.gov/legislator/H089.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=89
 sources:
-- url: http://www.lrc.ky.gov/legislator/H089.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House89.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=89
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house89.jpg
 other_identifiers:
 - identifier: KYL000275
   scheme: legacy_openstates

--- a/data/ky/people/Robert-Stivers-II-8659c7e3-ec01-4c40-b7ee-d21f37facff5.yml
+++ b/data/ky/people/Robert-Stivers-II-8659c7e3-ec01-4c40-b7ee-d21f37facff5.yml
@@ -7,16 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 236;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 319;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 236;Frankfort, KY 40601
   email: Robert.Stivers@lrc.ky.gov
   note: Capitol Office
   voice: 502-564-3120
 links:
-- url: http://www.lrc.ky.gov/legislator/S025.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=125
 sources:
-- url: http://www.lrc.ky.gov/legislator/S025.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate25.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=125
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate125.jpg
 other_identifiers:
 - identifier: KYL000031
   scheme: legacy_openstates

--- a/data/ky/people/Robin-L-Webb-42990da5-7020-4327-bbd8-496955b00040.yml
+++ b/data/ky/people/Robin-L-Webb-42990da5-7020-4327-bbd8-496955b00040.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 255;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 255;Frankfort, KY 40601
   email: Robin.Webb@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 676
 links:
-- url: http://www.lrc.ky.gov/legislator/S018.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=118
 sources:
-- url: http://www.lrc.ky.gov/legislator/S018.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate18.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=118
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate118.jpg
 other_identifiers:
 - identifier: KYL000034
   scheme: legacy_openstates

--- a/data/ky/people/Rocky-Adkins-64986d88-7010-478c-92c4-dc7b44ee0675.yml
+++ b/data/ky/people/Rocky-Adkins-64986d88-7010-478c-92c4-dc7b44ee0675.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 472;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-5565
+  email: Rocky.Adkins@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H099.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=99
 sources:
-- url: http://www.lrc.ky.gov/legislator/H099.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House99.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=99
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house99.jpg
 other_identifiers:
 - identifier: KYL000041
   scheme: legacy_openstates

--- a/data/ky/people/Russ-A-Meyer-f23a1be5-3634-4f40-990c-d4ae312557a6.yml
+++ b/data/ky/people/Russ-A-Meyer-f23a1be5-3634-4f40-990c-d4ae312557a6.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 457B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 457B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 623
+  email: russ.meyer@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H039.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=39
 sources:
-- url: http://www.lrc.ky.gov/legislator/H039.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House39.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=39
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house39.jpg
 other_identifiers:
 - identifier: KYL000207
   scheme: legacy_openstates

--- a/data/ky/people/Russell-Webber-1df79f72-3008-43c1-ba83-4ca5069f2b4a.yml
+++ b/data/ky/people/Russell-Webber-1df79f72-3008-43c1-ba83-4ca5069f2b4a.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 352A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 352A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 663
+  email: Russell.Webber@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H026.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=26
 sources:
-- url: http://www.lrc.ky.gov/legislator/H026.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House26.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=26
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house26.jpg
 other_identifiers:
 - identifier: KYL000165
   scheme: legacy_openstates

--- a/data/ky/people/Ruth-Ann-Palumbo-d9335cfd-1606-4b1a-acd8-422f6d7c9e27.yml
+++ b/data/ky/people/Ruth-Ann-Palumbo-d9335cfd-1606-4b1a-acd8-422f6d7c9e27.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 432E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 432E;Frankfort, KY 40601
   email: RuthAnn.Palumbo@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 600
 links:
-- url: http://www.lrc.ky.gov/legislator/H076.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=76
 sources:
-- url: http://www.lrc.ky.gov/legislator/H076.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House76.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=76
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house76.jpg
 other_identifiers:
 - identifier: KYL000108
   scheme: legacy_openstates

--- a/data/ky/people/Sal-Santoro-5aee67b6-7a3e-4364-9809-013752e6e31e.yml
+++ b/data/ky/people/Sal-Santoro-5aee67b6-7a3e-4364-9809-013752e6e31e.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 303;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 303;Frankfort, KY 40601
   email: Sal.Santoro@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 691
 links:
-- url: http://www.lrc.ky.gov/legislator/H060.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=60
 sources:
-- url: http://www.lrc.ky.gov/legislator/H060.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House60.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=60
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house60.jpg
 other_identifiers:
 - identifier: KYL000118
   scheme: legacy_openstates

--- a/data/ky/people/Savannah-Maddox-a8988de2-d65f-461c-96d1-4f1cddc6a969.yml
+++ b/data/ky/people/Savannah-Maddox-a8988de2-d65f-461c-96d1-4f1cddc6a969.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413G;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 413G;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 640
+  email: savannah.maddox@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H061.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=61
 sources:
-- url: http://www.lrc.ky.gov/legislator/H061.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House61.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=61
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house61.jpg

--- a/data/ky/people/Scott-Lewis-07773b3f-387f-4e4e-ba79-571940c186f0.yml
+++ b/data/ky/people/Scott-Lewis-07773b3f-387f-4e4e-ba79-571940c186f0.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 316A;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 316A;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 627
+  email: scott.lewis@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H014.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=14
 sources:
-- url: http://www.lrc.ky.gov/legislator/H014.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House14.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=14
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house14.jpg

--- a/data/ky/people/Stan-Humphries-5963d5ac-e9c4-4371-81d7-4e8b68e33626.yml
+++ b/data/ky/people/Stan-Humphries-5963d5ac-e9c4-4371-81d7-4e8b68e33626.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 209;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 870
+  email: Stan.Humphries@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S001.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=101
 sources:
-- url: http://www.lrc.ky.gov/legislator/S001.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate01.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=101
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate101.jpg
 other_identifiers:
 - identifier: KYL000148
   scheme: legacy_openstates

--- a/data/ky/people/Stan-Lee-b5ecc457-47d3-4086-ae81-c7fb4a2bca48.yml
+++ b/data/ky/people/Stan-Lee-b5ecc457-47d3-4086-ae81-c7fb4a2bca48.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 357D;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 357D;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 693
+  email: Stan.Lee@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H045.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=45
 sources:
-- url: http://www.lrc.ky.gov/legislator/H045.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House45.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=45
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house45.jpg
 other_identifiers:
 - identifier: KYL000091
   scheme: legacy_openstates

--- a/data/ky/people/Stephen-Meredith-8915acb8-6089-451f-be08-c79b0be59c40.yml
+++ b/data/ky/people/Stephen-Meredith-8915acb8-6089-451f-be08-c79b0be59c40.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: Annex;Room 229;Frankfort KY 40601
+- address: 702 Capital Ave;Room 229;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 644
+  email: Stephen.Meredith@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S005.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=105
 sources:
-- url: http://www.lrc.ky.gov/legislator/S005.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate05.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=105
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate105.jpg
 other_identifiers:
 - identifier: KYL000253
   scheme: legacy_openstates

--- a/data/ky/people/Stephen-West-1f3bbab4-2be0-496c-9c3b-b8f340f6b404.yml
+++ b/data/ky/people/Stephen-West-1f3bbab4-2be0-496c-9c3b-b8f340f6b404.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: Annex;Room 229;Frankfort KY 40601
+- address: 702 Capital Ave;Room 229;Frankfort, KY 40601
   email: steve.west@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 806
 links:
-- url: http://www.lrc.ky.gov/legislator/S027.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=127
 sources:
-- url: http://www.lrc.ky.gov/legislator/S027.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate27.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=127
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate127.jpg
 other_identifiers:
 - identifier: KYL000230
   scheme: legacy_openstates

--- a/data/ky/people/Steve-Riley-817df40b-8e76-460d-81cf-63277866268a.yml
+++ b/data/ky/people/Steve-Riley-817df40b-8e76-460d-81cf-63277866268a.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 352C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 352C;Frankfort, KY 40601
   email: Steve.Riley@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 680
 links:
-- url: http://www.lrc.ky.gov/legislator/H023.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=23
 sources:
-- url: http://www.lrc.ky.gov/legislator/H023.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House23.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=23
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house23.jpg
 other_identifiers:
 - identifier: KYL000252
   scheme: legacy_openstates

--- a/data/ky/people/Steve-Sheldon-183ef142-5b20-42cb-a128-99f7d1f738db.yml
+++ b/data/ky/people/Steve-Sheldon-183ef142-5b20-42cb-a128-99f7d1f738db.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 351B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 351B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 672
+  email: steve.sheldon@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H017.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=17
 sources:
-- url: http://www.lrc.ky.gov/legislator/H017.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House17.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=17
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house17.jpg

--- a/data/ky/people/Steven-Rudy-f73e54d0-9547-4688-b97d-4818b104d160.yml
+++ b/data/ky/people/Steven-Rudy-f73e54d0-9547-4688-b97d-4818b104d160.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 304;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 304;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 637
+  email: Steven.Rudy@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H001.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=1
 sources:
-- url: http://www.lrc.ky.gov/legislator/H001.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House01.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=1
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house1.jpg
 other_identifiers:
 - identifier: KYL000117
   scheme: legacy_openstates

--- a/data/ky/people/Susan-Westrom-6a2d83cc-b459-431b-8103-a28bbcede9b8.yml
+++ b/data/ky/people/Susan-Westrom-6a2d83cc-b459-431b-8103-a28bbcede9b8.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 424E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 424E;Frankfort, KY 40601
   email: Susan.Westrom@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 740
 links:
-- url: http://www.lrc.ky.gov/legislator/H079.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=79
 sources:
-- url: http://www.lrc.ky.gov/legislator/H079.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House79.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=79
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house79.jpg
 other_identifiers:
 - identifier: KYL000135
   scheme: legacy_openstates

--- a/data/ky/people/Suzanne-Miles-92576283-508e-4613-b1a0-3d227edf4068.yml
+++ b/data/ky/people/Suzanne-Miles-92576283-508e-4613-b1a0-3d227edf4068.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 367B;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
-- address: 702 Capitol Ave;Annex Room 370;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 309;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 370;Frankfort, KY 40601
   note: Capitol Office
   voice: 502-564-2217
+  email: Suzanne.miles@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H007.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=7
 sources:
-- url: http://www.lrc.ky.gov/legislator/H007.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House07.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=7
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house7.jpg
 other_identifiers:
 - identifier: KYL000205
   scheme: legacy_openstates

--- a/data/ky/people/Terri-Branham-Clark-a09193a4-7dda-452f-9be7-3411f8f22bc6.yml
+++ b/data/ky/people/Terri-Branham-Clark-a09193a4-7dda-452f-9be7-3411f8f22bc6.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 429B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429B;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 695
+  email: terri.branhamclark@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H100.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=100
 sources:
-- url: http://www.lrc.ky.gov/legislator/H100.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House100.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=100
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house100.jpg

--- a/data/ky/people/Thomas-Huff-7d2b01df-9356-4eaa-923f-144e3f229860.yml
+++ b/data/ky/people/Thomas-Huff-7d2b01df-9356-4eaa-923f-144e3f229860.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413F;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 413F;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 628
+  email: thomas.huff@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H049.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=49
 sources:
-- url: http://www.lrc.ky.gov/legislator/H049.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House49.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=49
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house49.jpg

--- a/data/ky/people/Tim-Moore-c3c70d8f-2032-4762-af59-d5907398767e.yml
+++ b/data/ky/people/Tim-Moore-c3c70d8f-2032-4762-af59-d5907398767e.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 358C;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 358C;Frankfort, KY 40601
   email: Tim.Moore@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 702
 links:
-- url: http://www.lrc.ky.gov/legislator/H018.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=18
 sources:
-- url: http://www.lrc.ky.gov/legislator/H018.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House18.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=18
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house18.jpg
 other_identifiers:
 - identifier: KYL000100
   scheme: legacy_openstates

--- a/data/ky/people/Tina-Bojanowski-77db7bcf-dfa8-4365-bb3a-4ca0351a8368.yml
+++ b/data/ky/people/Tina-Bojanowski-77db7bcf-dfa8-4365-bb3a-4ca0351a8368.yml
@@ -7,11 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 451E;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 451E;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 626
+  email: tina.bojanowski@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H032.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=32
 sources:
-- url: http://www.lrc.ky.gov/legislator/H032.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House32.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=32
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house32.jpg

--- a/data/ky/people/Tom-Buford-861fc098-0589-4ca1-b792-898163644eef.yml
+++ b/data/ky/people/Tom-Buford-861fc098-0589-4ca1-b792-898163644eef.yml
@@ -7,15 +7,16 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 252;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 252;Frankfort, KY 40601
   fax: 502-564-2466
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 610
+  email: Tom.Buford@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S022.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=122
 sources:
-- url: http://www.lrc.ky.gov/legislator/S022.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate22.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=122
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate122.jpg
 other_identifiers:
 - identifier: KYL000003
   scheme: legacy_openstates

--- a/data/ky/people/Tom-Burch-15e09c06-c5fa-4bfe-820f-f53fbabd1565.yml
+++ b/data/ky/people/Tom-Burch-15e09c06-c5fa-4bfe-820f-f53fbabd1565.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 457C;Frankfort, KY 40601
   email: Tom.Burch@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 601
 links:
-- url: http://www.lrc.ky.gov/legislator/H030.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=30
 sources:
-- url: http://www.lrc.ky.gov/legislator/H030.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House30.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=30
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house30.jpg
 other_identifiers:
 - identifier: KYL000047
   scheme: legacy_openstates

--- a/data/ky/people/Tommy-Turner-96468379-62ed-4c43-8a63-fc71019b0de0.yml
+++ b/data/ky/people/Tommy-Turner-96468379-62ed-4c43-8a63-fc71019b0de0.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 324B;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 324B;Frankfort, KY 40601
   email: Tommy.Turner@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 716
 links:
-- url: http://www.lrc.ky.gov/legislator/H085.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=85
 sources:
-- url: http://www.lrc.ky.gov/legislator/H085.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House85.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=85
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house85.jpg
 other_identifiers:
 - identifier: KYL000130
   scheme: legacy_openstates

--- a/data/ky/people/Walker-Thomas-ec846db3-c75b-4460-ba72-3e2b3fd9e04d.yml
+++ b/data/ky/people/Walker-Thomas-ec846db3-c75b-4460-ba72-3e2b3fd9e04d.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 413F;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 329C;Frankfort, KY 40601
   email: Walker.Thomas@lrc.ky.gov
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 658
 links:
-- url: http://www.lrc.ky.gov/legislator/H008.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=8
 sources:
-- url: http://www.lrc.ky.gov/legislator/H008.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House08.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=8
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house8.jpg
 other_identifiers:
 - identifier: KYL000238
   scheme: legacy_openstates

--- a/data/ky/people/Whitney-Westerfield-f81a2d15-a4d9-4a66-97bb-31304fcb7eab.yml
+++ b/data/ky/people/Whitney-Westerfield-f81a2d15-a4d9-4a66-97bb-31304fcb7eab.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 228;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 228;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 622
+  email: Whitney.Westerfield@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S003.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=103
 sources:
-- url: http://www.lrc.ky.gov/legislator/S003.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate03.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=103
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate103.jpg
 other_identifiers:
 - identifier: KYL000152
   scheme: legacy_openstates

--- a/data/ky/people/Wil-Schroder-40b94262-4365-4d5a-8add-d18dc6f96624.yml
+++ b/data/ky/people/Wil-Schroder-40b94262-4365-4d5a-8add-d18dc6f96624.yml
@@ -7,14 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
 contact_details:
-- address: 702 Capitol Ave;Annex Room 209;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 209;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 624
+  email: wil.schroder@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/S024.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=124
 sources:
-- url: http://www.lrc.ky.gov/legislator/S024.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/Senate24.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=124
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/senate124.jpg
 other_identifiers:
 - identifier: KYL000209
   scheme: legacy_openstates

--- a/data/ky/people/Wilson-Stone-9c1bf980-343c-4cef-b5e4-2c527f40f208.yml
+++ b/data/ky/people/Wilson-Stone-9c1bf980-343c-4cef-b5e4-2c527f40f208.yml
@@ -7,18 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: lower
 contact_details:
-- address: 702 Capitol Ave;Annex Room 472;Frankfort KY 40601;700 Capitol Ave;Capitol
-    Room 305;Frankfort KY 40601
+- address: 702 Capital Ave;Annex Room 429F;Frankfort, KY 40601
   note: Capitol Office
-  voice: 502-564-5565
-- address: 702 Capitol Ave;Annex Room 429F;Frankfort KY 40601
-  note: Capitol Office
-  voice: 502-564-8100
+  voice: 502-564-8100 ext. 674
+  email: Wilson.Stone@lrc.ky.gov
 links:
-- url: http://www.lrc.ky.gov/legislator/H022.htm
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=22
 sources:
-- url: http://www.lrc.ky.gov/legislator/H022.htm
-image: http://www.lrc.ky.gov/pubinfo/thumbnails/House22.jpg
+- url: https://legislature.ky.gov/Legislators/Pages/Legislator-Profile.aspx?DistrictNumber=22
+image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house22.jpg
 other_identifiers:
 - identifier: KYL000126
   scheme: legacy_openstates

--- a/data/ky/retired/Ray-S-Jones-II-a6366782-145a-433a-ac96-d20ed09c0050.yml
+++ b/data/ky/retired/Ray-S-Jones-II-a6366782-145a-433a-ac96-d20ed09c0050.yml
@@ -6,6 +6,7 @@ roles:
 - district: '31'
   jurisdiction: ocd-jurisdiction/country:us/state:ky/government
   type: upper
+  end_date: '2018-12-31'
 contact_details:
 - address: 702 Capitol Ave;Annex Room 254;Frankfort KY 40601;700 Capitol Ave;Capitol
     Room 331;Frankfort KY 40601

--- a/settings.yml
+++ b/settings.yml
@@ -128,6 +128,10 @@ ky:
   legislature_name: Kentucky General Assembly
   lower_seats: 100
   upper_seats: 38
+  vacancies:
+    - chamber: upper
+      district: 31
+      vacant_until: 2019-03-19
 la:
   legislature_name: Louisiana Legislature
   lower_seats: 105


### PR DESCRIPTION
Changes to KY legislators based on updated scraper (see https://github.com/openstates/openstates/pull/2865/).

Links have all changed. Some email addresses and phone extensions were added. One retirement since last update. (Amazingly, the Kentucky state *capitol* is on *Capital* Ave, relevant changes to addresses appear correct.)