### PR TITLE
IL: Add 2019 committees

### DIFF
--- a/data/il/organizations/Adoption--Child-Welfare-146b8dad-1f2d-4acf-925a-87157d434c1e.yml
+++ b/data/il/organizations/Adoption--Child-Welfare-146b8dad-1f2d-4acf-925a-87157d434c1e.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/146b8dad-1f2d-4acf-925a-87157d434c1e
+name: Adoption & Child Welfare
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2549&GA=101
+memberships:
+- name: Chris Miller
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Sara Feigenholtz
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  start_date: '2018'
+  end_date: '2019'
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Delia C. Ramirez
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Diane Pappas
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith P. Sommer
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Agriculture--Conservation-c4654c6c-35e8-46ec-bdbe-e658d367058b.yml
+++ b/data/il/organizations/Agriculture--Conservation-c4654c6c-35e8-46ec-bdbe-e658d367058b.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/c4654c6c-35e8-46ec-bdbe-e658d367058b
+name: Agriculture & Conservation
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2331&GA=101
+memberships:
+- name: Michael Halpin
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Lance Yednock
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Jerry Costello, II
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Swanson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Agriculture-81efc430-c536-49e7-baf6-1efdafa07e05.yml
+++ b/data/il/organizations/Agriculture-81efc430-c536-49e7-baf6-1efdafa07e05.yml
@@ -1,0 +1,48 @@
+id: ocd-organization/81efc430-c536-49e7-baf6-1efdafa07e05
+name: Agriculture
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2316&GA=101
+memberships:
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Holmes
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Amusement--Online-Gaming-Sub-bd4df69d-a260-4f5b-95c5-a0ebf31b6b54.yml
+++ b/data/il/organizations/Amusement--Online-Gaming-Sub-bd4df69d-a260-4f5b-95c5-a0ebf31b6b54.yml
@@ -1,0 +1,23 @@
+id: ocd-organization/bd4df69d-a260-4f5b-95c5-a0ebf31b6b54
+name: Amusement & Online Gaming Sub
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/21ae4c2b-d379-447e-8700-7c420db4f2bb
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2598&GA=101
+memberships:
+- name: Jaime M. Andrade, Jr.
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Anthony DeLuca
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Approp-Elementary--Secondary-Educ-2af482a3-0ff4-4580-9e0e-f56fa0c68d69.yml
+++ b/data/il/organizations/Approp-Elementary--Secondary-Educ-2af482a3-0ff4-4580-9e0e-f56fa0c68d69.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/2af482a3-0ff4-4580-9e0e-f56fa0c68d69
+name: Approp-Elementary & Secondary Educ
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2293&GA=101
+memberships:
+- name: Avery Bourne
+  start_date: '2018'
+  end_date: '2019'
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael P. McAuliffe
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Elizabeth Hernandez
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kambium Buckner
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-Capital-a1e4175a-1df0-4689-b056-0788aacebe38.yml
+++ b/data/il/organizations/Appropriations-Capital-a1e4175a-1df0-4689-b056-0788aacebe38.yml
@@ -1,0 +1,93 @@
+id: ocd-organization/a1e4175a-1df0-4689-b056-0788aacebe38
+name: Appropriations-Capital
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2550&GA=101
+memberships:
+- name: Jehan Gordon-Booth
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael P. McAuliffe
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  start_date: '2018'
+  end_date: '2019'
+- name: John M. Cabello
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael Halpin
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Melissa Conyears-Ervin
+  start_date: '2018'
+  end_date: '2019'
+- name: Luis Arroyo
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: Justin Slaughter
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'
+- name: Anne Stava-Murray
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Ugaste
+  start_date: '2018'
+  end_date: '2019'
+- name: Lawrence Walsh, Jr.
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Scherer
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-General-Service-6ef82743-6633-428d-8d3a-540ccba0ce2e.yml
+++ b/data/il/organizations/Appropriations-General-Service-6ef82743-6633-428d-8d3a-540ccba0ce2e.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/6ef82743-6633-428d-8d3a-540ccba0ce2e
+name: Appropriations-General Service
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2294&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: Diane Pappas
+  start_date: '2018'
+  end_date: '2019'
+- name: Allen Skillicorn
+  start_date: '2018'
+  end_date: '2019'
+- name: Brad Halbrook
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Caulkins
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  start_date: '2018'
+  end_date: '2019'
+- name: Chris Miller
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-Higher-Education-9dcc4342-30ef-4110-9624-f8bb549a77c1.yml
+++ b/data/il/organizations/Appropriations-Higher-Education-9dcc4342-30ef-4110-9624-f8bb549a77c1.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/9dcc4342-30ef-4110-9624-f8bb549a77c1
+name: Appropriations-Higher Education
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2296&GA=101
+memberships:
+- name: La Shawn K. Ford
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Nicholas K. Smith
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Aaron M. Ortiz
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Maurice A. West II
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-Human-Services-5255d306-fe2e-4715-b080-d0ef3b6d7a9f.yml
+++ b/data/il/organizations/Appropriations-Human-Services-5255d306-fe2e-4715-b080-d0ef3b6d7a9f.yml
@@ -1,0 +1,69 @@
+id: ocd-organization/5255d306-fe2e-4715-b080-d0ef3b6d7a9f
+name: Appropriations-Human Services
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2295&GA=101
+memberships:
+- name: Gregory Harris
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  start_date: '2018'
+  end_date: '2019'
+- name: Delia C. Ramirez
+  start_date: '2018'
+  end_date: '2019'
+- name: Robyn Gabel
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Sara Feigenholtz
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  start_date: '2018'
+  end_date: '2019'
+- name: Camille Y. Lilly
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Bob Morgan
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  start_date: '2018'
+  end_date: '2019'
+- name: Elizabeth Hernandez
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-I-d530de53-a6a5-4e72-81b4-0fbec81710a9.yml
+++ b/data/il/organizations/Appropriations-I-d530de53-a6a5-4e72-81b4-0fbec81710a9.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/d530de53-a6a5-4e72-81b4-0fbec81710a9
+name: Appropriations I
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2317&GA=101
+memberships:
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-II-5eb4293e-2149-4ff5-9cc8-98f9d110f16f.yml
+++ b/data/il/organizations/Appropriations-II-5eb4293e-2149-4ff5-9cc8-98f9d110f16f.yml
@@ -1,0 +1,66 @@
+id: ocd-organization/5eb4293e-2149-4ff5-9cc8-98f9d110f16f
+name: Appropriations II
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2329&GA=101
+memberships:
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven M. Landek
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Appropriations-Public-Safety-8c118b53-a717-445a-be5e-22f2f15ae949.yml
+++ b/data/il/organizations/Appropriations-Public-Safety-8c118b53-a717-445a-be5e-22f2f15ae949.yml
@@ -1,0 +1,60 @@
+id: ocd-organization/8c118b53-a717-445a-be5e-22f2f15ae949
+name: Appropriations-Public Safety
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2297&GA=101
+memberships:
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Swanson
+  start_date: '2018'
+  end_date: '2019'
+- name: John M. Cabello
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jehan Gordon-Booth
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: Aaron M. Ortiz
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Camille Y. Lilly
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jerry Costello, II
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Assignments-1594c911-63a9-4d95-b874-d7b1cff9978a.yml
+++ b/data/il/organizations/Assignments-1594c911-63a9-4d95-b874-d7b1cff9978a.yml
@@ -1,0 +1,30 @@
+id: ocd-organization/1594c911-63a9-4d95-b874-d7b1cff9978a
+name: Assignments
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2341&GA=101
+memberships:
+- name: Don Harmon
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Broadband-Access-and-IT-Assurance-5e3391ea-2c1f-4016-a6ff-3458a74ec382.yml
+++ b/data/il/organizations/Broadband-Access-and-IT-Assurance-5e3391ea-2c1f-4016-a6ff-3458a74ec382.yml
@@ -1,0 +1,23 @@
+id: ocd-organization/5e3391ea-2c1f-4016-a6ff-3458a74ec382
+name: Broadband Access and IT Assurance
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/21ae4c2b-d379-447e-8700-7c420db4f2bb
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2597&GA=101
+memberships:
+- name: Anthony DeLuca
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Business-and-Industry-Regulations-S-fe8c4688-b1b2-4053-b104-d27a0df56e25.yml
+++ b/data/il/organizations/Business-and-Industry-Regulations-S-fe8c4688-b1b2-4053-b104-d27a0df56e25.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/fe8c4688-b1b2-4053-b104-d27a0df56e25
+name: Business and Industry Regulations S
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2570&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Child-Care-Access--Early-Childhood-023d94a4-3fb4-4233-8452-7504bb4062b5.yml
+++ b/data/il/organizations/Child-Care-Access--Early-Childhood-023d94a4-3fb4-4233-8452-7504bb4062b5.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/023d94a4-3fb4-4233-8452-7504bb4062b5
+name: Child Care Access & Early Childhood
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2551&GA=101
+memberships:
+- name: Sue Scherer
+  start_date: '2018'
+  end_date: '2019'
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Melissa Conyears-Ervin
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'
+- name: Justin Slaughter
+  start_date: '2018'
+  end_date: '2019'
+- name: Nicholas K. Smith
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'
+- name: Jehan Gordon-Booth
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kambium Buckner
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Cities--Villages-6afaa36f-1fca-4cb5-9d72-cf654b9f575f.yml
+++ b/data/il/organizations/Cities--Villages-6afaa36f-1fca-4cb5-9d72-cf654b9f575f.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/6afaa36f-1fca-4cb5-9d72-cf654b9f575f
+name: Cities & Villages
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2347&GA=101
+memberships:
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Diane Pappas
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Brad Halbrook
+  start_date: '2018'
+  end_date: '2019'
+- name: Allen Skillicorn
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: Anthony DeLuca
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Civil-Procedure-Subcommittee-eee69293-5217-440e-bfc5-3d4a45de2731.yml
+++ b/data/il/organizations/Civil-Procedure-Subcommittee-eee69293-5217-440e-bfc5-3d4a45de2731.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/eee69293-5217-440e-bfc5-3d4a45de2731
+name: Civil Procedure Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2571&GA=101
+memberships:
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Commerce-and-Economic-Development-f5e0d713-143c-4e5c-a8b3-d84d6991ae6e.yml
+++ b/data/il/organizations/Commerce-and-Economic-Development-f5e0d713-143c-4e5c-a8b3-d84d6991ae6e.yml
@@ -1,0 +1,48 @@
+id: ocd-organization/f5e0d713-143c-4e5c-a8b3-d84d6991ae6e
+name: Commerce and Economic Development
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2358&GA=101
+memberships:
+- name: Laura M. Murphy
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Napoleon Harris, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Holmes
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Commerce-and-Innovation-Subcommitte-014b5af6-0065-4e05-80d0-94ba55fac103.yml
+++ b/data/il/organizations/Commerce-and-Innovation-Subcommitte-014b5af6-0065-4e05-80d0-94ba55fac103.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/014b5af6-0065-4e05-80d0-94ba55fac103
+name: Commerce and Innovation Subcommitte
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2569&GA=101
+memberships:
+- name: Jaime M. Andrade, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Commercial-Law-Subcommittee-99193b47-4fed-4e15-8855-693c303d5a74.yml
+++ b/data/il/organizations/Commercial-Law-Subcommittee-99193b47-4fed-4e15-8855-693c303d5a74.yml
@@ -1,0 +1,31 @@
+id: ocd-organization/99193b47-4fed-4e15-8855-693c303d5a74
+name: Commercial Law Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2573&GA=101
+memberships:
+- name: "Andr\xE9 Thapedi"
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Committee-of-the-Whole-3c605cdb-e0c0-4574-903c-bef11e794b35.yml
+++ b/data/il/organizations/Committee-of-the-Whole-3c605cdb-e0c0-4574-903c-bef11e794b35.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/3c605cdb-e0c0-4574-903c-bef11e794b35
+name: Committee of the Whole
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2299&GA=101
+memberships: []

--- a/data/il/organizations/Committee-of-the-Whole-b7a1cf51-d083-41e0-93e9-31a4f599741b.yml
+++ b/data/il/organizations/Committee-of-the-Whole-b7a1cf51-d083-41e0-93e9-31a4f599741b.yml
@@ -1,0 +1,186 @@
+id: ocd-organization/b7a1cf51-d083-41e0-93e9-31a4f599741b
+name: Committee of the Whole
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2332&GA=101
+memberships:
+- name: Steven M. Landek
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: William E. Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Holmes
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'
+- name: John J. Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  start_date: '2018'
+  end_date: '2019'
+- name: Jacqueline Y. Collins
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Napoleon Harris, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Consolidation--Tax-Subcommittee-ec3e883e-6448-4d0f-9d35-d6817f9fdbc0.yml
+++ b/data/il/organizations/Consolidation--Tax-Subcommittee-ec3e883e-6448-4d0f-9d35-d6817f9fdbc0.yml
@@ -1,0 +1,23 @@
+id: ocd-organization/ec3e883e-6448-4d0f-9d35-d6817f9fdbc0
+name: Consolidation & Tax Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/c8fc4719-65cb-4d65-9d2f-490eb09f89f6
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2593&GA=101
+memberships:
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: David McSweeney
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Constitutional-Law-Subcommittee-7359b0ba-7ca7-456b-a1ee-5c7501490910.yml
+++ b/data/il/organizations/Constitutional-Law-Subcommittee-7359b0ba-7ca7-456b-a1ee-5c7501490910.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/7359b0ba-7ca7-456b-a1ee-5c7501490910
+name: Constitutional Law Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2572&GA=101
+memberships:
+- name: "Andr\xE9 Thapedi"
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Consumer-Protection-48495a8e-3770-44b9-baf9-725f0bb7aa17.yml
+++ b/data/il/organizations/Consumer-Protection-48495a8e-3770-44b9-baf9-725f0bb7aa17.yml
@@ -1,0 +1,48 @@
+id: ocd-organization/48495a8e-3770-44b9-baf9-725f0bb7aa17
+name: Consumer Protection
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2298&GA=101
+memberships:
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Elizabeth Hernandez
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Scherer
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Counties--Townships-c8fc4719-65cb-4d65-9d2f-490eb09f89f6.yml
+++ b/data/il/organizations/Counties--Townships-c8fc4719-65cb-4d65-9d2f-490eb09f89f6.yml
@@ -1,0 +1,63 @@
+id: ocd-organization/c8fc4719-65cb-4d65-9d2f-490eb09f89f6
+name: Counties & Townships
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2348&GA=101
+memberships:
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark L. Walker
+  start_date: '2018'
+  end_date: '2019'
+- name: David McSweeney
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael T. Marron
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Brad Halbrook
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Lawrence Walsh, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Criminal-Law-e487f43f-9b6e-4c7a-9a33-f8d718e095c6.yml
+++ b/data/il/organizations/Criminal-Law-e487f43f-9b6e-4c7a-9a33-f8d718e095c6.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/e487f43f-9b6e-4c7a-9a33-f8d718e095c6
+name: Criminal Law
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2342&GA=101
+memberships:
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Cybersecurity-Data-Analytics--IT-21ae4c2b-d379-447e-8700-7c420db4f2bb.yml
+++ b/data/il/organizations/Cybersecurity-Data-Analytics--IT-21ae4c2b-d379-447e-8700-7c420db4f2bb.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/21ae4c2b-d379-447e-8700-7c420db4f2bb
+name: Cybersecurity, Data Analytics, & IT
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2379&GA=101
+memberships:
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  start_date: '2018'
+  end_date: '2019'
+- name: Aaron M. Ortiz
+  start_date: '2018'
+  end_date: '2019'
+- name: Allen Skillicorn
+  start_date: '2018'
+  end_date: '2019'
+- name: Diane Pappas
+  start_date: '2018'
+  end_date: '2019'
+- name: Anthony DeLuca
+  start_date: '2018'
+  end_date: '2019'
+- name: Anne Stava-Murray
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael P. McAuliffe
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Distributed-Ledgers--Cryptocurrenc-88981f9f-4932-477f-bebf-dc86e0c10223.yml
+++ b/data/il/organizations/Distributed-Ledgers--Cryptocurrenc-88981f9f-4932-477f-bebf-dc86e0c10223.yml
@@ -1,0 +1,17 @@
+id: ocd-organization/88981f9f-4932-477f-bebf-dc86e0c10223
+name: Distributed Ledgers & Cryptocurrenc
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/21ae4c2b-d379-447e-8700-7c420db4f2bb
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2599&GA=101
+memberships:
+- name: John Connor
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Economic-Opportunity--Equity-dd86eb5c-c9fe-4286-8b56-cb68e993a16b.yml
+++ b/data/il/organizations/Economic-Opportunity--Equity-dd86eb5c-c9fe-4286-8b56-cb68e993a16b.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/dd86eb5c-c9fe-4286-8b56-cb68e993a16b
+name: Economic Opportunity & Equity
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2381&GA=101
+memberships:
+- name: Will Guzzardi
+  start_date: '2018'
+  end_date: '2019'
+- name: Chris Miller
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark L. Walker
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael T. Marron
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Nicholas K. Smith
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  start_date: '2018'
+  end_date: '2019'
+- name: Jehan Gordon-Booth
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Education-69891dab-4f61-42a1-93b5-e93721944b57.yml
+++ b/data/il/organizations/Education-69891dab-4f61-42a1-93b5-e93721944b57.yml
@@ -1,0 +1,63 @@
+id: ocd-organization/69891dab-4f61-42a1-93b5-e93721944b57
+name: Education
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2318&GA=101
+memberships:
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Elem-Sec-Ed-Adm-Lic--Charter-be564bbd-8487-455a-9152-5c8f1e5fb71b.yml
+++ b/data/il/organizations/Elem-Sec-Ed-Adm-Lic--Charter-be564bbd-8487-455a-9152-5c8f1e5fb71b.yml
@@ -1,0 +1,36 @@
+id: ocd-organization/be564bbd-8487-455a-9152-5c8f1e5fb71b
+name: 'Elem Sec Ed: Adm., Lic. & Charter'
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2361&GA=101
+memberships:
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Delia C. Ramirez
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Scherer
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Elem-Sec-Ed-School-Curric-Policies-37283046-4392-46ae-8cf2-48c3ba746637.yml
+++ b/data/il/organizations/Elem-Sec-Ed-School-Curric-Policies-37283046-4392-46ae-8cf2-48c3ba746637.yml
@@ -1,0 +1,75 @@
+id: ocd-organization/37283046-4392-46ae-8cf2-48c3ba746637
+name: 'Elem Sec Ed: School Curric Policies'
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2300&GA=101
+memberships:
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Swanson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Anne Stava-Murray
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  start_date: '2018'
+  end_date: '2019'
+- name: Chris Miller
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Energy--Environment-e405d60e-70e7-4811-8b1d-5de953333b98.yml
+++ b/data/il/organizations/Energy--Environment-e405d60e-70e7-4811-8b1d-5de953333b98.yml
@@ -1,0 +1,105 @@
+id: ocd-organization/e405d60e-70e7-4811-8b1d-5de953333b98
+name: Energy & Environment
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2355&GA=101
+memberships:
+- name: Nicholas K. Smith
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Lawrence Walsh, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Robyn Gabel
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jerry Costello, II
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael T. Marron
+  start_date: '2018'
+  end_date: '2019'
+- name: Bob Morgan
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Caulkins
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Ugaste
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  start_date: '2018'
+  end_date: '2019'
+- name: Darren Bailey
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Chris Miller
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Energy-and-Public-Utilities-ae6b1b4b-2cf4-454d-b0b0-9b96e3769250.yml
+++ b/data/il/organizations/Energy-and-Public-Utilities-ae6b1b4b-2cf4-454d-b0b0-9b96e3769250.yml
@@ -1,0 +1,84 @@
+id: ocd-organization/ae6b1b4b-2cf4-454d-b0b0-9b96e3769250
+name: Energy and Public Utilities
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2343&GA=101
+memberships:
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Environment-and-Conservation-5cebedf8-6f18-4e99-9f48-3d150fbbeb3d.yml
+++ b/data/il/organizations/Environment-and-Conservation-5cebedf8-6f18-4e99-9f48-3d150fbbeb3d.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/5cebedf8-6f18-4e99-9f48-3d150fbbeb3d
+name: Environment and Conservation
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2344&GA=101
+memberships:
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Environmental-Justice-Subcommittee-db7741f4-6bb1-4805-8348-539a83e49597.yml
+++ b/data/il/organizations/Environmental-Justice-Subcommittee-db7741f4-6bb1-4805-8348-539a83e49597.yml
@@ -1,0 +1,26 @@
+id: ocd-organization/db7741f4-6bb1-4805-8348-539a83e49597
+name: Environmental Justice Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/e405d60e-70e7-4811-8b1d-5de953333b98
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2595&GA=101
+memberships:
+- name: Theresa Mah
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Executive-139eb4ad-4e90-4f58-8db7-0e842f28ff17.yml
+++ b/data/il/organizations/Executive-139eb4ad-4e90-4f58-8db7-0e842f28ff17.yml
@@ -1,0 +1,69 @@
+id: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+name: Executive
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2320&GA=101
+memberships:
+- name: Napoleon Harris, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'
+- name: John J. Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Holmes
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  start_date: '2018'
+  end_date: '2019'
+- name: William E. Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Executive-Appointments-ce0b0e68-4577-4aa5-b2a4-9231a459f1ee.yml
+++ b/data/il/organizations/Executive-Appointments-ce0b0e68-4577-4aa5-b2a4-9231a459f1ee.yml
@@ -1,0 +1,48 @@
+id: ocd-organization/ce0b0e68-4577-4aa5-b2a4-9231a459f1ee
+name: Executive Appointments
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2319&GA=101
+memberships:
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Executive-fd21701b-8cd3-43c6-be09-5d7e38896163.yml
+++ b/data/il/organizations/Executive-fd21701b-8cd3-43c6-be09-5d7e38896163.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/fd21701b-8cd3-43c6-be09-5d7e38896163
+name: Executive
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2302&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Luis Arroyo
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Jehan Gordon-Booth
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Facilities-Subcommittee-1578a6f3-6771-4139-9cfe-109683bd18f3.yml
+++ b/data/il/organizations/Facilities-Subcommittee-1578a6f3-6771-4139-9cfe-109683bd18f3.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/1578a6f3-6771-4139-9cfe-109683bd18f3
+name: Facilities Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/52e45d0a-a7dd-4c91-ab33-29d535f07094
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2577&GA=101
+memberships:
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Family-Law-Subcommittee-dc439504-b704-49b5-81f8-e5ec418aff11.yml
+++ b/data/il/organizations/Family-Law-Subcommittee-dc439504-b704-49b5-81f8-e5ec418aff11.yml
@@ -1,0 +1,37 @@
+id: ocd-organization/dc439504-b704-49b5-81f8-e5ec418aff11
+name: Family Law Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2574&GA=101
+memberships:
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Financial-Institutions-07e791cc-10b6-4735-a0cd-4e96597dfc50.yml
+++ b/data/il/organizations/Financial-Institutions-07e791cc-10b6-4735-a0cd-4e96597dfc50.yml
@@ -1,0 +1,63 @@
+id: ocd-organization/07e791cc-10b6-4735-a0cd-4e96597dfc50
+name: Financial Institutions
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2303&GA=101
+memberships:
+- name: Michael P. McAuliffe
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  start_date: '2018'
+  end_date: '2019'
+- name: Camille Y. Lilly
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: La Shawn K. Ford
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark L. Walker
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Melissa Conyears-Ervin
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith P. Sommer
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Financial-Institutions-4872d5fc-62fc-49d5-b82a-33cd7aa9e425.yml
+++ b/data/il/organizations/Financial-Institutions-4872d5fc-62fc-49d5-b82a-33cd7aa9e425.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/4872d5fc-62fc-49d5-b82a-33cd7aa9e425
+name: Financial Institutions
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2321&GA=101
+memberships:
+- name: Andy Manar
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jacqueline Y. Collins
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Government-AccountabilityPensions-538d987c-cb77-455a-b9bb-0b6691e54e94.yml
+++ b/data/il/organizations/Government-AccountabilityPensions-538d987c-cb77-455a-b9bb-0b6691e54e94.yml
@@ -1,0 +1,45 @@
+id: ocd-organization/538d987c-cb77-455a-b9bb-0b6691e54e94
+name: Government Accountability/Pensions
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2373&GA=101
+memberships:
+- name: Iris Y. Martinez
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven M. Landek
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Health-Care-Availability--Access-50eade97-206a-4a43-9039-1de035a31320.yml
+++ b/data/il/organizations/Health-Care-Availability--Access-50eade97-206a-4a43-9039-1de035a31320.yml
@@ -1,0 +1,30 @@
+id: ocd-organization/50eade97-206a-4a43-9039-1de035a31320
+name: Health Care Availability & Access
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2304&GA=101
+memberships:
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary E. Flowers
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Health-Care-Licenses-c96a4b74-715d-4113-965f-2147c24fd53e.yml
+++ b/data/il/organizations/Health-Care-Licenses-c96a4b74-715d-4113-965f-2147c24fd53e.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/c96a4b74-715d-4113-965f-2147c24fd53e
+name: Health Care Licenses
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2349&GA=101
+memberships:
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Ugaste
+  start_date: '2018'
+  end_date: '2019'
+- name: Elizabeth Hernandez
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Anthony DeLuca
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael P. McAuliffe
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark Batinick
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  start_date: '2018'
+  end_date: '2019'
+- name: Bob Morgan
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Health-Insurance-Subcommittee-64dded67-592f-4f03-9a80-6aece10f65b4.yml
+++ b/data/il/organizations/Health-Insurance-Subcommittee-64dded67-592f-4f03-9a80-6aece10f65b4.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/64dded67-592f-4f03-9a80-6aece10f65b4
+name: Health Insurance Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/07aa5d6e-d4ae-44e8-88d8-67f407138293
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2582&GA=101
+memberships:
+- name: Mark Batinick
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Higher-Education-27ab5308-d516-4d83-affa-8f49a4caad6c.yml
+++ b/data/il/organizations/Higher-Education-27ab5308-d516-4d83-affa-8f49a4caad6c.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/27ab5308-d516-4d83-affa-8f49a4caad6c
+name: Higher Education
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2333&GA=101
+memberships:
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Higher-Education-e36cecbf-7cfb-460f-9e22-56c7a59d87a0.yml
+++ b/data/il/organizations/Higher-Education-e36cecbf-7cfb-460f-9e22-56c7a59d87a0.yml
@@ -1,0 +1,72 @@
+id: ocd-organization/e36cecbf-7cfb-460f-9e22-56c7a59d87a0
+name: Higher Education
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2305&GA=101
+memberships:
+- name: Dan Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Elizabeth Hernandez
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Maurice A. West II
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  start_date: '2018'
+  end_date: '2019'
+- name: Kambium Buckner
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael T. Marron
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Human-Services-52e45d0a-a7dd-4c91-ab33-29d535f07094.yml
+++ b/data/il/organizations/Human-Services-52e45d0a-a7dd-4c91-ab33-29d535f07094.yml
@@ -1,0 +1,66 @@
+id: ocd-organization/52e45d0a-a7dd-4c91-ab33-29d535f07094
+name: Human Services
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2306&GA=101
+memberships:
+- name: Mary E. Flowers
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Sonya M. Harper
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael T. Marron
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Human-Services-a54622c5-6da4-43eb-a6f1-25178c5c05e9.yml
+++ b/data/il/organizations/Human-Services-a54622c5-6da4-43eb-a6f1-25178c5c05e9.yml
@@ -1,0 +1,45 @@
+id: ocd-organization/a54622c5-6da4-43eb-a6f1-25178c5c05e9
+name: Human Services
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2330&GA=101
+memberships:
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Napoleon Harris, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Fine
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  start_date: '2018'
+  end_date: '2019'
+- name: Heather A. Steans
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Income-Tax-Subcommittee-c2b873b4-54cd-468d-a64c-9f98a89fcb4c.yml
+++ b/data/il/organizations/Income-Tax-Subcommittee-c2b873b4-54cd-468d-a64c-9f98a89fcb4c.yml
@@ -1,0 +1,28 @@
+id: ocd-organization/c2b873b4-54cd-468d-a64c-9f98a89fcb4c
+name: Income Tax Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/cc286211-8841-48d8-a522-23f9fa759539
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2588&GA=101
+memberships:
+- name: Thomas M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Informed-Consent-Subcommittee-21da2e2f-674a-490c-b7f5-4f6623dbd82b.yml
+++ b/data/il/organizations/Informed-Consent-Subcommittee-21da2e2f-674a-490c-b7f5-4f6623dbd82b.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/21da2e2f-674a-490c-b7f5-4f6623dbd82b
+name: Informed Consent Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/52e45d0a-a7dd-4c91-ab33-29d535f07094
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2580&GA=101
+memberships:
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Insurance-07aa5d6e-d4ae-44e8-88d8-67f407138293.yml
+++ b/data/il/organizations/Insurance-07aa5d6e-d4ae-44e8-88d8-67f407138293.yml
@@ -1,0 +1,81 @@
+id: ocd-organization/07aa5d6e-d4ae-44e8-88d8-67f407138293
+name: Insurance
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2552&GA=101
+memberships:
+- name: Sara Feigenholtz
+  start_date: '2018'
+  end_date: '2019'
+- name: Debbie Meyers-Martin
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Bob Morgan
+  start_date: '2018'
+  end_date: '2019'
+- name: Camille Y. Lilly
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Robyn Gabel
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Allen Skillicorn
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith P. Sommer
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Anthony DeLuca
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark L. Walker
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark Batinick
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Insurance-15d30d8b-62be-480e-8090-1a199930480a.yml
+++ b/data/il/organizations/Insurance-15d30d8b-62be-480e-8090-1a199930480a.yml
@@ -1,0 +1,78 @@
+id: ocd-organization/15d30d8b-62be-480e-8090-1a199930480a
+name: Insurance
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2323&GA=101
+memberships:
+- name: John G. Mulroe
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: Jacqueline Y. Collins
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Napoleon Harris, III
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven M. Landek
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/International-Trade--Commerce-34243e10-b7ff-4a32-92d4-acff50ae1c7e.yml
+++ b/data/il/organizations/International-Trade--Commerce-34243e10-b7ff-4a32-92d4-acff50ae1c7e.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/34243e10-b7ff-4a32-92d4-acff50ae1c7e
+name: International Trade & Commerce
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2335&GA=101
+memberships:
+- name: Nicholas K. Smith
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith P. Sommer
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark L. Walker
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark Batinick
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Job-Growth-Preservation-and-Traini-00bd78de-a693-4e16-a727-097158e599ef.yml
+++ b/data/il/organizations/Job-Growth-Preservation-and-Traini-00bd78de-a693-4e16-a727-097158e599ef.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/00bd78de-a693-4e16-a727-097158e599ef
+name: Job Growth, Preservation and Traini
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2566&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Judiciary---Civil-827ea2ed-45c1-4cab-a176-eadc5b098f47.yml
+++ b/data/il/organizations/Judiciary---Civil-827ea2ed-45c1-4cab-a176-eadc5b098f47.yml
@@ -1,0 +1,54 @@
+id: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+name: Judiciary - Civil
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2308&GA=101
+memberships:
+- name: Ann M. Williams
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: Curtis J. Tarver II
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Judiciary---Criminal-b8da85dd-e689-4a42-989e-da456b24648d.yml
+++ b/data/il/organizations/Judiciary---Criminal-b8da85dd-e689-4a42-989e-da456b24648d.yml
@@ -1,0 +1,69 @@
+id: ocd-organization/b8da85dd-e689-4a42-989e-da456b24648d
+name: Judiciary - Criminal
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2362&GA=101
+memberships:
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Will Guzzardi
+  start_date: '2018'
+  end_date: '2019'
+- name: Kambium Buckner
+  start_date: '2018'
+  end_date: '2019'
+- name: Delia C. Ramirez
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Maurice A. West II
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: John M. Cabello
+  start_date: '2018'
+  end_date: '2019'
+- name: Terri Bryant
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael Halpin
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Justin Slaughter
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Anne Stava-Murray
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Judiciary-7e34bd44-1471-4e10-8aa9-7690d87fc5ea.yml
+++ b/data/il/organizations/Judiciary-7e34bd44-1471-4e10-8aa9-7690d87fc5ea.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/7e34bd44-1471-4e10-8aa9-7690d87fc5ea
+name: Judiciary
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2345&GA=101
+memberships:
+- name: John G. Mulroe
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann Gillespie
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Labor--Commerce-dbc07907-43ef-4f8c-9f74-045a4f7c6cb4.yml
+++ b/data/il/organizations/Labor--Commerce-dbc07907-43ef-4f8c-9f74-045a4f7c6cb4.yml
@@ -1,0 +1,102 @@
+id: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+name: Labor & Commerce
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2309&GA=101
+memberships:
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Ugaste
+  start_date: '2018'
+  end_date: '2019'
+- name: Lance Yednock
+  start_date: '2018'
+  end_date: '2019'
+- name: Ann M. Williams
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: John M. Cabello
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Jaime M. Andrade, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Allen Skillicorn
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Labor-d560c42b-9926-4574-b4a5-405fd486514f.yml
+++ b/data/il/organizations/Labor-d560c42b-9926-4574-b4a5-405fd486514f.yml
@@ -1,0 +1,66 @@
+id: ocd-organization/d560c42b-9926-4574-b4a5-405fd486514f
+name: Labor
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2334&GA=101
+memberships:
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Holmes
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Kimberly A. Lightford
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Licensed-Activities-40716f14-2a61-4bd0-8100-e6b19551bd6e.yml
+++ b/data/il/organizations/Licensed-Activities-40716f14-2a61-4bd0-8100-e6b19551bd6e.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/40716f14-2a61-4bd0-8100-e6b19551bd6e
+name: Licensed Activities
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2325&GA=101
+memberships:
+- name: Neil Anderson
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Christopher Belt
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Local-Government-7d712e5f-1c6a-427e-abd5-6e721a7dcb93.yml
+++ b/data/il/organizations/Local-Government-7d712e5f-1c6a-427e-abd5-6e721a7dcb93.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/7d712e5f-1c6a-427e-abd5-6e721a7dcb93
+name: Local Government
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2324&GA=101
+memberships:
+- name: Linda Holmes
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Suzy Glowiak
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven M. Landek
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Local-Government-Subcommittee-47fede09-79dd-495f-8b5b-6fb83c158882.yml
+++ b/data/il/organizations/Local-Government-Subcommittee-47fede09-79dd-495f-8b5b-6fb83c158882.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/47fede09-79dd-495f-8b5b-6fb83c158882
+name: Local Government Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/6afaa36f-1fca-4cb5-9d72-cf654b9f575f
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2596&GA=101
+memberships:
+- name: Anthony DeLuca
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Local-Government-Subcommittee-b4810477-4c35-4a0a-a9e1-9463aea6714e.yml
+++ b/data/il/organizations/Local-Government-Subcommittee-b4810477-4c35-4a0a-a9e1-9463aea6714e.yml
@@ -1,0 +1,20 @@
+id: ocd-organization/b4810477-4c35-4a0a-a9e1-9463aea6714e
+name: Local Government Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/c8fc4719-65cb-4d65-9d2f-490eb09f89f6
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2592&GA=101
+memberships:
+- name: David McSweeney
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Local-Retirement-System-Subcommitte-8ba2b017-d575-405d-9acd-f22f3d46d6ac.yml
+++ b/data/il/organizations/Local-Retirement-System-Subcommitte-8ba2b017-d575-405d-9acd-f22f3d46d6ac.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/8ba2b017-d575-405d-9acd-f22f3d46d6ac
+name: Local Retirement System Subcommitte
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/755fd4f9-aedb-4749-a84a-f8a350913d31
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2564&GA=101
+memberships:
+- name: Robert Martwick
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Medicaid-Subcommittee-24472a0b-7a4b-473a-a29a-222e961fa16f.yml
+++ b/data/il/organizations/Medicaid-Subcommittee-24472a0b-7a4b-473a-a29a-222e961fa16f.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/24472a0b-7a4b-473a-a29a-222e961fa16f
+name: Medicaid Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/52e45d0a-a7dd-4c91-ab33-29d535f07094
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2579&GA=101
+memberships:
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Mental-Health-3663bd03-053b-4cdd-ba80-f981ee7fe2c1.yml
+++ b/data/il/organizations/Mental-Health-3663bd03-053b-4cdd-ba80-f981ee7fe2c1.yml
@@ -1,0 +1,69 @@
+id: ocd-organization/3663bd03-053b-4cdd-ba80-f981ee7fe2c1
+name: Mental Health
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2389&GA=101
+memberships:
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  start_date: '2018'
+  end_date: '2019'
+- name: Charles Meier
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Patrick Windhorst
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'
+- name: Andrew S. Chesney
+  start_date: '2018'
+  end_date: '2019'
+- name: Will Guzzardi
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Swanson
+  start_date: '2018'
+  end_date: '2019'
+- name: Maurice A. West II
+  start_date: '2018'
+  end_date: '2019'
+- name: Sara Feigenholtz
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Gong-Gershowitz
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Delia C. Ramirez
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/MinorityDisadvantage-Analysis-Subc-d022acc2-1077-403c-a8aa-113e357e42a3.yml
+++ b/data/il/organizations/MinorityDisadvantage-Analysis-Subc-d022acc2-1077-403c-a8aa-113e357e42a3.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/d022acc2-1077-403c-a8aa-113e357e42a3
+name: Minority/Disadvantage Analysis Subc
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2568&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Museums-Arts--Cultural-Enhanceme-3bc1cfe0-acf2-4dee-b190-8868d960da3c.yml
+++ b/data/il/organizations/Museums-Arts--Cultural-Enhanceme-3bc1cfe0-acf2-4dee-b190-8868d960da3c.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/3bc1cfe0-acf2-4dee-b190-8868d960da3c
+name: Museums, Arts, & Cultural Enhanceme
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2356&GA=101
+memberships:
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Ugaste
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Camille Y. Lilly
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Robyn Gabel
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  start_date: '2018'
+  end_date: '2019'
+- name: Joyce Mason
+  start_date: '2018'
+  end_date: '2019'
+- name: Amy Grant
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Negotiations-Subcommittee-a0c9832f-c148-41b8-9b83-e6c6bb028e2e.yml
+++ b/data/il/organizations/Negotiations-Subcommittee-a0c9832f-c148-41b8-9b83-e6c6bb028e2e.yml
@@ -1,0 +1,26 @@
+id: ocd-organization/a0c9832f-c148-41b8-9b83-e6c6bb028e2e
+name: Negotiations Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/c96a4b74-715d-4113-965f-2147c24fd53e
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2594&GA=101
+memberships:
+- name: Michael P. McAuliffe
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  start_date: '2018'
+  end_date: '2019'
+- name: Theresa Mah
+  start_date: '2018'
+  end_date: '2019'
+- name: Anna Moeller
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Personnel--Pensions-755fd4f9-aedb-4749-a84a-f8a350913d31.yml
+++ b/data/il/organizations/Personnel--Pensions-755fd4f9-aedb-4749-a84a-f8a350913d31.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/755fd4f9-aedb-4749-a84a-f8a350913d31
+name: Personnel & Pensions
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2310&GA=101
+memberships:
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: La Shawn K. Ford
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mark Batinick
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Personnel-Code-Subcommittee-34409f08-6928-4def-85bb-e5862d67314d.yml
+++ b/data/il/organizations/Personnel-Code-Subcommittee-34409f08-6928-4def-85bb-e5862d67314d.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/34409f08-6928-4def-85bb-e5862d67314d
+name: Personnel Code Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/755fd4f9-aedb-4749-a84a-f8a350913d31
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2562&GA=101
+memberships:
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Prescription-Drug-Affordability-aba65e30-0568-4d31-9fc2-6522e8cb4b94.yml
+++ b/data/il/organizations/Prescription-Drug-Affordability-aba65e30-0568-4d31-9fc2-6522e8cb4b94.yml
@@ -1,0 +1,66 @@
+id: ocd-organization/aba65e30-0568-4d31-9fc2-6522e8cb4b94
+name: Prescription Drug Affordability
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2553&GA=101
+memberships:
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'
+- name: Yehiel M. Kalish
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary E. Flowers
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Caulkins
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'
+- name: Will Guzzardi
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Deanne M. Mazzochi
+  start_date: '2018'
+  end_date: '2019'
+- name: Diane Pappas
+  start_date: '2018'
+  end_date: '2019'
+- name: Nicholas K. Smith
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Lamont J. Robinson, Jr.
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Lawrence Walsh, Jr.
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Property-Tax-Subcommittee-6cc38cf5-c3ac-4d99-ba36-c00e3d97bdf3.yml
+++ b/data/il/organizations/Property-Tax-Subcommittee-6cc38cf5-c3ac-4d99-ba36-c00e3d97bdf3.yml
@@ -1,0 +1,28 @@
+id: ocd-organization/6cc38cf5-c3ac-4d99-ba36-c00e3d97bdf3
+name: Property Tax Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/cc286211-8841-48d8-a522-23f9fa759539
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2589&GA=101
+memberships:
+- name: Sam Yingling
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: David McSweeney
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Public-Benefits-Subcommittee-240ee36f-a8a0-440a-bee1-3824311fea8a.yml
+++ b/data/il/organizations/Public-Benefits-Subcommittee-240ee36f-a8a0-440a-bee1-3824311fea8a.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/240ee36f-a8a0-440a-bee1-3824311fea8a
+name: Public Benefits Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/52e45d0a-a7dd-4c91-ab33-29d535f07094
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2578&GA=101
+memberships:
+- name: Michelle Mussman
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Norine K. Hammond
+  start_date: '2018'
+  end_date: '2019'
+- name: Frances Ann Hurley
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Public-Health-a2bf7e23-c5fe-4902-8640-b4544a781291.yml
+++ b/data/il/organizations/Public-Health-a2bf7e23-c5fe-4902-8640-b4544a781291.yml
@@ -1,0 +1,48 @@
+id: ocd-organization/a2bf7e23-c5fe-4902-8640-b4544a781291
+name: Public Health
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2337&GA=101
+memberships:
+- name: Laura Fine
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Syverson
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura M. Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Jason Plummer
+  start_date: '2018'
+  end_date: '2019'
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Public-Utilities-f7baea65-a249-4ee1-8978-f3f676b96610.yml
+++ b/data/il/organizations/Public-Utilities-f7baea65-a249-4ee1-8978-f3f676b96610.yml
@@ -1,0 +1,69 @@
+id: ocd-organization/f7baea65-a249-4ee1-8978-f3f676b96610
+name: Public Utilities
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2311&GA=101
+memberships:
+- name: Melissa Conyears-Ervin
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: C.D. Davidsmeyer
+  start_date: '2018'
+  end_date: '2019'
+- name: Jay Hoffman
+  start_date: '2018'
+  end_date: '2019'
+- name: Luis Arroyo
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: "Andr\xE9 Thapedi"
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Celina Villanueva
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  start_date: '2018'
+  end_date: '2019'
+- name: Lawrence Walsh, Jr.
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jehan Gordon-Booth
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: La Shawn K. Ford
+  start_date: '2018'
+  end_date: '2019'
+- name: Tim Butler
+  start_date: '2018'
+  end_date: '2019'
+- name: Ryan Spain
+  start_date: '2018'
+  end_date: '2019'
+- name: Carol Ammons
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Caulkins
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Revenue--Finance-cc286211-8841-48d8-a522-23f9fa759539.yml
+++ b/data/il/organizations/Revenue--Finance-cc286211-8841-48d8-a522-23f9fa759539.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/cc286211-8841-48d8-a522-23f9fa759539
+name: Revenue & Finance
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2352&GA=101
+memberships:
+- name: David McSweeney
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Emanuel Chris Welch
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'
+- name: Jonathan Carroll
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Revenue-15203e6c-2515-446a-8bd6-290aa249b3c4.yml
+++ b/data/il/organizations/Revenue-15203e6c-2515-446a-8bd6-290aa249b3c4.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/15203e6c-2515-446a-8bd6-290aa249b3c4
+name: Revenue
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2326&GA=101
+memberships:
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Rezin
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Rules-82d19c7b-f27e-4006-be22-1bc93e41a348.yml
+++ b/data/il/organizations/Rules-82d19c7b-f27e-4006-be22-1bc93e41a348.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/82d19c7b-f27e-4006-be22-1bc93e41a348
+name: Rules
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2312&GA=101
+memberships:
+- name: Gregory Harris
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Demmer
+  start_date: '2018'
+  end_date: '2019'
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan Brady
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Sales-Amusement--Other-Taxes-d45207e0-afe4-4abf-84cc-765eaf8ac3c8.yml
+++ b/data/il/organizations/Sales-Amusement--Other-Taxes-d45207e0-afe4-4abf-84cc-765eaf8ac3c8.yml
@@ -1,0 +1,28 @@
+id: ocd-organization/d45207e0-afe4-4abf-84cc-765eaf8ac3c8
+name: Sales, Amusement & Other Taxes
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/cc286211-8841-48d8-a522-23f9fa759539
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2590&GA=101
+memberships:
+- name: Arthur Turner
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Rita
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Special-Issues-Subcommittee-526e9e3f-918b-41d2-ba1d-c719572d7fc7.yml
+++ b/data/il/organizations/Special-Issues-Subcommittee-526e9e3f-918b-41d2-ba1d-c719572d7fc7.yml
@@ -1,0 +1,38 @@
+id: ocd-organization/526e9e3f-918b-41d2-ba1d-c719572d7fc7
+name: Special Issues Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/37283046-4392-46ae-8cf2-48c3ba746637
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2600&GA=101
+memberships:
+- name: Michelle Mussman
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  start_date: '2018'
+  end_date: '2019'
+- name: Deb Conroy
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  role: sub-co-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Special-Issues-Subcommittee-696a7d45-9a41-4b12-9513-aff815882a3f.yml
+++ b/data/il/organizations/Special-Issues-Subcommittee-696a7d45-9a41-4b12-9513-aff815882a3f.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/696a7d45-9a41-4b12-9513-aff815882a3f
+name: Special Issues Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/be564bbd-8487-455a-9152-5c8f1e5fb71b
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2587&GA=101
+memberships:
+- name: Thomas Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Burke
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Scherer
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Joe Sosnowski
+  start_date: '2018'
+  end_date: '2019'
+- name: Fred Crespo
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Special-Issues-Subcommittee-b96871c1-0d02-42a7-8907-e6fd3ef3a36c.yml
+++ b/data/il/organizations/Special-Issues-Subcommittee-b96871c1-0d02-42a7-8907-e6fd3ef3a36c.yml
@@ -1,0 +1,25 @@
+id: ocd-organization/b96871c1-0d02-42a7-8907-e6fd3ef3a36c
+name: Special Issues Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/0bd07b40-0c93-4af8-9829-472e7d7956ef
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2586&GA=101
+memberships:
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: Luis Arroyo
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Special-Issues-Subcommittee-bccb4bcc-c73d-474b-8024-6996b6c16c38.yml
+++ b/data/il/organizations/Special-Issues-Subcommittee-bccb4bcc-c73d-474b-8024-6996b6c16c38.yml
@@ -1,0 +1,31 @@
+id: ocd-organization/bccb4bcc-c73d-474b-8024-6996b6c16c38
+name: Special Issues Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/2af482a3-0ff4-4580-9e0e-f56fa0c68d69
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2576&GA=101
+memberships:
+- name: Elizabeth Hernandez
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: Avery Bourne
+  start_date: '2018'
+  end_date: '2019'
+- name: LaToya Greenwood
+  start_date: '2018'
+  end_date: '2019'
+- name: William Davis
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas M. Bennett
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Special-Subcommittee-f4802938-5cf0-4bbc-9cc9-f5a78d74087d.yml
+++ b/data/il/organizations/Special-Subcommittee-f4802938-5cf0-4bbc-9cc9-f5a78d74087d.yml
@@ -1,0 +1,16 @@
+id: ocd-organization/f4802938-5cf0-4bbc-9cc9-f5a78d74087d
+name: Special Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/07aa5d6e-d4ae-44e8-88d8-67f407138293
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2581&GA=101
+memberships:
+- name: Anthony DeLuca
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/State-Government-Administration-f4d3626a-3fe5-4645-9d27-f1398c6f874b.yml
+++ b/data/il/organizations/State-Government-Administration-f4d3626a-3fe5-4645-9d27-f1398c6f874b.yml
@@ -1,0 +1,45 @@
+id: ocd-organization/f4d3626a-3fe5-4645-9d27-f1398c6f874b
+name: State Government Administration
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2313&GA=101
+memberships:
+- name: Brad Halbrook
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Didech
+  start_date: '2018'
+  end_date: '2019'
+- name: Bob Morgan
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Justin Slaughter
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mary Edly-Allen
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Kathleen Willis
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/State-Government-c14e38de-3d87-46b1-baca-6c63d4c85176.yml
+++ b/data/il/organizations/State-Government-c14e38de-3d87-46b1-baca-6c63d4c85176.yml
@@ -1,0 +1,39 @@
+id: ocd-organization/c14e38de-3d87-46b1-baca-6c63d4c85176
+name: State Government
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2322&GA=101
+memberships:
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'
+- name: Bill Cunningham
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Patricia Van Pelt
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve McClure
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven M. Landek
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/State-Retirement-System-Subcommitte-5f6931a2-0912-4b54-b953-84e0599e8241.yml
+++ b/data/il/organizations/State-Retirement-System-Subcommitte-5f6931a2-0912-4b54-b953-84e0599e8241.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/5f6931a2-0912-4b54-b953-84e0599e8241
+name: State Retirement System Subcommitte
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/755fd4f9-aedb-4749-a84a-f8a350913d31
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2563&GA=101
+memberships:
+- name: Michael J. Zalewski
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Martwick
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Sub-on-Interscholastic-Athletics-c567882f-68b3-4555-9908-80f5b04ab4da.yml
+++ b/data/il/organizations/Sub-on-Interscholastic-Athletics-c567882f-68b3-4555-9908-80f5b04ab4da.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/c567882f-68b3-4555-9908-80f5b04ab4da
+name: Sub. on Interscholastic Athletics
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/69891dab-4f61-42a1-93b5-e93721944b57
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2556&GA=101
+memberships: []

--- a/data/il/organizations/Subcommittee-on-Capital-AP-fcdcc2e4-ab22-4ccc-915f-d442509fdf01.yml
+++ b/data/il/organizations/Subcommittee-on-Capital-AP-fcdcc2e4-ab22-4ccc-915f-d442509fdf01.yml
@@ -1,0 +1,37 @@
+id: ocd-organization/fcdcc2e4-ab22-4ccc-915f-d442509fdf01
+name: Subcommittee on Capital (AP)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/5eb4293e-2149-4ff5-9cc8-98f9d110f16f
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2591&GA=101
+memberships:
+- name: Elgie R. Sims, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'
+- name: Chapin Rose
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Andy Manar
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Omar Aquino
+  start_date: '2018'
+  end_date: '2019'
+- name: Scott M. Bennett
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Capital-TR-083b6935-9b72-4814-ab4b-cd0bd9be728e.yml
+++ b/data/il/organizations/Subcommittee-on-Capital-TR-083b6935-9b72-4814-ab4b-cd0bd9be728e.yml
@@ -1,0 +1,40 @@
+id: ocd-organization/083b6935-9b72-4814-ab4b-cd0bd9be728e
+name: Subcommittee on Capital (TR)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/096c6f21-452d-4662-905c-0969d7c7c25e
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2583&GA=101
+memberships:
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: Jacqueline Y. Collins
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Charter-Schools-aac48da2-ab67-4cd6-b9d2-bbba3ab9a706.yml
+++ b/data/il/organizations/Subcommittee-on-Charter-Schools-aac48da2-ab67-4cd6-b9d2-bbba3ab9a706.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/aac48da2-ab67-4cd6-b9d2-bbba3ab9a706
+name: Subcommittee on Charter Schools
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/69891dab-4f61-42a1-93b5-e93721944b57
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2555&GA=101
+memberships: []

--- a/data/il/organizations/Subcommittee-on-Const-Amendments-074bf8a6-516c-46d2-b2ae-e8e5f1212e00.yml
+++ b/data/il/organizations/Subcommittee-on-Const-Amendments-074bf8a6-516c-46d2-b2ae-e8e5f1212e00.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/074bf8a6-516c-46d2-b2ae-e8e5f1212e00
+name: Subcommittee on Const. Amendments
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2557&GA=101
+memberships:
+- name: John G. Mulroe
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale A. Righter
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Election-Law-0cb70970-88e2-4e3f-bf18-87dfdd778cec.yml
+++ b/data/il/organizations/Subcommittee-on-Election-Law-0cb70970-88e2-4e3f-bf18-87dfdd778cec.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/0cb70970-88e2-4e3f-bf18-87dfdd778cec
+name: Subcommittee on Election Law
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2558&GA=101
+memberships:
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'
+- name: Don Harmon
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Gaming-9381b0c5-2c2a-4ad4-987c-82c748b4d946.yml
+++ b/data/il/organizations/Subcommittee-on-Gaming-9381b0c5-2c2a-4ad4-987c-82c748b4d946.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/9381b0c5-2c2a-4ad4-987c-82c748b4d946
+name: Subcommittee on Gaming
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2559&GA=101
+memberships:
+- name: Dave Syverson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael E. Hastings
+  start_date: '2018'
+  end_date: '2019'
+- name: Terry Link
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Gov-Operations-43b36851-02a7-44a7-94e3-f1e03ea70b21.yml
+++ b/data/il/organizations/Subcommittee-on-Gov-Operations-43b36851-02a7-44a7-94e3-f1e03ea70b21.yml
@@ -1,0 +1,12 @@
+id: ocd-organization/43b36851-02a7-44a7-94e3-f1e03ea70b21
+name: Subcommittee on Gov. Operations
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2561&GA=101
+memberships:
+- name: Jason A. Barickman
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Special-Issues-ED-7f5737a3-5978-49be-88a1-f70a3ebbcbe1.yml
+++ b/data/il/organizations/Subcommittee-on-Special-Issues-ED-7f5737a3-5978-49be-88a1-f70a3ebbcbe1.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/7f5737a3-5978-49be-88a1-f70a3ebbcbe1
+name: Subcommittee on Special Issues (ED)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/69891dab-4f61-42a1-93b5-e93721944b57
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2554&GA=101
+memberships: []

--- a/data/il/organizations/Subcommittee-on-Special-Issues-EX-ffc825cb-e353-4135-90e0-854a87757172.yml
+++ b/data/il/organizations/Subcommittee-on-Special-Issues-EX-ffc825cb-e353-4135-90e0-854a87757172.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/ffc825cb-e353-4135-90e0-854a87757172
+name: Subcommittee on Special Issues (EX)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/139eb4ad-4e90-4f58-8db7-0e842f28ff17
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2560&GA=101
+memberships:
+- name: Sue Rezin
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: Mattie Hunter
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Subcommittee-on-Special-Issues-LG-8184186c-95ac-42b7-bef2-a3c98fbd5f6b.yml
+++ b/data/il/organizations/Subcommittee-on-Special-Issues-LG-8184186c-95ac-42b7-bef2-a3c98fbd5f6b.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/8184186c-95ac-42b7-bef2-a3c98fbd5f6b
+name: Subcommittee on Special Issues (LG)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/7d712e5f-1c6a-427e-abd5-6e721a7dcb93
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2585&GA=101
+memberships: []

--- a/data/il/organizations/Subcommittee-on-Special-Issues-TR-e4d654f1-167a-46cc-af3c-0f6effdb21f9.yml
+++ b/data/il/organizations/Subcommittee-on-Special-Issues-TR-e4d654f1-167a-46cc-af3c-0f6effdb21f9.yml
@@ -1,0 +1,9 @@
+id: ocd-organization/e4d654f1-167a-46cc-af3c-0f6effdb21f9
+name: Subcommittee on Special Issues (TR)
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/096c6f21-452d-4662-905c-0969d7c7c25e
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2584&GA=101
+memberships: []

--- a/data/il/organizations/Telecommunications--InfoTechnology-0b3ca8f1-7a6d-49e4-a87e-e23d6f52ed9c.yml
+++ b/data/il/organizations/Telecommunications--InfoTechnology-0b3ca8f1-7a6d-49e4-a87e-e23d6f52ed9c.yml
@@ -1,0 +1,36 @@
+id: ocd-organization/0b3ca8f1-7a6d-49e4-a87e-e23d6f52ed9c
+name: Telecommunications & InfoTechnology
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2375&GA=101
+memberships:
+- name: Linda Holmes
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  start_date: '2018'
+  end_date: '2019'
+- name: Elgie R. Sims, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Jil Tracy
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: Napoleon Harris, III
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dan McConchie
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Tort-Liability-Subcommittee-fbc22898-4d87-430f-a519-5f9987bbd957.yml
+++ b/data/il/organizations/Tort-Liability-Subcommittee-fbc22898-4d87-430f-a519-5f9987bbd957.yml
@@ -1,0 +1,19 @@
+id: ocd-organization/fbc22898-4d87-430f-a519-5f9987bbd957
+name: Tort Liability Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/827ea2ed-45c1-4cab-a176-eadc5b098f47
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2575&GA=101
+memberships:
+- name: Jay Hoffman
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'
+- name: Margo McDermed
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Transportation-096c6f21-452d-4662-905c-0969d7c7c25e.yml
+++ b/data/il/organizations/Transportation-096c6f21-452d-4662-905c-0969d7c7c25e.yml
@@ -1,0 +1,78 @@
+id: ocd-organization/096c6f21-452d-4662-905c-0969d7c7c25e
+name: Transportation
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2327&GA=101
+memberships:
+- name: Thomas Cullerton
+  start_date: '2018'
+  end_date: '2019'
+- name: Chuck Weaver
+  start_date: '2018'
+  end_date: '2019'
+- name: Jennifer Bertino-Tarrant
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Melinda Bush
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  start_date: '2018'
+  end_date: '2019'
+- name: Ram Villivalam
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Toi W. Hutchinson
+  start_date: '2018'
+  end_date: '2019'
+- name: David Koehler
+  start_date: '2018'
+  end_date: '2019'
+- name: Pat McGuire
+  start_date: '2018'
+  end_date: '2019'
+- name: Dale Fowler
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin A. Sandoval
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: Iris Y. Martinez
+  start_date: '2018'
+  end_date: '2019'
+- name: Steve Stadelman
+  start_date: '2018'
+  end_date: '2019'
+- name: Jacqueline Y. Collins
+  start_date: '2018'
+  end_date: '2019'
+- name: John F. Curran
+  start_date: '2018'
+  end_date: '2019'
+- name: Julie A. Morrison
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  start_date: '2018'
+  end_date: '2019'
+- name: Donald P. DeWitte
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jim Oberweis
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Transportation-Regulation-Roads-8bf760cf-6e5a-4a97-8ca4-24d9c56c050f.yml
+++ b/data/il/organizations/Transportation-Regulation-Roads-8bf760cf-6e5a-4a97-8ca4-24d9c56c050f.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/8bf760cf-6e5a-4a97-8ca4-24d9c56c050f
+name: 'Transportation: Regulation, Roads'
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2350&GA=101
+memberships:
+- name: Margo McDermed
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Tony McCombie
+  start_date: '2018'
+  end_date: '2019'
+- name: John Connor
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: Lindsay Parkhurst
+  start_date: '2018'
+  end_date: '2019'
+- name: Tom Weber
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Terra Costa Howard
+  start_date: '2018'
+  end_date: '2019'
+- name: John M. Cabello
+  start_date: '2018'
+  end_date: '2019'
+- name: Sue Scherer
+  start_date: '2018'
+  end_date: '2019'
+- name: Sam Yingling
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Transportation-Vehicles--Safety-0bd07b40-0c93-4af8-9829-472e7d7956ef.yml
+++ b/data/il/organizations/Transportation-Vehicles--Safety-0bd07b40-0c93-4af8-9829-472e7d7956ef.yml
@@ -1,0 +1,51 @@
+id: ocd-organization/0bd07b40-0c93-4af8-9829-472e7d7956ef
+name: 'Transportation: Vehicles & Safety'
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2351&GA=101
+memberships:
+- name: Tim Butler
+  start_date: '2018'
+  end_date: '2019'
+- name: Lance Yednock
+  start_date: '2018'
+  end_date: '2019'
+- name: Kambium Buckner
+  start_date: '2018'
+  end_date: '2019'
+- name: Natalie A. Manley
+  start_date: '2018'
+  end_date: '2019'
+- name: Mike Murphy
+  start_date: '2018'
+  end_date: '2019'
+- name: Luis Arroyo
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Melissa Conyears-Ervin
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Blaine Wilhour
+  start_date: '2018'
+  end_date: '2019'
+- name: Jerry Costello, II
+  start_date: '2018'
+  end_date: '2019'
+- name: David A. Welter
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Veterans-Affairs-0108702c-3e17-459d-8b58-0b1754874b77.yml
+++ b/data/il/organizations/Veterans-Affairs-0108702c-3e17-459d-8b58-0b1754874b77.yml
@@ -1,0 +1,57 @@
+id: ocd-organization/0108702c-3e17-459d-8b58-0b1754874b77
+name: Veterans' Affairs
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: lower
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2315&GA=101
+memberships:
+- name: Lance Yednock
+  start_date: '2018'
+  end_date: '2019'
+- name: Randy E. Frese
+  role: republican spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Dave Severin
+  start_date: '2018'
+  end_date: '2019'
+- name: Jerry Costello, II
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael Halpin
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Stephanie A. Kifowit
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael D. Unes
+  start_date: '2018'
+  end_date: '2019'
+- name: Daniel Swanson
+  start_date: '2018'
+  end_date: '2019'
+- name: Jeff Keicher
+  start_date: '2018'
+  end_date: '2019'
+- name: Martin J. Moylan
+  start_date: '2018'
+  end_date: '2019'
+- name: Michael P. McAuliffe
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  start_date: '2018'
+  end_date: '2019'
+- name: Aaron M. Ortiz
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Monica Bristow
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Veterans-Affairs-54ef65c6-624f-4132-933e-3bb93ae55a2b.yml
+++ b/data/il/organizations/Veterans-Affairs-54ef65c6-624f-4132-933e-3bb93ae55a2b.yml
@@ -1,0 +1,45 @@
+id: ocd-organization/54ef65c6-624f-4132-933e-3bb93ae55a2b
+name: Veterans Affairs
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: upper
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/senate/committees/members.asp?CommitteeID=2374&GA=101
+memberships:
+- name: Neil Anderson
+  start_date: '2018'
+  end_date: '2019'
+- name: Laura Ellman
+  start_date: '2018'
+  end_date: '2019'
+- name: Rachelle Crowe
+  start_date: '2018'
+  end_date: '2019'
+- name: Emil Jones, III
+  start_date: '2018'
+  end_date: '2019'
+- name: Robert Peters
+  start_date: '2018'
+  end_date: '2019'
+- name: Craig Wilcox
+  start_date: '2018'
+  end_date: '2019'
+- name: "Antonio Mu\xF1oz"
+  start_date: '2018'
+  end_date: '2019'
+- name: Cristina Castro
+  role: chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Paul Schimpf
+  role: minority spokesperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Brian W. Stewart
+  start_date: '2018'
+  end_date: '2019'
+- name: Thomas Cullerton
+  role: vice-chairperson
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Wage-Policy-and-Study-Subcommittee-63f803ac-d024-4d88-8cd6-70304d9c1e73.yml
+++ b/data/il/organizations/Wage-Policy-and-Study-Subcommittee-63f803ac-d024-4d88-8cd6-70304d9c1e73.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/63f803ac-d024-4d88-8cd6-70304d9c1e73
+name: Wage Policy and Study Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2567&GA=101
+memberships:
+- name: Marcus C. Evans, Jr.
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'
+- name: John C. D'Amico
+  start_date: '2018'
+  end_date: '2019'
+- name: Linda Chapa LaVia
+  start_date: '2018'
+  end_date: '2019'
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Kelly M. Cassidy
+  start_date: '2018'
+  end_date: '2019'
+- name: Thaddeus Jones
+  start_date: '2018'
+  end_date: '2019'

--- a/data/il/organizations/Workforce-Development-Subcommittee-0ab5e248-7f1e-4f5c-a66b-ced673e73379.yml
+++ b/data/il/organizations/Workforce-Development-Subcommittee-0ab5e248-7f1e-4f5c-a66b-ced673e73379.yml
@@ -1,0 +1,34 @@
+id: ocd-organization/0ab5e248-7f1e-4f5c-a66b-ced673e73379
+name: Workforce Development Subcommittee
+jurisdiction: ocd-jurisdiction/country:us/state:il/government
+parent: ocd-organization/dbc07907-43ef-4f8c-9f74-045a4f7c6cb4
+classification: committee
+links: []
+sources:
+- url: http://ilga.gov/house/committees/members.asp?CommitteeID=2565&GA=101
+memberships:
+- name: Grant Wehrli
+  start_date: '2018'
+  end_date: '2019'
+- name: Lance Yednock
+  start_date: '2018'
+  end_date: '2019'
+- name: Katie Stuart
+  start_date: '2018'
+  end_date: '2019'
+- name: Rita Mayfield
+  start_date: '2018'
+  end_date: '2019'
+- name: Marcus C. Evans, Jr.
+  role: sub-chairperson
+  start_date: '2018'
+  end_date: '2019'
+- name: Karina Villa
+  start_date: '2018'
+  end_date: '2019'
+- name: Keith R. Wheeler
+  start_date: '2018'
+  end_date: '2019'
+- name: Steven Reick
+  start_date: '2018'
+  end_date: '2019'


### PR DESCRIPTION
This PR is a bit of a spitball.

The committee memberships are not resolved.  The `to_yaml.py` doesn't do it. and I don't see any other code in the people scripts that looks like it might.  If it isn't clear what I mean, newly imported yaml memberships look like:

```yaml
memberships:
- name: David Koehler
  start_date: '2018'
  end_date: '2019'
- name: Laura Ellman
  start_date: '2018'
  end_date: '2019'
```
but the existing ones have the people id's:
```yaml
memberships:
- id: ocd-person/f8e78760-4ec7-44f4-a00f-54f42fb834d5
  name: Napoleon Harris, III
  role: chairperson
  start_date: '2017'
  end_date: '2018'
- id: ocd-person/86147150-e615-43a2-a748-e95d06627ad3
  name: Scott M. Bennett
  role: vice-chairperson
  start_date: '2017'
  end_date: '2018'
```
Matching these up manually is prohibitively costly; Illinois has over a hundred committees, probably over a thousand individual memberships.  I see some other states have unresolved memberships, so I'm guessing it won't break anything.

In order to have correct memberships over time, I don't think the old committees should go away, or that these should be merged as individual files.  But it's just a guess.

Related: https://github.com/openstates/openstates/issues/2821, https://github.com/openstates/openstates/pull/2869 
