### PR TITLE
Update Illinois legislators for 2020

### DIFF
--- a/data/il/people/Aaron-M-Ortiz-a76e0c0e-81d3-4f3b-8cc8-b8360d3cecb4.yml
+++ b/data/il/people/Aaron-M-Ortiz-a76e0c0e-81d3-4f3b-8cc8-b8360d3cecb4.yml
@@ -11,8 +11,9 @@ contact_details:
   email: district@repaaronortiz.com
   note: capitol
   voice: 217-782-1117
-- address: 4374 S. Archer;Chicago, IL 60632
+- address: 4374 S. Archer Ave.;Chicago, IL 60632
   note: district
+  voice: 773-236-0117
 links:
 - url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2752
 sources:

--- a/data/il/people/Amy-Grant-f8dc94db-66cf-4d5e-b1af-0b6307140524.yml
+++ b/data/il/people/Amy-Grant-f8dc94db-66cf-4d5e-b1af-0b6307140524.yml
@@ -11,7 +11,7 @@ contact_details:
   email: grant@ilhousegop.org
   note: capitol
   voice: 217-558-1037
-- address: 211 E. Illinois Street;Wheaton, IL 60187
+- address: 416 E. Roosevelt Road;Suite 111;Wheaton, IL 60187
   note: district
   voice: 331-218-4182
 links:

--- a/data/il/people/Bradley-Stephens-49c0fac1-8cf0-48d2-8166-811afe9ac5c5.yml
+++ b/data/il/people/Bradley-Stephens-49c0fac1-8cf0-48d2-8166-811afe9ac5c5.yml
@@ -1,0 +1,24 @@
+id: ocd-person/49c0fac1-8cf0-48d2-8166-811afe9ac5c5
+name: Bradley Stephens
+party:
+- name: Republican
+roles:
+- district: '20'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: lower
+  start_date: 2019-06-29
+contact_details:
+- address: 227-N Stratton Office Building;Springfield, IL 62706
+  note: capitol
+  voice: 217-782-8182
+- address: 5515 N. East River Rd.;Chicago, IL 60656
+  note: district
+  voice: 773-444-0611
+links:
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2770
+sources:
+- url: http://ilga.gov/house/default.asp?GA=101
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2770
+image: http://ilga.gov/images/members/{BD3836AC-CD0C-4E20-AD4C-1F2AEA56A8A2}.jpg
+given_name: Bradley
+family_name: Stephens

--- a/data/il/people/Brian-W-Stewart-bdb2b767-7c04-4a7e-941b-9734155329d6.yml
+++ b/data/il/people/Brian-W-Stewart-bdb2b767-7c04-4a7e-941b-9734155329d6.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 105C Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-0180
-- address: 50 W. Douglas St., Suite 1001;Freeport, IL 61032
+- address: 50 W. Douglas St.;Suite 1001;Freeport, IL 61032
   fax: 815-232-0777
   note: district
   voice: 815-284-0045

--- a/data/il/people/Chris-Miller-f5a10a95-3160-4cac-9f4e-ba31e5362e7b.yml
+++ b/data/il/people/Chris-Miller-f5a10a95-3160-4cac-9f4e-ba31e5362e7b.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 222-N Stratton Office Building;Springfield, IL 62706
-  email: miller@ilhousegop.org
+  email: chrismiller2019gop@gmail.com
   note: capitol
   voice: 217-558-1040
 - address: 211 South Cross Street;Robinson, IL 62454

--- a/data/il/people/Christopher-Belt-ce79408a-9923-4ab4-9c3a-805a2b4162d5.yml
+++ b/data/il/people/Christopher-Belt-ce79408a-9923-4ab4-9c3a-805a2b4162d5.yml
@@ -12,6 +12,7 @@ contact_details:
   voice: 217-782-5399
 - address: Kenneth Hall Regional office Bldg.#10;Collinsville Ave. Suite 201A;East
     St. Louis, IL 62201
+  fax: 618-274-3010
   note: district
   voice: 618-875-1212
 links:

--- a/data/il/people/Chuck-Weaver-8ddcd799-8ef7-45ef-8161-65a1b6fe4040.yml
+++ b/data/il/people/Chuck-Weaver-8ddcd799-8ef7-45ef-8161-65a1b6fe4040.yml
@@ -8,7 +8,6 @@ roles:
   type: upper
 contact_details:
 - address: 103A Capitol Building;Springfield, IL 62706
-  fax: 217-782-9586
   note: capitol
   voice: 217-782-1942
 - address: 5415 University St.;Suite 105;Peoria, IL 61614

--- a/data/il/people/Craig-Wilcox-07e2527a-ae7d-4c58-b20b-ea2266a03a9e.yml
+++ b/data/il/people/Craig-Wilcox-07e2527a-ae7d-4c58-b20b-ea2266a03a9e.yml
@@ -10,7 +10,8 @@ contact_details:
 - address: 105D Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8000
-- address: 5400 W.Elm st.;Suite 103;McHenry, IL 60050
+- address: 5400 W. Elm St.;Suite 103;McHenry, IL 60050
+  fax: 815-679-6756
   note: district
   voice: 815-455-6330
 links:

--- a/data/il/people/Curtis-J-Tarver-II-7a4c9172-6836-453c-94a8-1254b76fa08f.yml
+++ b/data/il/people/Curtis-J-Tarver-II-7a4c9172-6836-453c-94a8-1254b76fa08f.yml
@@ -13,7 +13,7 @@ contact_details:
   voice: 217-782-8121
 - address: 1303 E 53rd St.;Chicago, IL 60615
   note: district
-  voice: 872-356-2055
+  voice: 773-363-8870
 links:
 - url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2748
 sources:

--- a/data/il/people/Dale-Fowler-5a84a944-7d29-454e-aec6-85e6c3238d53.yml
+++ b/data/il/people/Dale-Fowler-5a84a944-7d29-454e-aec6-85e6c3238d53.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M103C Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5509
-- address: 2 North Vine;6th Floor;Harrisburg, IL 62946
+- address: 2 North Vine;Suite 600;Harrisburg, IL 62946
   fax: 618-294-8950
   note: district
   voice: 618-294-8951

--- a/data/il/people/Daniel-Swanson-6e9ee3b5-fb44-49f3-81f6-5a470bfaf009.yml
+++ b/data/il/people/Daniel-Swanson-6e9ee3b5-fb44-49f3-81f6-5a470bfaf009.yml
@@ -11,7 +11,7 @@ contact_details:
   email: swanson@ilhousegop.org
   note: capitol
   voice: 217-782-8032
-- address: 536 Oxford Ave.;Suite D;Woodhull, IL 61490
+- address: 275 N. Division St.;PO Box 173;Woodhull, IL 61490
   fax: 309-334-8000
   note: district
   voice: 309-334-7474

--- a/data/il/people/Darren-Bailey-65768dc3-c4b1-4c8f-bb79-5da425fa59e0.yml
+++ b/data/il/people/Darren-Bailey-65768dc3-c4b1-4c8f-bb79-5da425fa59e0.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 228-N Stratton Office Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-2087
-- address: 152 S. Church Street;Louisville, IL 62858
+- address: 152 S. Church Street;P.O. Box I;Louisville, IL 62858
   note: district
   voice: 618-665-4109
 links:

--- a/data/il/people/Dave-Severin-cbbd1430-7c0b-4be0-9d45-deabdb0c3d0f.yml
+++ b/data/il/people/Dave-Severin-cbbd1430-7c0b-4be0-9d45-deabdb0c3d0f.yml
@@ -11,7 +11,7 @@ contact_details:
   fax: 217-782-1275
   note: capitol
   voice: 217-782-1051
-- address: 1301 Enterprise Way;Suite 40A;Marion, IL 62959
+- address: 600 Halfway Road;Suite 103;Marion, IL 62959
   fax: 618-440-5091
   note: district
   voice: 618-440-5090

--- a/data/il/people/David-McSweeney-84c8f6ae-3691-4b37-a979-1b714552c1ce.yml
+++ b/data/il/people/David-McSweeney-84c8f6ae-3691-4b37-a979-1b714552c1ce.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 226-N Stratton Office Building;Springfield, IL 62706
-  email: mcsweeney@ilhousegop.org
+  email: repdavidmcsweeney@gmail.com
   note: capitol
   voice: 217-782-1517
 - address: 105 E. Main Street;Cary, IL 60013

--- a/data/il/people/Diane-Pappas-9e49c0d4-2a40-47fb-851b-8344c64ee7bf.yml
+++ b/data/il/people/Diane-Pappas-9e49c0d4-2a40-47fb-851b-8344c64ee7bf.yml
@@ -11,7 +11,7 @@ contact_details:
   email: RepDPappas@gmail.com
   note: capitol
   voice: 217-782-4014
-- address: 1 Tiffany Pointe;Suite G3;Bloomingdale, IL 60108
+- address: One Tiffany Pointe;Suite G3;Bloomingdale, IL 60108
   note: district
   voice: 224-520-8838
 links:

--- a/data/il/people/Donald-P-DeWitte-c4a1e37c-3c81-448c-9349-199a8fa5c2d3.yml
+++ b/data/il/people/Donald-P-DeWitte-c4a1e37c-3c81-448c-9349-199a8fa5c2d3.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 105B Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-1977
-- address: 641 S. 8th st.;West Dundee, IL 60118
+- address: 641 S. 8th St.;West Dundee, IL 60118
   note: district
   voice: 847-214-8245
 links:

--- a/data/il/people/Eva-Dina-Delgado-01201203-526d-4d02-b6fc-cbe5a749b6ab.yml
+++ b/data/il/people/Eva-Dina-Delgado-01201203-526d-4d02-b6fc-cbe5a749b6ab.yml
@@ -1,0 +1,24 @@
+id: ocd-person/01201203-526d-4d02-b6fc-cbe5a749b6ab
+name: Eva Dina Delgado
+party:
+- name: Democratic
+roles:
+- district: '3'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: lower
+  start_date: 2019-11-18
+contact_details:
+- address: 200-1S Stratton Office Building;Springfield, IL 62706
+  email: StateRepDelgado@gmail.com
+  note: capitol
+  voice: 217-782-0480
+- address: 6309 W. Belmont Ave.;Chicago, IL 60634
+  note: district
+links:
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2775
+sources:
+- url: http://ilga.gov/house/default.asp?GA=101
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2775
+image: http://ilga.gov/images/members/{D02A93E7-7D84-4429-92AB-60B61084EBA1}.jpg
+given_name: Eva
+family_name: Delgado

--- a/data/il/people/Fred-Crespo-3806ac4f-5290-4eb7-ba30-aa406036dd7a.yml
+++ b/data/il/people/Fred-Crespo-3806ac4f-5290-4eb7-ba30-aa406036dd7a.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 109 Capitol Building;Springfield, IL 62706
+  email: fred@fredcrespo.com
   note: capitol
   voice: 217-782-0347
 - address: 1014 E. Schaumburg Road;Streamwood, IL 60107

--- a/data/il/people/Jaime-M-Andrade-Jr-c0d481c5-9d31-4780-b2b0-bc5327291d6b.yml
+++ b/data/il/people/Jaime-M-Andrade-Jr-c0d481c5-9d31-4780-b2b0-bc5327291d6b.yml
@@ -8,10 +8,10 @@ roles:
   type: lower
 contact_details:
 - address: 238-W Stratton Office Building;Springfield, IL 62706
-  email: staterep40@gmail.com
+  email: info@staterep40.com
   note: capitol
   voice: 217-782-8117
-- address: 3007 W. Irving Park Rd.;Suite A-Front;Chicago, IL 60616
+- address: 3007 W. Irving Park Rd.;Suite A-Front;Chicago, IL 60618
   fax: 773-267-2840
   note: district
   voice: 773-267-2880

--- a/data/il/people/Jawaharial-Williams-b79ed17d-30a6-4d03-af90-ad3b34610395.yml
+++ b/data/il/people/Jawaharial-Williams-b79ed17d-30a6-4d03-af90-ad3b34610395.yml
@@ -1,0 +1,25 @@
+id: ocd-person/b79ed17d-30a6-4d03-af90-ad3b34610395
+name: Jawaharial Williams
+party:
+- name: Democratic
+roles:
+- district: '10'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: lower
+  start_date: 2019-05-17
+contact_details:
+- address: 256-W Stratton Office Building;Springfield, IL 62706
+  email: RepWilliamsOffice@gmail.com
+  note: capitol
+  voice: 217-782-8077
+- address: 2532 W Warren Blvd.;Suite A;Chicago, IL 60612
+  note: district
+  voice: 312-265-1019
+links:
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2768
+sources:
+- url: http://ilga.gov/house/default.asp?GA=101
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2768
+image: http://ilga.gov/images/members/{32750D93-496F-42CA-9CCE-93C3451713A1}.jpg
+given_name: Jawaharial
+family_name: Williams

--- a/data/il/people/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
+++ b/data/il/people/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 103C Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-2479
-- address: 3701 East Lake Center Drive;Suite 3;Quincy, IL 62305
+- address: 3701 East Lake Centre Drive;Suite 3;Quincy, IL 62305
   fax: 217-223-1565
   note: district
   voice: 217-223-0833

--- a/data/il/people/John-C-DAmico-c0b89b99-cf21-41f2-b0ee-692725d61fe3.yml
+++ b/data/il/people/John-C-DAmico-c0b89b99-cf21-41f2-b0ee-692725d61fe3.yml
@@ -12,7 +12,7 @@ contact_details:
   fax: 217-782-2906
   note: capitol
   voice: 217-782-8198
-- address: 4404 W. Lawrence Avenue;Chicago, IL 60630
+- address: 4200 W. Lawrence Avenue;Chicago, IL 60630
   fax: 773-736-2333
   note: district
   voice: 773-736-0218

--- a/data/il/people/John-F-Curran-cb63cb04-f84b-4fc9-91cf-05c4e1f93345.yml
+++ b/data/il/people/John-F-Curran-cb63cb04-f84b-4fc9-91cf-05c4e1f93345.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 105A Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-9407
-- address: 7501 S. Lemont Road;Suite 315G;Woodridge, IL 60517
+- address: 7501 Lemont Road;Suite 315G;Woodridge, IL 60517
   fax: 630-796-2658
   note: district
   voice: 630-796-2623

--- a/data/il/people/Kambium-Buckner-8b7174cd-4081-4717-8ba9-184518f7b31e.yml
+++ b/data/il/people/Kambium-Buckner-8b7174cd-4081-4717-8ba9-184518f7b31e.yml
@@ -9,7 +9,7 @@ roles:
   start_date: '2019-01-18'
 contact_details:
 - address: 252-W Stratton Office Building;Springfield, IL 62706
-  email: Staterepbuckner@gmail.com
+  email: Buckner@illinois26.com
   note: capitol
   voice: 217-782-2023
 - address: 449 E. 35th Street;Chicago, IL 60616

--- a/data/il/people/Kimberly-A-Lightford-595f7bf4-5bd7-4238-94a3-e14d8b6d4545.yml
+++ b/data/il/people/Kimberly-A-Lightford-595f7bf4-5bd7-4238-94a3-e14d8b6d4545.yml
@@ -10,9 +10,10 @@ contact_details:
 - address: 329A Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8505
-- address: 10330 West Roosevelt Rd;Suite 308;Westchester, IL 60154
+- address: 4415 Harrison St.;Suite 550;Hillside, IL 60162
+  fax: 708-632-4515
   note: district
-  voice: 708-343-7444
+  voice: 708-632-4500
 links:
 - url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2535
 sources:

--- a/data/il/people/LaShawn-K-Ford-91164a3d-fc17-4252-a31f-a8d0d113b74b.yml
+++ b/data/il/people/LaShawn-K-Ford-91164a3d-fc17-4252-a31f-a8d0d113b74b.yml
@@ -14,7 +14,7 @@ contact_details:
   voice: 217-782-5962
 - address: 5051 W Chicago Ave.;Chicago, IL 60651
   note: district
-  voice: 773-378-5902
+  voice: 773-750-0866
 links:
 - url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2567
 sources:

--- a/data/il/people/Lamont-J-Robinson-Jr-4bdd4c01-bedd-4e79-8bd6-e0cd2ad6a4b8.yml
+++ b/data/il/people/Lamont-J-Robinson-Jr-4bdd4c01-bedd-4e79-8bd6-e0cd2ad6a4b8.yml
@@ -11,7 +11,7 @@ contact_details:
   email: lamont@lamontjrobinson.com
   note: capitol
   voice: 217-782-4535
-- address: 5048 S. Indiana;Chicago, IL 60615
+- address: 5048 S. Indiana Ave.;Chicago, IL 60615
   fax: 773-924-4652
   note: district
   voice: 773-924-4614

--- a/data/il/people/Laura-Ellman-9bc8c9e8-ed36-42a1-ae80-4b2dfe591839.yml
+++ b/data/il/people/Laura-Ellman-9bc8c9e8-ed36-42a1-ae80-4b2dfe591839.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M122 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8192
-- address: 552 S. Washington St;Suite 104;Naperville, IL 60540
+- address: 552 S. Washington St.;Suite 104;Naperville, IL 60540
   note: district
   voice: 630-453-5488
 links:

--- a/data/il/people/Laura-Fine-0ce44c13-37aa-4560-8489-67c309da913a.yml
+++ b/data/il/people/Laura-Fine-0ce44c13-37aa-4560-8489-67c309da913a.yml
@@ -15,8 +15,7 @@ contact_details:
 - address: M115 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-2119
-- address: 1812 Waukegan Road;Suite A;Glenview, IL
-  fax: 847-998-1707
+- address: 1812 Waukegan Road;Suite A;Glenview, IL 60025
   note: district
   voice: 847-998-1717
 links:

--- a/data/il/people/Linda-Holmes-8d0beff8-000c-470a-a6c8-a05e1b6816cb.yml
+++ b/data/il/people/Linda-Holmes-8d0beff8-000c-470a-a6c8-a05e1b6816cb.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 129 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-0422
-- address: 76 S. LaSalle Street,;Suite 202;Aurora, IL 60505
+- address: 76 S. LaSalle Street;Suite 202;Aurora, IL 60505
   fax: 630-801-8987
   note: district
   voice: 630-801-8985

--- a/data/il/people/Lindsey-LaPointe-ea4595af-64f9-4d91-9c12-48accdc04ff8.yml
+++ b/data/il/people/Lindsey-LaPointe-ea4595af-64f9-4d91-9c12-48accdc04ff8.yml
@@ -1,0 +1,26 @@
+id: ocd-person/ea4595af-64f9-4d91-9c12-48accdc04ff8
+name: Lindsey LaPointe
+party:
+- name: Democratic
+roles:
+- district: '19'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: lower
+  start_date: 2019-07-24
+contact_details:
+- address: 271-S Stratton Office Building;Springfield, IL 62706
+  email: RepLaPointe@gmail.com
+  fax: 217-557-1934
+  note: capitol
+  voice: 217-782-8400
+- address: 6315 N. Milwaukee Ave.;1st Fl;Chicago, IL 60646
+  note: district
+  voice: 773-647-1174
+links:
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2771
+sources:
+- url: http://ilga.gov/house/default.asp?GA=101
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2771
+image: http://ilga.gov/images/members/{7447C9D9-48D0-457E-BDC9-847FB8D35DB5}.jpg
+given_name: Lindsey
+family_name: LaPointe

--- a/data/il/people/Mary-E-Flowers-bb07ed41-05af-4e1d-82a3-c9da9f89d71c.yml
+++ b/data/il/people/Mary-E-Flowers-bb07ed41-05af-4e1d-82a3-c9da9f89d71c.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 251-E Stratton Office Building;Springfield, IL 62706
-  email: maryeflowers@ilga.gov
+  email: state.repflowers@comcast.net
   fax: 217-782-1130
   note: capitol
   voice: 217-782-4207

--- a/data/il/people/Mary-Edly-Allen-4961384a-0200-48da-a027-5b8a21103c37.yml
+++ b/data/il/people/Mary-Edly-Allen-4961384a-0200-48da-a027-5b8a21103c37.yml
@@ -11,7 +11,7 @@ contact_details:
   email: repedlyallen@gmail.com
   note: capitol
   voice: 217-782-3696
-- address: 1585 N. Milwaukee Ave.;Suite 7;Libertyville, IL 60048
+- address: 1585 N. Milwaukee Ave.;Suite 15;Libertyville, IL 60048
   note: district
   voice: 224-206-7647
 links:

--- a/data/il/people/Maurice-A-West-77906cdf-58a8-4329-bb24-c65e6e38342f.yml
+++ b/data/il/people/Maurice-A-West-77906cdf-58a8-4329-bb24-c65e6e38342f.yml
@@ -11,7 +11,7 @@ contact_details:
   email: Assistance@StateRepWest.com
   note: capitol
   voice: 217-782-3167
-- address: 200 S. Wyman;Suite 304;Rockford, IL 61101
+- address: E.J. "Zeke" Giorgi Center;200 S. Wyman, Suite 304;Rockford, IL 61101
   note: district
   voice: 815-987-7433
 links:

--- a/data/il/people/Napoleon-Harris-III-f8e78760-4ec7-44f4-a00f-54f42fb834d5.yml
+++ b/data/il/people/Napoleon-Harris-III-f8e78760-4ec7-44f4-a00f-54f42fb834d5.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M113 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8066
-- address: 369 E. 147th Street;Unit H;Harvey, IL 60426
+- address: 1350 E. Sibley Blvd.;Suite 403;Dolton, IL 60419
   fax: 708-566-4108
   note: district
   voice: 708-893-0552

--- a/data/il/people/Nathan-D-Reitz-6ab8127d-a128-496a-83f5-517702124f51.yml
+++ b/data/il/people/Nathan-D-Reitz-6ab8127d-a128-496a-83f5-517702124f51.yml
@@ -1,0 +1,26 @@
+id: ocd-person/6ab8127d-a128-496a-83f5-517702124f51
+name: Nathan D. Reitz
+party:
+- name: Democratic
+roles:
+- district: '116'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: lower
+  start_date: 2019-05-09
+contact_details:
+- address: 200-7S Stratton Office Building;Springfield, IL 62706
+  email: repnreitz@gmail com
+  note: capitol
+  voice: 217-782-1018
+- address: 124 Locust Street;Red Bud, IL 62278
+  fax: 618-282-7286
+  note: district
+  voice: 618-282-7284
+links:
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2767
+sources:
+- url: http://ilga.gov/house/default.asp?GA=101
+- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2767
+image: http://ilga.gov/images/members/{82C32B5B-1A1F-45D1-9F7C-B1BDDBCCCEE9}.jpg
+given_name: Nathan
+family_name: Reitz

--- a/data/il/people/Neil-Anderson-b676c70e-0bc2-45d2-bd4c-9f3fa70bf60e.yml
+++ b/data/il/people/Neil-Anderson-b676c70e-0bc2-45d2-bd4c-9f3fa70bf60e.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M103D Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5957
-- address: 1523 47th Avenue;Suite 2;Moline, IL 61265
+- address: 1523 47th Ave.;Suite 2;Moline, IL 61265
   note: district
   voice: 309-736-7084
 links:

--- a/data/il/people/Omar-Aquino-436c1e53-1203-4ce3-9931-d22f9e3c406a.yml
+++ b/data/il/people/Omar-Aquino-436c1e53-1203-4ce3-9931-d22f9e3c406a.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 623 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5652
-- address: 4353 W. Armitage Ave.;Chicago, IL 60639
+- address: 2511 W. Division st.;Chicago, IL 60622
   fax: 773-292-1903
   note: district
   voice: 773-292-0202

--- a/data/il/people/Patrick-J-Joyce-1ae7c123-b1a4-4c6e-b4d3-dc22db461e44.yml
+++ b/data/il/people/Patrick-J-Joyce-1ae7c123-b1a4-4c6e-b4d3-dc22db461e44.yml
@@ -1,0 +1,25 @@
+id: ocd-person/1ae7c123-b1a4-4c6e-b4d3-dc22db461e44
+name: Patrick J. Joyce
+party:
+- name: Democratic
+roles:
+- district: '40'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: upper
+  start_date: 2019-11-08
+contact_details:
+- address: 108A Capitol Building;Springfield, IL 62706
+  note: capitol
+  voice: 217-782-7419
+- address: 270 Main St.;Park Forest, IL 60466
+  fax: 708-756-0885
+  note: district
+  voice: 708-756-0882
+links:
+- url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2774
+sources:
+- url: http://ilga.gov/senate/default.asp?GA=101
+- url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2774
+image: http://ilga.gov/images/members/{39D6F100-DAEC-4C4B-A4F5-F20299B79152}.jpg
+given_name: Patrick
+family_name: Joyce

--- a/data/il/people/Patrick-Windhorst-6cb9bc2c-97b3-4dd1-b5ba-36a644360057.yml
+++ b/data/il/people/Patrick-Windhorst-6cb9bc2c-97b3-4dd1-b5ba-36a644360057.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 214-N Stratton Office Building;Springfield, IL 62706
+  email: windhorst@ilhousegop.org
   fax: 217-782-1275
   note: capitol
   voice: 217-782-5131

--- a/data/il/people/Rachelle-Crowe-9916a2a9-b075-4319-af0b-ba4ac7fcf564.yml
+++ b/data/il/people/Rachelle-Crowe-9916a2a9-b075-4319-af0b-ba4ac7fcf564.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 311B Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5247
-- address: 111 N. Wood River Ave.,;Suite A;Wood River, IL 62095
+- address: 111 N. Wood River Ave.;Suite A;Wood River, IL 62095
   note: district
   voice: 618-251-9840
 links:

--- a/data/il/people/Ram-Villivalam-d01a10b0-e391-4c65-ba1f-304ee6130f5c.yml
+++ b/data/il/people/Ram-Villivalam-d01a10b0-e391-4c65-ba1f-304ee6130f5c.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M120 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5500
-- address: 3851 W. Devon Ave;Chicago, IL
+- address: 3851 W. Devon Ave.;Chicago, IL 60659
   note: district
   voice: 872-208-5188
 links:

--- a/data/il/people/Robert-F-Martwick-4a3645fe-2a56-400f-ae2a-18e50f2b0bea.yml
+++ b/data/il/people/Robert-F-Martwick-4a3645fe-2a56-400f-ae2a-18e50f2b0bea.yml
@@ -6,22 +6,24 @@ roles:
 - district: '19'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
+  end_date: 2019-06-28
+- district: '10'
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  type: upper
+  start_date: 2019-06-28
 contact_details:
-- address: 271-S Stratton Office Building;Springfield, IL 62706
-  email: repmartwick@gmail.com
-  fax: 217-557-1934
+- address: 127 Capitol Building;Springfield, IL 62706
   note: capitol
-  voice: 217-782-8400
-- address: 5618 West Montrose;Suite 101;Chicago, IL 60634
-  fax: 773-545-7106
+  voice: 217-782-1035
+- address: 6315 N. Milwaukee Ave.;Suite 101;Chicago, IL 60646
   note: district
   voice: 773-286-1115
 links:
-- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2626
+- url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2769
 sources:
-- url: http://ilga.gov/house/default.asp?GA=101
-- url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2626
-image: http://ilga.gov/images/members/{F6FFE366-9A8B-422B-9111-1A63EFED05C6}.jpg
+- url: http://ilga.gov/senate/default.asp?GA=101
+- url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2769
+image: http://ilga.gov/images/members/{8FA2A22C-6775-4098-905C-0C7D8BBD7AEE}.jpg
 other_identifiers:
 - identifier: ILL000880
   scheme: legacy_openstates

--- a/data/il/people/Robert-Peters-86ee52dd-dc32-4895-bf16-746eb76df012.yml
+++ b/data/il/people/Robert-Peters-86ee52dd-dc32-4895-bf16-746eb76df012.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: M121 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-5338
-- address: 1509 E. 53rd St, 2nd Floor;Chicago, IL 60615
+- address: 1509 E. 53rd St.;2nd Floor;Chicago, IL 60615
   note: district
   voice: 773-363-1996
 links:

--- a/data/il/people/Robyn-Gabel-7d68f174-3504-4479-80c5-e3fbe69fd354.yml
+++ b/data/il/people/Robyn-Gabel-7d68f174-3504-4479-80c5-e3fbe69fd354.yml
@@ -11,10 +11,9 @@ contact_details:
   email: staterepgabel@robyngabel.com
   note: capitol
   voice: 217-782-8052
-- address: 820 Davis Street;Suite 103;Evanston, IL 60201
-  fax: 847-424-9828
+- address: 2100 Ridge Ave.;Suite 2600;Evanston, IL 60201
   note: district
-  voice: 847-424-9898
+  voice: 847-424-5401
 links:
 - url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2583
 sources:

--- a/data/il/people/Ryan-Spain-139cce29-08b9-4731-a7e9-bdeec8129eaa.yml
+++ b/data/il/people/Ryan-Spain-139cce29-08b9-4731-a7e9-bdeec8129eaa.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
 contact_details:
-- address: 227-N Stratton Office Building;Springfield, IL 62706
+- address: 219-N Stratton Office Building;Springfield, IL 62706
   email: repryanspain@gmail.com
   note: capitol
   voice: 217-782-8108

--- a/data/il/people/Scott-M-Bennett-86147150-e615-43a2-a748-e95d06627ad3.yml
+++ b/data/il/people/Scott-M-Bennett-86147150-e615-43a2-a748-e95d06627ad3.yml
@@ -11,7 +11,6 @@ contact_details:
   note: capitol
   voice: 217-782-2507
 - address: 45 E. University Ave.;Suite 206;Champaign, IL 61820
-  fax: 217-355-5255
   note: district
   voice: 217-355-5252
 links:

--- a/data/il/people/Steve-McClure-d3450848-4552-4b8f-97dc-fb3c26c2566c.yml
+++ b/data/il/people/Steve-McClure-d3450848-4552-4b8f-97dc-fb3c26c2566c.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 218 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8206
-- address: 229 S. Main;Suite B;Jacksonville, IL 62650
+- address: 229 S. Main St.;Suite B;Jacksonville, IL 62650
   note: district
   voice: 217-245-7456
 links:

--- a/data/il/people/Steve-Stadelman-ba9c4927-bf9b-4bd5-879f-c515a12a046c.yml
+++ b/data/il/people/Steve-Stadelman-ba9c4927-bf9b-4bd5-879f-c515a12a046c.yml
@@ -11,7 +11,6 @@ contact_details:
   note: capitol
   voice: 217-782-8022
 - address: State of Illinois Building;200 S. Wyman, Suite 301;Rockford, IL 61101
-  fax: 815-987-7529
   note: district
   voice: 815-987-7557
 links:

--- a/data/il/people/Suzy-Glowiak-16483678-e06e-4551-8cec-266335b56fff.yml
+++ b/data/il/people/Suzy-Glowiak-16483678-e06e-4551-8cec-266335b56fff.yml
@@ -1,5 +1,5 @@
 id: ocd-person/16483678-e06e-4551-8cec-266335b56fff
-name: Suzy Glowiak
+name: Suzy Glowiak Hilton
 party:
 - name: Democratic
 roles:
@@ -10,8 +10,9 @@ contact_details:
 - address: 124 Capitol Building;Springfield, IL 62706
   note: capitol
   voice: 217-782-8148
-- address: 17W715 East Butterfield Rd;Oakbrook Terrace, IL 60181
+- address: 17W715 East Butterfield Rd;Suite F;Oakbrook Terrace, IL 60181
   note: district
+  voice: 630-785-3177
 links:
 - url: http://ilga.gov/senate/Senator.asp?GA=101&MemberID=2727
 sources:

--- a/data/il/people/Tim-Butler-093bed37-c7b0-47ff-a96e-5a42859d515d.yml
+++ b/data/il/people/Tim-Butler-093bed37-c7b0-47ff-a96e-5a42859d515d.yml
@@ -7,11 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
 contact_details:
-- address: 1128-E Stratton Office Building;Springfield, IL 62706
+- address: E-1 Stratton Office Building;Springfield, IL 62706
   email: butler@ilhousegop.org
   note: capitol
   voice: 217-782-0053
-- address: 1128-E Stratton Office Building;Springfield, IL 62706
+- address: E-1 Stratton Office Building;Springfield, IL 62706
   note: district
   voice: 217-782-0053
 links:

--- a/data/il/people/Tom-Weber-ba3dd226-a1c6-47af-917a-e12696d5aae5.yml
+++ b/data/il/people/Tom-Weber-ba3dd226-a1c6-47af-917a-e12696d5aae5.yml
@@ -11,7 +11,7 @@ contact_details:
   email: weber@ilhousegop.org
   note: capitol
   voice: 217-782-1664
-- address: 74 E. Grand Ave.;Fox Lake, IL 60020
+- address: 74 E. Grand Ave.;Ste. 104;Fox Lake, IL 60020
   note: district
   voice: 847-629-5439
 links:

--- a/data/il/people/Will-Guzzardi-df11068d-eb77-4eb8-90c8-95056891e633.yml
+++ b/data/il/people/Will-Guzzardi-df11068d-eb77-4eb8-90c8-95056891e633.yml
@@ -13,7 +13,7 @@ contact_details:
   voice: 217-558-1032
 - address: 3458 N. Cicero Ave.;Chicago, IL 60647
   note: district
-  voice: 773-227-9720
+  voice: 773-853-2570
 links:
 - url: http://ilga.gov/house/Rep.asp?GA=101&MemberID=2662
 sources:

--- a/data/il/people/Yehiel-M-Kalish-7399a4b3-144a-4860-9edf-c1aed2063574.yml
+++ b/data/il/people/Yehiel-M-Kalish-7399a4b3-144a-4860-9edf-c1aed2063574.yml
@@ -12,7 +12,7 @@ contact_details:
   email: repymkalish@gmail.com
   note: capitol
   voice: 217-782-1252
-- address: 4508 Oakton St.;Skokie, IL 60076
+- address: 8707 Skokie Blvd.;Suite 102;Skokie, IL 60077
   fax: 847-982-0393
   note: district
   voice: 847-673-1131

--- a/data/il/retired/Jerry-F-Costello-II-cfced2a0-9db3-4055-a952-f37db5aa4310.yml
+++ b/data/il/retired/Jerry-F-Costello-II-cfced2a0-9db3-4055-a952-f37db5aa4310.yml
@@ -6,6 +6,7 @@ roles:
 - district: '116'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
+  end_date: '2019-05-07'
 contact_details:
 - address: 200-7S Stratton Office Building;Springfield, IL 62706
   email: staterepcostello@gmail.com

--- a/data/il/retired/John-G-Mulroe-36c7c16e-aab9-4d19-b8b8-2b2b0f9137d5.yml
+++ b/data/il/retired/John-G-Mulroe-36c7c16e-aab9-4d19-b8b8-2b2b0f9137d5.yml
@@ -6,6 +6,7 @@ roles:
 - district: '10'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: upper
+  end_date: '2019-06-17'
 contact_details:
 - address: 127 Capitol Building;Springfield, IL 62706
   note: capitol

--- a/data/il/retired/Luis-Arroyo-dee76fa3-21de-4aa6-be18-28645c0c30b2.yml
+++ b/data/il/retired/Luis-Arroyo-dee76fa3-21de-4aa6-be18-28645c0c30b2.yml
@@ -6,6 +6,7 @@ roles:
 - district: '3'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
+  end_date: '2019-11-01'
 contact_details:
 - address: 200-1S Stratton Office Buildingng;Springfield, IL 62706
   email: RepDistrict3@gmail.com

--- a/data/il/retired/Martin-A-Sandoval-d1a22314-8a12-4daf-a021-40e7b76741ae.yml
+++ b/data/il/retired/Martin-A-Sandoval-d1a22314-8a12-4daf-a021-40e7b76741ae.yml
@@ -6,6 +6,7 @@ roles:
 - district: '11'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: upper
+  end_date: '2020-01-01'
 contact_details:
 - address: 111 Capitol Building;Springfield, IL 62706
   note: capitol

--- a/data/il/retired/Melissa-Conyears-Ervin-7a6445ae-75be-41da-8281-92b3962fdf3a.yml
+++ b/data/il/retired/Melissa-Conyears-Ervin-7a6445ae-75be-41da-8281-92b3962fdf3a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '10'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
+  end_date: '2019-05-01'
 contact_details:
 - address: 256-W Stratton Office Building;Springfield, IL 62706
   email: Rep@ConyearsErvin.com

--- a/data/il/retired/Michael-P-McAuliffe-99767684-f579-4718-be88-1febd16d951c.yml
+++ b/data/il/retired/Michael-P-McAuliffe-99767684-f579-4718-be88-1febd16d951c.yml
@@ -6,6 +6,7 @@ roles:
 - district: '20'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: lower
+  end_date: '2019-06-17'
 contact_details:
 - address: 219-N Stratton Office Building;Springfield, IL 62706
   fax: 217-782-1141

--- a/data/il/retired/Toi-W-Hutchinson-55710d3f-c7cc-47f8-a9d1-3743e4f8d097.yml
+++ b/data/il/retired/Toi-W-Hutchinson-55710d3f-c7cc-47f8-a9d1-3743e4f8d097.yml
@@ -6,6 +6,7 @@ roles:
 - district: '40'
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   type: upper
+  end_date: '2019-11-03'
 contact_details:
 - address: 108A Capitol Building;Springfield, IL 62706
   note: capitol

--- a/settings.yml
+++ b/settings.yml
@@ -87,6 +87,10 @@ il:
   legislature_name: Illinois General Assembly
   lower_seats: 118
   upper_seats: 59
+  vacancies:
+    - chamber: upper
+      district: 11
+      vacant_until: 2020-05-01
 in:
   legislature_name: Indiana General Assembly
   lower_seats: 100


### PR DESCRIPTION
There were 6 appointments and 7 resignations, leaving one vacancy. This also updates some emails/addresses/phone numbers.