### PR TITLE
Update Colorado legislator data

### DIFF
--- a/data/co/organizations/Agriculture-Natural-Resources--Energy-6c6dc808-3cff-452c-bf3a-b595815556cf.yml
+++ b/data/co/organizations/Agriculture-Natural-Resources--Energy-6c6dc808-3cff-452c-bf3a-b595815556cf.yml
@@ -25,6 +25,7 @@ memberships:
 - name: Leroy M. Garcia, Jr.
 - id: ocd-person/b8a8f5b2-8686-47df-adb0-b51ae67a7698
   name: Matt Jones
+  end_date: '2019-01-01'
 - id: ocd-person/039a3a92-b143-46ba-9cbd-7a77a55b48c7
   name: Vicki Marble
 - id: ocd-person/01d42abe-6bf4-4e30-b58c-a52a29b8c809

--- a/data/co/organizations/Business-Labor--Technology-7b846c22-9fac-4bf7-9346-d791cbf0459b.yml
+++ b/data/co/organizations/Business-Labor--Technology-7b846c22-9fac-4bf7-9346-d791cbf0459b.yml
@@ -16,6 +16,7 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/c0e3910e-ee5b-429b-af27-041223b7eba0
   name: Cheri Jahn
+  end_date: '2019-01-03'
 - id: ocd-person/96149a77-fd88-4a24-b391-11f9f2ced36d
   name: Andy Kerr
   end_date: '2018-12-31'

--- a/data/co/organizations/Committee-on-Legal-Services-8cb96385-d13f-446f-b16d-cb82a1656429.yml
+++ b/data/co/organizations/Committee-on-Legal-Services-8cb96385-d13f-446f-b16d-cb82a1656429.yml
@@ -26,6 +26,7 @@ memberships:
   name: Chris Holbert
 - id: ocd-person/409c5477-733e-4d41-b60c-d60eea3ecbc1
   name: Daniel Kagan
+  end_date: '2019-01-11'
 - id: ocd-person/08988fe0-7fdc-4024-aeb5-baac53262aeb
   name: Yeulin Willett
   end_date: '2018-12-31'

--- a/data/co/organizations/Early-Childhood-and-School-Readiness-Legislative-Commission-b5b2a558-1b50-46a5-be04-46fb91ce6ceb.yml
+++ b/data/co/organizations/Early-Childhood-and-School-Readiness-Legislative-Commission-b5b2a558-1b50-46a5-be04-46fb91ce6ceb.yml
@@ -17,6 +17,7 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/a2fae534-01be-4682-a541-487d0918dad5
   name: Michael Merrifield
+  end_date: '2019-01-03'
 - id: ocd-person/c06efba5-249e-44a1-8e50-551ac73b3da9
   name: Brittany Pettersen
   end_date: '2018-12-31'

--- a/data/co/organizations/Legislative-Council-12ba7f8c-21a7-4385-bc18-e300c791f10a.yml
+++ b/data/co/organizations/Legislative-Council-12ba7f8c-21a7-4385-bc18-e300c791f10a.yml
@@ -24,6 +24,7 @@ memberships:
   name: Chris Holbert
 - id: ocd-person/b8a8f5b2-8686-47df-adb0-b51ae67a7698
   name: Matt Jones
+  end_date: '2019-01-01'
 - id: ocd-person/96149a77-fd88-4a24-b391-11f9f2ced36d
   name: Andy Kerr
   end_date: '2018-12-31'

--- a/data/co/organizations/Legislative-Interim-Committee-on-School-Finance-3b7a3e26-5904-4c8b-87cb-12bfea85f8dc.yml
+++ b/data/co/organizations/Legislative-Interim-Committee-on-School-Finance-3b7a3e26-5904-4c8b-87cb-12bfea85f8dc.yml
@@ -27,6 +27,7 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/a2fae534-01be-4682-a541-487d0918dad5
   name: Michael Merrifield
+  end_date: '2019-01-03'
 - id: ocd-person/ba633379-3da7-44a4-b302-b9e2b4536063
   name: Jerry Sonnenberg
 - id: ocd-person/f7486270-9e45-4213-9520-aa7150e34baa

--- a/data/co/organizations/Opioid-and-Other-Substance-Use-Disorders-Study-Committee-66f41c2e-effb-4585-bf6a-2e3f2a73f8c6.yml
+++ b/data/co/organizations/Opioid-and-Other-Substance-Use-Disorders-Study-Committee-66f41c2e-effb-4585-bf6a-2e3f2a73f8c6.yml
@@ -18,6 +18,7 @@ memberships:
   name: Perry Buck
 - id: ocd-person/c0e3910e-ee5b-429b-af27-041223b7eba0
   name: Cheri Jahn
+  end_date: '2019-01-03'
 - id: ocd-person/92715424-bafa-4ad8-b311-eca3e575c86f
   name: Chris Kennedy
 - id: ocd-person/039a3a92-b143-46ba-9cbd-7a77a55b48c7

--- a/data/co/organizations/Pension-Review-Commission-11940f0a-2ddb-49a3-bb25-c4b2742b5ef7.yml
+++ b/data/co/organizations/Pension-Review-Commission-11940f0a-2ddb-49a3-bb25-c4b2742b5ef7.yml
@@ -27,6 +27,7 @@ memberships:
   name: Dominique Jackson
 - id: ocd-person/409c5477-733e-4d41-b60c-d60eea3ecbc1
   name: Daniel Kagan
+  end_date: '2019-01-11'
 - id: ocd-person/c5745978-e793-451c-a6e3-6947e9ca4511
   name: Jovan Melton
 - id: ocd-person/01d42abe-6bf4-4e30-b58c-a52a29b8c809

--- a/data/co/organizations/Water-Resources-Review-Committee-42e087fa-0d4b-4c39-b328-381348e9e98f.yml
+++ b/data/co/organizations/Water-Resources-Review-Committee-42e087fa-0d4b-4c39-b328-381348e9e98f.yml
@@ -24,6 +24,7 @@ memberships:
   name: Daneya Esgar
 - id: ocd-person/b8a8f5b2-8686-47df-adb0-b51ae67a7698
   name: Matt Jones
+  end_date: '2019-01-01'
 - id: ocd-person/4be512fb-5ebc-422c-a858-d250cb5568ad
   name: Dylan Roberts
 - id: ocd-person/64ab88db-3baa-4d4c-85e6-bf395a6b8bbf

--- a/data/co/organizations/Wildfire-Matters-Review-Committee-f187fa09-9ae1-49c5-b250-6341fb451d0f.yml
+++ b/data/co/organizations/Wildfire-Matters-Review-Committee-f187fa09-9ae1-49c5-b250-6341fb451d0f.yml
@@ -22,6 +22,7 @@ memberships:
   name: Rhonda Fields
 - id: ocd-person/b8a8f5b2-8686-47df-adb0-b51ae67a7698
   name: Matt Jones
+  end_date: '2019-01-01'
 - id: ocd-person/039a3a92-b143-46ba-9cbd-7a77a55b48c7
   name: Vicki Marble
 - id: ocd-person/4ee693c2-1cdc-4631-a6e5-b541e7f9c797

--- a/data/co/people/Bob-Rankin-24072d04-8fb3-43a3-8f33-2881183ba6b4.yml
+++ b/data/co/people/Bob-Rankin-24072d04-8fb3-43a3-8f33-2881183ba6b4.yml
@@ -1,8 +1,8 @@
 contact_details:
-- address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: bob.rankin.house@state.co.us
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: bob.rankin.senate@state.co.us
   note: Capitol Office
-  voice: 303-866-2949
+  voice: 303-866-5292
 family_name: Rankin
 given_name: Bob
 id: ocd-person/24072d04-8fb3-43a3-8f33-2881183ba6b4
@@ -19,6 +19,11 @@ roles:
 - district: '57'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
+  end_date: '2019-01-22'
+- district: '8'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-22'
 sources:
 - url: http://leg.colorado.gov/legislators/bob-rankin
 - url: http://leg.colorado.gov/legislators

--- a/data/co/people/Brittany-Pettersen-c06efba5-249e-44a1-8e50-551ac73b3da9.yml
+++ b/data/co/people/Brittany-Pettersen-c06efba5-249e-44a1-8e50-551ac73b3da9.yml
@@ -1,6 +1,6 @@
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
-  email: brittany.pettersen.house@state.co.us
+  email: brittany.pettersen.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4859
 family_name: Pettersen
@@ -19,10 +19,11 @@ roles:
 - district: '28'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
-  end_date: 2018-12-31
+  end_date: '2019-01-03'
 - district: '22'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  start_date: '2019-01-04'
 sources:
 - url: http://leg.colorado.gov/legislators/brittany-pettersen
 - url: http://leg.colorado.gov/legislators

--- a/data/co/people/Cathy-Kipp-0ddf3b75-c450-419e-8235-553157770e49.yml
+++ b/data/co/people/Cathy-Kipp-0ddf3b75-c450-419e-8235-553157770e49.yml
@@ -1,0 +1,22 @@
+id: ocd-person/0ddf3b75-c450-419e-8235-553157770e49
+name: Cathy Kipp
+party:
+- name: Democratic
+roles:
+- district: '52'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: lower
+  start_date: '2019-01-03'
+contact_details:
+- address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: cathy.kipp.house@state.co.us
+  note: Capitol Office
+  voice: 303-866-4569
+links:
+- url: http://leg.colorado.gov/legislators/cathy-kipp
+sources:
+- url: http://leg.colorado.gov/legislators/cathy-kipp
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep_kipp_original.jpg?itok=mHkypKKy
+given_name: Cathy
+family_name: Kipp

--- a/data/co/people/Dennis-Hisey-c62006dc-a294-462c-a97f-430b67b0a550.yml
+++ b/data/co/people/Dennis-Hisey-c62006dc-a294-462c-a97f-430b67b0a550.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: dennis.hisey.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4877
 links:

--- a/data/co/people/Faith-Winter-d8091b89-e076-404f-a2a3-886f5cb9b89c.yml
+++ b/data/co/people/Faith-Winter-d8091b89-e076-404f-a2a3-886f5cb9b89c.yml
@@ -1,9 +1,6 @@
 contact_details:
-- address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: faith.winter.house@state.co.us
-  note: Capitol Office
-  voice: 303-866-2843
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: faith.winter.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4863
 family_name: Winter
@@ -22,7 +19,7 @@ roles:
 - district: '35'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
-  end_date: "2018-12-30"
+  end_date: '2018-12-30'
 - district: '24'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper

--- a/data/co/people/Janice-Rich-45efea89-1f3a-497d-8963-37d9f9d1281f.yml
+++ b/data/co/people/Janice-Rich-45efea89-1f3a-497d-8963-37d9f9d1281f.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: janice@janicerichforcolorado.com
+  email: janice.rich.house@state.co.us
   note: Capitol Office
   voice: 303-866-3068
 links:

--- a/data/co/people/Jeff-Bridges-c2cade07-9c95-4439-938c-77ac4ed44fab.yml
+++ b/data/co/people/Jeff-Bridges-c2cade07-9c95-4439-938c-77ac4ed44fab.yml
@@ -1,8 +1,8 @@
 contact_details:
-- address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: jeff.bridges.house@state.co.us
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: jeff.bridges.senate@state.co.us
   note: Capitol Office
-  voice: 303-866-2921
+  voice: 303-866-4846
 family_name: Bridges
 given_name: Jeff
 id: ocd-person/c2cade07-9c95-4439-938c-77ac4ed44fab
@@ -19,6 +19,11 @@ roles:
 - district: '3'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
+  end_date: '2019-01-14'
+- district: '26'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-14'
 sources:
 - url: http://leg.colorado.gov/legislators/jeff-bridges
 - url: http://leg.colorado.gov/legislators

--- a/data/co/people/Jeni-James-Arndt-e058cefb-c8bb-4251-947a-f0af071dfe02.yml
+++ b/data/co/people/Jeni-James-Arndt-e058cefb-c8bb-4251-947a-f0af071dfe02.yml
@@ -4,7 +4,7 @@ contact_details:
   note: Capitol Office
   voice: 303-866-2917
 family_name: Arndt
-given_name: Jeni James
+given_name: Jeni
 id: ocd-person/e058cefb-c8bb-4251-947a-f0af071dfe02
 image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_arndt-co-17.jpg?itok=JjJAv3JQ
 links:

--- a/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
+++ b/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
@@ -1,0 +1,22 @@
+id: ocd-person/c06af980-c553-4f79-a39d-295b7226f029
+name: Jessie Danielson
+party:
+- name: Democratic
+roles:
+- district: '20'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-04'
+contact_details:
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: jessie.danielson.senate@state.co.us
+  note: Capitol Office
+  voice: 303-866-4856
+links:
+- url: http://leg.colorado.gov/legislators/jessie-danielson
+sources:
+- url: http://leg.colorado.gov/legislators/jessie-danielson
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_danielson-jessie.jpg?itok=wkohEvVs
+given_name: Jessie
+family_name: Danielson

--- a/data/co/people/Julie-Gonzales-8dae5ba5-6741-4aca-8c1e-24f014fda187.yml
+++ b/data/co/people/Julie-Gonzales-8dae5ba5-6741-4aca-8c1e-24f014fda187.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: julie.gonzales.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4862
 links:

--- a/data/co/people/Kerry-Tipper-b45229f3-b995-4266-8398-aaf7f54dbdc8.yml
+++ b/data/co/people/Kerry-Tipper-b45229f3-b995-4266-8398-aaf7f54dbdc8.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: kerry.tipper.house@state.co.us
   note: Capitol Office
   voice: 303-866-2939
 links:

--- a/data/co/people/Lisa-Cutter-5226ebdd-0710-49da-b446-61fac19765ce.yml
+++ b/data/co/people/Lisa-Cutter-5226ebdd-0710-49da-b446-61fac19765ce.yml
@@ -10,6 +10,7 @@ contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
   email: lisa.cutter.house@state.co.us
   note: Capitol Office
+  voice: 303-866-2582
 links:
 - url: http://leg.colorado.gov/legislators/lisa-cutter
 sources:

--- a/data/co/people/Matt-Soper-9e529237-916b-407c-a60e-abd8e0708329.yml
+++ b/data/co/people/Matt-Soper-9e529237-916b-407c-a60e-abd8e0708329.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: matt.soper.house@state.co.us
+  email: matthew.soper.house@state.co.us
   note: Capitol Office
   voice: 303-866-2583
 links:

--- a/data/co/people/Meg-Froelich-8e6bc6cb-fe7e-4640-a938-eb32536e95c5.yml
+++ b/data/co/people/Meg-Froelich-8e6bc6cb-fe7e-4640-a938-eb32536e95c5.yml
@@ -1,0 +1,22 @@
+id: ocd-person/8e6bc6cb-fe7e-4640-a938-eb32536e95c5
+name: Meg Froelich
+party:
+- name: Democratic
+roles:
+- district: '3'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: lower
+  start_date: '2019-01-14'
+contact_details:
+- address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: meg.froelich.house@state.co.us
+  note: Capitol Office
+  voice: 303-866-2921
+links:
+- url: http://leg.colorado.gov/legislators/meg-froelich
+sources:
+- url: http://leg.colorado.gov/legislators/meg-froelich
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_h_froelich.jpg?itok=3wKkR-Wa
+given_name: Meg
+family_name: Froelich

--- a/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
+++ b/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
@@ -1,0 +1,22 @@
+id: ocd-person/faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f
+name: Mike Foote
+party:
+- name: Democratic
+roles:
+- district: '17'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-04'
+contact_details:
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: mike.foote.senate@state.co.us
+  note: Capitol Office
+  voice: 303-866-5291
+links:
+- url: http://leg.colorado.gov/legislators/mike-foote
+sources:
+- url: http://leg.colorado.gov/legislators/mike-foote
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_foote-co-17.jpg?itok=6GMfDFaJ
+given_name: Mike
+family_name: Foote

--- a/data/co/people/Monica-Duran-d8b6809c-61d9-4ea3-b21b-c846051468c2.yml
+++ b/data/co/people/Monica-Duran-d8b6809c-61d9-4ea3-b21b-c846051468c2.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/monica-duran
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_duran-monica.jpg?itok=NH8OzUE4
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep_duran.jpg?itok=gY1fEyEf

--- a/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
+++ b/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a58d77ac-807b-456e-8584-e4e08e98bf61
+name: Paul Lundeen
+party:
+- name: Republican
+roles:
+- district: '9'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-04'
+contact_details:
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: paul.lundeen.senate@state.co.us
+  note: Capitol Office
+  voice: 303-866-4835
+links:
+- url: http://leg.colorado.gov/legislators/paul-lundeen
+sources:
+- url: http://leg.colorado.gov/legislators/paul-lundeen
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_lundeen-paul.jpg?itok=VhKMGnGf
+given_name: Paul
+family_name: Lundeen

--- a/data/co/people/Perry-Will-221d86f6-e78f-4381-8826-e48451a8a97f.yml
+++ b/data/co/people/Perry-Will-221d86f6-e78f-4381-8826-e48451a8a97f.yml
@@ -1,0 +1,21 @@
+id: ocd-person/221d86f6-e78f-4381-8826-e48451a8a97f
+name: Perry Will
+party:
+- name: Republican
+roles:
+- district: '57'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: lower
+  start_date: '2019-03-05'
+contact_details:
+- address: 200 E. Colfax;RM 307;Denver, CO 80203
+  note: Capitol Office
+  voice: 303-866-2949
+links:
+- url: http://leg.colorado.gov/legislators/perry-will
+sources:
+- url: http://leg.colorado.gov/legislators/perry-will
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_repperrywill.jpeg?itok=rmOr0Jcp
+given_name: Perry
+family_name: Will

--- a/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
+++ b/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
@@ -1,0 +1,22 @@
+id: ocd-person/0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c
+name: Pete Lee
+party:
+- name: Democratic
+roles:
+- district: '11'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: '2019-01-04'
+contact_details:
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: pete.lee.senate@state.co.us
+  note: Capitol Office
+  voice: 303-866-6364
+links:
+- url: http://leg.colorado.gov/legislators/pete-lee
+sources:
+- url: http://leg.colorado.gov/legislators/pete-lee
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_lee-pete.jpg?itok=j5BU2bAW
+given_name: Pete
+family_name: Lee

--- a/data/co/people/Rob-Woodward-432eff55-4ac6-4d34-b663-9ebe58a77d97.yml
+++ b/data/co/people/Rob-Woodward-432eff55-4ac6-4d34-b663-9ebe58a77d97.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: rob.woodward.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4853
 links:

--- a/data/co/people/Robert-Rodriguez-ab377224-ab70-4c20-a535-baa429520e7c.yml
+++ b/data/co/people/Robert-Rodriguez-ab377224-ab70-4c20-a535-baa429520e7c.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: robert.rodriguez.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4852
 links:

--- a/data/co/people/Rochelle-Galindo-83c67daa-76c0-4df9-b9c2-665e4571c626.yml
+++ b/data/co/people/Rochelle-Galindo-83c67daa-76c0-4df9-b9c2-665e4571c626.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: rochelle.galindo.house@state.co.us
   note: Capitol Office
   voice: 303-866-2929
 links:

--- a/data/co/people/Serena-Gonzales-Gutierrez-c8bf4dd0-6d70-4585-a699-fed72b1ed9aa.yml
+++ b/data/co/people/Serena-Gonzales-Gutierrez-c8bf4dd0-6d70-4585-a699-fed72b1ed9aa.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: serena.gonzales.guiterrez.house@state.co.us
+  email: serena.gonzales-gutierrez.house@state.co.us
   note: Capitol Office
   voice: 303-866-2954
 links:

--- a/data/co/people/Sonya-Jaquez-Lewis-7641b446-38a9-4444-bbf1-536662a85e14.yml
+++ b/data/co/people/Sonya-Jaquez-Lewis-7641b446-38a9-4444-bbf1-536662a85e14.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: sonja.jaquez.lewis@state.co.us
+  email: sonya.jaquez.lewis.house@state.co.us
   note: Capitol Office
   voice: 303-866-2920
 links:

--- a/data/co/people/Tammy-Story-489b3afa-1e08-40f4-918a-f01c186b6f73.yml
+++ b/data/co/people/Tammy-Story-489b3afa-1e08-40f4-918a-f01c186b6f73.yml
@@ -1,13 +1,14 @@
 id: ocd-person/489b3afa-1e08-40f4-918a-f01c186b6f73
 name: Tammy Story
 party:
-- name: Republican
+- name: Democratic
 roles:
 - district: '16'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: tammy.story.senate@state.co.us
   note: Capitol Office
   voice: 303-866-4873
 links:

--- a/data/co/people/Terri-Carver-7a1e7a37-b136-44e5-b7bc-06c7c1dda059.yml
+++ b/data/co/people/Terri-Carver-7a1e7a37-b136-44e5-b7bc-06c7c1dda059.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Carver
 given_name: Terri
 id: ocd-person/7a1e7a37-b136-44e5-b7bc-06c7c1dda059
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_carver-co-17.jpg?itok=vVAs9OzB
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_h_carver.jpg?itok=tiMuZ4xd
 links:
 - url: http://leg.colorado.gov/legislators/terri-carver
 name: Terri Carver

--- a/data/co/people/Tom-Sullivan-7a09a2fa-0249-4751-8dd1-caa100395438.yml
+++ b/data/co/people/Tom-Sullivan-7a09a2fa-0249-4751-8dd1-caa100395438.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: tom.sullivan.house@state.co.us
   note: Capitol Office
   voice: 303-866-5510
 links:

--- a/data/co/retired/Cheri-Jahn-c0e3910e-ee5b-429b-af27-041223b7eba0.yml
+++ b/data/co/retired/Cheri-Jahn-c0e3910e-ee5b-429b-af27-041223b7eba0.yml
@@ -6,6 +6,7 @@ roles:
 - district: '20'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-03'
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
   email: cheri.jahn.senate@state.co.us

--- a/data/co/retired/Daniel-Kagan-409c5477-733e-4d41-b60c-d60eea3ecbc1.yml
+++ b/data/co/retired/Daniel-Kagan-409c5477-733e-4d41-b60c-d60eea3ecbc1.yml
@@ -19,6 +19,7 @@ roles:
 - district: '26'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-11'
 sources:
 - url: http://leg.colorado.gov/legislators/daniel-kagan
 - url: http://leg.colorado.gov/legislators

--- a/data/co/retired/Kent-Lambert-03216b36-1d0b-4c64-89b1-6d25240f5aaa.yml
+++ b/data/co/retired/Kent-Lambert-03216b36-1d0b-4c64-89b1-6d25240f5aaa.yml
@@ -6,6 +6,7 @@ roles:
 - district: '9'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-03'
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
   email: senatorlambert@comcast.net

--- a/data/co/retired/Matt-Jones-b8a8f5b2-8686-47df-adb0-b51ae67a7698.yml
+++ b/data/co/retired/Matt-Jones-b8a8f5b2-8686-47df-adb0-b51ae67a7698.yml
@@ -6,6 +6,7 @@ roles:
 - district: '17'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-01'
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
   email: senatormattjones@gmail.com

--- a/data/co/retired/Michael-Merrifield-a2fae534-01be-4682-a541-487d0918dad5.yml
+++ b/data/co/retired/Michael-Merrifield-a2fae534-01be-4682-a541-487d0918dad5.yml
@@ -6,6 +6,7 @@ roles:
 - district: '11'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-03'
 contact_details:
 - address: 200 E. Colfax;RM 346;Denver, CO 80203
   email: michael.merrifield.senate@state.co.us

--- a/data/co/retired/Randy-Baumgardner-0b885ca8-639b-4d09-847e-9f2d638b25ac.yml
+++ b/data/co/retired/Randy-Baumgardner-0b885ca8-639b-4d09-847e-9f2d638b25ac.yml
@@ -23,6 +23,7 @@ roles:
 - district: '8'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2019-01-21'
 sources:
 - url: http://leg.colorado.gov/legislators/randy-l-baumgardner
 - url: http://leg.colorado.gov/legislators

--- a/settings.yml
+++ b/settings.yml
@@ -24,10 +24,6 @@ co:
   legislature_name: Colorado General Assembly
   lower_seats: 65
   upper_seats: 35
-  vacancies:
-    - chamber: lower
-      district: 52
-      vacant_until: 2019-04-01   # unsure
 ct:
   legislature_name: Connecticut General Assembly
   lower_seats: 151


### PR DESCRIPTION
Some retirements/replacements. Also add some legislators that were elected and served from the beginning of the term.

Fixes #139 and fixes #134.