### PR TITLE
Updates to Minnesota legislators

### DIFF
--- a/data/mn/organizations/E--Policy-Committee-71855a86-c986-4ab2-8a36-7e066fa45e62.yml
+++ b/data/mn/organizations/E--Policy-Committee-71855a86-c986-4ab2-8a36-7e066fa45e62.yml
@@ -22,7 +22,7 @@ memberships:
 - id: ocd-person/e1c3b10e-a051-4df2-b8d4-dc1a6a01623b
   name: Gregory D. Clausen
 - id: ocd-person/e67843ce-752d-4cc0-abb9-4a45b8b8fdca
-  name: Steve A. Cwodzinski
+  name: Steve Cwodzinski
 - id: ocd-person/232c625b-79bc-48d3-addb-cfffa0f15108
   name: Susan Kent
   role: ranking minority member

--- a/data/mn/organizations/Environment-and-Natural-Resources-Policy-and-Legacy-Finance-Committee-9340747d-32c2-4bae-b1d9-ef6e693fc394.yml
+++ b/data/mn/organizations/Environment-and-Natural-Resources-Policy-and-Legacy-Finance-Committee-9340747d-32c2-4bae-b1d9-ef6e693fc394.yml
@@ -33,4 +33,4 @@ memberships:
 - id: ocd-person/aabdca28-85ec-41e4-be90-726acaaa0cff
   name: Andrew Mathews
 - id: ocd-person/e67843ce-752d-4cc0-abb9-4a45b8b8fdca
-  name: Steve A. Cwodzinski
+  name: Steve Cwodzinski

--- a/data/mn/organizations/Veterans-and-Military-Affairs-Finance-and-Policy-Committee-4b25eda8-48f5-4083-8712-e57c69305825.yml
+++ b/data/mn/organizations/Veterans-and-Military-Affairs-Finance-and-Policy-Committee-4b25eda8-48f5-4083-8712-e57c69305825.yml
@@ -8,7 +8,7 @@ sources:
 - url: http://www.senate.mn/committees/committee_bio.php?cmte_id=3103&ls=
 memberships:
 - id: ocd-person/e67843ce-752d-4cc0-abb9-4a45b8b8fdca
-  name: Steve A. Cwodzinski
+  name: Steve Cwodzinski
 - id: ocd-person/4e9b1387-c076-4e00-8719-e0866869ed38
   name: Dan D. Hall
 - id: ocd-person/ae46fe13-949c-444e-8dee-af9f9039c1d5

--- a/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
+++ b/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: upper
 contact_details:
-- address: 2327 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
+- address: 2325 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
   email: sen.carolyn.laine@senate.mn
   note: capitol
   voice: 651-296-4334

--- a/data/mn/people/Jason-Rarick-f15c0d42-4380-4f9b-b66d-14ffe61e1a40.yml
+++ b/data/mn/people/Jason-Rarick-f15c0d42-4380-4f9b-b66d-14ffe61e1a40.yml
@@ -6,16 +6,22 @@ roles:
 - district: 11B
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: lower
+  end_date: '2019-02-12'
+- district: '11'
+  jurisdiction: ocd-jurisdiction/country:us/state:mn/government
+  type: upper
+  start_date: '2019-02-13'
 contact_details:
-- address: 387 State Office Building;St. Paul, MN 55155
-  email: rep.jason.rarick@house.mn
+- address: 13954 Beroun Crossing Road;Brook Park, MN 55007
+  email: sen.jason.rarick@senate.mn
   note: capitol
-  voice: 651-296-0518
+  voice: 651-296-1508
 links:
-- url: http://www.house.leg.state.mn.us/members/profile/15445
+- url: http://www.senate.mn/members/member_bio.php?member_id=1240
 sources:
-- url: http://www.house.leg.state.mn.us/members/hmem.asp
-image: https://www.house.leg.state.mn.us/hinfo/memberimgls91/11B.gif
+- url: http://www.senate.mn/members/member_list_ascii.php?ls=
+- url: http://www.senate.mn/members/index.php
+image: http://www.senate.mn/graphics/member_thumbnails/11Rarick.jpg
 other_identifiers:
 - identifier: MNL000582
   scheme: legacy_openstates

--- a/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
+++ b/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: upper
 contact_details:
-- address: 3411 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
+- address: 2327 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
   note: capitol
   voice: 651-297-8060
 links:

--- a/data/mn/people/Paul-E-Gazelka-0a0641bd-4b3a-4eb3-8044-b1ff468b8193.yml
+++ b/data/mn/people/Paul-E-Gazelka-0a0641bd-4b3a-4eb3-8044-b1ff468b8193.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: upper
 contact_details:
-- address: 15229 Edgewood Drive;Suite 100A;Baxter, MN 56425
+- address: 7822 Fairview Road;Suite 95;Baxter, MN 56425
   note: capitol
   voice: 651-296-4875
 links:

--- a/data/mn/people/Steve-A-Cwodzinski-e67843ce-752d-4cc0-abb9-4a45b8b8fdca.yml
+++ b/data/mn/people/Steve-A-Cwodzinski-e67843ce-752d-4cc0-abb9-4a45b8b8fdca.yml
@@ -1,5 +1,5 @@
 id: ocd-person/e67843ce-752d-4cc0-abb9-4a45b8b8fdca
-name: Steve A. Cwodzinski
+name: Steve Cwodzinski
 party:
 - name: Democratic-Farmer-Labor
 roles:

--- a/data/mn/people/Susan-Kent-232c625b-79bc-48d3-addb-cfffa0f15108.yml
+++ b/data/mn/people/Susan-Kent-232c625b-79bc-48d3-addb-cfffa0f15108.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: upper
 contact_details:
-- address: 2325 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
+- address: 2227 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
   note: capitol
   voice: 651-296-4166
 links:

--- a/data/mn/people/Warren-Limmer-dc676c57-0779-4d0e-9ba4-a07d7034dfa1.yml
+++ b/data/mn/people/Warren-Limmer-dc676c57-0779-4d0e-9ba4-a07d7034dfa1.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: upper
 contact_details:
-- address: 12888 N. 73rd Avenue;Maple Grove, MN 55369
+- address: 12888 73rd Avenue N.;Maple Grove, MN 55369
   email: sen.warren.limmer@senate.mn
   note: capitol
   voice: 651-296-2159

--- a/settings.yml
+++ b/settings.yml
@@ -375,9 +375,9 @@ mn:
   legslature_name: Minnesota State Legislature
   upper_seats: 67
   vacancies:
-    - chamber: upper
-      district: 11
-      vacant_until: 2019-02-10
+    - chamber: lower
+      district: '11B'
+      vacant_until: 2019-05-01
 mt:
   legislature_name: Montana Legislature
   lower_seats: 100


### PR DESCRIPTION
Jason Rarick filled the vacancy for Senate district 11, so now his former House seat in district 11B is vacant. Also update some contact information and one name update (remove middle initial).