### PR TITLE
Remove redundant `roles` key

### DIFF
--- a/data/ks/people/Stephanie-Clayton-6c410bc7-76fd-4488-aca4-5158a5a55d70.yml
+++ b/data/ks/people/Stephanie-Clayton-6c410bc7-76fd-4488-aca4-5158a5a55d70.yml
@@ -6,7 +6,6 @@ party:
 - name: Democratic
   start_date: '2018-12-19'
 roles:
-roles:
 - district: '19'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower


### PR DESCRIPTION
There are two `roles` keys for this person. I'm not sure if this was the result of a manual error or if a scraper needs to be fixed.