### PR TITLE
Update Colorado legislators

### DIFF
--- a/data/co/organizations/Agriculture-Livestock--Natural-Resources-6f0593fa-50ad-4760-aa7f-3dc958babd04.yml
+++ b/data/co/organizations/Agriculture-Livestock--Natural-Resources-6f0593fa-50ad-4760-aa7f-3dc958babd04.yml
@@ -29,6 +29,7 @@ memberships:
   name: Dominique Jackson
 - id: ocd-person/bc7be948-aece-46e3-a6d7-a1009edfa473
   name: Kimmi Lewis
+  end_date: '2019-12-06'
 - id: ocd-person/567d2d5d-0c80-4024-8760-5c406b4855ff
   name: Hugh McKean
 - id: ocd-person/4be512fb-5ebc-422c-a858-d250cb5568ad

--- a/data/co/organizations/Alternatives-to-the-Gallagher-Amendment-Interim-Study-Committee-9364cd32-053a-458d-ada2-7679f35b9013.yml
+++ b/data/co/organizations/Alternatives-to-the-Gallagher-Amendment-Interim-Study-Committee-9364cd32-053a-458d-ada2-7679f35b9013.yml
@@ -17,6 +17,7 @@ memberships:
   name: Jeff Bridges
 - id: ocd-person/ed70bb55-696f-42ed-a8e4-ffbef69a4f1c
   name: Lois Court
+  end_date: '2020-01-16'
 - id: ocd-person/24072d04-8fb3-43a3-8f33-2881183ba6b4
   name: Bob Rankin
 - id: ocd-person/b76cd339-93bf-4af3-95f8-eb341ba6ec0f

--- a/data/co/organizations/State-Veterans--Military-Affairs-9489f849-319e-407c-9b16-92b301df01c5.yml
+++ b/data/co/organizations/State-Veterans--Military-Affairs-9489f849-319e-407c-9b16-92b301df01c5.yml
@@ -15,6 +15,7 @@ memberships:
   role: vice-chair
 - id: ocd-person/ed70bb55-696f-42ed-a8e4-ffbef69a4f1c
   name: Lois Court
+  end_date: '2020-01-16'
 - id: ocd-person/cda35383-f5af-40b7-ab1f-41798fe6444e
   name: Stephen Fenberg
 - id: ocd-person/3529913e-f34f-49e1-ae2b-79e26a5c48d0

--- a/data/co/organizations/Transportation--Energy-d51dee6b-c4b6-4a39-96a7-c4fbe7705f1c.yml
+++ b/data/co/organizations/Transportation--Energy-d51dee6b-c4b6-4a39-96a7-c4fbe7705f1c.yml
@@ -35,6 +35,7 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/bc7be948-aece-46e3-a6d7-a1009edfa473
   name: Kimmi Lewis
+  end_date: '2019-12-06'
 - id: ocd-person/8ed985fe-2105-4a32-87a1-3a93428813a2
   name: Paul Lundeen
   end_date: '2018-12-31'

--- a/data/co/organizations/Transportation-Legislation-Review-Committee-8f9517e1-c0ed-44c2-9e42-220c703582ff.yml
+++ b/data/co/organizations/Transportation-Legislation-Review-Committee-8f9517e1-c0ed-44c2-9e42-220c703582ff.yml
@@ -35,6 +35,7 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/bc7be948-aece-46e3-a6d7-a1009edfa473
   name: Kimmi Lewis
+  end_date: '2019-12-06'
 - id: ocd-person/8ed985fe-2105-4a32-87a1-3a93428813a2
   name: Paul Lundeen
   end_date: '2018-12-31'

--- a/data/co/people/Adrienne-Benavidez-a033ad21-bdb7-4af2-be2e-e21c3e4cfa24.yml
+++ b/data/co/people/Adrienne-Benavidez-a033ad21-bdb7-4af2-be2e-e21c3e4cfa24.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Benavidez
 given_name: Adrienne
 id: ocd-person/a033ad21-bdb7-4af2-be2e-e21c3e4cfa24
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_benavidez-co-17.jpg?itok=-SZmC73m
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_benavidez%2C%20adrienne.jpg
 links:
 - url: http://leg.colorado.gov/legislators/adrienne-benavidez
 name: Adrienne Benavidez

--- a/data/co/people/Alec-Garnett-a50f1be4-1037-4101-b696-7b88199656b4.yml
+++ b/data/co/people/Alec-Garnett-a50f1be4-1037-4101-b696-7b88199656b4.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Garnett
 given_name: Alec
 id: ocd-person/a50f1be4-1037-4101-b696-7b88199656b4
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_garnett-co-17.jpg?itok=7MHX36in
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_garnett%2C%20alec.jpg
 links:
 - url: http://leg.colorado.gov/legislators/alec-garnett
 name: Alec Garnett

--- a/data/co/people/Alex-Valdez-45c957a4-0017-4c0c-8650-393d656fc5a0.yml
+++ b/data/co/people/Alex-Valdez-45c957a4-0017-4c0c-8650-393d656fc5a0.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/alex-valdez
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_valdez-alex.jpg?itok=t8vlKKa2
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_valdez%2C%20alex.jpg

--- a/data/co/people/Angela-Williams-ea80ffed-2e2f-4cb1-90ce-49d083b30b7e.yml
+++ b/data/co/people/Angela-Williams-ea80ffed-2e2f-4cb1-90ce-49d083b30b7e.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Williams
 given_name: Angela
 id: ocd-person/ea80ffed-2e2f-4cb1-90ce-49d083b30b7e
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_williamsangela-co-17.jpg?itok=t-N-Bj-S
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_williams%2C%20angela.jpg
 links:
 - url: http://leg.colorado.gov/legislators/angela-williams
 name: Angela Williams

--- a/data/co/people/Barbara-McLachlan-4ee693c2-1cdc-4631-a6e5-b541e7f9c797.yml
+++ b/data/co/people/Barbara-McLachlan-4ee693c2-1cdc-4631-a6e5-b541e7f9c797.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: McLachlan
 given_name: Barbara
 id: ocd-person/4ee693c2-1cdc-4631-a6e5-b541e7f9c797
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_mclachlan-co-17.jpg?itok=ZNt___I2
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_mclachlan%2C%20barbara.jpg
 links:
 - url: http://leg.colorado.gov/legislators/barbara-mclachlan
 name: Barbara McLachlan

--- a/data/co/people/Bob-Gardner-167975f6-bf0d-49ea-885c-baea0fc0e4cd.yml
+++ b/data/co/people/Bob-Gardner-167975f6-bf0d-49ea-885c-baea0fc0e4cd.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Gardner
 given_name: Bob
 id: ocd-person/167975f6-bf0d-49ea-885c-baea0fc0e4cd
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_gardner-co-17.jpg?itok=3JXhc-vo
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_gardner%2C%20bob.jpg
 links:
 - url: http://leg.colorado.gov/legislators/bob-gardner
 name: Bob Gardner

--- a/data/co/people/Bob-Rankin-24072d04-8fb3-43a3-8f33-2881183ba6b4.yml
+++ b/data/co/people/Bob-Rankin-24072d04-8fb3-43a3-8f33-2881183ba6b4.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Rankin
 given_name: Bob
 id: ocd-person/24072d04-8fb3-43a3-8f33-2881183ba6b4
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_rankin-c-17.jpg?itok=z7tf6FP1
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rankin%2C%20bob.jpg
 links:
 - url: http://leg.colorado.gov/legislators/bob-rankin
 name: Bob Rankin

--- a/data/co/people/Bri-Buentello-1359fcda-b912-4b37-9bfe-10ff37fd72a6.yml
+++ b/data/co/people/Bri-Buentello-1359fcda-b912-4b37-9bfe-10ff37fd72a6.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/bri-buentello
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_buentello-bri.jpg?itok=EZaumYcE
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_buentello%2C%20bri.jpg

--- a/data/co/people/Brianna-Titone-fa9b604d-5981-4de1-97bc-9400e03909c9.yml
+++ b/data/co/people/Brianna-Titone-fa9b604d-5981-4de1-97bc-9400e03909c9.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/brianna-titone
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_titone-brianna.jpg?itok=MUXaXYWB
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_titone%2C%20brianna.jpg

--- a/data/co/people/Brittany-Pettersen-c06efba5-249e-44a1-8e50-551ac73b3da9.yml
+++ b/data/co/people/Brittany-Pettersen-c06efba5-249e-44a1-8e50-551ac73b3da9.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Pettersen
 given_name: Brittany
 id: ocd-person/c06efba5-249e-44a1-8e50-551ac73b3da9
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_pettersen-brittany.jpg?itok=_nHKIUdy
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_pettersen%2C%20britteny.jpg
 links:
 - url: http://leg.colorado.gov/legislators/brittany-pettersen
 name: Brittany Pettersen

--- a/data/co/people/Cathy-Kipp-0ddf3b75-c450-419e-8235-553157770e49.yml
+++ b/data/co/people/Cathy-Kipp-0ddf3b75-c450-419e-8235-553157770e49.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/cathy-kipp
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep_kipp_original.jpg?itok=mHkypKKy
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_kipp%2C%20cathy.jpg
 given_name: Cathy
 family_name: Kipp

--- a/data/co/people/Chris-Hansen-38bd0587-d043-4341-bad9-1bfa903d9dcd.yml
+++ b/data/co/people/Chris-Hansen-38bd0587-d043-4341-bad9-1bfa903d9dcd.yml
@@ -1,12 +1,12 @@
 contact_details:
-- address: 200 E. Colfax;RM 307;Denver, CO 80203
-  email: chris.hansen.house@state.co.us
+- address: 200 E. Colfax;RM 346;Denver, CO 80203
+  email: chris.hansen.senate@state.co.us
   note: Capitol Office
-  voice: 303-866-2967
+  voice: 303-866-4861
 family_name: Hansen
 given_name: Chris
 id: ocd-person/38bd0587-d043-4341-bad9-1bfa903d9dcd
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_hansen-co-17.jpg?itok=bLUlzHUf
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_hansen%2C%20chris.jpg
 links:
 - url: http://leg.colorado.gov/legislators/chris-hansen
 name: Chris Hansen
@@ -19,6 +19,11 @@ roles:
 - district: '6'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
+  end_date: 2020-01-21
+- district: '31'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: upper
+  start_date: 2020-01-21
 sources:
 - url: http://leg.colorado.gov/legislators/chris-hansen
 - url: http://leg.colorado.gov/legislators

--- a/data/co/people/Chris-Holbert-075fdf6c-4ce9-4095-9f68-e7b7ab755b48.yml
+++ b/data/co/people/Chris-Holbert-075fdf6c-4ce9-4095-9f68-e7b7ab755b48.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Holbert
 given_name: Chris
 id: ocd-person/075fdf6c-4ce9-4095-9f68-e7b7ab755b48
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_holbert-co-17.jpg?itok=dNp_ptIy
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rsz_holbert-co-17.jpg
 links:
 - url: http://leg.colorado.gov/legislators/chris-holbert
 name: Chris Holbert

--- a/data/co/people/Chris-Kennedy-92715424-bafa-4ad8-b311-eca3e575c86f.yml
+++ b/data/co/people/Chris-Kennedy-92715424-bafa-4ad8-b311-eca3e575c86f.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Kennedy
 given_name: Chris
 id: ocd-person/92715424-bafa-4ad8-b311-eca3e575c86f
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_kennedy-co-17.jpg?itok=aQAd0yev
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_kennedy%2C%20chris.jpg
 links:
 - url: http://leg.colorado.gov/legislators/chris-kennedy
 name: Chris Kennedy

--- a/data/co/people/Colin-Larson-ff73fe0b-5737-45a5-a032-b2cdb55caddc.yml
+++ b/data/co/people/Colin-Larson-ff73fe0b-5737-45a5-a032-b2cdb55caddc.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/colin-larson
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_larson-colin.jpg?itok=zvsXNDAG
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_larson%2C%20colin.jpg

--- a/data/co/people/Dafna-Michaelson-Jenet-a37712a4-bcbe-4179-83c7-ab0574fccedc.yml
+++ b/data/co/people/Dafna-Michaelson-Jenet-a37712a4-bcbe-4179-83c7-ab0574fccedc.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Michaelson Jenet
 given_name: Dafna
 id: ocd-person/a37712a4-bcbe-4179-83c7-ab0574fccedc
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_michaelson_jenet-co-17.jpg?itok=JaWxbtOV
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_michaelson%20jenet%2C%20dafra.jpg
 links:
 - url: http://leg.colorado.gov/legislators/dafna-michaelson-jenet
 name: Dafna Michaelson Jenet

--- a/data/co/people/Daneya-Esgar-86d825c7-ac05-4dbc-8f19-8d924a0c2d92.yml
+++ b/data/co/people/Daneya-Esgar-86d825c7-ac05-4dbc-8f19-8d924a0c2d92.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Esgar
 given_name: Daneya
 id: ocd-person/86d825c7-ac05-4dbc-8f19-8d924a0c2d92
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_esgar-co-17.jpg?itok=_GbR1JKU
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_esgar%2C%20daneya.jpg
 links:
 - url: http://leg.colorado.gov/legislators/daneya-esgar
 name: Daneya Esgar

--- a/data/co/people/Dave-Williams-aa5881af-90f2-4a0c-abc1-d2cad081598e.yml
+++ b/data/co/people/Dave-Williams-aa5881af-90f2-4a0c-abc1-d2cad081598e.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Williams
 given_name: Dave
 id: ocd-person/aa5881af-90f2-4a0c-abc1-d2cad081598e
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_williams-co-17.jpg?itok=yKkJbvvt
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_williams%2C%20dave.jpg
 links:
 - url: http://leg.colorado.gov/legislators/dave-williams
 name: Dave Williams

--- a/data/co/people/Dennis-Hisey-c62006dc-a294-462c-a97f-430b67b0a550.yml
+++ b/data/co/people/Dennis-Hisey-c62006dc-a294-462c-a97f-430b67b0a550.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/dennis-hisey
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_hisey-dennis.jpg?itok=10i1EBwn
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_hisey%2C%20dennis.jpg

--- a/data/co/people/Dominick-Moreno-698cdd09-6b39-4e6b-bdc7-5f8529a74c6e.yml
+++ b/data/co/people/Dominick-Moreno-698cdd09-6b39-4e6b-bdc7-5f8529a74c6e.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Moreno
 given_name: Dominick
 id: ocd-person/698cdd09-6b39-4e6b-bdc7-5f8529a74c6e
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_moreno-co-17.jpg?itok=znFiejwW
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_moreno-co-17.jpg
 links:
 - url: http://leg.colorado.gov/legislators/dominick-moreno
 name: Dominick Moreno

--- a/data/co/people/Dominique-Jackson-afc98d85-24dd-4dc8-9552-3d7f76f7d697.yml
+++ b/data/co/people/Dominique-Jackson-afc98d85-24dd-4dc8-9552-3d7f76f7d697.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Jackson
 given_name: Dominique
 id: ocd-person/afc98d85-24dd-4dc8-9552-3d7f76f7d697
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_jackson-co-17.jpg?itok=dnt0xqFm
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_jackson%2C%20dominique.jpg
 links:
 - url: http://leg.colorado.gov/legislators/dominique-jackson
 name: Dominique Jackson

--- a/data/co/people/Don-Coram-9ee37d1e-f113-4f77-b24f-b21fd66d3a16.yml
+++ b/data/co/people/Don-Coram-9ee37d1e-f113-4f77-b24f-b21fd66d3a16.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Coram
 given_name: Don
 id: ocd-person/9ee37d1e-f113-4f77-b24f-b21fd66d3a16
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_coram-co-17.jpg?itok=Z45YurSb
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_coram%2C%20dan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/don-coram
 name: Don Coram

--- a/data/co/people/Donald-Valdez-3cea6f74-197b-4b53-9afb-a461f6d656c6.yml
+++ b/data/co/people/Donald-Valdez-3cea6f74-197b-4b53-9afb-a461f6d656c6.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Valdez
 given_name: Donald
 id: ocd-person/3cea6f74-197b-4b53-9afb-a461f6d656c6
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_valdez-co-17.jpg?itok=rWC3-m34
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_valdez%2C%20donald.jpg
 links:
 - url: http://leg.colorado.gov/legislators/donald-valdez
 name: Donald Valdez

--- a/data/co/people/Dylan-Roberts-4be512fb-5ebc-422c-a858-d250cb5568ad.yml
+++ b/data/co/people/Dylan-Roberts-4be512fb-5ebc-422c-a858-d250cb5568ad.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Roberts
 given_name: Dylan
 id: ocd-person/4be512fb-5ebc-422c-a858-d250cb5568ad
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_droberts.jpg?itok=-Zz_VS8e
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_roberts%2C%20dylan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/dylan-roberts
 name: Dylan Roberts

--- a/data/co/people/Edie-Hooton-55c2b573-abb5-4055-b2d2-0a3a9318f27f.yml
+++ b/data/co/people/Edie-Hooton-55c2b573-abb5-4055-b2d2-0a3a9318f27f.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Hooton
 given_name: Edie
 id: ocd-person/55c2b573-abb5-4055-b2d2-0a3a9318f27f
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_hooton-co-17.jpg?itok=hK1XIh6V
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_hooten%2C%20edie.jpg
 links:
 - url: http://leg.colorado.gov/legislators/edie-hooton
 name: Edie Hooton

--- a/data/co/people/Emily-Sirota-c8c1a9c5-c7c2-4894-8829-fc83251bcaf2.yml
+++ b/data/co/people/Emily-Sirota-c8c1a9c5-c7c2-4894-8829-fc83251bcaf2.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/emily-sirota
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_sirota-emily.jpg?itok=e9XBXJ5t
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_h_sirota.jpg

--- a/data/co/people/Faith-Winter-d8091b89-e076-404f-a2a3-886f5cb9b89c.yml
+++ b/data/co/people/Faith-Winter-d8091b89-e076-404f-a2a3-886f5cb9b89c.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Winter
 given_name: Faith
 id: ocd-person/d8091b89-e076-404f-a2a3-886f5cb9b89c
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_winter-faith.jpg?itok=Vd3YcwP_
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_winter%2C%20faith.jpg
 links:
 - url: http://leg.colorado.gov/legislators/faith-winter
 name: Faith Winter

--- a/data/co/people/Hugh-McKean-567d2d5d-0c80-4024-8760-5c406b4855ff.yml
+++ b/data/co/people/Hugh-McKean-567d2d5d-0c80-4024-8760-5c406b4855ff.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: McKean
 given_name: Hugh
 id: ocd-person/567d2d5d-0c80-4024-8760-5c406b4855ff
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_mckean-co-17.jpg?itok=cBxlBINn
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_mckean%2C%20hugh.jpg
 links:
 - url: http://leg.colorado.gov/legislators/hugh-mckean
 name: Hugh McKean

--- a/data/co/people/Jack-Tate-b76cd339-93bf-4af3-95f8-eb341ba6ec0f.yml
+++ b/data/co/people/Jack-Tate-b76cd339-93bf-4af3-95f8-eb341ba6ec0f.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Tate
 given_name: Jack
 id: ocd-person/b76cd339-93bf-4af3-95f8-eb341ba6ec0f
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_tate-co-17.jpg?itok=WAQ88DkU
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_tate%2C%20john.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jack-tate
 name: Jack Tate

--- a/data/co/people/James-Coleman-ff2f6795-50ae-4554-a2bb-ff5ae29c54ea.yml
+++ b/data/co/people/James-Coleman-ff2f6795-50ae-4554-a2bb-ff5ae29c54ea.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Coleman
 given_name: James
 id: ocd-person/ff2f6795-50ae-4554-a2bb-ff5ae29c54ea
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_coleman-co-17.jpg?itok=SXA5cYUc
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_coleman%2C%20james.jpg
 links:
 - url: http://leg.colorado.gov/legislators/james-coleman
 name: James Coleman

--- a/data/co/people/James-Wilson-2fd45c8b-8d38-49b5-a260-982d7c50423d.yml
+++ b/data/co/people/James-Wilson-2fd45c8b-8d38-49b5-a260-982d7c50423d.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Wilson
 given_name: James
 id: ocd-person/2fd45c8b-8d38-49b5-a260-982d7c50423d
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_wilson-co-17.jpg?itok=7g6jQQMS
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_wilson%2C%20james%20d.jpg
 links:
 - url: http://leg.colorado.gov/legislators/james-d-wilson
 name: James Wilson

--- a/data/co/people/Janet-Buckner-317988cd-610a-4840-b55d-9d050a07fb32.yml
+++ b/data/co/people/Janet-Buckner-317988cd-610a-4840-b55d-9d050a07fb32.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Buckner
 given_name: Janet
 id: ocd-person/317988cd-610a-4840-b55d-9d050a07fb32
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_buckner-co-17.jpg?itok=pJUma4U9
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_buckner%2C%20janet.jpg
 links:
 - url: http://leg.colorado.gov/legislators/janet-p-buckner
 name: Janet Buckner

--- a/data/co/people/Janice-Rich-45efea89-1f3a-497d-8963-37d9f9d1281f.yml
+++ b/data/co/people/Janice-Rich-45efea89-1f3a-497d-8963-37d9f9d1281f.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/janice-rich
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rich-janice.jpg?itok=suPk-5q1
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rich%2C%20janice.jpg

--- a/data/co/people/Jeff-Bridges-c2cade07-9c95-4439-938c-77ac4ed44fab.yml
+++ b/data/co/people/Jeff-Bridges-c2cade07-9c95-4439-938c-77ac4ed44fab.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Bridges
 given_name: Jeff
 id: ocd-person/c2cade07-9c95-4439-938c-77ac4ed44fab
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_bridges-co-17.jpg?itok=gRelez2U
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_bridges%2C%20jeff.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jeff-bridges
 name: Jeff Bridges

--- a/data/co/people/Jeni-James-Arndt-e058cefb-c8bb-4251-947a-f0af071dfe02.yml
+++ b/data/co/people/Jeni-James-Arndt-e058cefb-c8bb-4251-947a-f0af071dfe02.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Arndt
 given_name: Jeni
 id: ocd-person/e058cefb-c8bb-4251-947a-f0af071dfe02
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_arndt-co-17.jpg?itok=JjJAv3JQ
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_arndt%2C%20jeni.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jeni-james-arndt
 name: Jeni James Arndt

--- a/data/co/people/Jerry-Sonnenberg-ba633379-3da7-44a4-b302-b9e2b4536063.yml
+++ b/data/co/people/Jerry-Sonnenberg-ba633379-3da7-44a4-b302-b9e2b4536063.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Sonnenberg
 given_name: Jerry
 id: ocd-person/ba633379-3da7-44a4-b302-b9e2b4536063
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_sonnenberg-co-17.jpg?itok=QwrUUCp8
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_sonnenberg%2C%20jerry.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jerry-sonnenberg
 name: Jerry Sonnenberg

--- a/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
+++ b/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/jessie-danielson
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_danielson-jessie.jpg?itok=wkohEvVs
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_danielson%2C%20jessie.jpg
 given_name: Jessie
 family_name: Danielson

--- a/data/co/people/Jim-Smallwood-e389192e-edc9-448f-a6ca-6a9eb800ae8e.yml
+++ b/data/co/people/Jim-Smallwood-e389192e-edc9-448f-a6ca-6a9eb800ae8e.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Smallwood
 given_name: Jim
 id: ocd-person/e389192e-edc9-448f-a6ca-6a9eb800ae8e
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_smallwood-co-17.jpg?itok=e3iIFp2J
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_smallwood%2C%20jim.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jim-smallwood
 name: Jim Smallwood

--- a/data/co/people/Joann-Ginal-a9bfb020-3b00-4b9d-8c22-447e365c3b0f.yml
+++ b/data/co/people/Joann-Ginal-a9bfb020-3b00-4b9d-8c22-447e365c3b0f.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Ginal
 given_name: Joann
 id: ocd-person/a9bfb020-3b00-4b9d-8c22-447e365c3b0f
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_ginal-co-17.jpg?itok=b1cKah4Q
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_ginal%2C%20joann.jpg
 links:
 - url: http://leg.colorado.gov/legislators/joann-ginal
 name: Joann Ginal

--- a/data/co/people/John-Cooke-215dd9a2-b7ee-45b8-8407-b469afccfcf9.yml
+++ b/data/co/people/John-Cooke-215dd9a2-b7ee-45b8-8407-b469afccfcf9.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Cooke
 given_name: John
 id: ocd-person/215dd9a2-b7ee-45b8-8407-b469afccfcf9
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_cooke-co-17.jpg?itok=Xrb75dyd
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_cooke%2C%20john.jpg
 links:
 - url: http://leg.colorado.gov/legislators/john-cooke
 name: John Cooke

--- a/data/co/people/Jonathan-Singer-6f4bf28b-e0dd-450f-89c9-88108d44db2b.yml
+++ b/data/co/people/Jonathan-Singer-6f4bf28b-e0dd-450f-89c9-88108d44db2b.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Singer
 given_name: Jonathan
 id: ocd-person/6f4bf28b-e0dd-450f-89c9-88108d44db2b
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_singer-co-17.jpg?itok=egBrUUHK
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_singer%2C%20jonathan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jonathan-singer
 name: Jonathan Singer

--- a/data/co/people/Jovan-Melton-c5745978-e793-451c-a6e3-6947e9ca4511.yml
+++ b/data/co/people/Jovan-Melton-c5745978-e793-451c-a6e3-6947e9ca4511.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Melton
 given_name: Jovan
 id: ocd-person/c5745978-e793-451c-a6e3-6947e9ca4511
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_melton-co-17.jpg?itok=WAuhhBxo
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_melton%2C%20jovan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/jovan-melton
 name: Jovan Melton

--- a/data/co/people/Julie-Gonzales-8dae5ba5-6741-4aca-8c1e-24f014fda187.yml
+++ b/data/co/people/Julie-Gonzales-8dae5ba5-6741-4aca-8c1e-24f014fda187.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/julie-gonzales
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_gonzales-julie.jpg?itok=6oU22Tul
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_gonzales%2C%20julie.jpg

--- a/data/co/people/Julie-McCluskie-fd2cb73e-2c46-4009-932b-d235f24fc442.yml
+++ b/data/co/people/Julie-McCluskie-fd2cb73e-2c46-4009-932b-d235f24fc442.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/julie-mccluskie
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_mccluskie-julie.jpg?itok=OR2uQk0x
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_mccluskie%2C%20julie.jpg

--- a/data/co/people/KC-Becker-c10d3618-30ab-4b09-8858-828d71e97f6d.yml
+++ b/data/co/people/KC-Becker-c10d3618-30ab-4b09-8858-828d71e97f6d.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Becker
 given_name: KC
 id: ocd-person/c10d3618-30ab-4b09-8858-828d71e97f6d
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_beckerkc-co-17.jpg?itok=0RQCvI7T
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_becker%2C%20kc%20-%20speaker.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kc-becker
 name: KC Becker

--- a/data/co/people/Kerry-Donovan-e88f6ebc-1e9e-4c7c-9045-e6f3c22dc90a.yml
+++ b/data/co/people/Kerry-Donovan-e88f6ebc-1e9e-4c7c-9045-e6f3c22dc90a.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Donovan
 given_name: Kerry
 id: ocd-person/e88f6ebc-1e9e-4c7c-9045-e6f3c22dc90a
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_donovan-co-17.jpg?itok=9FXQqDOk
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_donovan%2C%20kerry.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kerry-donovan
 name: Kerry Donovan

--- a/data/co/people/Kerry-Tipper-b45229f3-b995-4266-8398-aaf7f54dbdc8.yml
+++ b/data/co/people/Kerry-Tipper-b45229f3-b995-4266-8398-aaf7f54dbdc8.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/kerry-tipper
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep%20tipper.jpg?itok=DG4C6LJD
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_tipper%2C%20kerry.jpg

--- a/data/co/people/Kevin-Priola-a68ea419-4fcb-4f7f-9797-77dd2b57ebca.yml
+++ b/data/co/people/Kevin-Priola-a68ea419-4fcb-4f7f-9797-77dd2b57ebca.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Priola
 given_name: Kevin
 id: ocd-person/a68ea419-4fcb-4f7f-9797-77dd2b57ebca
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_priola-co-17.jpg?itok=-TzBx3rF
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_priola%2C%20kevin.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kevin-priola
 name: Kevin Priola

--- a/data/co/people/Kevin-Van-Winkle-f4af69ce-6bef-4127-bbf7-bb92c5b80465.yml
+++ b/data/co/people/Kevin-Van-Winkle-f4af69ce-6bef-4127-bbf7-bb92c5b80465.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Van Winkle
 given_name: Kevin
 id: ocd-person/f4af69ce-6bef-4127-bbf7-bb92c5b80465
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_vanwinkle-co-17.jpg?itok=JpKFq5dk
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_van%20winkle%2C%20kevin.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kevin-van-winkle
 name: Kevin Van Winkle

--- a/data/co/people/Kim-Ransom-1e7fd7df-2f64-4122-834d-1864793c69fb.yml
+++ b/data/co/people/Kim-Ransom-1e7fd7df-2f64-4122-834d-1864793c69fb.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Ransom
 given_name: Kim
 id: ocd-person/1e7fd7df-2f64-4122-834d-1864793c69fb
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_ransom-co-17.jpg?itok=aSF4PGyK
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_ransom%2C%20kim.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kim-ransom
 name: Kim Ransom

--- a/data/co/people/Kyle-Mullica-ebf0c3de-2f58-436f-af67-12863f9cb552.yml
+++ b/data/co/people/Kyle-Mullica-ebf0c3de-2f58-436f-af67-12863f9cb552.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/kyle-mullica
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_mullica-kyle.jpg?itok=6swzK0ij
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_mullica%2C%20kyle.jpg

--- a/data/co/people/Larry-Crowder-0aa23426-e455-4250-b246-ed302688ecea.yml
+++ b/data/co/people/Larry-Crowder-0aa23426-e455-4250-b246-ed302688ecea.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Crowder
 given_name: Larry
 id: ocd-person/0aa23426-e455-4250-b246-ed302688ecea
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_crowder-co-17.jpg?itok=RQJQiORs
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_crowder%2C%20larry.jpg
 links:
 - url: http://leg.colorado.gov/legislators/larry-w-crowder
 name: Larry Crowder

--- a/data/co/people/Larry-Liston-c9fd6b10-91a3-44ec-ac6a-48f73eee3ed1.yml
+++ b/data/co/people/Larry-Liston-c9fd6b10-91a3-44ec-ac6a-48f73eee3ed1.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Liston
 given_name: Larry
 id: ocd-person/c9fd6b10-91a3-44ec-ac6a-48f73eee3ed1
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_liston-co-17.jpg?itok=O8XE3u7r
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_liston%2C%20larry.jpg
 links:
 - url: http://leg.colorado.gov/legislators/larry-liston
 name: Larry Liston

--- a/data/co/people/Leroy-Garcia-6aa0113f-e293-4be5-b0e2-715581e84878.yml
+++ b/data/co/people/Leroy-Garcia-6aa0113f-e293-4be5-b0e2-715581e84878.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Garcia
 given_name: Leroy
 id: ocd-person/6aa0113f-e293-4be5-b0e2-715581e84878
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_s-garcia%2C%20leroy.jpg?itok=xDVUIFpK
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_garcia%2C%20leroy.png
 links:
 - url: http://leg.colorado.gov/legislators/leroy-m-garcia-jr
 name: Leroy Garcia

--- a/data/co/people/Leslie-Herod-a91826de-a61a-44e8-84b1-9f31f3dd32cb.yml
+++ b/data/co/people/Leslie-Herod-a91826de-a61a-44e8-84b1-9f31f3dd32cb.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Herod
 given_name: Leslie
 id: ocd-person/a91826de-a61a-44e8-84b1-9f31f3dd32cb
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_herod-co-17.jpg?itok=KJf8fAmU
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_herod-17.jpg
 links:
 - url: http://leg.colorado.gov/legislators/leslie-herod
 name: Leslie Herod

--- a/data/co/people/Lisa-Cutter-5226ebdd-0710-49da-b446-61fac19765ce.yml
+++ b/data/co/people/Lisa-Cutter-5226ebdd-0710-49da-b446-61fac19765ce.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/lisa-cutter
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_cutter-lisa.jpg?itok=u_DgfPi5
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_cutter%2C%20lisa.jpg

--- a/data/co/people/Lois-Landgraf-4b7843aa-1ab0-40f9-9ef0-2837daa9fbed.yml
+++ b/data/co/people/Lois-Landgraf-4b7843aa-1ab0-40f9-9ef0-2837daa9fbed.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Landgraf
 given_name: Lois
 id: ocd-person/4b7843aa-1ab0-40f9-9ef0-2837daa9fbed
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_landgraf-c-17.jpg?itok=YSoCYGeD
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_landgraf-17.jpg
 links:
 - url: http://leg.colorado.gov/legislators/lois-landgraf
 name: Lois Landgraf

--- a/data/co/people/Lori-Saine-64ab88db-3baa-4d4c-85e6-bf395a6b8bbf.yml
+++ b/data/co/people/Lori-Saine-64ab88db-3baa-4d4c-85e6-bf395a6b8bbf.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Saine
 given_name: Lori
 id: ocd-person/64ab88db-3baa-4d4c-85e6-bf395a6b8bbf
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_saine-co-15.jpg?itok=FGkSOUdd
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_saine%2C%20lori.jpg
 links:
 - url: http://leg.colorado.gov/legislators/lori-saine
 name: Lori Saine

--- a/data/co/people/Marc-Catlin-c0cfa7d3-2c5e-4b68-8692-2e1b6f1b3372.yml
+++ b/data/co/people/Marc-Catlin-c0cfa7d3-2c5e-4b68-8692-2e1b6f1b3372.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Catlin
 given_name: Marc
 id: ocd-person/c0cfa7d3-2c5e-4b68-8692-2e1b6f1b3372
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_catlin-co-17.jpg?itok=NZPcI6iS
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_catlin%2C%20marc.jpg
 links:
 - url: http://leg.colorado.gov/legislators/marc-catlin
 name: Marc Catlin

--- a/data/co/people/Marc-Snyder-5dbb7ac2-a4c8-42b8-bfb1-1b012737fa74.yml
+++ b/data/co/people/Marc-Snyder-5dbb7ac2-a4c8-42b8-bfb1-1b012737fa74.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/marc-snyder
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_snyder-marc.jpg?itok=Q30DJpdP
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_snyder%2C%20marc.jpg

--- a/data/co/people/Mark-Baisley-b4002b84-79a0-481a-94a8-00136c2dabb6.yml
+++ b/data/co/people/Mark-Baisley-b4002b84-79a0-481a-94a8-00136c2dabb6.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/mark-baisley
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_baisley-mark.jpg?itok=pi04-vXf
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_baisley%2C%20mark.jpg

--- a/data/co/people/Mary-Young-ffc5caa4-29c4-475a-b662-a814bae9f8c5.yml
+++ b/data/co/people/Mary-Young-ffc5caa4-29c4-475a-b662-a814bae9f8c5.yml
@@ -2,7 +2,7 @@ id: ocd-person/ffc5caa4-29c4-475a-b662-a814bae9f8c5
 name: Mary Young
 given_name: Mary
 family_name: Young
-image: https://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep%20young.jpg
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rep%20young.jpg
 party:
 - name: Democratic
 roles:
@@ -14,3 +14,4 @@ links:
 - url: https://leg.colorado.gov/legislators/mary-young
 sources:
 - url: https://leg.colorado.gov/legislators/mary-young
+- url: http://leg.colorado.gov/legislators

--- a/data/co/people/Matt-Gray-addfd1da-9ebe-4806-ac1b-cb46b28746af.yml
+++ b/data/co/people/Matt-Gray-addfd1da-9ebe-4806-ac1b-cb46b28746af.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Gray
 given_name: Matt
 id: ocd-person/addfd1da-9ebe-4806-ac1b-cb46b28746af
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_gray-co-17.jpg?itok=U5d2RHq1
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_gray%2C%20matt.jpg
 links:
 - url: http://leg.colorado.gov/legislators/matt-gray
 name: Matt Gray

--- a/data/co/people/Matt-Soper-9e529237-916b-407c-a60e-abd8e0708329.yml
+++ b/data/co/people/Matt-Soper-9e529237-916b-407c-a60e-abd8e0708329.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/matt-soper
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_soper-matt.jpg?itok=y9R4da5D
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_soper%2C%20matthew.jpg

--- a/data/co/people/Meg-Froelich-8e6bc6cb-fe7e-4640-a938-eb32536e95c5.yml
+++ b/data/co/people/Meg-Froelich-8e6bc6cb-fe7e-4640-a938-eb32536e95c5.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/meg-froelich
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_h_froelich.jpg?itok=3wKkR-Wa
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_froelich%2C%20meg.jpg
 given_name: Meg
 family_name: Froelich

--- a/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
+++ b/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/mike-foote
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_foote-co-17.jpg?itok=6GMfDFaJ
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_foote%2C%20mike.jpg
 given_name: Mike
 family_name: Foote

--- a/data/co/people/Mike-Weissman-b680cb39-442c-4dd2-81bd-88696cfe9df2.yml
+++ b/data/co/people/Mike-Weissman-b680cb39-442c-4dd2-81bd-88696cfe9df2.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Weissman
 given_name: Mike
 id: ocd-person/b680cb39-442c-4dd2-81bd-88696cfe9df2
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_weissman-co-17.jpg?itok=2lKrp8YF
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_weissman%2C%20mike.jpg
 links:
 - url: http://leg.colorado.gov/legislators/mike-weissman
 name: Mike Weissman

--- a/data/co/people/Monica-Duran-d8b6809c-61d9-4ea3-b21b-c846051468c2.yml
+++ b/data/co/people/Monica-Duran-d8b6809c-61d9-4ea3-b21b-c846051468c2.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/monica-duran
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep_duran.jpg?itok=gY1fEyEf
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_duran%2C%20monica.jpg

--- a/data/co/people/Nancy-Todd-940d7d25-bd6c-42c2-8ee2-8952c4494b11.yml
+++ b/data/co/people/Nancy-Todd-940d7d25-bd6c-42c2-8ee2-8952c4494b11.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Todd
 given_name: Nancy
 id: ocd-person/940d7d25-bd6c-42c2-8ee2-8952c4494b11
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_todd-co-17.jpg?itok=SdyV5t9P
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_todd%2C%20nancy.jpg
 links:
 - url: http://leg.colorado.gov/legislators/nancy-todd
 name: Nancy Todd

--- a/data/co/people/Owen-Hill-3529913e-f34f-49e1-ae2b-79e26a5c48d0.yml
+++ b/data/co/people/Owen-Hill-3529913e-f34f-49e1-ae2b-79e26a5c48d0.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Hill
 given_name: Owen
 id: ocd-person/3529913e-f34f-49e1-ae2b-79e26a5c48d0
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_hill-co-17.jpg?itok=OALJBRcR
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_hill%2C%20owen.jpg
 links:
 - url: http://leg.colorado.gov/legislators/owen-hill
 name: Owen Hill

--- a/data/co/people/Patrick-Neville-3e67bde9-4588-42ad-b3e7-2b243e14ab73.yml
+++ b/data/co/people/Patrick-Neville-3e67bde9-4588-42ad-b3e7-2b243e14ab73.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Neville
 given_name: Patrick
 id: ocd-person/3e67bde9-4588-42ad-b3e7-2b243e14ab73
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_nevillep-co-17.jpg?itok=dPbDUimB
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_neville%2C%20patrick.jpg
 links:
 - url: http://leg.colorado.gov/legislators/patrick-neville
 name: Patrick Neville

--- a/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
+++ b/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/paul-lundeen
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_lundeen-paul.jpg?itok=VhKMGnGf
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_lundeen%2C%20paul.jpg
 given_name: Paul
 family_name: Lundeen

--- a/data/co/people/Perry-Buck-66fda760-b19d-4627-97c0-77014f0d2f16.yml
+++ b/data/co/people/Perry-Buck-66fda760-b19d-4627-97c0-77014f0d2f16.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Buck
 given_name: Perry
 id: ocd-person/66fda760-b19d-4627-97c0-77014f0d2f16
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_buck-co-17.jpg?itok=j2vTDJiW
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_buck%2C%20perry.jpg
 links:
 - url: http://leg.colorado.gov/legislators/perry-buck
 name: Perry Buck

--- a/data/co/people/Perry-Will-221d86f6-e78f-4381-8826-e48451a8a97f.yml
+++ b/data/co/people/Perry-Will-221d86f6-e78f-4381-8826-e48451a8a97f.yml
@@ -9,6 +9,7 @@ roles:
   start_date: '2019-03-05'
 contact_details:
 - address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: perry.will.house@state.co.us
   note: Capitol Office
   voice: 303-866-2949
 links:
@@ -16,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/perry-will
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_repperrywill.jpeg?itok=rmOr0Jcp
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_co-h-will%2C%20perry.jpg
 given_name: Perry
 family_name: Will

--- a/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
+++ b/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
@@ -17,6 +17,6 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/pete-lee
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_lee-pete.jpg?itok=j5BU2bAW
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_lee%2C%20sanford%20pete.jpg
 given_name: Pete
 family_name: Lee

--- a/data/co/people/Rachel-Zenzinger-f7486270-9e45-4213-9520-aa7150e34baa.yml
+++ b/data/co/people/Rachel-Zenzinger-f7486270-9e45-4213-9520-aa7150e34baa.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Zenzinger
 given_name: Rachel
 id: ocd-person/f7486270-9e45-4213-9520-aa7150e34baa
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_zenzinger-co-17.jpg?itok=FDhyftu8
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_zenzinger%2C%20rachel.jpg
 links:
 - url: http://leg.colorado.gov/legislators/rachel-zenzinger
 name: Rachel Zenzinger

--- a/data/co/people/Ray-Scott-01d42abe-6bf4-4e30-b58c-a52a29b8c809.yml
+++ b/data/co/people/Ray-Scott-01d42abe-6bf4-4e30-b58c-a52a29b8c809.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Scott
 given_name: Ray
 id: ocd-person/01d42abe-6bf4-4e30-b58c-a52a29b8c809
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_scott-co-17.jpg?itok=WWvnwDf9
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_scott%2C%20ray.jpg
 links:
 - url: http://leg.colorado.gov/legislators/ray-scott
 name: Ray Scott

--- a/data/co/people/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
+++ b/data/co/people/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Fields
 given_name: Rhonda
 id: ocd-person/654b2a04-55a4-4158-b45f-2aefdef39a1c
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_fields-co-17.jpg?itok=dDcR0ODr
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_fields%2C%20rhonda.jpg
 links:
 - url: http://leg.colorado.gov/legislators/rhonda-fields
 name: Rhonda Fields

--- a/data/co/people/Richard-Holtorf-6ce16578-2d36-4bd6-a456-4b9f8a68bb3e.yml
+++ b/data/co/people/Richard-Holtorf-6ce16578-2d36-4bd6-a456-4b9f8a68bb3e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/6ce16578-2d36-4bd6-a456-4b9f8a68bb3e
+name: Richard Holtorf
+party:
+- name: Republican
+roles:
+- district: '64'
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+  type: lower
+  start_date: 2020-01-07
+contact_details:
+- address: 200 E. Colfax;RM 307;Denver, CO 80203
+  email: richard.holtorf.house@state.co.us
+  note: Capitol Office
+  voice: 303-866-2398
+links:
+- url: http://leg.colorado.gov/legislators/richard-holtorf
+sources:
+- url: http://leg.colorado.gov/legislators/richard-holtorf
+- url: http://leg.colorado.gov/legislators
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rep.%20holtorf.jpg?itok=hUujSsJg
+given_name: Richard
+family_name: Holtorf

--- a/data/co/people/Rob-Woodward-432eff55-4ac6-4d34-b663-9ebe58a77d97.yml
+++ b/data/co/people/Rob-Woodward-432eff55-4ac6-4d34-b663-9ebe58a77d97.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/rob-woodward
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_woodward-rob.jpg?itok=iTs1kjgy
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_woodward%2C%20rob.jpg

--- a/data/co/people/Robert-Rodriguez-ab377224-ab70-4c20-a535-baa429520e7c.yml
+++ b/data/co/people/Robert-Rodriguez-ab377224-ab70-4c20-a535-baa429520e7c.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/robert-rodriguez
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rodriguez-robert.jpg?itok=Bz3sKr8l
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_rodriguez%2C%20robert.jpg

--- a/data/co/people/Rod-Bockenfeld-134e76cb-3f07-48cf-8bee-580e00786b82.yml
+++ b/data/co/people/Rod-Bockenfeld-134e76cb-3f07-48cf-8bee-580e00786b82.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/rod-bockenfeld
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep-electrobbockenfeld.jpg?itok=Ck3EuS6m
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_bockenfeld%2C%20rod.jpg

--- a/data/co/people/Rod-Pelton-45cd06eb-9967-4468-9e4e-677549e7638d.yml
+++ b/data/co/people/Rod-Pelton-45cd06eb-9967-4468-9e4e-677549e7638d.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/rod-pelton
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_pelton-rod.jpg?itok=C5rGypcT
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_pelton%2C%20rod.jpg

--- a/data/co/people/Serena-Gonzales-Gutierrez-c8bf4dd0-6d70-4585-a699-fed72b1ed9aa.yml
+++ b/data/co/people/Serena-Gonzales-Gutierrez-c8bf4dd0-6d70-4585-a699-fed72b1ed9aa.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/serena-gonzales-gutierrez
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rep-electgonzales-gutierrez.jpg?itok=PmfLKiA-
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_gonzales-gutierrez%2C%20serena.jpg

--- a/data/co/people/Shane-Sandridge-530a13be-91ef-448e-b874-ae4df7e776e4.yml
+++ b/data/co/people/Shane-Sandridge-530a13be-91ef-448e-b874-ae4df7e776e4.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Sandridge
 given_name: Shane
 id: ocd-person/530a13be-91ef-448e-b874-ae4df7e776e4
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_ssandridge.jpg?itok=7SzglrD3
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_sandbridge.jpg
 links:
 - url: http://leg.colorado.gov/legislators/shane-sandridge
 name: Shane Sandridge

--- a/data/co/people/Shannon-Bird-308dfb14-bd0d-4e11-b86b-384960e3152c.yml
+++ b/data/co/people/Shannon-Bird-308dfb14-bd0d-4e11-b86b-384960e3152c.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/shannon-bird
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_bird-shannon.jpg?itok=7G6-P06u
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_bird%2C%20shannon.jpg

--- a/data/co/people/Sonya-Jaquez-Lewis-7641b446-38a9-4444-bbf1-536662a85e14.yml
+++ b/data/co/people/Sonya-Jaquez-Lewis-7641b446-38a9-4444-bbf1-536662a85e14.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/sonya-jaquez-lewis
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_jaquez-lewis-sonya.jpg?itok=BtVIkvXw
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_jaquez%20lewis%2C%20sonya.jpg

--- a/data/co/people/Stephen-Fenberg-cda35383-f5af-40b7-ab1f-41798fe6444e.yml
+++ b/data/co/people/Stephen-Fenberg-cda35383-f5af-40b7-ab1f-41798fe6444e.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Fenberg
 given_name: Stephen
 id: ocd-person/cda35383-f5af-40b7-ab1f-41798fe6444e
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_fenberg-co-17.jpg?itok=XlpRxR2c
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_fenberg%2C%20steve.jpg
 links:
 - url: http://leg.colorado.gov/legislators/stephen-fenberg
 name: Stephen Fenberg

--- a/data/co/people/Stephen-Humphrey-48bbfb96-0ba9-40d8-a589-6086f51e7792.yml
+++ b/data/co/people/Stephen-Humphrey-48bbfb96-0ba9-40d8-a589-6086f51e7792.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Humphrey
 given_name: Stephen
 id: ocd-person/48bbfb96-0ba9-40d8-a589-6086f51e7792
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_humphrey-co-17.jpg?itok=872aaKBL
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_humphrey%2C%20stephen.jpg
 links:
 - url: http://leg.colorado.gov/legislators/stephen-humphrey
 name: Stephen Humphrey

--- a/data/co/people/Susan-Beckman-8a101153-85fa-41f3-a839-a21e31998dce.yml
+++ b/data/co/people/Susan-Beckman-8a101153-85fa-41f3-a839-a21e31998dce.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Beckman
 given_name: Susan
 id: ocd-person/8a101153-85fa-41f3-a839-a21e31998dce
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_beckman-co-17.jpg?itok=9y9xu9oj
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_beckman%2C%20susan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/susan-beckman
 name: Susan Beckman

--- a/data/co/people/Susan-Lontine-9133797a-3bc2-4537-be65-435396e302ef.yml
+++ b/data/co/people/Susan-Lontine-9133797a-3bc2-4537-be65-435396e302ef.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Lontine
 given_name: Susan
 id: ocd-person/9133797a-3bc2-4537-be65-435396e302ef
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_lontine-co-17.jpg?itok=qFM8KpIH
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_lontine%2C%20susan.jpg
 links:
 - url: http://leg.colorado.gov/legislators/susan-lontine
 name: Susan Lontine

--- a/data/co/people/Tammy-Story-489b3afa-1e08-40f4-918a-f01c186b6f73.yml
+++ b/data/co/people/Tammy-Story-489b3afa-1e08-40f4-918a-f01c186b6f73.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/tammy-story
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_story-tammy.jpg?itok=fMomkSY8
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_story%2C%20tammy.jpg

--- a/data/co/people/Terri-Carver-7a1e7a37-b136-44e5-b7bc-06c7c1dda059.yml
+++ b/data/co/people/Terri-Carver-7a1e7a37-b136-44e5-b7bc-06c7c1dda059.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Carver
 given_name: Terri
 id: ocd-person/7a1e7a37-b136-44e5-b7bc-06c7c1dda059
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_h_carver.jpg?itok=tiMuZ4xd
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_h_carver.jpg
 links:
 - url: http://leg.colorado.gov/legislators/terri-carver
 name: Terri Carver

--- a/data/co/people/Tim-Geitner-01e212e2-800b-4835-aa39-f2ad26f9aa88.yml
+++ b/data/co/people/Tim-Geitner-01e212e2-800b-4835-aa39-f2ad26f9aa88.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/tim-geitner
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_geitner-tim.jpg?itok=5Y98lOgJ
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_geitner%2C%20tim.jpg

--- a/data/co/people/Tom-Sullivan-7a09a2fa-0249-4751-8dd1-caa100395438.yml
+++ b/data/co/people/Tom-Sullivan-7a09a2fa-0249-4751-8dd1-caa100395438.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/tom-sullivan
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_sullivan-tom.jpg?itok=3A07JUpR
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_sullivan%2C%20tom.jpg

--- a/data/co/people/Tony-Exum-a7c5f656-26d8-4ad1-bef4-24bb2d667964.yml
+++ b/data/co/people/Tony-Exum-a7c5f656-26d8-4ad1-bef4-24bb2d667964.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Exum
 given_name: Tony
 id: ocd-person/a7c5f656-26d8-4ad1-bef4-24bb2d667964
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_exum-co-17.jpg?itok=onY8_jiO
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_exum%2C%20tony.jpg
 links:
 - url: http://leg.colorado.gov/legislators/tony-exum-sr
 name: Tony Exum

--- a/data/co/people/Tracy-Kraft-Tharp-5814c9b6-03ec-48f2-967f-364414113fda.yml
+++ b/data/co/people/Tracy-Kraft-Tharp-5814c9b6-03ec-48f2-967f-364414113fda.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Kraft-Tharp
 given_name: Tracy
 id: ocd-person/5814c9b6-03ec-48f2-967f-364414113fda
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_kraft-tharp-c-17.jpg?itok=9yIqRTQt
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_kraft-tharp%2C%20tracy.jpg
 links:
 - url: http://leg.colorado.gov/legislators/tracy-kraft-tharp
 name: Tracy Kraft-Tharp

--- a/data/co/people/Vicki-Marble-039a3a92-b143-46ba-9cbd-7a77a55b48c7.yml
+++ b/data/co/people/Vicki-Marble-039a3a92-b143-46ba-9cbd-7a77a55b48c7.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Marble
 given_name: Vicki
 id: ocd-person/039a3a92-b143-46ba-9cbd-7a77a55b48c7
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_s-marble%2C%20vicki.jpg?itok=NPxGWEkQ
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_marble%2C%20vicki.jpg
 links:
 - url: http://leg.colorado.gov/legislators/vicki-marble
 name: Vicki Marble

--- a/data/co/people/Yadira-Caraveo-6621e7c8-485c-467a-98a9-4f2ba1cebcb2.yml
+++ b/data/co/people/Yadira-Caraveo-6621e7c8-485c-467a-98a9-4f2ba1cebcb2.yml
@@ -16,4 +16,4 @@ links:
 sources:
 - url: http://leg.colorado.gov/legislators/yadira-caraveo
 - url: http://leg.colorado.gov/legislators
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_caraveo-yadira.jpg?itok=L_5aW8N4
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_caraveo%2C%20yadira.jpg

--- a/data/co/retired/Kimmi-Lewis-bc7be948-aece-46e3-a6d7-a1009edfa473.yml
+++ b/data/co/retired/Kimmi-Lewis-bc7be948-aece-46e3-a6d7-a1009edfa473.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Lewis
 given_name: Kimmi
 id: ocd-person/bc7be948-aece-46e3-a6d7-a1009edfa473
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_lewis-co-17.jpg?itok=8-e4m5Bj
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_lewis-co-17.jpg
 links:
 - url: http://leg.colorado.gov/legislators/kimmi-lewis
 name: Kimmi Lewis
@@ -19,6 +19,8 @@ roles:
 - district: '64'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: lower
+  end_date: '2019-12-06'
+  end_reason: Deceased
 sources:
 - url: http://leg.colorado.gov/legislators/kimmi-lewis
 - url: http://leg.colorado.gov/legislators

--- a/data/co/retired/Lois-Court-ed70bb55-696f-42ed-a8e4-ffbef69a4f1c.yml
+++ b/data/co/retired/Lois-Court-ed70bb55-696f-42ed-a8e4-ffbef69a4f1c.yml
@@ -6,7 +6,7 @@ contact_details:
 family_name: Court
 given_name: Lois
 id: ocd-person/ed70bb55-696f-42ed-a8e4-ffbef69a4f1c
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2019a_rsz_court-co-17.jpg?itok=AMnu1UYs
+image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2020a_court%2C%20lois.jpg
 links:
 - url: http://leg.colorado.gov/legislators/lois-court
 name: Lois Court
@@ -19,6 +19,7 @@ roles:
 - district: '31'
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   type: upper
+  end_date: '2020-01-16'
 sources:
 - url: http://leg.colorado.gov/legislators/lois-court
 - url: http://leg.colorado.gov/legislators

--- a/settings.yml
+++ b/settings.yml
@@ -1,3 +1,8 @@
+co:
+  vacancies:
+    - chamber: lower
+      district: 6
+      vacant_until: 2020-03-01
 ct:
   vacancies:
     - chamber: lower


### PR DESCRIPTION
One death, one resignation, two appointments, and one remaining vacancy from one of the appointments.  Also update the image links from a new scrape.