### PR TITLE
Fl legislators special election

### DIFF
--- a/data/fl/people/Dan-Daily-66308162-9b64-4d34-a8bc-fac71407f7d5.yml
+++ b/data/fl/people/Dan-Daily-66308162-9b64-4d34-a8bc-fac71407f7d5.yml
@@ -1,0 +1,16 @@
+id: ocd-person/66308162-9b64-4d34-a8bc-fac71407f7d5
+name: Dan Daily
+given_name: Dan
+family_name: Daily
+image: https://www.myfloridahouse.gov/FileStores/Web/Imaging/Member/4757.jpg
+party:
+- name: Democrat
+roles:
+- district: '97'
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+  start_date: "2019-06-26"
+  type: lower
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4757&LegislativeTermId=88
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4757&LegislativeTermId=88

--- a/data/fl/people/Dan-Daily-66308162-9b64-4d34-a8bc-fac71407f7d5.yml
+++ b/data/fl/people/Dan-Daily-66308162-9b64-4d34-a8bc-fac71407f7d5.yml
@@ -4,7 +4,7 @@ given_name: Dan
 family_name: Daily
 image: https://www.myfloridahouse.gov/FileStores/Web/Imaging/Member/4757.jpg
 party:
-- name: Democrat
+- name: Democratic
 roles:
 - district: '97'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government

--- a/data/fl/people/Jason-Shoaf-2bae38cc-f703-446b-93ec-576c0e388760.yml
+++ b/data/fl/people/Jason-Shoaf-2bae38cc-f703-446b-93ec-576c0e388760.yml
@@ -1,0 +1,16 @@
+id: ocd-person/2bae38cc-f703-446b-93ec-576c0e388760
+name: Jason Shoaf
+given_name: Jason
+family_name: Shoaf
+image: https://www.myfloridahouse.gov/FileStores/Web/Imaging/Member/4756.jpg
+party:
+- name: Republican
+roles:
+- district: '7'
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+  start_date: '2019-06-19'
+  type: lower
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4756&LegislativeTermId=88
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4756&LegislativeTermId=88

--- a/data/fl/people/Randall-Scott-Maggard-2a415c08-da66-402b-ada6-93390a5df820.yml
+++ b/data/fl/people/Randall-Scott-Maggard-2a415c08-da66-402b-ada6-93390a5df820.yml
@@ -1,0 +1,16 @@
+id: ocd-person/2a415c08-da66-402b-ada6-93390a5df820
+name: Randall Scott Maggard
+given_name: Randall
+family_name: Maggard
+image: https://www.myfloridahouse.gov/FileStores/Web/Imaging/Member/4758.jpg
+party:
+- name: Republican
+roles:
+- district: '38'
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+  start_date: '2019-06-18'
+  type: lower
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4758&LegislativeTermId=88
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4758&LegislativeTermId=88

--- a/settings.yml
+++ b/settings.yml
@@ -71,16 +71,6 @@ fl:
   legislature_name: Florida Legislature
   lower_seats: 120
   upper_seats: 40
-  vacancies:
-    - chamber: lower
-      district: 7
-      vacant_until: 2019-12-01
-    - chamber: lower
-      district: 38
-      vacant_until: 2019-12-01
-    - chamber: lower
-      district: 97
-      vacant_until: 2019-12-01
 ga:
   legislature_name: Georgia General Assembly
   lower_seats: 180


### PR DESCRIPTION
Added missing FL legislators after the special election in 2019. Related to issue #185.