### PR TITLE
Update New Jersey legislators for 2020

### DIFF
--- a/data/nj/organizations/Budget-and-Appropriations-605b6133-95d4-4b93-a109-06246d72f13f.yml
+++ b/data/nj/organizations/Budget-and-Appropriations-605b6133-95d4-4b93-a109-06246d72f13f.yml
@@ -29,6 +29,7 @@ memberships:
   name: Samuel D. Thompson
 - id: ocd-person/e4e95ef4-33eb-4b15-86fd-c87c3deeea3d
   name: Anthony R. Bucco
+  end_date: '2019-09-16'
 - id: ocd-person/e021e915-73b7-4881-83fa-9178fb602f39
   name: Steven V. Oroho
 - id: ocd-person/b656905a-de58-4d36-b433-276788233b1f

--- a/data/nj/organizations/Budget-ee600af6-3245-4f04-b757-225c1f8f7a70.yml
+++ b/data/nj/organizations/Budget-ee600af6-3245-4f04-b757-225c1f8f7a70.yml
@@ -27,6 +27,7 @@ memberships:
   name: John DiMaio
 - id: ocd-person/442676ac-33b2-4f79-be9b-62b7b9f2afcc
   name: Patricia Egan Jones
+  end_date: '2020-01-14'
 - id: ocd-person/e6d7f07e-8f68-49b5-8e8e-970817a6c8c4
   name: Edward H. Thomson
 - id: ocd-person/b94db48b-9083-48c9-8b27-3603db14fa3e

--- a/data/nj/organizations/Community-and-Urban-Affairs-f9db7d5d-63b4-448b-8d54-27f695ce7b7c.yml
+++ b/data/nj/organizations/Community-and-Urban-Affairs-f9db7d5d-63b4-448b-8d54-27f695ce7b7c.yml
@@ -15,6 +15,7 @@ memberships:
 - id: ocd-person/628d09ef-e8a6-4e02-8a4d-4e5a95e28408
   name: Jeff Van Drew
   role: chair
+  end_date: '2019-01-01'
 - name: Declan J. O'Scanlon
 - id: ocd-person/1ebbb9b9-1582-4b52-9c6f-41b112fec666
   name: Christopher J. Connors

--- a/data/nj/organizations/Education-997e97b2-6dd5-476c-8f97-6fc505f6ca0d.yml
+++ b/data/nj/organizations/Education-997e97b2-6dd5-476c-8f97-6fc505f6ca0d.yml
@@ -29,5 +29,6 @@ memberships:
   name: Britnee N. Timberlake
 - id: ocd-person/d56981d2-8d8d-4bc4-bdba-d2e6f1ec7f6a
   name: David W. Wolfe
+  end_date: '2020-01-14'
 - id: ocd-person/93a1a3ce-eb52-4e71-b01c-346f41b6bde4
   name: Gary S. Schaer

--- a/data/nj/organizations/Environment-and-Solid-Waste-ed68eb6c-1f95-42d1-a43e-52d4cad89da0.yml
+++ b/data/nj/organizations/Environment-and-Solid-Waste-ed68eb6c-1f95-42d1-a43e-52d4cad89da0.yml
@@ -15,6 +15,7 @@ memberships:
   role: vice-chair
 - id: ocd-person/d56981d2-8d8d-4bc4-bdba-d2e6f1ec7f6a
   name: David W. Wolfe
+  end_date: '2020-01-14'
 - id: ocd-person/0aca0d16-9cf3-46f8-acd9-155f739badaa
   name: Kevin J. Rooney
 - id: ocd-person/1fec06e0-00df-4d84-8c9a-18e80a6f29e2

--- a/data/nj/organizations/Higher-Education-7cc6e606-99fe-4a21-aae4-c34d12cb6e12.yml
+++ b/data/nj/organizations/Higher-Education-7cc6e606-99fe-4a21-aae4-c34d12cb6e12.yml
@@ -13,8 +13,10 @@ memberships:
   name: Clinton Calabrese
 - id: ocd-person/63b4dea8-52fa-4fb3-9725-fefd41a5dced
   name: Amy H. Handlin
+  end_date: '2020-01-14'
 - id: ocd-person/95c7cd69-0eb2-4041-97df-9764a1cd3593
   name: Michael Patrick Carroll
+  end_date: '2020-01-14'
 - id: ocd-person/5e50bdd3-07c1-481f-8dc8-c59dbae85f4d
   name: Mila M. Jasey
   role: chair
@@ -27,3 +29,4 @@ memberships:
   name: Thomas P. Giblin
 - id: ocd-person/442676ac-33b2-4f79-be9b-62b7b9f2afcc
   name: Patricia Egan Jones
+  end_date: '2020-01-14'

--- a/data/nj/organizations/Judiciary-2af536e1-f23b-4e30-ae7a-fb649c1f81f6.yml
+++ b/data/nj/organizations/Judiciary-2af536e1-f23b-4e30-ae7a-fb649c1f81f6.yml
@@ -14,6 +14,7 @@ memberships:
   role: chair
 - id: ocd-person/95c7cd69-0eb2-4041-97df-9764a1cd3593
   name: Michael Patrick Carroll
+  end_date: '2020-01-14'
 - id: ocd-person/df6d2d1f-3fb0-4e93-93cf-26665cae9a23
   name: Erik Peterson
 - id: ocd-person/3d5d3c07-70ed-481a-91ba-a19fce581561

--- a/data/nj/organizations/Labor-1b024fd2-345f-4933-95b7-63135ffd1679.yml
+++ b/data/nj/organizations/Labor-1b024fd2-345f-4933-95b7-63135ffd1679.yml
@@ -11,6 +11,7 @@ memberships:
   name: Dawn Marie Addiego
 - id: ocd-person/e4e95ef4-33eb-4b15-86fd-c87c3deeea3d
   name: Anthony R. Bucco
+  end_date: '2019-09-16'
 - name: Fred H. Madden
   role: chair
 - id: ocd-person/97fba3ff-adc8-4323-bf77-37acfe18b735

--- a/data/nj/organizations/Law-and-Public-Safety-1872439e-124a-415b-a3a3-68eb95c500f6.yml
+++ b/data/nj/organizations/Law-and-Public-Safety-1872439e-124a-415b-a3a3-68eb95c500f6.yml
@@ -16,6 +16,7 @@ memberships:
   role: chair
 - id: ocd-person/8907a1f7-2ed9-4d6b-a380-eca77a210504
   name: Joe Howarth
+  end_date: '2020-01-14'
 - id: ocd-person/1119c78d-cad9-4d90-a950-425001f5a2a1
   name: Nancy J. Pinkin
 - id: ocd-person/6cab3e19-7a7c-4488-877f-a6a167306ba5

--- a/data/nj/organizations/Military-and-Veterans-Affairs-98469311-88cb-43aa-a004-662f7ccb3a8b.yml
+++ b/data/nj/organizations/Military-and-Veterans-Affairs-98469311-88cb-43aa-a004-662f7ccb3a8b.yml
@@ -19,3 +19,4 @@ memberships:
 - id: ocd-person/628d09ef-e8a6-4e02-8a4d-4e5a95e28408
   name: Jeff Van Drew
   role: vice-chair
+  end_date: '2019-01-01'

--- a/data/nj/organizations/Regulated-Professions-78dca7e0-1b6b-4dd8-98c7-59349e0c40fe.yml
+++ b/data/nj/organizations/Regulated-Professions-78dca7e0-1b6b-4dd8-98c7-59349e0c40fe.yml
@@ -18,6 +18,7 @@ memberships:
   role: vice-chair
 - id: ocd-person/bdae3c0f-cb2e-401d-bb6d-92427a53354f
   name: R. Bruce Land
+  end_date: '2020-01-14'
 - id: ocd-person/fd2836af-d444-48b7-9518-c8843d30c41d
   name: Pedro Mejia
 - id: ocd-person/1277b3fe-c85b-41af-ada7-e01cc910c397
@@ -27,3 +28,4 @@ memberships:
   name: Christopher P. DePhillips
 - id: ocd-person/63b4dea8-52fa-4fb3-9725-fefd41a5dced
   name: Amy H. Handlin
+  end_date: '2020-01-14'

--- a/data/nj/organizations/State-and-Local-Government-872e4849-c92a-4cc1-abdc-67da41272abd.yml
+++ b/data/nj/organizations/State-and-Local-Government-872e4849-c92a-4cc1-abdc-67da41272abd.yml
@@ -19,5 +19,6 @@ memberships:
   name: Ryan E. Peters
 - id: ocd-person/95c7cd69-0eb2-4041-97df-9764a1cd3593
   name: Michael Patrick Carroll
+  end_date: '2020-01-14'
 - id: ocd-person/b432ec8c-f914-47dc-addd-740dfc95daaf
   name: Verlina Reynolds-Jackson

--- a/data/nj/organizations/Tourism-Gaming-and-the-Arts-9c7afc0c-f700-436d-88d8-fe72a98ba701.yml
+++ b/data/nj/organizations/Tourism-Gaming-and-the-Arts-9c7afc0c-f700-436d-88d8-fe72a98ba701.yml
@@ -9,6 +9,7 @@ sources:
 memberships:
 - id: ocd-person/8907a1f7-2ed9-4d6b-a380-eca77a210504
   name: Joe Howarth
+  end_date: '2020-01-14'
 - id: ocd-person/3dcf1086-76e4-4e2e-b765-8230439056c3
   name: Ralph R. Caputo
   role: chair
@@ -19,6 +20,7 @@ memberships:
 - id: ocd-person/bdae3c0f-cb2e-401d-bb6d-92427a53354f
   name: R. Bruce Land
   role: vice-chair
+  end_date: '2020-01-14'
 - id: ocd-person/0125cf6a-80a1-4c7c-a173-8e6125a96dfa
   name: Vincent Mazzeo
 - id: ocd-person/e06080db-abc0-40ab-ae4b-43fd3d0a5430

--- a/data/nj/organizations/Transportation-and-Independent-Authorities-e27609ec-3913-4a1d-a0fa-bfadf07a11b1.yml
+++ b/data/nj/organizations/Transportation-and-Independent-Authorities-e27609ec-3913-4a1d-a0fa-bfadf07a11b1.yml
@@ -25,6 +25,7 @@ memberships:
 - id: ocd-person/442676ac-33b2-4f79-be9b-62b7b9f2afcc
   name: Patricia Egan Jones
   role: vice-chair
+  end_date: '2020-01-14'
 - id: ocd-person/d6732f77-1c72-4ee6-8d52-5c9b79987976
   name: Robert J. Karabinchak
 - id: ocd-person/2ac520a3-ae36-4936-a9c3-6842401b6c83

--- a/data/nj/people/Adam-J-Taliaferro-fc828855-1f56-416b-b218-c45c9d8aa652.yml
+++ b/data/nj/people/Adam-J-Taliaferro-fc828855-1f56-416b-b218-c45c9d8aa652.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000189
   scheme: legacy_openstates
-given_name: Adam J.
+given_name: Adam
 family_name: Taliaferro

--- a/data/nj/people/Andrew-Zwicker-7782ffcd-73df-41b5-9857-fd7b10953bf3.yml
+++ b/data/nj/people/Andrew-Zwicker-7782ffcd-73df-41b5-9857-fd7b10953bf3.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=386
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/zwicker_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/zwicker_andrew_2019.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000204

--- a/data/nj/people/Angela-V-McKnight-d8c826c4-95c7-465b-8448-1f05495bfc45.yml
+++ b/data/nj/people/Angela-V-McKnight-d8c826c4-95c7-465b-8448-1f05495bfc45.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000197
   scheme: legacy_openstates
-given_name: Angela V.
+given_name: Angela
 family_name: McKnight

--- a/data/nj/people/Angelica-M-Jimenez-2845eb57-3b9a-4d8d-9ee3-55bda4967805.yml
+++ b/data/nj/people/Angelica-M-Jimenez-2845eb57-3b9a-4d8d-9ee3-55bda4967805.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000161
   scheme: legacy_openstates
-given_name: Angelica M.
+given_name: Angelica
 family_name: Jimenez

--- a/data/nj/people/Annette-Chaparro-a0281bb5-d164-48ca-959b-4cb52e389cc7.yml
+++ b/data/nj/people/Annette-Chaparro-a0281bb5-d164-48ca-959b-4cb52e389cc7.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=385
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/chaparro_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/chaparro_annette_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000201

--- a/data/nj/people/Anthony-M-Bucco-f321f20f-b8af-4d0b-85ba-e7b8dcf9ae03.yml
+++ b/data/nj/people/Anthony-M-Bucco-f321f20f-b8af-4d0b-85ba-e7b8dcf9ae03.yml
@@ -6,15 +6,20 @@ roles:
 - district: '25'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: 2019-10-24
+- district: '25'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: upper
+  start_date: 2019-10-24
 contact_details:
-- address: 1040 Route 10 West, 1st Floor;Randolph, NJ 07869
-  email: AsmBucco@njleg.org
+- address: 75 Bloomfield Ave., Suite 302, 3rd Floor;Denville, NJ 07834
+  email: SenBucco@njleg.org
   note: District Office
-  voice: 973-927-2526
+  voice: 973-627-9700
 links:
-- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=321
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=419
 sources:
-- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=321
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=419
 - url: http://www.njleg.state.nj.us/downloads.asp
 image: http://www.njleg.state.nj.us/members/memberphotos/bucco_a_m_color.jpg
 gender: Male
@@ -23,5 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000077
   scheme: legacy_openstates
-given_name: Anthony M.
+given_name: Anthony
 family_name: Bucco

--- a/data/nj/people/Anthony-S-Verrelli-c6d61a12-eeb5-4400-943d-68a81b0728f0.yml
+++ b/data/nj/people/Anthony-S-Verrelli-c6d61a12-eeb5-4400-943d-68a81b0728f0.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000239
   scheme: legacy_openstates
-given_name: Anthony S.
+given_name: Anthony
 family_name: Verrelli

--- a/data/nj/people/Antwan-McClellan-4ebe8d6e-9814-4f68-aa9f-148c0942eaab.yml
+++ b/data/nj/people/Antwan-McClellan-4ebe8d6e-9814-4f68-aa9f-148c0942eaab.yml
@@ -1,0 +1,24 @@
+id: ocd-person/4ebe8d6e-9814-4f68-aa9f-148c0942eaab
+name: Antwan McClellan
+party:
+- name: Republican
+roles:
+- district: '1'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- address: School House Office Park, 211 S. Main Street, Suite 104;Cape May Coury
+    House, NJ 08210
+  email: AsmMcClellan@njleg.org
+  note: District Office
+  voice: 609-778-2012
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=425
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=425
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/mcclellan_antwan_2020.jpg
+gender: Male
+given_name: Antwan
+family_name: McClellan

--- a/data/nj/people/Benjie-E-Wimberly-18fa38fc-954e-43d9-a294-a2068828216e.yml
+++ b/data/nj/people/Benjie-E-Wimberly-18fa38fc-954e-43d9-a294-a2068828216e.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000165
   scheme: legacy_openstates
-given_name: Benjie E.
+given_name: Benjie
 family_name: Wimberly

--- a/data/nj/people/BettyLou-DeCroce-8f64e662-f32e-4d21-ab61-333ec77c18c5.yml
+++ b/data/nj/people/BettyLou-DeCroce-8f64e662-f32e-4d21-ab61-333ec77c18c5.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=355
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/decroce_betty_lou_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/decroce_bettylou_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000170

--- a/data/nj/people/Brian-Bergen-006c1bd9-54e9-49be-9d02-12dda1119149.yml
+++ b/data/nj/people/Brian-Bergen-006c1bd9-54e9-49be-9d02-12dda1119149.yml
@@ -1,0 +1,23 @@
+id: ocd-person/006c1bd9-54e9-49be-9d02-12dda1119149
+name: Brian Bergen
+party:
+- name: Republican
+roles:
+- district: '25'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- address: 146 Speedwell Avenue;Morris Plains, NJ 07950
+  email: AsmBergen@njleg.org
+  note: District Office
+  voice: 973-539-8113
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=423
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=423
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/bergen_brian_2020.jpg
+gender: Male
+given_name: Brian
+family_name: Bergen

--- a/data/nj/people/Brian-E-Rumpf-d6731a7f-a22e-48dd-8bba-fd2c155c16c3.yml
+++ b/data/nj/people/Brian-E-Rumpf-d6731a7f-a22e-48dd-8bba-fd2c155c16c3.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=228
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/rumpf_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/rumpf_brian_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000027
   scheme: legacy_openstates
-given_name: Brian E.
+given_name: Brian
 family_name: Rumpf

--- a/data/nj/people/Brian-P-Stack-6f616307-dafe-44ca-a6b3-5f9516d21f89.yml
+++ b/data/nj/people/Brian-P-Stack-6f616307-dafe-44ca-a6b3-5f9516d21f89.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000100
   scheme: legacy_openstates
-given_name: Brian P.
+given_name: Brian
 family_name: Stack

--- a/data/nj/people/Britnee-N-Timberlake-707e3027-d06f-4346-8c11-3ff1becbe725.yml
+++ b/data/nj/people/Britnee-N-Timberlake-707e3027-d06f-4346-8c11-3ff1becbe725.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 15-33 Halsted St., Suite 202;East Orange, NJ 07018
+- address: 520 Main Street, Suite 1;East Orange, NJ 07018
   email: AswTimberlake@njleg.org
   note: District Office
   voice: 973-395-1166
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000230
   scheme: legacy_openstates
-given_name: Britnee N.
+given_name: Britnee
 family_name: Timberlake

--- a/data/nj/people/Carol-A-Murphy-c33b5f2b-0494-414f-aa84-d2286ae46095.yml
+++ b/data/nj/people/Carol-A-Murphy-c33b5f2b-0494-414f-aa84-d2286ae46095.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000220
   scheme: legacy_openstates
-given_name: Carol A.
+given_name: Carol
 family_name: Murphy

--- a/data/nj/people/Chris-A-Brown-30a41595-e0b5-403a-a7cc-568983f8e327.yml
+++ b/data/nj/people/Chris-A-Brown-30a41595-e0b5-403a-a7cc-568983f8e327.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000215
   scheme: legacy_openstates
-given_name: Chris A.
+given_name: Chris
 family_name: Brown

--- a/data/nj/people/Christopher-J-Connors-1ebbb9b9-1582-4b52-9c6f-41b112fec666.yml
+++ b/data/nj/people/Christopher-J-Connors-1ebbb9b9-1582-4b52-9c6f-41b112fec666.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000026
   scheme: legacy_openstates
-given_name: Christopher J.
+given_name: Christopher
 family_name: Connors

--- a/data/nj/people/Christopher-P-DePhillips-33050562-f29d-4c4f-9e21-022822792a5c.yml
+++ b/data/nj/people/Christopher-P-DePhillips-33050562-f29d-4c4f-9e21-022822792a5c.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=404
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/dephillips_christopher_2017.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/dephillips_christopher_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000226
   scheme: legacy_openstates
-given_name: Christopher P.
+given_name: Christopher
 family_name: DePhillips

--- a/data/nj/people/Cleopatra-G-Tucker-c5469bd6-29bd-4054-9ac0-3577d17422d4.yml
+++ b/data/nj/people/Cleopatra-G-Tucker-c5469bd6-29bd-4054-9ac0-3577d17422d4.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000085
   scheme: legacy_openstates
-given_name: Cleopatra G.
+given_name: Cleopatra
 family_name: Tucker

--- a/data/nj/people/Craig-J-Coughlin-9d1ae08a-66b3-4d68-bafe-956d4eaeb57f.yml
+++ b/data/nj/people/Craig-J-Coughlin-9d1ae08a-66b3-4d68-bafe-956d4eaeb57f.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000059
   scheme: legacy_openstates
-given_name: Craig J.
+given_name: Craig
 family_name: Coughlin

--- a/data/nj/people/Daniel-R-Benson-a0bdc29a-2ff2-42b1-b53a-36f598f99b52.yml
+++ b/data/nj/people/Daniel-R-Benson-a0bdc29a-2ff2-42b1-b53a-36f598f99b52.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000128
   scheme: legacy_openstates
-given_name: Daniel R.
+given_name: Daniel
 family_name: Benson

--- a/data/nj/people/Dawn-Marie-Addiego-d63af6e5-b012-4390-9488-e9ede2258f00.yml
+++ b/data/nj/people/Dawn-Marie-Addiego-d63af6e5-b012-4390-9488-e9ede2258f00.yml
@@ -2,6 +2,9 @@ id: ocd-person/d63af6e5-b012-4390-9488-e9ede2258f00
 name: Dawn Marie Addiego
 party:
 - name: Republican
+  end_date: 2019-01-28
+- name: Democratic
+  start_date: 2019-01-28
 roles:
 - district: '8'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
@@ -23,5 +26,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000124
   scheme: legacy_openstates
-given_name: Dawn Marie
+given_name: Dawn
 family_name: Addiego

--- a/data/nj/people/Declan-J-OScanlon-Jr-ac044b70-7745-435a-9c38-c4af013d0b0e.yml
+++ b/data/nj/people/Declan-J-OScanlon-Jr-ac044b70-7745-435a-9c38-c4af013d0b0e.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000222
   scheme: legacy_openstates
-given_name: Declan J.
+given_name: Declan
 family_name: O'Scanlon

--- a/data/nj/people/DiAnne-C-Gove-0fdc52e3-8772-4466-a19c-93a6c39eae65.yml
+++ b/data/nj/people/DiAnne-C-Gove-0fdc52e3-8772-4466-a19c-93a6c39eae65.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=318
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/gove_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/gove_dianne_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000028
   scheme: legacy_openstates
-given_name: DiAnne C.
+given_name: DiAnne
 family_name: Gove

--- a/data/nj/people/Edward-H-Thomson-e6d7f07e-8f68-49b5-8e8e-970817a6c8c4.yml
+++ b/data/nj/people/Edward-H-Thomson-e6d7f07e-8f68-49b5-8e8e-970817a6c8c4.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000210
   scheme: legacy_openstates
-given_name: Edward H.
+given_name: Edward
 family_name: Thomson

--- a/data/nj/people/Eliana-Pintor-Marin-6056438b-65d3-4db4-b0ad-c367074bd47e.yml
+++ b/data/nj/people/Eliana-Pintor-Marin-6056438b-65d3-4db4-b0ad-c367074bd47e.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000177
   scheme: legacy_openstates
-given_name: Eliana Pintor
-family_name: Marin
+given_name: Eliana
+family_name: Pintor Marin

--- a/data/nj/people/Erik-Peterson-df6d2d1f-3fb0-4e93-93cf-26665cae9a23.yml
+++ b/data/nj/people/Erik-Peterson-df6d2d1f-3fb0-4e93-93cf-26665cae9a23.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=320
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/peterson_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/peterson_erik_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000071

--- a/data/nj/people/Erik-Simonsen-7f9ebe1c-d4fa-4dd0-8948-7cf6248ffb6d.yml
+++ b/data/nj/people/Erik-Simonsen-7f9ebe1c-d4fa-4dd0-8948-7cf6248ffb6d.yml
@@ -1,0 +1,24 @@
+id: ocd-person/7f9ebe1c-d4fa-4dd0-8948-7cf6248ffb6d
+name: Erik Simonsen
+party:
+- name: Republican
+roles:
+- district: '1'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- address: School House Office Park, 211 S. Main Street, Suite 104;Cape May Court
+    House, NJ 08201
+  email: AsmSimonsen@njleg.org
+  note: District Office
+  voice: 609-778-2012
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=426
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=426
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/simonsen_erik_2020.jpg
+gender: Male
+given_name: Erik
+family_name: Simonsen

--- a/data/nj/people/Fred-H-Madden-Jr-19da3948-96b1-4a6b-8734-a58fdcefc777.yml
+++ b/data/nj/people/Fred-H-Madden-Jr-19da3948-96b1-4a6b-8734-a58fdcefc777.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000010
   scheme: legacy_openstates
-given_name: Fred H.
+given_name: Fred
 family_name: Madden

--- a/data/nj/people/Gabriela-M-Mosquera-b74b5f86-8982-4852-a2da-c1007a991156.yml
+++ b/data/nj/people/Gabriela-M-Mosquera-b74b5f86-8982-4852-a2da-c1007a991156.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000171
   scheme: legacy_openstates
-given_name: Gabriela M.
+given_name: Gabriela
 family_name: Mosquera

--- a/data/nj/people/Gary-S-Schaer-93a1a3ce-eb52-4e71-b01c-346f41b6bde4.yml
+++ b/data/nj/people/Gary-S-Schaer-93a1a3ce-eb52-4e71-b01c-346f41b6bde4.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000111
   scheme: legacy_openstates
-given_name: Gary S.
+given_name: Gary
 family_name: Schaer

--- a/data/nj/people/Gerard-Scharfenberger-4323bf03-63e6-4f8b-9b2e-3554df7723bf.yml
+++ b/data/nj/people/Gerard-Scharfenberger-4323bf03-63e6-4f8b-9b2e-3554df7723bf.yml
@@ -1,0 +1,21 @@
+id: ocd-person/4323bf03-63e6-4f8b-9b2e-3554df7723bf
+name: Gerard Scharfenberger
+party:
+- name: Republican
+roles:
+- district: '13'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- email: AsmScharfenberger@njleg.org
+  note: District Office
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=422
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=422
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/scharfenberger_gerard_2020a.jpg
+gender: Male
+given_name: Gerard
+family_name: Scharfenberger

--- a/data/nj/people/Gordon-M-Johnson-bd45cf15-bb60-4435-8739-6a837124ce67.yml
+++ b/data/nj/people/Gordon-M-Johnson-bd45cf15-bb60-4435-8739-6a837124ce67.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000114
   scheme: legacy_openstates
-given_name: Gordon M.
+given_name: Gordon
 family_name: Johnson

--- a/data/nj/people/Gregory-P-McGuckin-2ac520a3-ae36-4936-a9c3-6842401b6c83.yml
+++ b/data/nj/people/Gregory-P-McGuckin-2ac520a3-ae36-4936-a9c3-6842401b6c83.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=341
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/mcguckin_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/mcguckin_gregory_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000152
   scheme: legacy_openstates
-given_name: Gregory P.
+given_name: Gregory
 family_name: McGuckin

--- a/data/nj/people/Harold-J-Wirths-ccd54a2a-c814-469f-a415-e2e667c5caed.yml
+++ b/data/nj/people/Harold-J-Wirths-ccd54a2a-c814-469f-a415-e2e667c5caed.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=402
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/wirths_harold_2017.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/wirths_harold_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000227
   scheme: legacy_openstates
-given_name: Harold J.
+given_name: Harold
 family_name: Wirths

--- a/data/nj/people/Herb-Conaway-Jr-6b67938b-adbf-488a-a3c1-3de2c3bc3b8f.yml
+++ b/data/nj/people/Herb-Conaway-Jr-6b67938b-adbf-488a-a3c1-3de2c3bc3b8f.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=186
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/conaway_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/conaway_herb_2019.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000022

--- a/data/nj/people/Holly-T-Schepisi-57fe7d05-af12-4f44-b143-e19814f2cfa2.yml
+++ b/data/nj/people/Holly-T-Schepisi-57fe7d05-af12-4f44-b143-e19814f2cfa2.yml
@@ -16,12 +16,12 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=350
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/schepisi_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/schepisi_holly_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000168
   scheme: legacy_openstates
 - identifier: NJL000214
   scheme: legacy_openstates
-given_name: Holly T.
+given_name: Holly
 family_name: Schepisi

--- a/data/nj/people/Jamel-C-Holley-9f2bbe0d-1ab1-435a-a6e4-71e98204b844.yml
+++ b/data/nj/people/Jamel-C-Holley-9f2bbe0d-1ab1-435a-a6e4-71e98204b844.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=374
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/holley_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/holley_jamel_2019.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000193
   scheme: legacy_openstates
-given_name: Jamel C.
+given_name: Jamel
 family_name: Holley

--- a/data/nj/people/James-J-Kennedy-d80f0df2-57cd-436b-a250-7413ec11fe27.yml
+++ b/data/nj/people/James-J-Kennedy-d80f0df2-57cd-436b-a250-7413ec11fe27.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 34 E. Cherry St.;Rahway, NJ 07065
+- address: 1445 Main St.;Rahway, NJ 07065
   email: AsmKennedy@njleg.org
   note: District Office
   voice: 732-943-2660
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000200
   scheme: legacy_openstates
-given_name: James J.
+given_name: James
 family_name: Kennedy

--- a/data/nj/people/James-W-Holzapfel-32e625c0-5e22-40b4-a6a3-4040d10e6ff0.yml
+++ b/data/nj/people/James-W-Holzapfel-32e625c0-5e22-40b4-a6a3-4040d10e6ff0.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000151
   scheme: legacy_openstates
-given_name: James W.
+given_name: James
 family_name: Holzapfel

--- a/data/nj/people/Jay-Webber-dbe67894-e4cd-46ea-bb59-877a8b4f26d0.yml
+++ b/data/nj/people/Jay-Webber-dbe67894-e4cd-46ea-bb59-877a8b4f26d0.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=283
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/webber_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/webber_jay_2019.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000080

--- a/data/nj/people/Jean-Stanfield-772c3784-d7af-4ebf-aca1-abd46ee98727.yml
+++ b/data/nj/people/Jean-Stanfield-772c3784-d7af-4ebf-aca1-abd46ee98727.yml
@@ -1,0 +1,23 @@
+id: ocd-person/772c3784-d7af-4ebf-aca1-abd46ee98727
+name: Jean Stanfield
+party:
+- name: Republican
+roles:
+- district: '8'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- address: 668 Main St.;Lumberton, NJ 08048
+  email: AswStanfield@njleg.org
+  note: District Office
+  voice: 609-667-7360
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=427
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=427
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/stanfield_jean_2020.jpg
+gender: Female
+given_name: Jean
+family_name: Stanfield

--- a/data/nj/people/John-Catalano-022c6b02-77d3-416e-9ddf-cdfa2ca46add.yml
+++ b/data/nj/people/John-Catalano-022c6b02-77d3-416e-9ddf-cdfa2ca46add.yml
@@ -1,0 +1,21 @@
+id: ocd-person/022c6b02-77d3-416e-9ddf-cdfa2ca46add
+name: John Catalano
+party:
+- name: Republican
+roles:
+- district: '10'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- email: AsmCatalano@njleg.org
+  note: District Office
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=421
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=421
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/catalano_john_2020.jpg
+gender: Male
+given_name: John
+family_name: Catalano

--- a/data/nj/people/John-DiMaio-dce6ec3a-7d62-4b33-8693-259364c85285.yml
+++ b/data/nj/people/John-DiMaio-dce6ec3a-7d62-4b33-8693-259364c85285.yml
@@ -7,16 +7,16 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 245 Route 22, Suite 208;Bridgewater, NJ 08807
+- address: 208 Mountain Ave., Suite 3;Hackettstown, NJ 07840
   email: AsmDiMaio@njleg.org
   note: District Office
-  voice: 908-722-1365
+  voice: 908-684-9550
 links:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=313
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=313
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/dimaio_john_2017.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/dimaio_john_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000070

--- a/data/nj/people/John-F-McKeon-1fec06e0-00df-4d84-8c9a-18e80a6f29e2.yml
+++ b/data/nj/people/John-F-McKeon-1fec06e0-00df-4d84-8c9a-18e80a6f29e2.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000082
   scheme: legacy_openstates
-given_name: John F.
+given_name: John
 family_name: McKeon

--- a/data/nj/people/John-J-Burzichelli-1b726d76-851a-487b-a6e6-42ee4fa5c050.yml
+++ b/data/nj/people/John-J-Burzichelli-1b726d76-851a-487b-a6e6-42ee4fa5c050.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000008
   scheme: legacy_openstates
-given_name: John J.
+given_name: John
 family_name: Burzichelli

--- a/data/nj/people/Jon-M-Bramnick-f201aae9-beef-450e-82c4-68e50aa241fa.yml
+++ b/data/nj/people/Jon-M-Bramnick-f201aae9-beef-450e-82c4-68e50aa241fa.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=222
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/bramnick_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/bramnick_jon_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000064
   scheme: legacy_openstates
-given_name: Jon M.
+given_name: Jon
 family_name: Bramnick

--- a/data/nj/people/Joseph-A-Lagana-90a0a109-2ce3-4a55-8761-1e07ff875703.yml
+++ b/data/nj/people/Joseph-A-Lagana-90a0a109-2ce3-4a55-8761-1e07ff875703.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: upper
 contact_details:
-- address: 205 Robin Rd., Suite 222;Paramus, NJ 07652
+- address: 205 Robin Rd., Suite 122;Paramus, NJ 07652
   email: SenLagana@njleg.org
   note: District Office
   voice: 201-576-9199
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000234
   scheme: legacy_openstates
-given_name: Joseph A.
+given_name: Joseph
 family_name: Lagana

--- a/data/nj/people/Joseph-F-Vitale-97fba3ff-adc8-4323-bf77-37acfe18b735.yml
+++ b/data/nj/people/Joseph-F-Vitale-97fba3ff-adc8-4323-bf77-37acfe18b735.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000057
   scheme: legacy_openstates
-given_name: Joseph F.
+given_name: Joseph
 family_name: Vitale

--- a/data/nj/people/Joseph-P-Cryan-5dcef6ac-7dbe-4c65-a53b-670c89a615e7.yml
+++ b/data/nj/people/Joseph-P-Cryan-5dcef6ac-7dbe-4c65-a53b-670c89a615e7.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000224
   scheme: legacy_openstates
-given_name: Joseph P.
+given_name: Joseph
 family_name: Cryan

--- a/data/nj/people/Joseph-V-Egan-1ef49582-10ab-4e05-b699-74a6956d24ea.yml
+++ b/data/nj/people/Joseph-V-Egan-1ef49582-10ab-4e05-b699-74a6956d24ea.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000052
   scheme: legacy_openstates
-given_name: Joseph V.
+given_name: Joseph
 family_name: Egan

--- a/data/nj/people/Kevin-J-Rooney-0aca0d16-9cf3-46f8-acd9-155f739badaa.yml
+++ b/data/nj/people/Kevin-J-Rooney-0aca0d16-9cf3-46f8-acd9-155f739badaa.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=390
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/rooney.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/rooney_kevin_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000209
   scheme: legacy_openstates
-given_name: Kevin J.
+given_name: Kevin
 family_name: Rooney

--- a/data/nj/people/Kristin-M-Corrado-0880a4b0-8e91-484b-aa12-6e0444838c44.yml
+++ b/data/nj/people/Kristin-M-Corrado-0880a4b0-8e91-484b-aa12-6e0444838c44.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000213
   scheme: legacy_openstates
-given_name: Kristin M.
+given_name: Kristin
 family_name: Corrado

--- a/data/nj/people/Linda-R-Greenstein-27646653-40e2-4c79-b608-0f2edcaa0322.yml
+++ b/data/nj/people/Linda-R-Greenstein-27646653-40e2-4c79-b608-0f2edcaa0322.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000125
   scheme: legacy_openstates
-given_name: Linda R.
+given_name: Linda
 family_name: Greenstein

--- a/data/nj/people/Linda-S-Carter-199dd5c8-3ef1-4a2c-9585-9de5def27e98.yml
+++ b/data/nj/people/Linda-S-Carter-199dd5c8-3ef1-4a2c-9585-9de5def27e98.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000236
   scheme: legacy_openstates
-given_name: Linda S.
+given_name: Linda
 family_name: Carter

--- a/data/nj/people/Lisa-Swain-28b4c7d2-d1c3-4735-b321-0f348ec27299.yml
+++ b/data/nj/people/Lisa-Swain-28b4c7d2-d1c3-4735-b321-0f348ec27299.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 205 Robin Rd., Suite 222;Paramus, NJ 07652
+- address: 205 Robin Rd., Suite 122;Paramus, NJ 07652
   email: AswSwain@njleg.org
   note: District Office
   voice: 201-576-9199

--- a/data/nj/people/Louis-D-Greenwald-a27823aa-f5a9-4d6c-8089-1d8ceee6f8e0.yml
+++ b/data/nj/people/Louis-D-Greenwald-a27823aa-f5a9-4d6c-8089-1d8ceee6f8e0.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000019
   scheme: legacy_openstates
-given_name: Louis D.
+given_name: Louis
 family_name: Greenwald

--- a/data/nj/people/Michael-J-Doherty-1d31ed23-f4b1-4393-800d-c7241dfc9437.yml
+++ b/data/nj/people/Michael-J-Doherty-1d31ed23-f4b1-4393-800d-c7241dfc9437.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000144
   scheme: legacy_openstates
-given_name: Michael J.
+given_name: Michael
 family_name: Doherty

--- a/data/nj/people/Michael-L-Testa-Jr-4cb8db73-8982-4b4f-9c90-f86b20b217bc.yml
+++ b/data/nj/people/Michael-L-Testa-Jr-4cb8db73-8982-4b4f-9c90-f86b20b217bc.yml
@@ -1,0 +1,24 @@
+id: ocd-person/4cb8db73-8982-4b4f-9c90-f86b20b217bc
+name: Michael L. Testa Jr
+party:
+- name: Republican
+roles:
+- district: '1'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: upper
+  start_date: 2019-12-05
+contact_details:
+- address: School House Office Park, 211 S. Main Street, Suite 104;Cape May Court
+    House, NJ 08210
+  email: SenTesta@njleg.org
+  note: District Office
+  voice: 609-778-2012
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=424
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=424
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/testa_michael_2019.jpg
+gender: Male
+given_name: Michael
+family_name: Testa

--- a/data/nj/people/Mila-M-Jasey-5e50bdd3-07c1-481f-8dc8-c59dbae85f4d.yml
+++ b/data/nj/people/Mila-M-Jasey-5e50bdd3-07c1-481f-8dc8-c59dbae85f4d.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000083
   scheme: legacy_openstates
-given_name: Mila M.
+given_name: Mila
 family_name: Jasey

--- a/data/nj/people/Nancy-F-Munoz-f553c0d7-7c53-4197-9a83-b0a1d2b56dd3.yml
+++ b/data/nj/people/Nancy-F-Munoz-f553c0d7-7c53-4197-9a83-b0a1d2b56dd3.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=314
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/munoz_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/munoz_nancy_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000065
   scheme: legacy_openstates
-given_name: Nancy F.
+given_name: Nancy
 family_name: Munoz

--- a/data/nj/people/Nancy-J-Pinkin-1119c78d-cad9-4d90-a950-425001f5a2a1.yml
+++ b/data/nj/people/Nancy-J-Pinkin-1119c78d-cad9-4d90-a950-425001f5a2a1.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000183
   scheme: legacy_openstates
-given_name: Nancy J.
+given_name: Nancy
 family_name: Pinkin

--- a/data/nj/people/Nellie-Pou-a1deda3b-81ab-4453-8fa5-1d5ab8c0631d.yml
+++ b/data/nj/people/Nellie-Pou-a1deda3b-81ab-4453-8fa5-1d5ab8c0631d.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: upper
 contact_details:
-- address: 100 Hamilton Plaza, Suite1405;Paterson, NJ 07505
+- address: 100 Hamilton Plaza, Suite 1405;Paterson, NJ 07505
   email: SenPou@njleg.org
   note: District Office
   voice: 973-247-1555

--- a/data/nj/people/Nia-H-Gill-Esq-fa88557a-49d9-42d4-857c-184abb031768.yml
+++ b/data/nj/people/Nia-H-Gill-Esq-fa88557a-49d9-42d4-857c-184abb031768.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000103
   scheme: legacy_openstates
-given_name: Nia H.
+given_name: Nia
 family_name: Gill

--- a/data/nj/people/Nicholas-J-Sacco-859af441-9e3b-4065-be80-5ef889ef8751.yml
+++ b/data/nj/people/Nicholas-J-Sacco-859af441-9e3b-4065-be80-5ef889ef8751.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000097
   scheme: legacy_openstates
-given_name: Nicholas J.
+given_name: Nicholas
 family_name: Sacco

--- a/data/nj/people/Nicholas-P-Scutari-4d47b297-b5f4-4d83-94e6-bb95eb91ecd7.yml
+++ b/data/nj/people/Nicholas-P-Scutari-4d47b297-b5f4-4d83-94e6-bb95eb91ecd7.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000066
   scheme: legacy_openstates
-given_name: Nicholas P.
+given_name: Nicholas
 family_name: Scutari

--- a/data/nj/people/P-Christopher-Tully-934c3022-709b-4768-b2df-635d25579128.yml
+++ b/data/nj/people/P-Christopher-Tully-934c3022-709b-4768-b2df-635d25579128.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 205 Robin Rd., Suite 222;Paramus, NJ 07652
+- address: 205 Robin Rd., Suite 122;Paramus, NJ 07652
   email: AsmTully@njleg.org
   note: District Office
   voice: 201-576-9199

--- a/data/nj/people/Pamela-R-Lampitt-279cf9a8-0a51-45cd-b79f-b174f6f1cbc0.yml
+++ b/data/nj/people/Pamela-R-Lampitt-279cf9a8-0a51-45cd-b79f-b174f6f1cbc0.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000018
   scheme: legacy_openstates
-given_name: Pamela R.
+given_name: Pamela
 family_name: Lampitt

--- a/data/nj/people/Parker-Space-1dde507a-70ed-4f89-95f8-cd11748a753c.yml
+++ b/data/nj/people/Parker-Space-1dde507a-70ed-4f89-95f8-cd11748a753c.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=358
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/space_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/space_parker_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000176

--- a/data/nj/people/Patrick-J-Diegnan-Jr-16048732-130c-4102-b6e7-2d8faa0c3f52.yml
+++ b/data/nj/people/Patrick-J-Diegnan-Jr-16048732-130c-4102-b6e7-2d8faa0c3f52.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000206
   scheme: legacy_openstates
-given_name: Patrick J.
+given_name: Patrick
 family_name: Diegnan

--- a/data/nj/people/Paul-A-Sarlo-1d8eb6cf-cff2-4948-ba03-7f31fcadd4ec.yml
+++ b/data/nj/people/Paul-A-Sarlo-1d8eb6cf-cff2-4948-ba03-7f31fcadd4ec.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000109
   scheme: legacy_openstates
-given_name: Paul A.
+given_name: Paul
 family_name: Sarlo

--- a/data/nj/people/Paul-D-Moriarty-f15f8b7e-96ee-41e8-b59c-b277927985c0.yml
+++ b/data/nj/people/Paul-D-Moriarty-f15f8b7e-96ee-41e8-b59c-b277927985c0.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000011
   scheme: legacy_openstates
-given_name: Paul D.
+given_name: Paul
 family_name: Moriarty

--- a/data/nj/people/Ralph-R-Caputo-3dcf1086-76e4-4e2e-b765-8230439056c3.yml
+++ b/data/nj/people/Ralph-R-Caputo-3dcf1086-76e4-4e2e-b765-8230439056c3.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000086
   scheme: legacy_openstates
-given_name: Ralph R.
+given_name: Ralph
 family_name: Caputo

--- a/data/nj/people/Richard-J-Codey-19edf299-e13d-4a90-81bf-483bcb18f38f.yml
+++ b/data/nj/people/Richard-J-Codey-19edf299-e13d-4a90-81bf-483bcb18f38f.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000081
   scheme: legacy_openstates
-given_name: Richard J.
+given_name: Richard
 family_name: Codey

--- a/data/nj/people/Robert-D-Clifton-b94db48b-9083-48c9-8b27-3603db14fa3e.yml
+++ b/data/nj/people/Robert-D-Clifton-b94db48b-9083-48c9-8b27-3603db14fa3e.yml
@@ -16,10 +16,10 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=342
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/clifton_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/clifton_robert_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000157
   scheme: legacy_openstates
-given_name: Robert D.
+given_name: Robert
 family_name: Clifton

--- a/data/nj/people/Robert-J-Karabinchak-d6732f77-1c72-4ee6-8d52-5c9b79987976.yml
+++ b/data/nj/people/Robert-J-Karabinchak-d6732f77-1c72-4ee6-8d52-5c9b79987976.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000207
   scheme: legacy_openstates
-given_name: Robert J.
+given_name: Robert
 family_name: Karabinchak

--- a/data/nj/people/Robert-W-Singer-45219a29-080f-4452-9b05-92488e96f2f1.yml
+++ b/data/nj/people/Robert-W-Singer-45219a29-080f-4452-9b05-92488e96f2f1.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000090
   scheme: legacy_openstates
-given_name: Robert W.
+given_name: Robert
 family_name: Singer

--- a/data/nj/people/Ronald-L-Rice-044178a6-7504-40bc-8321-83eae780d0ee.yml
+++ b/data/nj/people/Ronald-L-Rice-044178a6-7504-40bc-8321-83eae780d0ee.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000084
   scheme: legacy_openstates
-given_name: Ronald L.
+given_name: Ronald
 family_name: Rice

--- a/data/nj/people/Ronald-S-Dancer-e06080db-abc0-40ab-ae4b-43fd3d0a5430.yml
+++ b/data/nj/people/Ronald-S-Dancer-e06080db-abc0-40ab-ae4b-43fd3d0a5430.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: (Prefered Mailing Address) 405 Rt. 539;Cream Ridge, NJ 08514
+- address: 405 Rt. 539;Cream Ridge, NJ 08514
   email: AsmDancer@njleg.org
   note: District Office
   voice: 609-758-0205
@@ -16,12 +16,12 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=352
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/dancer_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/dancer_ronald_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000092
   scheme: legacy_openstates
 - identifier: NJL000156
   scheme: legacy_openstates
-given_name: Ronald S.
+given_name: Ronald
 family_name: Dancer

--- a/data/nj/people/Ryan-E-Peters-529833e4-2dd9-4caa-b6f3-c51a1dfa19c4.yml
+++ b/data/nj/people/Ryan-E-Peters-529833e4-2dd9-4caa-b6f3-c51a1dfa19c4.yml
@@ -7,21 +7,21 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 176 Route 70, Suite 13;Medford, NJ 08055
+- address: 668 Main St.;Lumberton, NJ 08048
   email: AsmPeters@njleg.org
   note: District Office
-  voice: 609-654-1498
+  voice: 609-667-7360
 links:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=398
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=398
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/peters_ryan_2017.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/peters_ryan_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000223
   scheme: legacy_openstates
 - identifier: NJL000229
   scheme: legacy_openstates
-given_name: Ryan E.
+given_name: Ryan
 family_name: Peters

--- a/data/nj/people/Samuel-D-Thompson-bac25997-329a-497a-b7d9-fc88064166c0.yml
+++ b/data/nj/people/Samuel-D-Thompson-bac25997-329a-497a-b7d9-fc88064166c0.yml
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000155
   scheme: legacy_openstates
-given_name: Samuel D.
+given_name: Samuel
 family_name: Thompson

--- a/data/nj/people/Sandra-B-Cunningham-5cf4eaa9-cc0d-4838-ad5e-6c2e66326fe3.yml
+++ b/data/nj/people/Sandra-B-Cunningham-5cf4eaa9-cc0d-4838-ad5e-6c2e66326fe3.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000093
   scheme: legacy_openstates
-given_name: Sandra B.
+given_name: Sandra
 family_name: Cunningham

--- a/data/nj/people/Sean-T-Kean-ac95c4e3-057b-43bc-8bee-752137bb2d12.yml
+++ b/data/nj/people/Sean-T-Kean-ac95c4e3-057b-43bc-8bee-752137bb2d12.yml
@@ -16,12 +16,12 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=333
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/kean_sean_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/kean_sean_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000032
   scheme: legacy_openstates
 - identifier: NJL000160
   scheme: legacy_openstates
-given_name: Sean T.
+given_name: Sean
 family_name: Kean

--- a/data/nj/people/Serena-DiMaso-3a80b85d-d1a1-4a93-9696-e99e45df4a42.yml
+++ b/data/nj/people/Serena-DiMaso-3a80b85d-d1a1-4a93-9696-e99e45df4a42.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=399
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/dimaso_serena_2017.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/dimaso_serena_2020.jpg
 gender: Female
 other_identifiers:
 - identifier: NJL000221

--- a/data/nj/people/Shavonda-E-Sumter-6cab3e19-7a7c-4488-877f-a6a167306ba5.yml
+++ b/data/nj/people/Shavonda-E-Sumter-6cab3e19-7a7c-4488-877f-a6a167306ba5.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
 contact_details:
-- address: 191 Market St.;Paterson, NJ 07505
+- address: 21 Mill St., Suite 5;Paterson, NJ 07501
   email: AswSumter@njleg.org
   note: District Office
   voice: 973-925-7063
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000164
   scheme: legacy_openstates
-given_name: Shavonda E.
+given_name: Shavonda
 family_name: Sumter

--- a/data/nj/people/Shirley-K-Turner-26eb8b3c-59a5-49ca-841c-13a569444994.yml
+++ b/data/nj/people/Shirley-K-Turner-26eb8b3c-59a5-49ca-841c-13a569444994.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000045
   scheme: legacy_openstates
-given_name: Shirley K.
+given_name: Shirley
 family_name: Turner

--- a/data/nj/people/Stephen-M-Sweeney-3a6c120e-7e9b-46e0-a6ff-9a7b706d365b.yml
+++ b/data/nj/people/Stephen-M-Sweeney-3a6c120e-7e9b-46e0-a6ff-9a7b706d365b.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000007
   scheme: legacy_openstates
-given_name: Stephen M.
+given_name: Stephen
 family_name: Sweeney

--- a/data/nj/people/Steven-V-Oroho-e021e915-73b7-4881-83fa-9178fb602f39.yml
+++ b/data/nj/people/Steven-V-Oroho-e021e915-73b7-4881-83fa-9178fb602f39.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000072
   scheme: legacy_openstates
-given_name: Steven V.
+given_name: Steven
 family_name: Oroho

--- a/data/nj/people/Thomas-H-Kean-Jr-3ec06e68-3a88-4f78-81c6-deb8116baf4f.yml
+++ b/data/nj/people/Thomas-H-Kean-Jr-3ec06e68-3a88-4f78-81c6-deb8116baf4f.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000063
   scheme: legacy_openstates
-given_name: Thomas H.
+given_name: Thomas
 family_name: Kean

--- a/data/nj/people/Thomas-P-Giblin-1277b3fe-c85b-41af-ada7-e01cc910c397.yml
+++ b/data/nj/people/Thomas-P-Giblin-1277b3fe-c85b-41af-ada7-e01cc910c397.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000105
   scheme: legacy_openstates
-given_name: Thomas P.
+given_name: Thomas
 family_name: Giblin

--- a/data/nj/people/Troy-Singleton-a1c9ec59-4127-4973-b100-f35c30bb817c.yml
+++ b/data/nj/people/Troy-Singleton-a1c9ec59-4127-4973-b100-f35c30bb817c.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=395
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/singleton_troy_2018.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/singleton_troy_2019.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000218

--- a/data/nj/people/Valerie-Vainieri-Huttle-174ed857-3a2d-468e-affb-19b1c6c8e18a.yml
+++ b/data/nj/people/Valerie-Vainieri-Huttle-174ed857-3a2d-468e-affb-19b1c6c8e18a.yml
@@ -21,5 +21,5 @@ gender: Female
 other_identifiers:
 - identifier: NJL000113
   scheme: legacy_openstates
-given_name: Valerie Vainieri
+given_name: Valerie
 family_name: Huttle

--- a/data/nj/people/Vincent-Mazzeo-0125cf6a-80a1-4c7c-a173-8e6125a96dfa.yml
+++ b/data/nj/people/Vincent-Mazzeo-0125cf6a-80a1-4c7c-a173-8e6125a96dfa.yml
@@ -16,7 +16,7 @@ links:
 sources:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=368
 - url: http://www.njleg.state.nj.us/downloads.asp
-image: http://www.njleg.state.nj.us/members/memberphotos/mazzeo_color.jpg
+image: http://www.njleg.state.nj.us/members/memberphotos/mazzeo_vincent_2020.jpg
 gender: Male
 other_identifiers:
 - identifier: NJL000184

--- a/data/nj/people/Wayne-P-DeAngelo-08016f74-f5d6-4554-91b4-385fdbd558a7.yml
+++ b/data/nj/people/Wayne-P-DeAngelo-08016f74-f5d6-4554-91b4-385fdbd558a7.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000044
   scheme: legacy_openstates
-given_name: Wayne P.
+given_name: Wayne
 family_name: DeAngelo

--- a/data/nj/people/William-F-Moen-Jr-1e9cd368-349e-4ddc-a34d-8301d0ac4841.yml
+++ b/data/nj/people/William-F-Moen-Jr-1e9cd368-349e-4ddc-a34d-8301d0ac4841.yml
@@ -1,0 +1,21 @@
+id: ocd-person/1e9cd368-349e-4ddc-a34d-8301d0ac4841
+name: William F. Moen Jr
+party:
+- name: Democratic
+roles:
+- district: '5'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: lower
+  start_date: 2020-01-14
+contact_details:
+- email: AsmMoen@njleg.org
+  note: District Office
+links:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=420
+sources:
+- url: http://www.njleg.state.nj.us/members/bio.asp?Leg=420
+- url: http://www.njleg.state.nj.us/downloads.asp
+image: http://www.njleg.state.nj.us/members/memberphotos/moen_william_2019.jpg
+gender: Male
+given_name: William
+family_name: Moen

--- a/data/nj/people/William-W-Spearman-3d5d3c07-70ed-481a-91ba-a19fce581561.yml
+++ b/data/nj/people/William-W-Spearman-3d5d3c07-70ed-481a-91ba-a19fce581561.yml
@@ -21,5 +21,5 @@ gender: Male
 other_identifiers:
 - identifier: NJL000238
   scheme: legacy_openstates
-given_name: William W.
+given_name: William
 family_name: Spearman

--- a/data/nj/retired/Amy-H-Handlin-63b4dea8-52fa-4fb3-9725-fefd41a5dced.yml
+++ b/data/nj/retired/Amy-H-Handlin-63b4dea8-52fa-4fb3-9725-fefd41a5dced.yml
@@ -6,6 +6,7 @@ roles:
 - district: '13'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 225 Route 35, Suite 202;Red Bank, NJ 07701
   email: AswHandlin@njleg.org

--- a/data/nj/retired/Anthony-R-Bucco-e4e95ef4-33eb-4b15-86fd-c87c3deeea3d.yml
+++ b/data/nj/retired/Anthony-R-Bucco-e4e95ef4-33eb-4b15-86fd-c87c3deeea3d.yml
@@ -6,6 +6,7 @@ roles:
 - district: '25'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: upper
+  end_date: '2019-09-16'
 contact_details:
 - address: 75 Bloomfield Ave., Suite 302, 3rd Floor;Denville, NJ 07834
   email: SenBucco@njleg.org

--- a/data/nj/retired/Bob-Andrzejczak-623725aa-b13f-4852-a43c-b782393d4418.yml
+++ b/data/nj/retired/Bob-Andrzejczak-623725aa-b13f-4852-a43c-b782393d4418.yml
@@ -7,6 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
   end_date: '2019-01-14'
+- district: '1'
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+  type: upper
+  start_date: 2019-01-15
+  end_date: 2020-01-14
 contact_details:
 - address: School House Office Park, 211 S. Main St., Suite 104;Cape May Court House,
     NJ 08210

--- a/data/nj/retired/David-W-Wolfe-d56981d2-8d8d-4bc4-bdba-d2e6f1ec7f6a.yml
+++ b/data/nj/retired/David-W-Wolfe-d56981d2-8d8d-4bc4-bdba-d2e6f1ec7f6a.yml
@@ -6,6 +6,7 @@ roles:
 - district: '10'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 852 Highway 70;Brick, NJ 08724
   email: AsmWolfe@njleg.org

--- a/data/nj/retired/Jeff-Van-Drew-628d09ef-e8a6-4e02-8a4d-4e5a95e28408.yml
+++ b/data/nj/retired/Jeff-Van-Drew-628d09ef-e8a6-4e02-8a4d-4e5a95e28408.yml
@@ -6,6 +6,7 @@ roles:
 - district: '1'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: upper
+  end_date: '2019-01-01'
 contact_details:
 - address: School House Office Park, 211 S. Main St., Suite 104;Cape May Court House,
     NJ 08210

--- a/data/nj/retired/Joe-Howarth-8907a1f7-2ed9-4d6b-a380-eca77a210504.yml
+++ b/data/nj/retired/Joe-Howarth-8907a1f7-2ed9-4d6b-a380-eca77a210504.yml
@@ -6,6 +6,7 @@ roles:
 - district: '8'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 176 Route 70, Suite 13;Medford, NJ 08055
   email: AsmHowarth@njleg.org

--- a/data/nj/retired/Matthew-W-Milam-a709fd2d-f43e-4eb2-9a00-6b2a708d8a22.yml
+++ b/data/nj/retired/Matthew-W-Milam-a709fd2d-f43e-4eb2-9a00-6b2a708d8a22.yml
@@ -15,6 +15,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
   start_date: '2019-01-31'
+  end_date: '2020-01-14'
 image: https://www.njleg.state.nj.us/members/memberphotos/milam_matthew_2018.jpg
 links:
 - url: http://www.njleg.state.nj.us/members/bio.asp?Leg=418
@@ -25,7 +26,8 @@ other_identifiers:
 - identifier: NJL000003
   scheme: legacy_openstates
 contact_details:
-- address: School House Office Park; 211 S. Main St.;  Suite 104; Cape May Court House, NJ 08210
+- address: School House Office Park; 211 S. Main St.;  Suite 104; Cape May Court House,
+    NJ 08210
   voice: 609-465-0700
   note: District Office
 - address: 219 High St.; Suite B; Millville, NJ 08332

--- a/data/nj/retired/Michael-Patrick-Carroll-95c7cd69-0eb2-4041-97df-9764a1cd3593.yml
+++ b/data/nj/retired/Michael-Patrick-Carroll-95c7cd69-0eb2-4041-97df-9764a1cd3593.yml
@@ -6,6 +6,7 @@ roles:
 - district: '25'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 146 Speedwell Ave.;Morris Plains, NJ 07950
   email: AsmCarroll@njleg.org

--- a/data/nj/retired/Patricia-Egan-Jones-442676ac-33b2-4f79-be9b-62b7b9f2afcc.yml
+++ b/data/nj/retired/Patricia-Egan-Jones-442676ac-33b2-4f79-be9b-62b7b9f2afcc.yml
@@ -6,6 +6,7 @@ roles:
 - district: '5'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 515 White Horse Pike;Audubon, NJ 08106
   email: AswJones@njleg.org

--- a/data/nj/retired/R-Bruce-Land-bdae3c0f-cb2e-401d-bb6d-92427a53354f.yml
+++ b/data/nj/retired/R-Bruce-Land-bdae3c0f-cb2e-401d-bb6d-92427a53354f.yml
@@ -6,6 +6,7 @@ roles:
 - district: '1'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/government
   type: lower
+  end_date: '2020-01-14'
 contact_details:
 - address: 1117 E. Landis Avenue;Vineland, NJ 08360
   email: AsmLand@njleg.org

--- a/settings.yml
+++ b/settings.yml
@@ -47,6 +47,11 @@ nc:
       - chamber: upper
         district: 7
         vacant_until: 2021-01-01
+nj:
+  vacancies:
+      - chamber: lower
+        district: 25
+        vacant_until: 2020-03-01
 pa:
   vacancies:
     - chamber: upper


### PR DESCRIPTION
Mostly adding/removing new/old legislators, with some name fixes (removing middle names/initials) as well. Also add Senate term for Andrzejczak that ended in January. For #222.