### PR TITLE
Add old IDs to other_identifiers for duplicate legislators

### DIFF
--- a/data/ak/people/Shelley-Hughes-f0e5bb6f-c8d1-43c1-a671-9c15d23781a1.yml
+++ b/data/ak/people/Shelley-Hughes-f0e5bb6f-c8d1-43c1-a671-9c15d23781a1.yml
@@ -42,5 +42,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AKL000159
   scheme: legacy_openstates
+- identifier: ocd-person/f4a6ea26-a05a-4d1e-b92d-9a8bf1fdb20c
+  scheme: openstates
 given_name: Shelley
 family_name: Hughes

--- a/data/ar/people/David-Whitaker-7c229d62-dd8f-491c-8aab-15118335cfe9.yml
+++ b/data/ar/people/David-Whitaker-7c229d62-dd8f-491c-8aab-15118335cfe9.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000249
   scheme: legacy_openstates
+- identifier: ocd-person/0eb93465-4725-4dbb-9a4f-4bc188853328
+  scheme: openstates
 given_name: David
 family_name: Whitaker

--- a/data/ar/people/Fred-Allen-b325559c-79b9-4ce3-a548-4c0c4116815e.yml
+++ b/data/ar/people/Fred-Allen-b325559c-79b9-4ce3-a548-4c0c4116815e.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000001
   scheme: legacy_openstates
+- identifier: ocd-person/791db008-194a-45c1-b9ff-5cdef426b120
+  scheme: openstates
 given_name: Fred
 family_name: Allen

--- a/data/ar/people/James-Sturch-7d505c4d-e5b4-4998-8b48-c7499b3a714b.yml
+++ b/data/ar/people/James-Sturch-7d505c4d-e5b4-4998-8b48-c7499b3a714b.yml
@@ -27,3 +27,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000315
   scheme: legacy_openstates
+- identifier: ocd-person/d12deb94-297b-4e41-a9d1-616c81381711
+  scheme: openstates

--- a/data/ar/people/Julie-Mayberry-1621cc3a-d18c-486f-96fb-57c6a2890da1.yml
+++ b/data/ar/people/Julie-Mayberry-1621cc3a-d18c-486f-96fb-57c6a2890da1.yml
@@ -24,3 +24,5 @@ extras:
 other_identifiers:
 - identifier: ARL000350
   scheme: legacy_openstates
+- identifier: ocd-person/82f2e54f-83c4-4ce1-929f-780a6468cef5
+  scheme: openstates

--- a/data/ar/people/Mark-Perry-4b44cfe9-fb9b-4c18-ba6e-34cf679ac3ef.yml
+++ b/data/ar/people/Mark-Perry-4b44cfe9-fb9b-4c18-ba6e-34cf679ac3ef.yml
@@ -29,3 +29,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000229
   scheme: legacy_openstates
+- identifier: ocd-person/da77f1c8-27e9-48df-b5fc-1018381b9f52
+  scheme: openstates

--- a/data/ar/people/Mathew-Pitsch-8f6ce7a3-849a-44bd-a825-d595f68b8675.yml
+++ b/data/ar/people/Mathew-Pitsch-8f6ce7a3-849a-44bd-a825-d595f68b8675.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000333
   scheme: legacy_openstates
+- identifier: ocd-person/6a8350de-2c25-47f6-a476-8cf5d1da4578
+  scheme: openstates

--- a/data/ar/people/Richard-Womack-f2b10588-1d21-4f8f-b313-d668bf58d967.yml
+++ b/data/ar/people/Richard-Womack-f2b10588-1d21-4f8f-b313-d668bf58d967.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ARL000252
   scheme: legacy_openstates
+- identifier: ocd-person/d3d54087-6425-406b-b5a1-7202eaf41856
+  scheme: openstates
 given_name: Richard
 family_name: Womack

--- a/data/az/people/David-Gowan-96ec9994-949d-47bd-8b20-79dec573323f.yml
+++ b/data/az/people/David-Gowan-96ec9994-949d-47bd-8b20-79dec573323f.yml
@@ -36,3 +36,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000259
   scheme: legacy_openstates
+- identifier: ocd-person/ca382858-d04d-4fc9-9861-00be4bda1363
+  scheme: openstates

--- a/data/az/people/Frank-Pratt-bf2e75c1-220e-4b88-9cbc-f4a4e9ddf46b.yml
+++ b/data/az/people/Frank-Pratt-bf2e75c1-220e-4b88-9cbc-f4a4e9ddf46b.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000283
   scheme: legacy_openstates
+- identifier: ocd-person/d5dc1d75-7cbe-4460-96a1-8fb501d84b80
+  scheme: openstates
 given_name: Frank
 family_name: Pratt

--- a/data/az/people/Jamescita-Peshlakai-de5058e3-6fff-45fc-b426-2ef2b3e68de0.yml
+++ b/data/az/people/Jamescita-Peshlakai-de5058e3-6fff-45fc-b426-2ef2b3e68de0.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000280
   scheme: legacy_openstates
+- identifier: ocd-person/8fb8a9b0-b361-455d-9d19-309cb721d622
+  scheme: openstates
 given_name: Jamescita
 family_name: Peshlakai

--- a/data/az/people/John-Fillmore-bb0869c0-43d2-4a04-8199-143e80f9e6b2.yml
+++ b/data/az/people/John-Fillmore-bb0869c0-43d2-4a04-8199-143e80f9e6b2.yml
@@ -26,3 +26,5 @@ image: https://www.azleg.gov/alisImages/MemberPhotos/54leg/House/FILLMORE.jpg
 other_identifiers:
 - identifier: AZL000145
   scheme: legacy_openstates
+- identifier: ocd-person/32e86127-f56d-4e24-aefb-1a41187f231f
+  scheme: openstates

--- a/data/az/people/John-M-Allen-37ea1ccb-7cba-40ef-ae0b-4840f2f5a3ed.yml
+++ b/data/az/people/John-M-Allen-37ea1ccb-7cba-40ef-ae0b-4840f2f5a3ed.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: openstates
 - identifier: AZL000239
   scheme: legacy_openstates
+- identifier: ocd-person/ac82ba6e-b5a3-45db-96cd-46ad068b8cbd
+  scheme: openstates
 given_name: John
 family_name: Allen

--- a/data/az/people/Juan-Mendez-535e197f-a602-4194-83cc-f820756caa17.yml
+++ b/data/az/people/Juan-Mendez-535e197f-a602-4194-83cc-f820756caa17.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000271
   scheme: legacy_openstates
+- identifier: ocd-person/7a2babc7-6e73-4791-bd99-c7fbb9796ccf
+  scheme: openstates
 given_name: Juan
 family_name: Mendez

--- a/data/az/people/Karen-Fann-ec5d3f80-13c8-4a87-bd47-a11967064b43.yml
+++ b/data/az/people/Karen-Fann-ec5d3f80-13c8-4a87-bd47-a11967064b43.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000142
   scheme: legacy_openstates
+- identifier: ocd-person/acbdf612-28e4-4664-9ddd-12e2ef4cb5de
+  scheme: openstates
 given_name: Karen
 family_name: Fann

--- a/data/az/people/Kate-Brophy-McGee-9ffacde4-ee93-4db4-8951-9d53e0a1306a.yml
+++ b/data/az/people/Kate-Brophy-McGee-9ffacde4-ee93-4db4-8951-9d53e0a1306a.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000244
   scheme: legacy_openstates
+- identifier: ocd-person/74f5591e-80fe-4367-84e1-d496fd1186c9
+  scheme: openstates
 given_name: Kate
 family_name: Brophy McGee

--- a/data/az/people/Lisa-Otondo-d4935313-9d39-4853-a36f-d80c0fceab87.yml
+++ b/data/az/people/Lisa-Otondo-d4935313-9d39-4853-a36f-d80c0fceab87.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000279
   scheme: legacy_openstates
+- identifier: ocd-person/8c3dcc9f-4d8d-4c17-af6b-b539683e5521
+  scheme: openstates
 given_name: Lisa
 family_name: Otondo

--- a/data/az/people/Rick-Gray-8f07f729-f3a4-4608-894c-5a87bbfb8012.yml
+++ b/data/az/people/Rick-Gray-8f07f729-f3a4-4608-894c-5a87bbfb8012.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000260
   scheme: legacy_openstates
+- identifier: ocd-person/f1cea00a-8f62-4445-b04b-3c84ed708902
+  scheme: openstates
 given_name: Rick
 family_name: Gray

--- a/data/az/people/Russell-Bowers-b9343c4d-9f9b-4bbd-ba02-06fbb1b09a22.yml
+++ b/data/az/people/Russell-Bowers-b9343c4d-9f9b-4bbd-ba02-06fbb1b09a22.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: openstates
 - identifier: AZL000307
   scheme: legacy_openstates
+- identifier: ocd-person/48364ca0-5d35-4e90-8e8c-e3e63562fa01
+  scheme: openstates
 given_name: Russell
 family_name: Bowers

--- a/data/az/people/Sonny-Borrelli-b861ef92-d8da-4510-98ec-c40f36d06acd.yml
+++ b/data/az/people/Sonny-Borrelli-b861ef92-d8da-4510-98ec-c40f36d06acd.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000242
   scheme: legacy_openstates
+- identifier: ocd-person/0e0a1287-51d8-4148-9f56-2501eb7fdd5c
+  scheme: openstates
 given_name: Sonny
 family_name: Borrelli

--- a/data/az/people/Steve-Pierce-92295bb9-e926-45a1-9bb3-519d384da186.yml
+++ b/data/az/people/Steve-Pierce-92295bb9-e926-45a1-9bb3-519d384da186.yml
@@ -30,3 +30,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000030
   scheme: legacy_openstates
+- identifier: ocd-person/1c75a9ff-42ad-4cb4-b60d-7920b6b38c97
+  scheme: openstates

--- a/data/az/people/Victoria-Steele-85bad9c8-db84-4385-96d4-61f16729c56a.yml
+++ b/data/az/people/Victoria-Steele-85bad9c8-db84-4385-96d4-61f16729c56a.yml
@@ -25,3 +25,5 @@ image: https://www.azleg.gov/alisImages/MemberPhotos/54leg/Senate/STEELE.gif
 other_identifiers:
 - identifier: AZL000291
   scheme: legacy_openstates
+- identifier: ocd-person/2ba9d6ac-af0e-41d7-aa8f-66e28312c3ba
+  scheme: openstates

--- a/data/az/people/Warren-Petersen-1bbf0d07-d4d6-4654-b330-8d7f6542e258.yml
+++ b/data/az/people/Warren-Petersen-1bbf0d07-d4d6-4654-b330-8d7f6542e258.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: AZL000281
   scheme: legacy_openstates
+- identifier: ocd-person/5fc1f722-4689-47b1-873a-16a26d234e3c
+  scheme: openstates
 given_name: Warren
 family_name: Petersen

--- a/data/ca/people/Al-Muratsuchi-78610d0e-c790-4fc9-ab8e-0887adbbe063.yml
+++ b/data/ca/people/Al-Muratsuchi-78610d0e-c790-4fc9-ab8e-0887adbbe063.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000392
   scheme: legacy_openstates
+- identifier: ocd-person/267964ec-a417-4abc-812d-25e6713acd6b
+  scheme: openstates
 given_name: Al
 family_name: Muratsuchi
 gender: Male

--- a/data/ca/people/Bill-Dodd-7ecd4221-a627-42dc-9029-bbc543ef3735.yml
+++ b/data/ca/people/Bill-Dodd-7ecd4221-a627-42dc-9029-bbc543ef3735.yml
@@ -28,6 +28,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000453
   scheme: legacy_openstates
+- identifier: ocd-person/5f62600a-6817-491e-9306-bc244fe4cf17
+  scheme: openstates
 given_name: Bill
 family_name: Dodd
 gender: Male

--- a/data/ca/people/Ling-Ling-Chang-8f7c9114-beb1-45ae-8b09-1a5d916be7e5.yml
+++ b/data/ca/people/Ling-Ling-Chang-8f7c9114-beb1-45ae-8b09-1a5d916be7e5.yml
@@ -28,6 +28,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000489
   scheme: legacy_openstates
+- identifier: ocd-person/2a5db101-474e-4991-8e38-72f53a215094
+  scheme: openstates
 given_name: Ling Ling
 family_name: Chang
 gender: Female

--- a/data/ca/people/Lorena-Gonzalez-dfe28cb5-1e06-418d-b4dd-8328f43c2783.yml
+++ b/data/ca/people/Lorena-Gonzalez-dfe28cb5-1e06-418d-b4dd-8328f43c2783.yml
@@ -25,3 +25,5 @@ gender: Female
 other_identifiers:
 - identifier: CAL000425
   scheme: legacy_openstates
+- identifier: ocd-person/2fe17faa-293f-42db-b726-c44387f942e3
+  scheme: openstates

--- a/data/ca/people/Nancy-Skinner-da008178-5da9-4adb-a690-1360a9bce2db.yml
+++ b/data/ca/people/Nancy-Skinner-da008178-5da9-4adb-a690-1360a9bce2db.yml
@@ -37,6 +37,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000405
   scheme: legacy_openstates
+- identifier: ocd-person/7f9a2356-3291-4aa2-a996-2c3b62ab2a11
+  scheme: openstates
 given_name: Nancy
 family_name: Skinner
 gender: Female

--- a/data/ca/people/Scott-Wilk-f82658a8-e4e5-4f12-807b-b1eec79782d1.yml
+++ b/data/ca/people/Scott-Wilk-f82658a8-e4e5-4f12-807b-b1eec79782d1.yml
@@ -28,6 +28,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000413
   scheme: legacy_openstates
+- identifier: ocd-person/a3260637-0996-40bf-8ac4-71ea0b1de895
+  scheme: openstates
 given_name: Scott
 family_name: Wilk
 gender: Male

--- a/data/ca/people/Shannon-Grove-b4b8e8fb-831b-4cae-9081-b8f75477fcd0.yml
+++ b/data/ca/people/Shannon-Grove-b4b8e8fb-831b-4cae-9081-b8f75477fcd0.yml
@@ -39,3 +39,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000372
   scheme: legacy_openstates
+- identifier: ocd-person/073f7648-8887-4469-bbb5-dea5f7f1f87b
+  scheme: openstates

--- a/data/ca/people/Sharon-Quirk-Silva-840aa009-3ae4-4484-b9f0-5c5f5060e7db.yml
+++ b/data/ca/people/Sharon-Quirk-Silva-840aa009-3ae4-4484-b9f0-5c5f5060e7db.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000402
   scheme: legacy_openstates
+- identifier: ocd-person/586dd96f-9fe1-4d69-a048-d409f08f5eca
+  scheme: openstates
 given_name: Sharon
 family_name: Quirk-Silva
 gender: Female

--- a/data/ca/people/Steven-Bradford-99fd8cce-55ba-493a-b787-e339a57de7df.yml
+++ b/data/ca/people/Steven-Bradford-99fd8cce-55ba-493a-b787-e339a57de7df.yml
@@ -37,6 +37,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CAL000347
   scheme: legacy_openstates
+- identifier: ocd-person/186990bd-0061-4494-a16c-0c19fc5f9e92
+  scheme: openstates
 given_name: Steven
 family_name: Bradford
 gender: Male

--- a/data/co/people/Bob-Gardner-167975f6-bf0d-49ea-885c-baea0fc0e4cd.yml
+++ b/data/co/people/Bob-Gardner-167975f6-bf0d-49ea-885c-baea0fc0e4cd.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000153
   scheme: legacy_openstates
+- identifier: ocd-person/2a931a88-d3a0-40c8-8d2a-165af4db0838
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/co/people/Dominick-Moreno-698cdd09-6b39-4e6b-bdc7-5f8529a74c6e.yml
+++ b/data/co/people/Dominick-Moreno-698cdd09-6b39-4e6b-bdc7-5f8529a74c6e.yml
@@ -15,6 +15,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000120
   scheme: legacy_openstates
+- identifier: ocd-person/9d62c91a-3ec3-463d-90cf-b6d3cc892483
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/co/people/Don-Coram-9ee37d1e-f113-4f77-b24f-b21fd66d3a16.yml
+++ b/data/co/people/Don-Coram-9ee37d1e-f113-4f77-b24f-b21fd66d3a16.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000213
   scheme: legacy_openstates
+- identifier: ocd-person/4afaea1e-341f-40fe-ab36-e9c9ecfbf54d
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
+++ b/data/co/people/Jessie-Danielson-c06af980-c553-4f79-a39d-295b7226f029.yml
@@ -27,3 +27,5 @@ family_name: Danielson
 other_identifiers:
 - identifier: COL000183
   scheme: legacy_openstates
+- identifier: ocd-person/ed95a811-9d25-4769-90a0-4a48d1240f83
+  scheme: openstates

--- a/data/co/people/Kevin-Priola-a68ea419-4fcb-4f7f-9797-77dd2b57ebca.yml
+++ b/data/co/people/Kevin-Priola-a68ea419-4fcb-4f7f-9797-77dd2b57ebca.yml
@@ -17,6 +17,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000142
   scheme: legacy_openstates
+- identifier: ocd-person/207c92e4-bdfc-4f7c-9519-a620c9ee255d
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
+++ b/data/co/people/Mike-Foote-faac1f1b-7c09-4ea2-905c-fd90f7fd0d2f.yml
@@ -27,3 +27,5 @@ family_name: Foote
 other_identifiers:
 - identifier: COL000136
   scheme: legacy_openstates
+- identifier: ocd-person/066d6ffd-0ebe-4bc3-ab92-2bdd3be19ae6
+  scheme: openstates

--- a/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
+++ b/data/co/people/Paul-Lundeen-a58d77ac-807b-456e-8584-e4e08e98bf61.yml
@@ -27,3 +27,5 @@ family_name: Lundeen
 other_identifiers:
 - identifier: COL000189
   scheme: legacy_openstates
+- identifier: ocd-person/8ed985fe-2105-4a32-87a1-3a93428813a2
+  scheme: openstates

--- a/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
+++ b/data/co/people/Pete-Lee-0ef5d45b-ae38-4dd8-b04a-c4bc653eaa0c.yml
@@ -37,3 +37,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000208
   scheme: legacy_openstates
+- identifier: ocd-person/c2de8d3b-05cd-4d76-988e-17829385b54b
+  scheme: openstates

--- a/data/co/people/Rachel-Zenzinger-f7486270-9e45-4213-9520-aa7150e34baa.yml
+++ b/data/co/people/Rachel-Zenzinger-f7486270-9e45-4213-9520-aa7150e34baa.yml
@@ -15,6 +15,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000162
   scheme: legacy_openstates
+- identifier: ocd-person/8d2f4d64-bd17-45e1-aa9d-805cd9d6e7b2
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/co/people/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
+++ b/data/co/people/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
@@ -15,6 +15,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: COL000059
   scheme: legacy_openstates
+- identifier: ocd-person/7fbdb8b1-b884-483b-8ca2-daeffdaeb4fa
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/ct/people/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
+++ b/data/ct/people/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
@@ -22,3 +22,5 @@ sources:
 other_identifiers:
 - identifier: CTL000048
   scheme: legacy_openstates
+- identifier: ocd-person/d36d807e-c27c-4085-97a8-9a98898d84d6
+  scheme: openstates

--- a/data/de/people/Harris-B-McDowell-d1682e6d-cb10-4bdd-81d3-aa010625f00b.yml
+++ b/data/de/people/Harris-B-McDowell-d1682e6d-cb10-4bdd-81d3-aa010625f00b.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: DEL000077
   scheme: legacy_openstates
+- identifier: ocd-person/512eed7d-5465-4853-8d00-b33f5f391683
+  scheme: openstates
 given_name: Harris B.
 family_name: McDowell

--- a/data/de/people/John-A-Kowalko-bba26dc6-26e1-442d-bb1e-57ea0bfdfa81.yml
+++ b/data/de/people/John-A-Kowalko-bba26dc6-26e1-442d-bb1e-57ea0bfdfa81.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: DEL000103
   scheme: legacy_openstates
+- identifier: ocd-person/70053c17-10a6-4458-9eb7-9e67664b148e
+  scheme: openstates
 given_name: John A.
 family_name: Kowalko

--- a/data/de/people/John-L-Mitchell-f72c6ca6-919d-4bc5-afec-b7fc04566628.yml
+++ b/data/de/people/John-L-Mitchell-f72c6ca6-919d-4bc5-afec-b7fc04566628.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: DEL000106
   scheme: legacy_openstates
+- identifier: ocd-person/e8605bce-630f-491c-b9d2-68a7ec0a8e2e
+  scheme: openstates
 given_name: John L.
 family_name: Mitchell

--- a/data/fl/people/Anitere-Flores-4a692ad6-7804-4693-a22f-5ea43a1283cb.yml
+++ b/data/fl/people/Anitere-Flores-4a692ad6-7804-4693-a22f-5ea43a1283cb.yml
@@ -44,5 +44,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000179
   scheme: legacy_openstates
+- identifier: ocd-person/27aa7b48-c4cf-42ea-9f0b-c374d51732d4
+  scheme: openstates
 given_name: Anitere
 family_name: Flores

--- a/data/fl/people/Audrey-Gibson-96e8b5c1-6c40-4072-a9d0-f6b979bf013b.yml
+++ b/data/fl/people/Audrey-Gibson-96e8b5c1-6c40-4072-a9d0-f6b979bf013b.yml
@@ -46,5 +46,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000184
   scheme: legacy_openstates
+- identifier: ocd-person/4264c126-6b6b-446a-8357-dc778c0cf9aa
+  scheme: openstates
 given_name: Audrey
 family_name: Gibson

--- a/data/fl/people/Bill-Galvano-217d761e-60a9-4b05-8693-9c388d764394.yml
+++ b/data/fl/people/Bill-Galvano-217d761e-60a9-4b05-8693-9c388d764394.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000181
   scheme: legacy_openstates
+- identifier: ocd-person/59d386dd-86ae-40ae-a03d-54c679f27eaf
+  scheme: openstates
 given_name: Bill
 family_name: Galvano

--- a/data/fl/people/Bobby-Powell-efe6dfff-38e5-4a7f-822e-8cb4cfba7e71.yml
+++ b/data/fl/people/Bobby-Powell-efe6dfff-38e5-4a7f-822e-8cb4cfba7e71.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000280
   scheme: legacy_openstates
+- identifier: ocd-person/0ce95301-fbb1-4d80-9852-bba69fec4158
+  scheme: openstates
 given_name: Bobby
 family_name: Powell

--- a/data/fl/people/Darryl-Ervin-Rouson-3de11937-c291-4561-bee5-4f747665cb37.yml
+++ b/data/fl/people/Darryl-Ervin-Rouson-3de11937-c291-4561-bee5-4f747665cb37.yml
@@ -45,5 +45,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000298
   scheme: legacy_openstates
+- identifier: ocd-person/194b7995-a6cb-4eb8-912e-06e39276c8f2
+  scheme: openstates
 given_name: Darryl Ervin
 family_name: Rouson

--- a/data/fl/people/David-Simmons-5fddb6ac-e35a-493e-b548-6f2f52b5a5c9.yml
+++ b/data/fl/people/David-Simmons-5fddb6ac-e35a-493e-b548-6f2f52b5a5c9.yml
@@ -46,5 +46,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000198
   scheme: legacy_openstates
+- identifier: ocd-person/ecbf75d2-3d67-4ab2-93f8-a2ba7c78be59
+  scheme: openstates
 given_name: David
 family_name: Simmons

--- a/data/fl/people/Debbie-Mayfield-a41e2c13-be68-4af3-8229-3c657b8d980d.yml
+++ b/data/fl/people/Debbie-Mayfield-a41e2c13-be68-4af3-8229-3c657b8d980d.yml
@@ -45,5 +45,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000261
   scheme: legacy_openstates
+- identifier: ocd-person/fd8295e4-127d-4802-b84f-574e4046348c
+  scheme: openstates
 given_name: Debbie
 family_name: Mayfield

--- a/data/fl/people/Doug-Broxson-684ec9bf-65e9-4e43-850d-01ea9569d224.yml
+++ b/data/fl/people/Doug-Broxson-684ec9bf-65e9-4e43-850d-01ea9569d224.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000402
   scheme: legacy_openstates
+- identifier: ocd-person/97934a61-a014-479b-8a70-5fd95e37068f
+  scheme: openstates
 given_name: Doug
 family_name: Broxson

--- a/data/fl/people/Ed-Hooper-0e375630-02a4-4e59-ac80-869f9a199b2a.yml
+++ b/data/fl/people/Ed-Hooper-0e375630-02a4-4e59-ac80-869f9a199b2a.yml
@@ -42,3 +42,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000251
   scheme: legacy_openstates
+- identifier: ocd-person/570f727a-634c-465a-8347-ab1477e8f634
+  scheme: openstates

--- a/data/fl/people/Jr-Thurston-Perry-E-0b527203-a2ca-4ad9-aa44-d63e02c0b336.yml
+++ b/data/fl/people/Jr-Thurston-Perry-E-0b527203-a2ca-4ad9-aa44-d63e02c0b336.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000478
   scheme: legacy_openstates
+- identifier: ocd-person/c6a6e309-1ed0-4943-91f4-2e65611f8706
+  scheme: openstates
 given_name: Perry
 family_name: Thurston

--- a/data/fl/people/Jr-Torres-Victor-M-a2009599-2f38-4f53-adac-466e2fa172ab.yml
+++ b/data/fl/people/Jr-Torres-Victor-M-a2009599-2f38-4f53-adac-466e2fa172ab.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000488
   scheme: legacy_openstates
+- identifier: ocd-person/6c9c73eb-9281-4fa3-bf08-f7541c6ecc6e
+  scheme: openstates
 given_name: Victor
 family_name: Torres

--- a/data/fl/people/Kelli-Stargel-ad685327-7771-4e24-9b68-40f6a71182b9.yml
+++ b/data/fl/people/Kelli-Stargel-ad685327-7771-4e24-9b68-40f6a71182b9.yml
@@ -44,5 +44,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000203
   scheme: legacy_openstates
+- identifier: ocd-person/2341e91d-8ecb-4431-9051-2d91f78583a1
+  scheme: openstates
 given_name: Kelli
 family_name: Stargel

--- a/data/fl/people/Linda-Stewart-ece5c5bd-6ac1-4800-bd2b-1f1ab4a707e7.yml
+++ b/data/fl/people/Linda-Stewart-ece5c5bd-6ac1-4800-bd2b-1f1ab4a707e7.yml
@@ -39,5 +39,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000309
   scheme: legacy_openstates
+- identifier: ocd-person/32f47647-4a5e-4e20-bbff-1a9defc1455c
+  scheme: openstates
 given_name: Linda
 family_name: Stewart

--- a/data/fl/people/Lizbeth-Benacquisto-f2a0cd99-cf2e-482a-bcd2-ad1c04e05f01.yml
+++ b/data/fl/people/Lizbeth-Benacquisto-f2a0cd99-cf2e-482a-bcd2-ad1c04e05f01.yml
@@ -44,5 +44,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000169
   scheme: legacy_openstates
+- identifier: ocd-person/f151dd07-ecb3-4db5-95cb-5447770baed9
+  scheme: openstates
 given_name: Lizbeth
 family_name: Benacquisto

--- a/data/fl/people/Lori-Berman-762d321c-5bbe-4513-b9f0-7e3d8a6972f5.yml
+++ b/data/fl/people/Lori-Berman-762d321c-5bbe-4513-b9f0-7e3d8a6972f5.yml
@@ -46,5 +46,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000212
   scheme: legacy_openstates
+- identifier: ocd-person/066b4d01-1fd4-41a9-88f9-e35ef39291f4
+  scheme: openstates
 given_name: Lori
 family_name: Berman

--- a/data/fl/people/Oscar-II-Braynon-51899e87-f8e9-4dde-871f-c7ee849a2374.yml
+++ b/data/fl/people/Oscar-II-Braynon-51899e87-f8e9-4dde-871f-c7ee849a2374.yml
@@ -54,6 +54,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000410
   scheme: legacy_openstates
+- identifier: ocd-person/4d17136f-4018-4c92-bf7a-ac9679ca8e80
+  scheme: openstates
 given_name: Oscar
 family_name: Braynon
 other_names:

--- a/data/fl/people/Randolph-Bracy-f876d4a8-eb53-43de-886c-07a10a63b9d6.yml
+++ b/data/fl/people/Randolph-Bracy-f876d4a8-eb53-43de-886c-07a10a63b9d6.yml
@@ -39,5 +39,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000216
   scheme: legacy_openstates
+- identifier: ocd-person/74b24fb9-0497-42f1-aa07-de7e33782679
+  scheme: openstates
 given_name: Randolph
 family_name: Bracy

--- a/data/fl/people/Rene-Coach-P-Plasencia-32888a93-b636-4c26-963b-2467072826e4.yml
+++ b/data/fl/people/Rene-Coach-P-Plasencia-32888a93-b636-4c26-963b-2467072826e4.yml
@@ -40,5 +40,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000385
   scheme: legacy_openstates
+- identifier: ocd-person/6a2b32d1-e3a9-4602-9f1c-a44bb3b5d515
+  scheme: openstates
 given_name: Rene
 family_name: Plasencia

--- a/data/fl/people/Rob-Bradley-81bb2e7a-bb3a-4b57-98b5-ce52787fb3c6.yml
+++ b/data/fl/people/Rob-Bradley-81bb2e7a-bb3a-4b57-98b5-ce52787fb3c6.yml
@@ -39,5 +39,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000170
   scheme: legacy_openstates
+- identifier: ocd-person/ae94d8ae-5a34-4870-a858-fdeea045ed35
+  scheme: openstates
 given_name: Rob
 family_name: Bradley

--- a/data/fl/people/Thad-Altman-8ae6fdaf-d47d-46a8-b69c-118459f23ecd.yml
+++ b/data/fl/people/Thad-Altman-8ae6fdaf-d47d-46a8-b69c-118459f23ecd.yml
@@ -45,5 +45,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000167
   scheme: legacy_openstates
+- identifier: ocd-person/b4d74443-d0dd-4b20-ab8c-e2055a336d98
+  scheme: openstates
 given_name: Thad
 family_name: Altman

--- a/data/fl/people/Tom-Lee-cd62a6b2-dcac-4b5a-8378-a5d366aa19ed.yml
+++ b/data/fl/people/Tom-Lee-cd62a6b2-dcac-4b5a-8378-a5d366aa19ed.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000190
   scheme: legacy_openstates
+- identifier: ocd-person/4ec6a4f5-1571-4136-bcdf-9b05a957528c
+  scheme: openstates
 given_name: Tom
 family_name: Lee

--- a/data/fl/people/Travis-Hutson-ab530396-3077-4806-acfe-5203a4109a23.yml
+++ b/data/fl/people/Travis-Hutson-ab530396-3077-4806-acfe-5203a4109a23.yml
@@ -46,5 +46,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000408
   scheme: legacy_openstates
+- identifier: ocd-person/5af95f45-a587-4d5c-b8c1-51f4e9e71278
+  scheme: openstates
 given_name: Travis
 family_name: Hutson

--- a/data/fl/people/Walter-Bryan-Mike-Hill-ca62c53a-7a36-4f88-9680-4fd8f7353993.yml
+++ b/data/fl/people/Walter-Bryan-Mike-Hill-ca62c53a-7a36-4f88-9680-4fd8f7353993.yml
@@ -27,3 +27,5 @@ image: http://www.flhouse.gov/FileStores/Web/Imaging/Member/4595.jpg
 other_identifiers:
 - identifier: FLL000332
   scheme: legacy_openstates
+- identifier: ocd-person/b4bcb393-416b-4acd-bc3c-34c672fe2e65
+  scheme: openstates

--- a/data/fl/people/Wilton-Simpson-a3a79bb4-b7ac-4edf-bd12-7ff37b2117b0.yml
+++ b/data/fl/people/Wilton-Simpson-a3a79bb4-b7ac-4edf-bd12-7ff37b2117b0.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: FLL000199
   scheme: legacy_openstates
+- identifier: ocd-person/ea787e10-f3a0-463a-94e9-e44b02e5ff89
+  scheme: openstates
 given_name: Wilton
 family_name: Simpson

--- a/data/ga/people/Brian-Strickland-3a5721a0-d848-40d0-a48a-66b797e7d7d9.yml
+++ b/data/ga/people/Brian-Strickland-3a5721a0-d848-40d0-a48a-66b797e7d7d9.yml
@@ -33,3 +33,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: GAL000361
   scheme: legacy_openstates
+- identifier: ocd-person/9377bdba-e623-477c-ba0f-828b830a99c3
+  scheme: openstates

--- a/data/ga/people/Lee-Anderson-e11cecf4-f2e5-49d9-ba9e-47681f779438.yml
+++ b/data/ga/people/Lee-Anderson-e11cecf4-f2e5-49d9-ba9e-47681f779438.yml
@@ -33,3 +33,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: GAL000059
   scheme: legacy_openstates
+- identifier: ocd-person/5e9e4a33-4c6e-4e96-b87a-0f4a4b59aaf6
+  scheme: openstates

--- a/data/ga/people/Mike-Cheokas-1831cc73-e694-4cea-83a4-b55c3495f76a.yml
+++ b/data/ga/people/Mike-Cheokas-1831cc73-e694-4cea-83a4-b55c3495f76a.yml
@@ -36,3 +36,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: GAL000262
   scheme: legacy_openstates
+- identifier: ocd-person/00a9c185-5235-4c96-ba15-c5a0406b3027
+  scheme: openstates

--- a/data/ga/people/Miriam-Paris-bad14891-c7bc-4ac4-b23a-fb5ae3878d67.yml
+++ b/data/ga/people/Miriam-Paris-bad14891-c7bc-4ac4-b23a-fb5ae3878d67.yml
@@ -34,3 +34,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: GAL000039
   scheme: legacy_openstates
+- identifier: ocd-person/6828474f-f544-4258-aa6a-5ddb6b8e11f1
+  scheme: openstates

--- a/data/ga/people/Tonya-Anderson-d9f1ea57-7b90-484a-9664-927a36c87e0c.yml
+++ b/data/ga/people/Tonya-Anderson-d9f1ea57-7b90-484a-9664-927a36c87e0c.yml
@@ -33,3 +33,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: GAL000241
   scheme: legacy_openstates
+- identifier: ocd-person/936dece6-443d-4164-97f4-3f9737f7807d
+  scheme: openstates

--- a/data/hi/people/Karl-Rhoads-099756de-3b84-4531-b5da-6d1c5d4c89ee.yml
+++ b/data/hi/people/Karl-Rhoads-099756de-3b84-4531-b5da-6d1c5d4c89ee.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: HIL000123
   scheme: legacy_openstates
+- identifier: ocd-person/51dd7b59-30ec-4846-997f-85a5894d3462
+  scheme: openstates
 given_name: Karl
 family_name: Rhoads

--- a/data/ia/people/Annette-Sweeney-79eacd35-8caf-466e-b75f-0d878dcf5221.yml
+++ b/data/ia/people/Annette-Sweeney-79eacd35-8caf-466e-b75f-0d878dcf5221.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000132
   scheme: legacy_openstates
+- identifier: ocd-person/a106ce13-a95a-4e11-b8fd-36e759f64856
+  scheme: openstates
 given_name: Annette
 family_name: Sweeney

--- a/data/ia/people/Jim-Lykam-094193ae-8c5c-4bce-97ed-2ac8f054b3f9.yml
+++ b/data/ia/people/Jim-Lykam-094193ae-8c5c-4bce-97ed-2ac8f054b3f9.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IAL000275
   scheme: legacy_openstates
+- identifier: ocd-person/6d38e0a9-e9e2-4a7a-b01a-430c9b44b0b3
+  scheme: openstates
 given_name: Jim
 family_name: Lykam

--- a/data/id/people/Abby-Lee-64c5be72-e09b-4b48-acb2-0db6349c796b.yml
+++ b/data/id/people/Abby-Lee-64c5be72-e09b-4b48-acb2-0db6349c796b.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000207
   scheme: legacy_openstates
+- identifier: ocd-person/52016106-7a6a-454f-a59f-7d2297593ef5
+  scheme: openstates
 given_name: Abby
 family_name: Lee

--- a/data/id/people/Bert-Brackett-9a408e49-29bb-480d-aea2-f0c3050849c6.yml
+++ b/data/id/people/Bert-Brackett-9a408e49-29bb-480d-aea2-f0c3050849c6.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000005
   scheme: legacy_openstates
+- identifier: ocd-person/cbf953d3-f77f-47db-bc0b-7a851a7b05be
+  scheme: openstates
 given_name: Bert
 family_name: Brackett

--- a/data/id/people/Brent-Hill-56622a77-66c5-4506-8f98-d756c976b121.yml
+++ b/data/id/people/Brent-Hill-56622a77-66c5-4506-8f98-d756c976b121.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000015
   scheme: legacy_openstates
+- identifier: ocd-person/77772fd4-75ff-4a37-aa2e-548c0dcb60bc
+  scheme: openstates
 given_name: Brent
 family_name: Hill

--- a/data/id/people/Brent-J-Crane-81d4b890-9bf4-44e0-99b2-eda866f02d48.yml
+++ b/data/id/people/Brent-J-Crane-81d4b890-9bf4-44e0-99b2-eda866f02d48.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000054
   scheme: legacy_openstates
+- identifier: ocd-person/5d9104b3-6039-4fdd-a422-97963070a9ce
+  scheme: openstates
 given_name: Brent
 family_name: Crane

--- a/data/id/people/Caroline-Nilsson-Troy-b0c4754d-d3b0-4077-8008-0233ff9c7bd4.yml
+++ b/data/id/people/Caroline-Nilsson-Troy-b0c4754d-d3b0-4077-8008-0233ff9c7bd4.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000226
   scheme: legacy_openstates
+- identifier: ocd-person/9dcb12fb-e0a4-489e-a46a-c6ee3eaf1b7f
+  scheme: openstates
 given_name: Caroline
 family_name: Troy

--- a/data/id/people/Cherie-Buckner-Webb-0e371a8a-9993-4a09-a8bf-6ff2781331f1.yml
+++ b/data/id/people/Cherie-Buckner-Webb-0e371a8a-9993-4a09-a8bf-6ff2781331f1.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000117
   scheme: legacy_openstates
+- identifier: ocd-person/f9ce2c92-14a3-4330-abed-b62e32d74ee4
+  scheme: openstates
 given_name: Cherie
 family_name: Buckner-Webb

--- a/data/id/people/Chuck-Winder-9a87e02d-3c35-4d39-99cb-3c4c7d112b22.yml
+++ b/data/id/people/Chuck-Winder-9a87e02d-3c35-4d39-99cb-3c4c7d112b22.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000138
   scheme: legacy_openstates
+- identifier: ocd-person/6d0133c6-b296-477c-883d-ee3765efa91c
+  scheme: openstates
 given_name: Chuck
 family_name: Winder

--- a/data/id/people/Clark-Kauffman-7e4dba64-b998-44af-9f11-430bd5c782ea.yml
+++ b/data/id/people/Clark-Kauffman-7e4dba64-b998-44af-9f11-430bd5c782ea.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000161
   scheme: legacy_openstates
+- identifier: ocd-person/195923bb-c409-4967-b091-44c737ed3ff8
+  scheme: openstates
 given_name: Clark
 family_name: Kauffman

--- a/data/id/people/Dan-G-Johnson-50aa3753-ad43-4fe4-b58e-1c107b0db944.yml
+++ b/data/id/people/Dan-G-Johnson-50aa3753-ad43-4fe4-b58e-1c107b0db944.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000123
   scheme: legacy_openstates
+- identifier: ocd-person/7aa15e71-693f-43fe-9fb0-f715c56b4901
+  scheme: openstates
 given_name: Dan
 family_name: Johnson

--- a/data/id/people/Dean-M-Mortimer-a32faf94-ce7b-4a21-bfec-ce6613d2d16d.yml
+++ b/data/id/people/Dean-M-Mortimer-a32faf94-ce7b-4a21-bfec-ce6613d2d16d.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000129
   scheme: legacy_openstates
+- identifier: ocd-person/74153f59-085e-4afd-a72c-1601855eb7cb
+  scheme: openstates
 given_name: Dean
 family_name: Mortimer

--- a/data/id/people/Don-Cheatham-c9796eca-ec00-4887-96ab-225d9bc96585.yml
+++ b/data/id/people/Don-Cheatham-c9796eca-ec00-4887-96ab-225d9bc96585.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000197
   scheme: legacy_openstates
+- identifier: ocd-person/4fe0504a-af53-4adc-bd6c-1bd80d2577bf
+  scheme: openstates
 given_name: Don
 family_name: Cheatham

--- a/data/id/people/Elaine-Smith-838b9ee0-80e3-4a93-af7a-733e8d341ba6.yml
+++ b/data/id/people/Elaine-Smith-838b9ee0-80e3-4a93-af7a-733e8d341ba6.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000180
   scheme: legacy_openstates
+- identifier: ocd-person/0ddd1bc8-e4cc-4541-9eb8-560de9a89977
+  scheme: openstates
 given_name: Elaine
 family_name: Smith

--- a/data/id/people/Fred-S-Martin-07105cf7-dbac-4b79-8882-650dd55fc927.yml
+++ b/data/id/people/Fred-S-Martin-07105cf7-dbac-4b79-8882-650dd55fc927.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000127
   scheme: legacy_openstates
+- identifier: ocd-person/62c14abc-151a-422b-b94d-968da93f9016
+  scheme: openstates
 given_name: Fred
 family_name: Martin

--- a/data/id/people/Fred-Wood-6532fb1d-59bb-4dab-a9e4-761a4d6c29a5.yml
+++ b/data/id/people/Fred-Wood-6532fb1d-59bb-4dab-a9e4-761a4d6c29a5.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000105
   scheme: legacy_openstates
+- identifier: ocd-person/d8eedd2e-cd3d-4c1e-a3e0-b4943ac6494c
+  scheme: openstates
 given_name: Fred
 family_name: Wood

--- a/data/id/people/Gary-E-Collins-1988ae38-d01e-4cdc-aec9-11634c6e40dd.yml
+++ b/data/id/people/Gary-E-Collins-1988ae38-d01e-4cdc-aec9-11634c6e40dd.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000149
   scheme: legacy_openstates
+- identifier: ocd-person/ba4b01f9-25e8-4a45-907b-79037fa43a20
+  scheme: openstates
 given_name: Gary
 family_name: Collins

--- a/data/id/people/Grant-Burgoyne-4cb44f30-5408-4c99-b8f8-e4abcec09196.yml
+++ b/data/id/people/Grant-Burgoyne-4cb44f30-5408-4c99-b8f8-e4abcec09196.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000202
   scheme: legacy_openstates
+- identifier: ocd-person/6dba294c-bf89-41dd-9e15-1cc03174ba20
+  scheme: openstates
 given_name: Grant
 family_name: Burgoyne

--- a/data/id/people/Greg-Chaney-aee7a2a2-82ff-4da9-bd16-bff4d51e4168.yml
+++ b/data/id/people/Greg-Chaney-aee7a2a2-82ff-4da9-bd16-bff4d51e4168.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000195
   scheme: legacy_openstates
+- identifier: ocd-person/f5da0861-1f33-40a5-b6f0-df8eb8e44f42
+  scheme: openstates
 given_name: Greg
 family_name: Chaney

--- a/data/id/people/Heather-Scott-bd967aaf-a9d5-4bec-bf7c-cf0aa19d72ca.yml
+++ b/data/id/people/Heather-Scott-bd967aaf-a9d5-4bec-bf7c-cf0aa19d72ca.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000205
   scheme: legacy_openstates
+- identifier: ocd-person/a03dd08f-1313-4b42-9f6b-c3dc8e257c07
+  scheme: openstates
 given_name: Heather
 family_name: Scott

--- a/data/id/people/Ilana-Rubel-8b37fbb7-bc05-4fd5-be33-a8940e489195.yml
+++ b/data/id/people/Ilana-Rubel-8b37fbb7-bc05-4fd5-be33-a8940e489195.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000193
   scheme: legacy_openstates
+- identifier: ocd-person/eea287fe-a444-4577-bbff-51faeecb211a
+  scheme: openstates
 given_name: Ilana
 family_name: Rubel

--- a/data/id/people/James-Holtzclaw-28827442-9341-4768-86ea-a9186d718be0.yml
+++ b/data/id/people/James-Holtzclaw-28827442-9341-4768-86ea-a9186d718be0.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000159
   scheme: legacy_openstates
+- identifier: ocd-person/f76f743d-d80f-4df3-b94c-de592a45c064
+  scheme: openstates
 given_name: James
 family_name: Holtzclaw

--- a/data/id/people/Janie-Ward-Engelking-c3b6822b-8900-408d-8745-7066b79e1e52.yml
+++ b/data/id/people/Janie-Ward-Engelking-c3b6822b-8900-408d-8745-7066b79e1e52.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000192
   scheme: legacy_openstates
+- identifier: ocd-person/1a50f6b5-289a-4f21-9fcc-d86185baf670
+  scheme: openstates
 given_name: Janie
 family_name: Ward-Engelking

--- a/data/id/people/Jason-A-Monks-9808edb1-15b0-4b9b-91d9-91a97ff7bb4b.yml
+++ b/data/id/people/Jason-A-Monks-9808edb1-15b0-4b9b-91d9-91a97ff7bb4b.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000169
   scheme: legacy_openstates
+- identifier: ocd-person/667a662e-d98d-4c49-879c-ad9d5e0a4c03
+  scheme: openstates
 given_name: Jason
 family_name: Monks

--- a/data/id/people/Jim-Guthrie-e2a8fbe1-e9dc-4569-865f-450fa5f13665.yml
+++ b/data/id/people/Jim-Guthrie-e2a8fbe1-e9dc-4569-865f-450fa5f13665.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000121
   scheme: legacy_openstates
+- identifier: ocd-person/46491008-a8d6-44ec-be47-bc39a11b2d91
+  scheme: openstates
 given_name: Jim
 family_name: Guthrie

--- a/data/id/people/Jim-Rice-24523aa7-de0a-4297-9bef-83c225313d57.yml
+++ b/data/id/people/Jim-Rice-24523aa7-de0a-4297-9bef-83c225313d57.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000112
   scheme: legacy_openstates
+- identifier: ocd-person/be48fd49-3b1c-432d-83a5-a636b5183bf5
+  scheme: openstates
 given_name: Jim
 family_name: Rice

--- a/data/id/people/Joe-Palmer-ed09bbbc-7b10-4ee8-be6b-a4dfcd7330ec.yml
+++ b/data/id/people/Joe-Palmer-ed09bbbc-7b10-4ee8-be6b-a4dfcd7330ec.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000082
   scheme: legacy_openstates
+- identifier: ocd-person/ac5fec91-bd3b-4f3c-a188-ce2ed12ab367
+  scheme: openstates
 given_name: Joe
 family_name: Palmer

--- a/data/id/people/John-Gannon-048117e1-cf54-4ebf-9afc-f244d023e039.yml
+++ b/data/id/people/John-Gannon-048117e1-cf54-4ebf-9afc-f244d023e039.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000152
   scheme: legacy_openstates
+- identifier: ocd-person/27ee275b-ac80-47b9-8bc3-1f2f42eda1ff
+  scheme: openstates
 given_name: John
 family_name: Gannon

--- a/data/id/people/John-McCrostie-2352921d-bf09-49ed-a0d9-e7cec714c0a7.yml
+++ b/data/id/people/John-McCrostie-2352921d-bf09-49ed-a0d9-e7cec714c0a7.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000203
   scheme: legacy_openstates
+- identifier: ocd-person/1c0a856c-8c61-425d-a757-14524a4463cd
+  scheme: openstates
 given_name: John
 family_name: McCrostie

--- a/data/id/people/John-Vander-Woude-ed9290a6-47b1-4b24-8b61-0c0de9b45c73.yml
+++ b/data/id/people/John-Vander-Woude-ed9290a6-47b1-4b24-8b61-0c0de9b45c73.yml
@@ -31,5 +31,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000185
   scheme: legacy_openstates
+- identifier: ocd-person/7ce419cd-8375-46d7-87a1-eb7d3bc533ce
+  scheme: openstates
 given_name: John
 family_name: Woude

--- a/data/id/people/Judy-Boyle-bcaace10-c9c4-4018-a87c-6112eeb33346.yml
+++ b/data/id/people/Judy-Boyle-bcaace10-c9c4-4018-a87c-6112eeb33346.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000048
   scheme: legacy_openstates
+- identifier: ocd-person/b4eca473-c7a6-4953-a7ab-6ee84e564ef9
+  scheme: openstates
 given_name: Judy
 family_name: Boyle

--- a/data/id/people/Lee-Heider-70fd8062-aba5-4705-818c-21fe29064ca8.yml
+++ b/data/id/people/Lee-Heider-70fd8062-aba5-4705-818c-21fe29064ca8.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000014
   scheme: legacy_openstates
+- identifier: ocd-person/5867d1d6-0efd-47e1-af63-f273c5314bba
+  scheme: openstates
 given_name: Lee
 family_name: Heider

--- a/data/id/people/Lori-Den-Hartog-d3ee525f-429f-4ac6-ba52-e947881a3e6c.yml
+++ b/data/id/people/Lori-Den-Hartog-d3ee525f-429f-4ac6-ba52-e947881a3e6c.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000210
   scheme: legacy_openstates
+- identifier: ocd-person/2a3c21f7-09cf-4e53-82ab-bad426b34158
+  scheme: openstates
 given_name: Lori
 family_name: Hartog

--- a/data/id/people/Marc-Gibbs-67a21bbe-6582-42fe-a252-8bff7a07ce90.yml
+++ b/data/id/people/Marc-Gibbs-67a21bbe-6582-42fe-a252-8bff7a07ce90.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000153
   scheme: legacy_openstates
+- identifier: ocd-person/a930a229-2e68-4ea3-8e88-ba9f539ead80
+  scheme: openstates
 given_name: Marc
 family_name: Gibbs

--- a/data/id/people/Mark-Harris-84d9ffa4-35f6-4baf-acdd-c3bafee537e7.yml
+++ b/data/id/people/Mark-Harris-84d9ffa4-35f6-4baf-acdd-c3bafee537e7.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000219
   scheme: legacy_openstates
+- identifier: ocd-person/9766a542-dbe1-4d59-a51b-e1dd0100d5a8
+  scheme: openstates
 given_name: Mark
 family_name: Harris

--- a/data/id/people/Mark-Nye-1063d5d1-d080-44bb-b4cb-1f8a923c6530.yml
+++ b/data/id/people/Mark-Nye-1063d5d1-d080-44bb-b4cb-1f8a923c6530.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000212
   scheme: legacy_openstates
+- identifier: ocd-person/16471aa1-de39-4863-b900-c6f4c9dff7bc
+  scheme: openstates
 given_name: Mark
 family_name: Nye

--- a/data/id/people/Mary-Souza-f6737ef4-32b7-45a6-8b03-a3c719904c05.yml
+++ b/data/id/people/Mary-Souza-f6737ef4-32b7-45a6-8b03-a3c719904c05.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000211
   scheme: legacy_openstates
+- identifier: ocd-person/d7728b2b-2dc2-4eb0-91e5-52fb52a06676
+  scheme: openstates
 given_name: Mary
 family_name: Souza

--- a/data/id/people/Maryanne-Jordan-d64da36a-d4e4-4fe3-94da-16c7cfc4ac6e.yml
+++ b/data/id/people/Maryanne-Jordan-d64da36a-d4e4-4fe3-94da-16c7cfc4ac6e.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000217
   scheme: legacy_openstates
+- identifier: ocd-person/63f003e1-d08d-401b-b441-3d76543c3709
+  scheme: openstates
 given_name: Maryanne
 family_name: Jordan

--- a/data/id/people/Melissa-Wintrow-c6b06b7d-05f8-45a3-8415-4cd1e76c5642.yml
+++ b/data/id/people/Melissa-Wintrow-c6b06b7d-05f8-45a3-8415-4cd1e76c5642.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000204
   scheme: legacy_openstates
+- identifier: ocd-person/98f06ce5-9e0b-46ad-bdf4-d2846b8baf85
+  scheme: openstates
 given_name: Melissa
 family_name: Wintrow

--- a/data/id/people/Michelle-Stennett-2951e173-f22a-4750-871b-fc3294522bb1.yml
+++ b/data/id/people/Michelle-Stennett-2951e173-f22a-4750-871b-fc3294522bb1.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000134
   scheme: legacy_openstates
+- identifier: ocd-person/f6232882-71b6-4eb8-ad5c-6206326506e1
+  scheme: openstates
 given_name: Michelle
 family_name: Stennett

--- a/data/id/people/Mike-Moyle-060e3496-76ff-4895-9637-4ff7bbe7a05e.yml
+++ b/data/id/people/Mike-Moyle-060e3496-76ff-4895-9637-4ff7bbe7a05e.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000078
   scheme: legacy_openstates
+- identifier: ocd-person/ebec18f7-09c2-40cf-86f0-2fa842fc3ee5
+  scheme: openstates
 given_name: Mike
 family_name: Moyle

--- a/data/id/people/Neil-A-Anderson-a97d2624-90c1-48fd-93d1-80a9b473eb08.yml
+++ b/data/id/people/Neil-A-Anderson-a97d2624-90c1-48fd-93d1-80a9b473eb08.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000140
   scheme: legacy_openstates
+- identifier: ocd-person/00706f5e-db7b-4292-87b9-6444a3be63dd
+  scheme: openstates
 given_name: Neil
 family_name: Anderson

--- a/data/id/people/Patti-Anne-Lodge-62b03da1-4e7b-445c-b819-52a27fe92a30.yml
+++ b/data/id/people/Patti-Anne-Lodge-62b03da1-4e7b-445c-b819-52a27fe92a30.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000126
   scheme: legacy_openstates
+- identifier: ocd-person/e76bc886-df41-491c-8c12-fd3a75ff6104
+  scheme: openstates
 given_name: Patti
 family_name: Lodge

--- a/data/id/people/Paul-E-Shepherd-95cee851-71a4-42aa-bd4f-c804acd42314.yml
+++ b/data/id/people/Paul-E-Shepherd-95cee851-71a4-42aa-bd4f-c804acd42314.yml
@@ -31,5 +31,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000179
   scheme: legacy_openstates
+- identifier: ocd-person/eb7a65c6-fa44-4933-b16d-0a6f08521d1b
+  scheme: openstates
 given_name: Paul
 family_name: Shepherd

--- a/data/id/people/Rick-D-Youngblood-ddc1b1dc-d5ca-4fea-a577-888388bbb98b.yml
+++ b/data/id/people/Rick-D-Youngblood-ddc1b1dc-d5ca-4fea-a577-888388bbb98b.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000189
   scheme: legacy_openstates
+- identifier: ocd-person/87ed547a-3729-4c9b-86c5-9491320e3292
+  scheme: openstates
 given_name: Rick
 family_name: Youngblood

--- a/data/id/people/Robert-Anderst-7efbc627-7cfa-42c2-9c04-86d504f27867.yml
+++ b/data/id/people/Robert-Anderst-7efbc627-7cfa-42c2-9c04-86d504f27867.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000141
   scheme: legacy_openstates
+- identifier: ocd-person/c3891fd2-babf-4ec6-a385-2dc1dbf37b7d
+  scheme: openstates
 given_name: Robert
 family_name: Anderst

--- a/data/id/people/Ron-Mendive-71489ac3-457d-41ec-b285-a099648b601b.yml
+++ b/data/id/people/Ron-Mendive-71489ac3-457d-41ec-b285-a099648b601b.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000167
   scheme: legacy_openstates
+- identifier: ocd-person/37949003-2caf-47ce-b857-ea722af000e0
+  scheme: openstates
 given_name: Ron
 family_name: Mendive

--- a/data/id/people/Ryan-Kerby-2eaec855-ab6d-434f-acee-54991af971dc.yml
+++ b/data/id/people/Ryan-Kerby-2eaec855-ab6d-434f-acee-54991af971dc.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000199
   scheme: legacy_openstates
+- identifier: ocd-person/8684df17-8113-4a67-8d05-62d41c43bd20
+  scheme: openstates
 given_name: Ryan
 family_name: Kerby

--- a/data/id/people/Sage-G-Dixon-e5ee7c55-aa4e-4ce8-b3c8-5ab542f7a836.yml
+++ b/data/id/people/Sage-G-Dixon-e5ee7c55-aa4e-4ce8-b3c8-5ab542f7a836.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000222
   scheme: legacy_openstates
+- identifier: ocd-person/11c05e7a-2f2b-4a0f-8d25-11cde1a6d22a
+  scheme: openstates
 given_name: Sage
 family_name: Dixon

--- a/data/id/people/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
+++ b/data/id/people/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000042
   scheme: legacy_openstates
+- identifier: ocd-person/a94b8eb9-d687-41e3-b095-f52c46812d1f
+  scheme: openstates
 given_name: Scott
 family_name: Bedke

--- a/data/id/people/Steve-Bair-7b47f208-2330-43be-8466-bc752f986208.yml
+++ b/data/id/people/Steve-Bair-7b47f208-2330-43be-8466-bc752f986208.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000115
   scheme: legacy_openstates
+- identifier: ocd-person/c77c8859-6a10-45f2-bb72-af77ec0464a0
+  scheme: openstates
 given_name: Steve
 family_name: Bair

--- a/data/id/people/Steve-Vick-824fd47e-fb8c-47e2-b5ab-67af71e6f6bc.yml
+++ b/data/id/people/Steve-Vick-824fd47e-fb8c-47e2-b5ab-67af71e6f6bc.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000137
   scheme: legacy_openstates
+- identifier: ocd-person/2c1dc41c-d9b9-46bf-97ae-74a9b689b7be
+  scheme: openstates
 given_name: Steve
 family_name: Vick

--- a/data/id/people/Steven-Harris-f2fbca50-a033-4d0c-b0cf-8244bf2c92c6.yml
+++ b/data/id/people/Steven-Harris-f2fbca50-a033-4d0c-b0cf-8244bf2c92c6.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000155
   scheme: legacy_openstates
+- identifier: ocd-person/14a9535f-a294-44f6-be6f-ff34f206ca05
+  scheme: openstates
 given_name: Steven
 family_name: Harris

--- a/data/id/people/Steven-P-Thayn-634fd776-4a10-495d-acea-c9b2e73c1030.yml
+++ b/data/id/people/Steven-P-Thayn-634fd776-4a10-495d-acea-c9b2e73c1030.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000135
   scheme: legacy_openstates
+- identifier: ocd-person/0d1677c3-5fbf-4137-b71b-d409605f33cc
+  scheme: openstates
 given_name: Steven
 family_name: Thayn

--- a/data/id/people/Terry-Gestrin-7ab92990-521b-41fa-9c85-bb384709d35e.yml
+++ b/data/id/people/Terry-Gestrin-7ab92990-521b-41fa-9c85-bb384709d35e.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000114
   scheme: legacy_openstates
+- identifier: ocd-person/5b34a140-62ab-4ca1-a2eb-12ca6c1d567b
+  scheme: openstates
 given_name: Terry
 family_name: Gestrin

--- a/data/id/people/Thyra-Stevenson-5a6c491f-3225-4fd3-80a1-31a7817de994.yml
+++ b/data/id/people/Thyra-Stevenson-5a6c491f-3225-4fd3-80a1-31a7817de994.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000181
   scheme: legacy_openstates
+- identifier: ocd-person/bddbab4b-769e-42b5-888a-6dd444bcad36
+  scheme: openstates
 given_name: Thyra
 family_name: Stevenson

--- a/data/id/people/Todd-M-Lakey-0b894582-b3d6-4600-a401-ed874e8c632d.yml
+++ b/data/id/people/Todd-M-Lakey-0b894582-b3d6-4600-a401-ed874e8c632d.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000125
   scheme: legacy_openstates
+- identifier: ocd-person/71732f1d-faaa-4fd6-8c5d-ae03aec520c6
+  scheme: openstates
 given_name: Todd
 family_name: Lakey

--- a/data/id/people/Van-T-Burtenshaw-2a8943d8-c4fe-4286-8b26-6240d9ff26f8.yml
+++ b/data/id/people/Van-T-Burtenshaw-2a8943d8-c4fe-4286-8b26-6240d9ff26f8.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000223
   scheme: legacy_openstates
+- identifier: ocd-person/933d4a8f-1581-43df-8116-b8b1dcdb9e98
+  scheme: openstates
 given_name: Van
 family_name: Burtenshaw

--- a/data/id/people/Vito-Barbieri-1abcdba2-7ed6-4871-889e-9e4c47c4d000.yml
+++ b/data/id/people/Vito-Barbieri-1abcdba2-7ed6-4871-889e-9e4c47c4d000.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000143
   scheme: legacy_openstates
+- identifier: ocd-person/0e844eb2-de20-4d4c-b827-a0b1834e2392
+  scheme: openstates
 given_name: Vito
 family_name: Barbieri

--- a/data/id/people/Wendy-Horman-8a220a7f-f629-493c-81e8-5f56d40440a9.yml
+++ b/data/id/people/Wendy-Horman-8a220a7f-f629-493c-81e8-5f56d40440a9.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: IDL000160
   scheme: legacy_openstates
+- identifier: ocd-person/452e15dc-2dd6-4fac-84c6-dd09f92b8f30
+  scheme: openstates
 given_name: Wendy
 family_name: Horman

--- a/data/il/people/Brian-W-Stewart-bdb2b767-7c04-4a7e-941b-9734155329d6.yml
+++ b/data/il/people/Brian-W-Stewart-bdb2b767-7c04-4a7e-941b-9734155329d6.yml
@@ -27,3 +27,5 @@ image: http://ilga.gov/images/members/{9542D32E-E8F8-4E42-963E-23FC7621D747}.jpg
 other_identifiers:
 - identifier: ILL000980
   scheme: legacy_openstates
+- identifier: ocd-person/9d292bbd-3218-458b-bfa1-dd0c411d70f6
+  scheme: openstates

--- a/data/il/people/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
+++ b/data/il/people/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
@@ -39,5 +39,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ILL000899
   scheme: legacy_openstates
+- identifier: ocd-person/c8d511b0-5199-4699-9b1c-b025d417d0a1
+  scheme: openstates
 given_name: Jil
 family_name: Tracy

--- a/data/il/people/Mark-L-Walker-d1c2870a-8fee-47bf-a48e-4320311f06fd.yml
+++ b/data/il/people/Mark-L-Walker-d1c2870a-8fee-47bf-a48e-4320311f06fd.yml
@@ -28,3 +28,5 @@ image: http://ilga.gov/images/members/{BC2AF76D-FAE4-44C4-8632-AA4E629A9678}.jpg
 other_identifiers:
 - identifier: ILL000830
   scheme: legacy_openstates
+- identifier: ocd-person/2f5ab721-2a6f-4c54-ab55-d1e9920079fd
+  scheme: openstates

--- a/data/in/people/David-Niezgodski-1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371.yml
+++ b/data/in/people/David-Niezgodski-1fad6d9f-7d2c-4b2e-a74f-26a2ea44f371.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: INL000117
   scheme: legacy_openstates
+- identifier: ocd-person/d29388f9-37d0-4e03-952c-47e1ad2bb0b5
+  scheme: openstates
 given_name: David
 family_name: Niezgodski

--- a/data/in/people/Mara-Candelaria-Reardon-86e50c79-ff31-4cdb-99df-52a775bdb81f.yml
+++ b/data/in/people/Mara-Candelaria-Reardon-86e50c79-ff31-4cdb-99df-52a775bdb81f.yml
@@ -22,5 +22,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: INL000064
   scheme: legacy_openstates
+- identifier: ocd-person/78338c16-c720-47e8-9b7f-3da4d9403281
+  scheme: openstates
 given_name: Mara
 family_name: Candelaria Reardon

--- a/data/in/people/Michael-Young-01bb6149-aa0f-457f-b759-1338b6c8ae5f.yml
+++ b/data/in/people/Michael-Young-01bb6149-aa0f-457f-b759-1338b6c8ae5f.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: INL000201
   scheme: legacy_openstates
+- identifier: ocd-person/9e08695a-438f-4a4b-93b3-9d02e7bb6b80
+  scheme: openstates
 given_name: Michael
 family_name: Young

--- a/data/ks/people/Barbara-Bollier-247a7316-39fc-4697-9ed1-1da877d31d48.yml
+++ b/data/ks/people/Barbara-Bollier-247a7316-39fc-4697-9ed1-1da877d31d48.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000194
   scheme: legacy_openstates
+- identifier: ocd-person/734bd178-7926-430c-9b4b-c7d44895f7d3
+  scheme: openstates
 given_name: Barbara
 family_name: Bollier

--- a/data/ks/people/Brenda-Landwehr-4f9fb266-2de1-4d94-948e-9e0255666c52.yml
+++ b/data/ks/people/Brenda-Landwehr-4f9fb266-2de1-4d94-948e-9e0255666c52.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000104
   scheme: legacy_openstates
+- identifier: ocd-person/e8c3810c-8f81-483f-898f-d07de0fca118
+  scheme: openstates
 given_name: Brenda
 family_name: Landwehr

--- a/data/ks/people/Bud-Estes-4741cd41-7788-4d20-8313-27b6e05d9e14.yml
+++ b/data/ks/people/Bud-Estes-4741cd41-7788-4d20-8313-27b6e05d9e14.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000276
   scheme: legacy_openstates
+- identifier: ocd-person/f0a051f5-fe21-4294-ab3e-37632f9f1a96
+  scheme: openstates
 given_name: Bud
 family_name: Estes

--- a/data/ks/people/Gene-Suellentrop-497bab51-3d41-4997-a1bf-b52e178133f9.yml
+++ b/data/ks/people/Gene-Suellentrop-497bab51-3d41-4997-a1bf-b52e178133f9.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000254
   scheme: legacy_openstates
+- identifier: ocd-person/b7c27af1-c3be-4d7b-b419-6dba1b708c12
+  scheme: openstates
 given_name: Gene
 family_name: Suellentrop

--- a/data/ks/people/Jim-Gartner-058bdfbc-818f-437c-a37c-2d2717a136f0.yml
+++ b/data/ks/people/Jim-Gartner-058bdfbc-818f-437c-a37c-2d2717a136f0.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000322
   scheme: legacy_openstates
+- identifier: ocd-person/70c67e4f-994e-4c09-88d4-bbf82814376e
+  scheme: openstates
 given_name: Jim
 family_name: Gartner

--- a/data/ks/people/John-Doll-b2e4bec5-55fb-4bd2-a0f1-728997f9e780.yml
+++ b/data/ks/people/John-Doll-b2e4bec5-55fb-4bd2-a0f1-728997f9e780.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000206
   scheme: legacy_openstates
+- identifier: ocd-person/688d0f00-232d-4ef6-85f8-08885cdf6981
+  scheme: openstates
 given_name: John
 family_name: Doll

--- a/data/ks/people/Owen-Donohoe-0287e900-55b6-4497-8142-73fcf4774572.yml
+++ b/data/ks/people/Owen-Donohoe-0287e900-55b6-4497-8142-73fcf4774572.yml
@@ -24,3 +24,5 @@ family_name: Donohoe
 other_identifiers:
 - identifier: KSL000065
   scheme: legacy_openstates
+- identifier: ocd-person/d0e8647a-1a58-4856-8426-b314848d2f4a
+  scheme: openstates

--- a/data/ks/people/Rick-Billinger-e5d951f2-88c7-47d4-ac28-08c175ba440d.yml
+++ b/data/ks/people/Rick-Billinger-e5d951f2-88c7-47d4-ac28-08c175ba440d.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000305
   scheme: legacy_openstates
+- identifier: ocd-person/0cc0ee30-b797-4e2e-9e2a-7e4a8bff9b3b
+  scheme: openstates
 given_name: Rick
 family_name: Billinger

--- a/data/ks/people/Virgil-Weigel-acb8f24a-aecd-43a5-887c-be8bbf963e3d.yml
+++ b/data/ks/people/Virgil-Weigel-acb8f24a-aecd-43a5-887c-be8bbf963e3d.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: KSL000261
   scheme: legacy_openstates
+- identifier: ocd-person/3d0d1fa6-6c72-45cc-82d7-e1bd87da8e94
+  scheme: openstates
 given_name: Virgil
 family_name: Weigel

--- a/data/ks/people/Will-Carpenter-695c8e66-9ee6-4431-8bd4-b7435b04e2c7.yml
+++ b/data/ks/people/Will-Carpenter-695c8e66-9ee6-4431-8bd4-b7435b04e2c7.yml
@@ -24,3 +24,5 @@ family_name: Carpenter
 other_identifiers:
 - identifier: KSL000197
   scheme: legacy_openstates
+- identifier: ocd-person/74ae6a4e-3715-498a-aa0b-7c30326fbdc8
+  scheme: openstates

--- a/data/ky/people/Cluster-Howard-36b01740-6f38-4f87-b007-763e45ef1eb1.yml
+++ b/data/ky/people/Cluster-Howard-36b01740-6f38-4f87-b007-763e45ef1eb1.yml
@@ -24,3 +24,5 @@ image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house91.jpg
 other_identifiers:
 - identifier: KYL000221
   scheme: legacy_openstates
+- identifier: ocd-person/ca91333b-5f3e-4643-a771-288162a646f3
+  scheme: openstates

--- a/data/ky/people/Jim-Glenn-e642c0f0-a3aa-485d-8f3a-9a6f05f5b606.yml
+++ b/data/ky/people/Jim-Glenn-e642c0f0-a3aa-485d-8f3a-9a6f05f5b606.yml
@@ -24,3 +24,5 @@ image: https://legislature.ky.gov/Legislators%20Full%20Res%20Images/house13.jpg
 other_identifiers:
 - identifier: KYL000071
   scheme: legacy_openstates
+- identifier: ocd-person/311aed42-f8a0-4766-b29e-4f6fc9dc2472
+  scheme: openstates

--- a/data/la/people/Eddie-J-Lambert-c89a156e-8426-4001-8364-94a179482d76.yml
+++ b/data/la/people/Eddie-J-Lambert-c89a156e-8426-4001-8364-94a179482d76.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: LAL000700
   scheme: legacy_openstates
+- identifier: ocd-person/34e3d0ac-f867-45ec-9114-1bf2695462c9
+  scheme: openstates
 given_name: Eddie J.
 family_name: Lambert

--- a/data/la/people/Wesley-T-Bishop-16de42f8-8074-4b7a-a511-75a87d660850.yml
+++ b/data/la/people/Wesley-T-Bishop-16de42f8-8074-4b7a-a511-75a87d660850.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: LAL000649
   scheme: legacy_openstates
+- identifier: ocd-person/01b306e3-a382-4148-bb14-f0e12b39353e
+  scheme: openstates
 given_name: Wesley T.
 family_name: Bishop

--- a/data/ma/people/Aaron-Vega-445ac849-5e68-4714-adda-759425ad72cf.yml
+++ b/data/ma/people/Aaron-Vega-445ac849-5e68-4714-adda-759425ad72cf.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000224
   scheme: legacy_openstates
+- identifier: ocd-person/ddb47af7-41e6-49b5-a915-610f0341ec82
+  scheme: openstates
 given_name: Aaron
 family_name: Vega
 gender: Male

--- a/data/ma/people/Alan-Silvia-6e81dcb7-4a04-4a88-b5f2-728a3336cf9d.yml
+++ b/data/ma/people/Alan-Silvia-6e81dcb7-4a04-4a88-b5f2-728a3336cf9d.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000223
   scheme: legacy_openstates
+- identifier: ocd-person/71d14bb3-d7d9-4599-a930-31e01fe31540
+  scheme: openstates
 given_name: Alan
 family_name: Silvia
 gender: Male

--- a/data/ma/people/Alice-Hanlon-Peisch-2a9569a0-feaf-431d-8a8d-012d8ebccbf8.yml
+++ b/data/ma/people/Alice-Hanlon-Peisch-2a9569a0-feaf-431d-8a8d-012d8ebccbf8.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000155
   scheme: legacy_openstates
+- identifier: ocd-person/9ff50f03-e7dc-407d-afd9-16cae5c80667
+  scheme: openstates
 given_name: Alice Hanlon
 family_name: Peisch
 gender: Female

--- a/data/ma/people/Angelo-L-DEmilia-650d9459-5ecd-4e1a-8a96-f061a15e0ebc.yml
+++ b/data/ma/people/Angelo-L-DEmilia-650d9459-5ecd-4e1a-8a96-f061a15e0ebc.yml
@@ -30,6 +30,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000291
   scheme: legacy_openstates
+- identifier: ocd-person/4b173d91-bc71-4635-b90a-aa17d656b3f3
+  scheme: openstates
 given_name: Angelo
 family_name: D'Emilia
 gender: Male

--- a/data/ma/people/Angelo-M-Scaccia-09ed2b39-bf07-455f-a60c-72cb36a11c27.yml
+++ b/data/ma/people/Angelo-M-Scaccia-09ed2b39-bf07-455f-a60c-72cb36a11c27.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000169
   scheme: legacy_openstates
+- identifier: ocd-person/160e1a6b-0ac7-4c9a-a8ca-5226c4efbf10
+  scheme: openstates
 given_name: Angelo
 family_name: Scaccia
 gender: Male

--- a/data/ma/people/Ann-Margaret-Ferrante-3b6297d5-2c8d-42a8-ba9b-bb4e8f50c0e2.yml
+++ b/data/ma/people/Ann-Margaret-Ferrante-3b6297d5-2c8d-42a8-ba9b-bb4e8f50c0e2.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000093
   scheme: legacy_openstates
+- identifier: ocd-person/1bd99be5-a34e-487f-b14e-2a4418117034
+  scheme: openstates
 given_name: Ann-Margaret
 family_name: Ferrante
 gender: Female

--- a/data/ma/people/Barry-Finegold-49397268-3fc9-4c83-a385-f55be18597f4.yml
+++ b/data/ma/people/Barry-Finegold-49397268-3fc9-4c83-a385-f55be18597f4.yml
@@ -24,3 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000253
   scheme: legacy_openstates
+- identifier: ocd-person/a19b224b-60fa-4ee2-bb9b-b30fc58cfa01
+  scheme: openstates

--- a/data/ma/people/Bradford-R-Hill-6e64e8db-c1f5-4f72-994b-dbe9cfdab8a5.yml
+++ b/data/ma/people/Bradford-R-Hill-6e64e8db-c1f5-4f72-994b-dbe9cfdab8a5.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000383
   scheme: legacy_openstates
+- identifier: ocd-person/e3a58717-2344-4382-b641-39571f06a487
+  scheme: openstates
 given_name: Bradford
 family_name: Hill
 gender: Male

--- a/data/ma/people/Brendan-P-Crighton-77994b2c-f88c-4a5f-bf9d-7abd1875d8dc.yml
+++ b/data/ma/people/Brendan-P-Crighton-77994b2c-f88c-4a5f-bf9d-7abd1875d8dc.yml
@@ -29,6 +29,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000356
   scheme: legacy_openstates
+- identifier: ocd-person/68f513ed-71a1-4f5c-b299-c7ef99196e3e
+  scheme: openstates
 given_name: Brendan P.
 family_name: Crighton
 gender: Male

--- a/data/ma/people/Brian-M-Ashe-503a0888-f086-4b52-b03c-c5293378bc51.yml
+++ b/data/ma/people/Brian-M-Ashe-503a0888-f086-4b52-b03c-c5293378bc51.yml
@@ -18,6 +18,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000045
   scheme: legacy_openstates
+- identifier: ocd-person/0bb70c3b-7b55-4af7-9b9c-5e419c3bcb75
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/ma/people/Bruce-J-Ayers-f81b07bd-cc43-47be-95ea-dca26f19a647.yml
+++ b/data/ma/people/Bruce-J-Ayers-f81b07bd-cc43-47be-95ea-dca26f19a647.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000048
   scheme: legacy_openstates
+- identifier: ocd-person/78df089d-a1f9-4cf3-9b1c-aaef4ddbefa9
+  scheme: openstates
 given_name: Bruce
 family_name: Ayers
 gender: Male

--- a/data/ma/people/Carole-A-Fiola-af41924a-7c46-4b6b-b71b-bba683c62c5f.yml
+++ b/data/ma/people/Carole-A-Fiola-af41924a-7c46-4b6b-b71b-bba683c62c5f.yml
@@ -28,6 +28,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000384
   scheme: legacy_openstates
+- identifier: ocd-person/fd2814dc-089d-4b6c-b069-480836c204ab
+  scheme: openstates
 given_name: Carole
 family_name: Fiola
 gender: Female

--- a/data/ma/people/Carolyn-C-Dykema-1368c833-35b4-4cf3-9bb4-e9e41d1434f7.yml
+++ b/data/ma/people/Carolyn-C-Dykema-1368c833-35b4-4cf3-9bb4-e9e41d1434f7.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000086
   scheme: legacy_openstates
+- identifier: ocd-person/c2843f6e-314b-4d24-b573-547602d27bee
+  scheme: openstates
 given_name: Carolyn
 family_name: Dykema
 gender: Female

--- a/data/ma/people/Christine-P-Barber-35396516-6096-4336-ab74-80d6d8e53bcd.yml
+++ b/data/ma/people/Christine-P-Barber-35396516-6096-4336-ab74-80d6d8e53bcd.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000354
   scheme: legacy_openstates
+- identifier: ocd-person/22b33feb-92ef-4795-b95f-7e88cd4ac489
+  scheme: openstates
 given_name: Christine
 family_name: Barber
 gender: Female

--- a/data/ma/people/Christopher-M-Markey-560c5ca3-d9b4-4c47-998c-a9baa16a8309.yml
+++ b/data/ma/people/Christopher-M-Markey-560c5ca3-d9b4-4c47-998c-a9baa16a8309.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000138
   scheme: legacy_openstates
+- identifier: ocd-person/b70c443f-b1a8-4aa1-b72b-a076ccd7a408
+  scheme: openstates
 given_name: Christopher
 family_name: Markey
 gender: Male

--- a/data/ma/people/Claire-D-Cronin-8535e83a-df7d-4c14-9a19-1f32fd2147cb.yml
+++ b/data/ma/people/Claire-D-Cronin-8535e83a-df7d-4c14-9a19-1f32fd2147cb.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000231
   scheme: legacy_openstates
+- identifier: ocd-person/dd89e355-b12d-4bbe-ad83-cc0deb6ae3c4
+  scheme: openstates
 given_name: Claire
 family_name: Cronin
 gender: Female

--- a/data/ma/people/Colleen-M-Garry-0e38852a-52b0-4aac-8a65-fa3fc964c88e.yml
+++ b/data/ma/people/Colleen-M-Garry-0e38852a-52b0-4aac-8a65-fa3fc964c88e.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000102
   scheme: legacy_openstates
+- identifier: ocd-person/81000b71-94d2-40b1-bc96-1b59a7a3d84b
+  scheme: openstates
 given_name: Colleen
 family_name: Garry
 gender: Female

--- a/data/ma/people/Daniel-Cahill-5f227f77-f58b-4ac6-b193-9f406bde4055.yml
+++ b/data/ma/people/Daniel-Cahill-5f227f77-f58b-4ac6-b193-9f406bde4055.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000397
   scheme: legacy_openstates
+- identifier: ocd-person/7890caa5-2805-4dac-96f5-7a8866a3c4b9
+  scheme: openstates
 given_name: Daniel
 family_name: Cahill
 gender: Male

--- a/data/ma/people/Daniel-J-Hunt-2990f236-cb76-4d93-af19-7792fa77290b.yml
+++ b/data/ma/people/Daniel-J-Hunt-2990f236-cb76-4d93-af19-7792fa77290b.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000373
   scheme: legacy_openstates
+- identifier: ocd-person/ad5bb7f7-1292-4a11-a3f0-c6b4ea0dfd08
+  scheme: openstates
 given_name: Daniel
 family_name: Hunt
 gender: Male

--- a/data/ma/people/Daniel-J-Ryan-c0519476-08fc-44af-9114-c77d197f883d.yml
+++ b/data/ma/people/Daniel-J-Ryan-c0519476-08fc-44af-9114-c77d197f883d.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000333
   scheme: legacy_openstates
+- identifier: ocd-person/d4a36444-3f7c-4a7b-975e-879353b6e453
+  scheme: openstates
 given_name: Daniel
 family_name: Ryan
 gender: Male

--- a/data/ma/people/Daniel-M-Donahue-d70e97f1-b8ec-489d-ab5a-2b7f3775ae8a.yml
+++ b/data/ma/people/Daniel-M-Donahue-d70e97f1-b8ec-489d-ab5a-2b7f3775ae8a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000304
   scheme: legacy_openstates
+- identifier: ocd-person/addb9e7b-a1b5-4488-b4f0-050879b2484c
+  scheme: openstates
 given_name: Daniel
 family_name: Donahue
 gender: Male

--- a/data/ma/people/Danielle-W-Gregoire-5696763c-5fd6-44dd-9dce-7be56632cedd.yml
+++ b/data/ma/people/Danielle-W-Gregoire-5696763c-5fd6-44dd-9dce-7be56632cedd.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000275
   scheme: legacy_openstates
+- identifier: ocd-person/c7884df3-74e9-4ef1-8d23-a1bbb646b7b7
+  scheme: openstates
 given_name: Danielle
 family_name: Gregoire
 gender: Female

--- a/data/ma/people/David-F-DeCoste-cf295962-4f8d-427a-84e9-c7615ff94c8c.yml
+++ b/data/ma/people/David-F-DeCoste-cf295962-4f8d-427a-84e9-c7615ff94c8c.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000353
   scheme: legacy_openstates
+- identifier: ocd-person/c5f4cdbe-0488-4867-8e58-d721028416fe
+  scheme: openstates
 given_name: David
 family_name: DeCoste
 gender: Male

--- a/data/ma/people/David-K-Muradian-Jr-b601dee7-1ad1-4f36-b585-b0fb5077fd89.yml
+++ b/data/ma/people/David-K-Muradian-Jr-b601dee7-1ad1-4f36-b585-b0fb5077fd89.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000377
   scheme: legacy_openstates
+- identifier: ocd-person/cecc5621-126e-4161-8693-317f90e36eec
+  scheme: openstates
 given_name: David
 family_name: Muradian
 gender: Male

--- a/data/ma/people/David-M-Nangle-6eb6d59e-8df1-4a69-9335-391b8c30e7ea.yml
+++ b/data/ma/people/David-M-Nangle-6eb6d59e-8df1-4a69-9335-391b8c30e7ea.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000146
   scheme: legacy_openstates
+- identifier: ocd-person/c4f9c816-43ce-4c13-845a-3b35ffdb4e54
+  scheme: openstates
 given_name: David
 family_name: Nangle
 gender: Male

--- a/data/ma/people/David-M-Rogers-51adc4d9-23d8-442f-b692-c4e4204f552e.yml
+++ b/data/ma/people/David-M-Rogers-51adc4d9-23d8-442f-b692-c4e4204f552e.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000221
   scheme: legacy_openstates
+- identifier: ocd-person/e2a61a9d-eb11-47d9-afd8-22fcb6f8d267
+  scheme: openstates
 given_name: David
 family_name: Rogers
 gender: Male

--- a/data/ma/people/David-Paul-Linsky-06867e5f-9de5-4cb2-a3ae-a039e890718c.yml
+++ b/data/ma/people/David-Paul-Linsky-06867e5f-9de5-4cb2-a3ae-a039e890718c.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000130
   scheme: legacy_openstates
+- identifier: ocd-person/7a135146-29f5-4942-aa45-e7ad794380bf
+  scheme: openstates
 given_name: David Paul
 family_name: Linsky
 gender: Male

--- a/data/ma/people/David-T-Vieira-5c798735-2f95-40a6-9ef7-4cd25eb638f6.yml
+++ b/data/ma/people/David-T-Vieira-5c798735-2f95-40a6-9ef7-4cd25eb638f6.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000190
   scheme: legacy_openstates
+- identifier: ocd-person/ea72ce0f-5c4b-400a-bc2a-6cf1e82399b8
+  scheme: openstates
 given_name: David
 family_name: Vieira
 gender: Male

--- a/data/ma/people/Denise-C-Garlick-7be05b7f-d3dd-4a0f-b7d0-f29144d47f92.yml
+++ b/data/ma/people/Denise-C-Garlick-7be05b7f-d3dd-4a0f-b7d0-f29144d47f92.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000101
   scheme: legacy_openstates
+- identifier: ocd-person/06b9febe-c064-4b80-b659-e9ad8bf2ff0f
+  scheme: openstates
 given_name: Denise
 family_name: Garlick
 gender: Female

--- a/data/ma/people/Denise-Provost-d887e897-63da-48da-b7cb-b5cc3a3a6e2a.yml
+++ b/data/ma/people/Denise-Provost-d887e897-63da-48da-b7cb-b5cc3a3a6e2a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000160
   scheme: legacy_openstates
+- identifier: ocd-person/15c226b8-ac01-4746-a407-8176c8a5e510
+  scheme: openstates
 given_name: Denise
 family_name: Provost
 gender: Female

--- a/data/ma/people/Diana-DiZoglio-ec37a070-639f-4c27-9228-33c9d38f9639.yml
+++ b/data/ma/people/Diana-DiZoglio-ec37a070-639f-4c27-9228-33c9d38f9639.yml
@@ -29,6 +29,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000226
   scheme: legacy_openstates
+- identifier: ocd-person/a7896d17-c4a8-4f48-9c9f-08d459f446b5
+  scheme: openstates
 given_name: Diana
 family_name: DiZoglio
 gender: Female

--- a/data/ma/people/Donald-H-Wong-e8071049-2a8d-4633-b6cb-c1f6ae83bb7a.yml
+++ b/data/ma/people/Donald-H-Wong-e8071049-2a8d-4633-b6cb-c1f6ae83bb7a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000199
   scheme: legacy_openstates
+- identifier: ocd-person/07acd12f-85e9-48aa-966d-98119eb9ae4c
+  scheme: openstates
 given_name: Donald
 family_name: Wong
 gender: Male

--- a/data/ma/people/Donald-R-Berthiaume-Jr-5a276629-f50a-4d9a-a54e-2c0e07f84968.yml
+++ b/data/ma/people/Donald-R-Berthiaume-Jr-5a276629-f50a-4d9a-a54e-2c0e07f84968.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000374
   scheme: legacy_openstates
+- identifier: ocd-person/86bd47de-3cc2-4818-b050-5d5cba364624
+  scheme: openstates
 given_name: Donald
 family_name: Berthiaume
 gender: Male

--- a/data/ma/people/Edward-F-Coppinger-24929c64-96a3-41f9-b97f-dcf06024b8de.yml
+++ b/data/ma/people/Edward-F-Coppinger-24929c64-96a3-41f9-b97f-dcf06024b8de.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000071
   scheme: legacy_openstates
+- identifier: ocd-person/d8287492-1d4d-42b1-937d-0f0fedaff47d
+  scheme: openstates
 given_name: Edward
 family_name: Coppinger
 gender: Male

--- a/data/ma/people/Elizabeth-A-Malia-3687ae6d-f9c3-4b18-81b8-dfca4d0d81d8.yml
+++ b/data/ma/people/Elizabeth-A-Malia-3687ae6d-f9c3-4b18-81b8-dfca4d0d81d8.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000135
   scheme: legacy_openstates
+- identifier: ocd-person/c3ea5baf-021d-4db6-9d59-9146beaa914c
+  scheme: openstates
 given_name: Elizabeth
 family_name: Malia
 gender: Female

--- a/data/ma/people/Elizabeth-A-Poirier-c4e46af4-a67d-4f8a-96ba-bf2a95efbe24.yml
+++ b/data/ma/people/Elizabeth-A-Poirier-c4e46af4-a67d-4f8a-96ba-bf2a95efbe24.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000159
   scheme: legacy_openstates
+- identifier: ocd-person/8d6a0cad-0cf0-4cc5-9719-e32e06b5a9ef
+  scheme: openstates
 given_name: Elizabeth
 family_name: Poirier
 gender: Female

--- a/data/ma/people/F-Jay-Barrows-ee42e89c-24dd-47b1-aafa-e16472680e07.yml
+++ b/data/ma/people/F-Jay-Barrows-ee42e89c-24dd-47b1-aafa-e16472680e07.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000050
   scheme: legacy_openstates
+- identifier: ocd-person/3c611229-c99e-4719-ac22-cda840483579
+  scheme: openstates
 given_name: F. Jay
 family_name: Barrows
 gender: Male

--- a/data/ma/people/Frank-A-Moran-8c42603e-4483-44f1-995f-5956fa09c73c.yml
+++ b/data/ma/people/Frank-A-Moran-8c42603e-4483-44f1-995f-5956fa09c73c.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000243
   scheme: legacy_openstates
+- identifier: ocd-person/352e6ddf-aaae-4557-88db-24bb799ea59d
+  scheme: openstates
 given_name: Frank
 family_name: Moran
 gender: Male

--- a/data/ma/people/Hannah-Kane-3dd1e2a8-3fdd-4d3a-9504-88a04f3fc973.yml
+++ b/data/ma/people/Hannah-Kane-3dd1e2a8-3fdd-4d3a-9504-88a04f3fc973.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000389
   scheme: legacy_openstates
+- identifier: ocd-person/eaf452b6-7487-48c3-b27c-a9b9d4844100
+  scheme: openstates
 given_name: Hannah
 family_name: Kane
 gender: Female

--- a/data/ma/people/James-Arciero-70e42c78-89e1-43cb-bc65-7d0da132daa2.yml
+++ b/data/ma/people/James-Arciero-70e42c78-89e1-43cb-bc65-7d0da132daa2.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000044
   scheme: legacy_openstates
+- identifier: ocd-person/21f0c6ab-de54-44b3-8cfd-8aed860f3137
+  scheme: openstates
 given_name: James
 family_name: Arciero
 gender: Male

--- a/data/ma/people/James-J-ODay-67f64532-7f9a-4cd3-8c89-dc9b5df06517.yml
+++ b/data/ma/people/James-J-ODay-67f64532-7f9a-4cd3-8c89-dc9b5df06517.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000150
   scheme: legacy_openstates
+- identifier: ocd-person/cda5b25d-d48f-4ab1-8a8f-4d674e756066
+  scheme: openstates
 given_name: James
 family_name: O'Day
 gender: Male

--- a/data/ma/people/James-M-Kelcourse-b2e82b19-68d5-4f18-88a3-c4c399252a58.yml
+++ b/data/ma/people/James-M-Kelcourse-b2e82b19-68d5-4f18-88a3-c4c399252a58.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000359
   scheme: legacy_openstates
+- identifier: ocd-person/01b54f92-d8d7-4308-ade7-6a9f96934dd3
+  scheme: openstates
 given_name: James
 family_name: Kelcourse
 gender: Male

--- a/data/ma/people/James-M-Murphy-ef175304-020e-4f79-b71f-dc961b738254.yml
+++ b/data/ma/people/James-M-Murphy-ef175304-020e-4f79-b71f-dc961b738254.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000144
   scheme: legacy_openstates
+- identifier: ocd-person/1960f0f4-836b-48ed-81ba-bfb92965a1fb
+  scheme: openstates
 given_name: James
 family_name: Murphy
 gender: Male

--- a/data/ma/people/Jay-D-Livingstone-033bf9eb-2706-4c5f-9f93-8e8d222bf2c0.yml
+++ b/data/ma/people/Jay-D-Livingstone-033bf9eb-2706-4c5f-9f93-8e8d222bf2c0.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000375
   scheme: legacy_openstates
+- identifier: ocd-person/807e24b4-f166-4393-990f-03585c1d8be5
+  scheme: openstates
 given_name: Jay
 family_name: Livingstone
 gender: Male

--- a/data/ma/people/Jeffrey-N-Roy-b23d4ed5-1994-4355-a102-cdf15ae57230.yml
+++ b/data/ma/people/Jeffrey-N-Roy-b23d4ed5-1994-4355-a102-cdf15ae57230.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000222
   scheme: legacy_openstates
+- identifier: ocd-person/173f7a0d-c31b-481d-8315-45686a325878
+  scheme: openstates
 given_name: Jeffrey
 family_name: Roy
 gender: Male

--- a/data/ma/people/Jerald-A-Parisella-67833a9e-e086-4494-a364-fecdcd6aa609.yml
+++ b/data/ma/people/Jerald-A-Parisella-67833a9e-e086-4494-a364-fecdcd6aa609.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000152
   scheme: legacy_openstates
+- identifier: ocd-person/b0ea3e5b-74ad-4f37-91f1-ef74f20a4277
+  scheme: openstates
 given_name: Jerald
 family_name: Parisella
 gender: Male

--- a/data/ma/people/John-C-Velis-a37a3f66-83a2-4a7e-90e3-8de41be7262d.yml
+++ b/data/ma/people/John-C-Velis-a37a3f66-83a2-4a7e-90e3-8de41be7262d.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000380
   scheme: legacy_openstates
+- identifier: ocd-person/39ec435b-538e-4110-aa18-ee0de255e045
+  scheme: openstates
 given_name: John
 family_name: Velis
 gender: Male

--- a/data/ma/people/John-H-Rogers-50942563-77bb-49ec-a54c-6e26048a31a3.yml
+++ b/data/ma/people/John-H-Rogers-50942563-77bb-49ec-a54c-6e26048a31a3.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000163
   scheme: legacy_openstates
+- identifier: ocd-person/0f18ec9e-b520-4edb-9862-014dd0e8ee8d
+  scheme: openstates
 given_name: John
 family_name: Rogers
 gender: Male

--- a/data/ma/people/John-J-Mahoney-2abbc0cb-6339-42d9-9947-69412a24301b.yml
+++ b/data/ma/people/John-J-Mahoney-2abbc0cb-6339-42d9-9947-69412a24301b.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000134
   scheme: legacy_openstates
+- identifier: ocd-person/04e214f0-7982-4d03-ab06-aedb0ff12570
+  scheme: openstates
 given_name: John
 family_name: Mahoney
 gender: Male

--- a/data/ma/people/Jonathan-D-Zlotnik-49c4bb4e-fadd-4136-953f-6bd64a970acb.yml
+++ b/data/ma/people/Jonathan-D-Zlotnik-49c4bb4e-fadd-4136-953f-6bd64a970acb.yml
@@ -28,6 +28,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000232
   scheme: legacy_openstates
+- identifier: ocd-person/e822c318-c469-42b8-9a15-2ce32283bcb2
+  scheme: openstates
 given_name: Jonathan
 family_name: Zlotnik
 gender: Male

--- a/data/ma/people/Jonathan-Hecht-3b5ba366-0e1a-4d72-ba0a-515010e67d9a.yml
+++ b/data/ma/people/Jonathan-Hecht-3b5ba366-0e1a-4d72-ba0a-515010e67d9a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000108
   scheme: legacy_openstates
+- identifier: ocd-person/7bfb2338-fba5-4912-ac0e-900cae0498a0
+  scheme: openstates
 given_name: Jonathan
 family_name: Hecht
 gender: Male

--- a/data/ma/people/Joseph-D-McKenna-0e6c20bd-bfcb-445c-a1ce-3be99e26398e.yml
+++ b/data/ma/people/Joseph-D-McKenna-0e6c20bd-bfcb-445c-a1ce-3be99e26398e.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000340
   scheme: legacy_openstates
+- identifier: ocd-person/0d39516c-5ffe-45da-be2e-40aab0a09f74
+  scheme: openstates
 given_name: Joseph
 family_name: McKenna
 gender: Male

--- a/data/ma/people/Joseph-F-Wagner-22647240-e595-43f4-84d4-3984ebc846e2.yml
+++ b/data/ma/people/Joseph-F-Wagner-22647240-e595-43f4-84d4-3984ebc846e2.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000192
   scheme: legacy_openstates
+- identifier: ocd-person/9307e2ab-b515-451c-ac05-73bb6c9656ff
+  scheme: openstates
 given_name: Joseph
 family_name: Wagner
 gender: Male

--- a/data/ma/people/Joseph-W-McGonagle-Jr-6c3b63a2-ef13-43e5-b6de-d5e0901aa65a.yml
+++ b/data/ma/people/Joseph-W-McGonagle-Jr-6c3b63a2-ef13-43e5-b6de-d5e0901aa65a.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000369
   scheme: legacy_openstates
+- identifier: ocd-person/a7136f3d-eb7f-43f5-92d5-1d35feb3e95e
+  scheme: openstates
 given_name: Joseph
 family_name: McGonagle
 gender: Male

--- a/data/ma/people/Josh-S-Cutler-0ba5a0af-7aee-4bb7-af58-982b687f81d8.yml
+++ b/data/ma/people/Josh-S-Cutler-0ba5a0af-7aee-4bb7-af58-982b687f81d8.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000212
   scheme: legacy_openstates
+- identifier: ocd-person/84486bdc-7cb2-41db-9c8c-9e5639390211
+  scheme: openstates
 given_name: Josh
 family_name: Cutler
 gender: Male

--- a/data/ma/people/Kate-Hogan-3d709a64-6cd2-49c6-ad0d-b007e834bfec.yml
+++ b/data/ma/people/Kate-Hogan-3d709a64-6cd2-49c6-ad0d-b007e834bfec.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000111
   scheme: legacy_openstates
+- identifier: ocd-person/4b37ce1f-b6c6-4379-901c-0fa817259da6
+  scheme: openstates
 given_name: Kate
 family_name: Hogan
 gender: Female

--- a/data/ma/people/Kay-Khan-61a670a7-37a6-42f0-8c8f-4cfc1d93693a.yml
+++ b/data/ma/people/Kay-Khan-61a670a7-37a6-42f0-8c8f-4cfc1d93693a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000122
   scheme: legacy_openstates
+- identifier: ocd-person/6902e1a2-ece4-40b8-8422-0b9427731e5f
+  scheme: openstates
 given_name: Kay
 family_name: Khan
 gender: Female

--- a/data/ma/people/Kenneth-I-Gordon-47c42957-b618-41b7-a557-5d24c33568cf.yml
+++ b/data/ma/people/Kenneth-I-Gordon-47c42957-b618-41b7-a557-5d24c33568cf.yml
@@ -29,6 +29,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000316
   scheme: legacy_openstates
+- identifier: ocd-person/e3cdf450-2f70-4618-a10b-1e525ed249ac
+  scheme: openstates
 given_name: Kenneth
 family_name: Gordon
 gender: Male

--- a/data/ma/people/Kevin-G-Honan-9e4b8b32-233e-443f-a147-46fbaa778a58.yml
+++ b/data/ma/people/Kevin-G-Honan-9e4b8b32-233e-443f-a147-46fbaa778a58.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000113
   scheme: legacy_openstates
+- identifier: ocd-person/533b1880-c82c-4588-a1d6-a7211f9f83aa
+  scheme: openstates
 given_name: Kevin
 family_name: Honan
 gender: Male

--- a/data/ma/people/Kimberly-N-Ferguson-888457ba-c348-4826-b2c6-450dba5e38bd.yml
+++ b/data/ma/people/Kimberly-N-Ferguson-888457ba-c348-4826-b2c6-450dba5e38bd.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000091
   scheme: legacy_openstates
+- identifier: ocd-person/bbb1af40-1efa-4357-8a0e-defe5d27baf5
+  scheme: openstates
 given_name: Kimberly
 family_name: Ferguson
 gender: Female

--- a/data/ma/people/Linda-Dean-Campbell-b38a106c-7659-493e-a27f-fed4c6456b3c.yml
+++ b/data/ma/people/Linda-Dean-Campbell-b38a106c-7659-493e-a27f-fed4c6456b3c.yml
@@ -30,6 +30,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000385
   scheme: legacy_openstates
+- identifier: ocd-person/171c7fab-eb26-487f-b002-f81fd3b191d2
+  scheme: openstates
 given_name: Linda Dean
 family_name: Campbell
 gender: Female

--- a/data/ma/people/Lori-A-Ehrlich-9f7305fa-a7b5-4931-98fc-621a53d3717b.yml
+++ b/data/ma/people/Lori-A-Ehrlich-9f7305fa-a7b5-4931-98fc-621a53d3717b.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000087
   scheme: legacy_openstates
+- identifier: ocd-person/b6beb651-3b01-4e6d-9ff7-b42de9633f72
+  scheme: openstates
 given_name: Lori
 family_name: Ehrlich
 gender: Female

--- a/data/ma/people/Louis-L-Kafka-6847f063-97fd-4091-8f82-041d36d374b1.yml
+++ b/data/ma/people/Louis-L-Kafka-6847f063-97fd-4091-8f82-041d36d374b1.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000118
   scheme: legacy_openstates
+- identifier: ocd-person/c430da14-e86e-45e7-8f10-fba2cd8f3f32
+  scheme: openstates
 given_name: Louis
 family_name: Kafka
 gender: Male

--- a/data/ma/people/Marc-T-Lombardo-398f9a47-bc65-4c2a-b12e-347f375d8fac.yml
+++ b/data/ma/people/Marc-T-Lombardo-398f9a47-bc65-4c2a-b12e-347f375d8fac.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000131
   scheme: legacy_openstates
+- identifier: ocd-person/2560f61b-eef5-43b6-994c-c84d41b280db
+  scheme: openstates
 given_name: Marc
 family_name: Lombardo
 gender: Male

--- a/data/ma/people/Marcos-Devers-127bb871-7119-4732-8c8f-0208750c3a56.yml
+++ b/data/ma/people/Marcos-Devers-127bb871-7119-4732-8c8f-0208750c3a56.yml
@@ -24,3 +24,5 @@ gender: Male
 other_identifiers:
 - identifier: MAL000080
   scheme: legacy_openstates
+- identifier: ocd-person/05435a17-624a-499d-8cce-d7f09f958cba
+  scheme: openstates

--- a/data/ma/people/Marjorie-C-Decker-b9019024-899b-41b3-a283-69c50866fabd.yml
+++ b/data/ma/people/Marjorie-C-Decker-b9019024-899b-41b3-a283-69c50866fabd.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000213
   scheme: legacy_openstates
+- identifier: ocd-person/ffd50d19-6d53-4860-923d-04761e3ed246
+  scheme: openstates
 given_name: Marjorie
 family_name: Decker
 gender: Female

--- a/data/ma/people/Mark-J-Cusack-b51c5c27-7da0-42f5-b67b-22085173af7a.yml
+++ b/data/ma/people/Mark-J-Cusack-b51c5c27-7da0-42f5-b67b-22085173af7a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000075
   scheme: legacy_openstates
+- identifier: ocd-person/a7a32f33-b076-4f6b-b0f5-06e8e8bb399a
+  scheme: openstates
 given_name: Mark
 family_name: Cusack
 gender: Male

--- a/data/ma/people/Mary-S-Keefe-4d0b5dda-d9d1-4c25-9c94-ce8fbd8ff398.yml
+++ b/data/ma/people/Mary-S-Keefe-4d0b5dda-d9d1-4c25-9c94-ce8fbd8ff398.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000217
   scheme: legacy_openstates
+- identifier: ocd-person/38f2bdc1-1c26-49ec-a822-803ba0a3ad91
+  scheme: openstates
 given_name: Mary
 family_name: Keefe
 gender: Female

--- a/data/ma/people/Michael-J-Finn-b61922e8-c775-4c74-8ecb-557d79162195.yml
+++ b/data/ma/people/Michael-J-Finn-b61922e8-c775-4c74-8ecb-557d79162195.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000094
   scheme: legacy_openstates
+- identifier: ocd-person/461e8555-8243-4716-ae36-5b62bd6346c8
+  scheme: openstates
 given_name: Michael
 family_name: Finn
 gender: Male

--- a/data/ma/people/Michael-J-Moran-2fd8669d-a5e2-40fd-bb2f-595210f1bf49.yml
+++ b/data/ma/people/Michael-J-Moran-2fd8669d-a5e2-40fd-bb2f-595210f1bf49.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000142
   scheme: legacy_openstates
+- identifier: ocd-person/2ff81dfe-78b5-406a-91fe-db5caf83f560
+  scheme: openstates
 given_name: Michael
 family_name: Moran
 gender: Male

--- a/data/ma/people/Michael-S-Day-2e198563-4aeb-499b-8333-b4a46b605491.yml
+++ b/data/ma/people/Michael-S-Day-2e198563-4aeb-499b-8333-b4a46b605491.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000381
   scheme: legacy_openstates
+- identifier: ocd-person/8bc68814-dc62-4746-b4c9-772cd6f25145
+  scheme: openstates
 given_name: Michael
 family_name: Day
 gender: Male

--- a/data/ma/people/Michelle-M-DuBois-f41834f0-0d73-4e8e-8758-66184772c081.yml
+++ b/data/ma/people/Michelle-M-DuBois-f41834f0-0d73-4e8e-8758-66184772c081.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000351
   scheme: legacy_openstates
+- identifier: ocd-person/e0c0e880-a112-439b-90a5-4b4431f342e8
+  scheme: openstates
 given_name: Michelle
 family_name: DuBois
 gender: Female

--- a/data/ma/people/Nicholas-A-Boldyga-0e72fc19-89be-49b9-8baf-5f35f938ec87.yml
+++ b/data/ma/people/Nicholas-A-Boldyga-0e72fc19-89be-49b9-8baf-5f35f938ec87.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000056
   scheme: legacy_openstates
+- identifier: ocd-person/e9b3f573-75cb-42ef-bcf5-f25304499668
+  scheme: openstates
 given_name: Nicholas
 family_name: Boldyga
 gender: Male

--- a/data/ma/people/Nick-Collins-8ca6ea6c-1121-40b3-a5cf-9b55dfe6a2b0.yml
+++ b/data/ma/people/Nick-Collins-8ca6ea6c-1121-40b3-a5cf-9b55dfe6a2b0.yml
@@ -29,6 +29,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000411
   scheme: legacy_openstates
+- identifier: ocd-person/c961b7d5-cfdf-4801-9b0a-e8f9ea0b519b
+  scheme: openstates
 given_name: Nick
 family_name: Collins
 gender: Male

--- a/data/ma/people/Patricia-A-Haddad-d2f16a1f-415d-4e60-b905-2f4c71959e0f.yml
+++ b/data/ma/people/Patricia-A-Haddad-d2f16a1f-415d-4e60-b905-2f4c71959e0f.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000106
   scheme: legacy_openstates
+- identifier: ocd-person/74ac6b05-8d8c-48ee-b241-196a4db9dee7
+  scheme: openstates
 given_name: Patricia
 family_name: Haddad
 gender: Female

--- a/data/ma/people/Paul-J-Donato-18bf433d-24e5-46cb-9d83-c2f9373204bd.yml
+++ b/data/ma/people/Paul-J-Donato-18bf433d-24e5-46cb-9d83-c2f9373204bd.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000083
   scheme: legacy_openstates
+- identifier: ocd-person/2f3747b7-1d92-421f-8329-12278b53c6c6
+  scheme: openstates
 given_name: Paul
 family_name: Donato
 gender: Male

--- a/data/ma/people/Paul-K-Frost-fdc5586f-0db3-4614-af1f-72a42cf5e6f0.yml
+++ b/data/ma/people/Paul-K-Frost-fdc5586f-0db3-4614-af1f-72a42cf5e6f0.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000098
   scheme: legacy_openstates
+- identifier: ocd-person/41193d72-4cf5-47b8-9fee-2c869bbdf813
+  scheme: openstates
 given_name: Paul
 family_name: Frost
 gender: Male

--- a/data/ma/people/Paul-McMurtry-d0e66289-022e-4a99-ac8c-f20fb7557e7f.yml
+++ b/data/ma/people/Paul-McMurtry-d0e66289-022e-4a99-ac8c-f20fb7557e7f.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000139
   scheme: legacy_openstates
+- identifier: ocd-person/dafac9b1-d26e-4248-98d2-483c56c8485e
+  scheme: openstates
 given_name: Paul
 family_name: McMurtry
 gender: Male

--- a/data/ma/people/Paul-W-Mark-fd5aaac8-48f5-42c2-82a8-abaf6c5de650.yml
+++ b/data/ma/people/Paul-W-Mark-fd5aaac8-48f5-42c2-82a8-abaf6c5de650.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000137
   scheme: legacy_openstates
+- identifier: ocd-person/e2b89817-48c9-4db9-9227-3c3fb6cb5ea3
+  scheme: openstates
 given_name: Paul
 family_name: Mark
 gender: Male

--- a/data/ma/people/Rady-Mom-7b9e688f-a9aa-425b-8d3d-833993d6d58a.yml
+++ b/data/ma/people/Rady-Mom-7b9e688f-a9aa-425b-8d3d-833993d6d58a.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000362
   scheme: legacy_openstates
+- identifier: ocd-person/60303410-a0fc-4787-b5d6-aaa9fcfbd2b7
+  scheme: openstates
 given_name: Rady
 family_name: Mom
 gender: Male

--- a/data/ma/people/Randy-Hunt-11811997-cc3d-49e1-a9de-685b9021af9a.yml
+++ b/data/ma/people/Randy-Hunt-11811997-cc3d-49e1-a9de-685b9021af9a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000116
   scheme: legacy_openstates
+- identifier: ocd-person/2ead7f8a-34fe-4be6-9fc7-9ea75edd7767
+  scheme: openstates
 given_name: Randy
 family_name: Hunt
 gender: Male

--- a/data/ma/people/Robert-A-DeLeo-7e081a6a-1b40-40e8-bf6d-bb2fc39c812f.yml
+++ b/data/ma/people/Robert-A-DeLeo-7e081a6a-1b40-40e8-bf6d-bb2fc39c812f.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000077
   scheme: legacy_openstates
+- identifier: ocd-person/55d26fcc-9039-4bce-8b98-22d94758a03e
+  scheme: openstates
 given_name: Robert
 family_name: DeLeo
 gender: Male

--- a/data/ma/people/Ronald-Mariano-e142d28d-e57a-4ff9-afa4-c3cd149f2114.yml
+++ b/data/ma/people/Ronald-Mariano-e142d28d-e57a-4ff9-afa4-c3cd149f2114.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000136
   scheme: legacy_openstates
+- identifier: ocd-person/00ab60f4-d27a-47f7-acb6-e8d1b004508a
+  scheme: openstates
 given_name: Ronald
 family_name: Mariano
 gender: Male

--- a/data/ma/people/RoseLee-Vincent-2de2c3a2-84f4-495d-89a3-fd4ee36fb29b.yml
+++ b/data/ma/people/RoseLee-Vincent-2de2c3a2-84f4-495d-89a3-fd4ee36fb29b.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000327
   scheme: legacy_openstates
+- identifier: ocd-person/d39c5945-f9b1-44e1-b1ec-bca1e290c712
+  scheme: openstates
 given_name: RoseLee
 family_name: Vincent
 gender: Female

--- a/data/ma/people/Russell-E-Holmes-078692f2-2afe-4aa1-a320-d4747edacbbb.yml
+++ b/data/ma/people/Russell-E-Holmes-078692f2-2afe-4aa1-a320-d4747edacbbb.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000112
   scheme: legacy_openstates
+- identifier: ocd-person/256c6cd9-2b63-4c03-8118-f570a44c96e0
+  scheme: openstates
 given_name: Russell
 family_name: Holmes
 gender: Male

--- a/data/ma/people/Ruth-B-Balser-0df5de43-f3a3-4988-82fb-7f951fa02753.yml
+++ b/data/ma/people/Ruth-B-Balser-0df5de43-f3a3-4988-82fb-7f951fa02753.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000049
   scheme: legacy_openstates
+- identifier: ocd-person/9db89358-c4f7-43ad-a761-5296188eff5d
+  scheme: openstates
 given_name: Ruth
 family_name: Balser
 gender: Female

--- a/data/ma/people/Sarah-K-Peake-6b1bbe32-1b86-48a4-909e-ee1ba6c5c746.yml
+++ b/data/ma/people/Sarah-K-Peake-6b1bbe32-1b86-48a4-909e-ee1ba6c5c746.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000153
   scheme: legacy_openstates
+- identifier: ocd-person/ad6497d6-b7da-4ea1-892f-9c73aa0697c3
+  scheme: openstates
 given_name: Sarah
 family_name: Peake
 gender: Female

--- a/data/ma/people/Sean-Garballey-1e9d742c-c20b-45cf-9e22-e7752189fa7a.yml
+++ b/data/ma/people/Sean-Garballey-1e9d742c-c20b-45cf-9e22-e7752189fa7a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000100
   scheme: legacy_openstates
+- identifier: ocd-person/dda2082e-88b7-417b-b61b-1a69b2264f6d
+  scheme: openstates
 given_name: Sean
 family_name: Garballey
 gender: Male

--- a/data/ma/people/Shawn-Dooley-76b56fe8-bd61-4e1d-a664-773844234d35.yml
+++ b/data/ma/people/Shawn-Dooley-76b56fe8-bd61-4e1d-a664-773844234d35.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000309
   scheme: legacy_openstates
+- identifier: ocd-person/7c9814fe-451f-4697-a0bc-269557a5688c
+  scheme: openstates
 given_name: Shawn
 family_name: Dooley
 gender: Male

--- a/data/ma/people/Sheila-C-Harrington-dc73a702-5899-4b1a-b996-4c4c21d00d0f.yml
+++ b/data/ma/people/Sheila-C-Harrington-dc73a702-5899-4b1a-b996-4c4c21d00d0f.yml
@@ -26,6 +26,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000200
   scheme: legacy_openstates
+- identifier: ocd-person/4b0eecc3-51df-4999-b2ac-f51a60c03268
+  scheme: openstates
 given_name: Sheila
 family_name: Harrington
 gender: Female

--- a/data/ma/people/Stephan-Hay-706d94f1-3c2e-4f39-8386-e159b8de775e.yml
+++ b/data/ma/people/Stephan-Hay-706d94f1-3c2e-4f39-8386-e159b8de775e.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000395
   scheme: legacy_openstates
+- identifier: ocd-person/d6c7a39a-6812-4bc5-b634-b08ed1fdbfdd
+  scheme: openstates
 given_name: Stephan
 family_name: Hay
 gender: Male

--- a/data/ma/people/Steven-S-Howitt-54487f49-5377-4c41-bd97-60b748cc240a.yml
+++ b/data/ma/people/Steven-S-Howitt-54487f49-5377-4c41-bd97-60b748cc240a.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000114
   scheme: legacy_openstates
+- identifier: ocd-person/ce31b39e-fa7b-4b15-a0bb-9bb20b4766cf
+  scheme: openstates
 given_name: Steven
 family_name: Howitt
 gender: Male

--- a/data/ma/people/Steven-Ultrino-209427dd-91f0-45d6-ae8c-05a51872c10c.yml
+++ b/data/ma/people/Steven-Ultrino-209427dd-91f0-45d6-ae8c-05a51872c10c.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000370
   scheme: legacy_openstates
+- identifier: ocd-person/9c082627-ca4d-49e2-aace-e4ba239d9ebd
+  scheme: openstates
 given_name: Steven
 family_name: Ultrino
 gender: Male

--- a/data/ma/people/Susan-Williams-Gifford-adb172f4-64c0-4c96-8097-71bd125fc2e0.yml
+++ b/data/ma/people/Susan-Williams-Gifford-adb172f4-64c0-4c96-8097-71bd125fc2e0.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000103
   scheme: legacy_openstates
+- identifier: ocd-person/6701dae6-9ac1-48dd-875e-f6fa8a71a8bb
+  scheme: openstates
 given_name: Susan Williams
 family_name: Gifford
 gender: Female

--- a/data/ma/people/Tackey-Chan-6b420d2a-f12d-40ca-a13f-04cf9061a66b.yml
+++ b/data/ma/people/Tackey-Chan-6b420d2a-f12d-40ca-a13f-04cf9061a66b.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000067
   scheme: legacy_openstates
+- identifier: ocd-person/f8b7d632-d156-4ebf-aed9-7d1f9a71b2a7
+  scheme: openstates
 given_name: Tackey
 family_name: Chan
 gender: Male

--- a/data/ma/people/Theodore-C-Speliotis-66f8e4bd-3729-4d3b-92b7-842eee659348.yml
+++ b/data/ma/people/Theodore-C-Speliotis-66f8e4bd-3729-4d3b-92b7-842eee659348.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000176
   scheme: legacy_openstates
+- identifier: ocd-person/ad3faa8b-aff8-481c-9e91-81ebcc85cb8a
+  scheme: openstates
 given_name: Theodore
 family_name: Speliotis
 gender: Male

--- a/data/ma/people/Thomas-M-Petrolati-ca2aefac-9eaa-4873-8334-24ac92f047c0.yml
+++ b/data/ma/people/Thomas-M-Petrolati-ca2aefac-9eaa-4873-8334-24ac92f047c0.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000157
   scheme: legacy_openstates
+- identifier: ocd-person/f8fac093-d2f2-412d-a413-97c6ff474b34
+  scheme: openstates
 given_name: Thomas
 family_name: Petrolati
 gender: Male

--- a/data/ma/people/Thomas-M-Stanley-2becbe4e-5b5e-4b42-be87-b4abf57550c7.yml
+++ b/data/ma/people/Thomas-M-Stanley-2becbe4e-5b5e-4b42-be87-b4abf57550c7.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000180
   scheme: legacy_openstates
+- identifier: ocd-person/25992bed-fbe6-48de-9cc1-af847d46b33c
+  scheme: openstates
 given_name: Thomas
 family_name: Stanley
 gender: Male

--- a/data/ma/people/Thomas-P-Walsh-5f796cb3-08ae-40c4-8c11-a2758f317cc2.yml
+++ b/data/ma/people/Thomas-P-Walsh-5f796cb3-08ae-40c4-8c11-a2758f317cc2.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000402
   scheme: legacy_openstates
+- identifier: ocd-person/a8c00350-56b4-4acf-9ebe-2c1712757d5f
+  scheme: openstates
 given_name: Thomas
 family_name: Walsh
 gender: Male

--- a/data/ma/people/Timothy-R-Whelan-46d663c3-6d1a-42d6-8ae4-db406f20af8a.yml
+++ b/data/ma/people/Timothy-R-Whelan-46d663c3-6d1a-42d6-8ae4-db406f20af8a.yml
@@ -25,6 +25,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000382
   scheme: legacy_openstates
+- identifier: ocd-person/152d0e47-c106-48c2-9f10-a5263ca9c3d6
+  scheme: openstates
 given_name: Timothy
 family_name: Whelan
 gender: Male

--- a/data/ma/people/Todd-M-Smola-d8895862-a95b-4982-bb2e-31c8ffa4bf57.yml
+++ b/data/ma/people/Todd-M-Smola-d8895862-a95b-4982-bb2e-31c8ffa4bf57.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000175
   scheme: legacy_openstates
+- identifier: ocd-person/8519f4da-64d4-48e0-a9fe-1a61b9b5ef6d
+  scheme: openstates
 given_name: Todd
 family_name: Smola
 gender: Male

--- a/data/ma/people/Tricia-Farley-Bouvier-1f444dfe-d3b3-4852-ab10-0682206d773d.yml
+++ b/data/ma/people/Tricia-Farley-Bouvier-1f444dfe-d3b3-4852-ab10-0682206d773d.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000203
   scheme: legacy_openstates
+- identifier: ocd-person/99a786de-969a-4c9f-ba6a-be3eb4ca2c58
+  scheme: openstates
 given_name: Tricia
 family_name: Farley-Bouvier
 gender: Female

--- a/data/ma/people/Walter-F-Timilty-0db5ab85-b9c0-4b48-a0b4-d5944bab0a2d.yml
+++ b/data/ma/people/Walter-F-Timilty-0db5ab85-b9c0-4b48-a0b4-d5944bab0a2d.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000185
   scheme: legacy_openstates
+- identifier: ocd-person/f79d6133-0b8f-4191-922c-b8bfd73205b4
+  scheme: openstates
 given_name: Walter
 family_name: Timilty
 gender: Male

--- a/data/ma/people/William-C-Galvin-04997a33-67a9-4535-95d2-c9a4c260519d.yml
+++ b/data/ma/people/William-C-Galvin-04997a33-67a9-4535-95d2-c9a4c260519d.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000099
   scheme: legacy_openstates
+- identifier: ocd-person/d2414296-b7f7-471c-b31a-64a09b0de846
+  scheme: openstates
 given_name: William
 family_name: Galvin
 gender: Male

--- a/data/ma/people/William-M-Straus-95fef9c7-c5c1-415c-95ef-94e4d87e3a72.yml
+++ b/data/ma/people/William-M-Straus-95fef9c7-c5c1-415c-95ef-94e4d87e3a72.yml
@@ -24,6 +24,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MAL000182
   scheme: legacy_openstates
+- identifier: ocd-person/b2b63675-764d-47ee-8e44-e44766c8cc8e
+  scheme: openstates
 given_name: William
 family_name: Straus
 gender: Male

--- a/data/md/people/Jr-William-C-Smith-6e1c09ac-57e7-4a54-bd83-74905670ad7f.yml
+++ b/data/md/people/Jr-William-C-Smith-6e1c09ac-57e7-4a54-bd83-74905670ad7f.yml
@@ -24,5 +24,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MDL000727
   scheme: legacy_openstates
+- identifier: ocd-person/57e76ce9-8c0e-47f1-8a92-ca19370eccc7
+  scheme: openstates
 given_name: William
 family_name: Smith

--- a/data/me/people/Ann-E-Peoples-fb285235-d921-4164-bb86-5caa42c8ac49.yml
+++ b/data/me/people/Ann-E-Peoples-fb285235-d921-4164-bb86-5caa42c8ac49.yml
@@ -22,3 +22,5 @@ image: https://legislature.maine.gov/house/house/Repository/MemberProfiles/96da4
 other_identifiers:
 - identifier: MEL000159
   scheme: legacy_openstates
+- identifier: ocd-person/b71b2715-d37c-45e9-bce5-b974d8f46654
+  scheme: openstates

--- a/data/me/people/Arthur-C-Verow-d19b1cf7-09d4-4761-99cd-f82d52aaa6d1.yml
+++ b/data/me/people/Arthur-C-Verow-d19b1cf7-09d4-4761-99cd-f82d52aaa6d1.yml
@@ -25,3 +25,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000414
   scheme: legacy_openstates
+- identifier: ocd-person/fabd8f5a-b123-417d-99ce-831b775c8b20
+  scheme: openstates

--- a/data/me/people/Benjamin-M-Chipman-7dc90231-0b7d-40d5-93e2-e32335922a48.yml
+++ b/data/me/people/Benjamin-M-Chipman-7dc90231-0b7d-40d5-93e2-e32335922a48.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000359
   scheme: legacy_openstates
+- identifier: ocd-person/7fce70bf-5ec9-4dc0-ad3a-2792fe8b97b4
+  scheme: openstates
 given_name: Benjamin
 family_name: Chipman

--- a/data/me/people/Dana-L-Dow-58f54c96-e985-46de-9788-bb9f9ab33510.yml
+++ b/data/me/people/Dana-L-Dow-58f54c96-e985-46de-9788-bb9f9ab33510.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000085
   scheme: legacy_openstates
+- identifier: ocd-person/cd1732d5-61e0-459b-84ee-ae5565bf73a6
+  scheme: openstates
 given_name: Dana
 family_name: Dow

--- a/data/me/people/Dennis-L-Keschl-deb3e08d-dfd1-49de-b425-4c53f51cf144.yml
+++ b/data/me/people/Dennis-L-Keschl-deb3e08d-dfd1-49de-b425-4c53f51cf144.yml
@@ -22,3 +22,5 @@ image: https://legislature.maine.gov/house/house/Repository/MemberProfiles/52492
 other_identifiers:
 - identifier: MEL000118
   scheme: legacy_openstates
+- identifier: ocd-person/6cee659f-2c95-41e5-9e9c-e307b856c982
+  scheme: openstates

--- a/data/me/people/Eloise-A-Vitelli-7506df16-2523-4f35-85a2-d8fdf5c59b38.yml
+++ b/data/me/people/Eloise-A-Vitelli-7506df16-2523-4f35-85a2-d8fdf5c59b38.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000277
   scheme: legacy_openstates
+- identifier: ocd-person/fdd45885-1f71-445a-9dc8-e63a230f4bed
+  scheme: openstates
 given_name: Eloise
 family_name: Vitelli

--- a/data/me/people/Jeffrey-Evangelos-c78368af-d3a2-4ee5-9d0f-61428e5ae5df.yml
+++ b/data/me/people/Jeffrey-Evangelos-c78368af-d3a2-4ee5-9d0f-61428e5ae5df.yml
@@ -25,3 +25,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000290
   scheme: legacy_openstates
+- identifier: ocd-person/d84673b4-3b71-42b8-b6e7-02c5d9e958f4
+  scheme: openstates

--- a/data/me/people/Justin-M-Chenette-7ecc9627-9abe-4464-a35a-8b08bf6c88b5.yml
+++ b/data/me/people/Justin-M-Chenette-7ecc9627-9abe-4464-a35a-8b08bf6c88b5.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000424
   scheme: legacy_openstates
+- identifier: ocd-person/3af150ee-211d-499b-86e9-7d18e7522621
+  scheme: openstates
 given_name: Justin
 family_name: Chenette

--- a/data/me/people/Philip-A-Curtis-3dc89cfe-f773-4d6b-ac9f-7d5e0bb7f2b7.yml
+++ b/data/me/people/Philip-A-Curtis-3dc89cfe-f773-4d6b-ac9f-7d5e0bb7f2b7.yml
@@ -22,3 +22,5 @@ image: https://legislature.maine.gov/house/house/Repository/MemberProfiles/bb863
 other_identifiers:
 - identifier: MEL000121
   scheme: legacy_openstates
+- identifier: ocd-person/3c20d903-30fd-46bb-8ce9-8e1a4f04dc69
+  scheme: openstates

--- a/data/me/people/Richard-M-Cebra-544a2670-8b80-435d-bb66-01ce0a0a2d72.yml
+++ b/data/me/people/Richard-M-Cebra-544a2670-8b80-435d-bb66-01ce0a0a2d72.yml
@@ -17,6 +17,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000136
   scheme: legacy_openstates
+- identifier: ocd-person/01f65af5-eed7-4b0d-b715-cca519f0d7ea
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/me/people/Seth-A-Berry-3795c944-bdfa-4362-b1b9-0f634cd6a06c.yml
+++ b/data/me/people/Seth-A-Berry-3795c944-bdfa-4362-b1b9-0f634cd6a06c.yml
@@ -16,6 +16,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MEL000102
   scheme: legacy_openstates
+- identifier: ocd-person/e89428e2-f486-4795-9da4-585f884b960f
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/mi/people/Aric-Nesbitt-6d11944d-f19f-4697-811c-0c9dca750c57.yml
+++ b/data/mi/people/Aric-Nesbitt-6d11944d-f19f-4697-811c-0c9dca750c57.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MIL000226
   scheme: legacy_openstates
+- identifier: ocd-person/8ceafa66-da4a-4bd6-82e1-9587a7180ce2
+  scheme: openstates

--- a/data/mi/people/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
+++ b/data/mi/people/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
@@ -31,5 +31,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MIL000221
   scheme: legacy_openstates
+- identifier: ocd-person/772c2e21-c14d-478d-a246-3d9f288d31d0
+  scheme: openstates
 given_name: Dale
 family_name: Zorn

--- a/data/mi/people/Ed-McBroom-4fc7e235-2446-405d-9a56-5e010017f617.yml
+++ b/data/mi/people/Ed-McBroom-4fc7e235-2446-405d-9a56-5e010017f617.yml
@@ -23,3 +23,5 @@ sources:
 other_identifiers:
 - identifier: MIL000146
   scheme: legacy_openstates
+- identifier: ocd-person/bb118460-5b8b-43b7-906e-434d46d46c31
+  scheme: openstates

--- a/data/mi/people/Jeff-Irwin-a1c1163d-af8d-4b88-9365-07717d4a45c3.yml
+++ b/data/mi/people/Jeff-Irwin-a1c1163d-af8d-4b88-9365-07717d4a45c3.yml
@@ -24,3 +24,5 @@ sources:
 other_identifiers:
 - identifier: MIL000091
   scheme: legacy_openstates
+- identifier: ocd-person/eb7e3814-a580-44ad-9585-df207e0879e4
+  scheme: openstates

--- a/data/mi/people/Jim-Stamas-0c662b88-2758-4277-9b21-bab723581b70.yml
+++ b/data/mi/people/Jim-Stamas-0c662b88-2758-4277-9b21-bab723581b70.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MIL000136
   scheme: legacy_openstates
+- identifier: ocd-person/8d3f135e-50a1-4b79-a2a6-0d30e12d0d8c
+  scheme: openstates
 given_name: Jim
 family_name: Stamas

--- a/data/mi/people/Jon-Bumstead-5a58fa81-639b-4304-87ca-7471ba9ade96.yml
+++ b/data/mi/people/Jon-Bumstead-5a58fa81-639b-4304-87ca-7471ba9ade96.yml
@@ -24,3 +24,5 @@ sources:
 other_identifiers:
 - identifier: MIL000138
   scheme: legacy_openstates
+- identifier: ocd-person/0ebee0f3-1176-42ee-844d-b61c8cdaca18
+  scheme: openstates

--- a/data/mi/people/Kevin-Daley-cf7ed8de-2df4-41ff-9dcb-489980b031a0.yml
+++ b/data/mi/people/Kevin-Daley-cf7ed8de-2df4-41ff-9dcb-489980b031a0.yml
@@ -23,3 +23,5 @@ sources:
 other_identifiers:
 - identifier: MIL000120
   scheme: legacy_openstates
+- identifier: ocd-person/2526e60c-522f-4e9e-a7cc-b7861c597ae5
+  scheme: openstates

--- a/data/mi/people/Peter-MacGregor-5f26b688-690e-4ec2-921e-6d9c2895d71a.yml
+++ b/data/mi/people/Peter-MacGregor-5f26b688-690e-4ec2-921e-6d9c2895d71a.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MIL000111
   scheme: legacy_openstates
+- identifier: ocd-person/f0f6a151-1374-4dc9-a748-4e6e37547214
+  scheme: openstates
 given_name: Peter
 family_name: MacGregor

--- a/data/mi/people/Rick-Outman-9c525554-fb85-45f3-87fa-cf6a3208ce32.yml
+++ b/data/mi/people/Rick-Outman-9c525554-fb85-45f3-87fa-cf6a3208ce32.yml
@@ -24,3 +24,5 @@ sources:
 other_identifiers:
 - identifier: MIL000108
   scheme: legacy_openstates
+- identifier: ocd-person/cfb05b53-0fd0-46fb-a6d0-6ffc1b26e84d
+  scheme: openstates

--- a/data/mi/people/Sean-McCann-c15f272e-73f2-410c-8afe-1cc91ad3603a.yml
+++ b/data/mi/people/Sean-McCann-c15f272e-73f2-410c-8afe-1cc91ad3603a.yml
@@ -24,3 +24,5 @@ sources:
 other_identifiers:
 - identifier: MIL000098
   scheme: legacy_openstates
+- identifier: ocd-person/29bfbb5e-dfb5-4fc4-9bdc-a7a2b447bfaa
+  scheme: openstates

--- a/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
+++ b/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000572
   scheme: legacy_openstates
+- identifier: ocd-person/eeb5bd20-3040-44ed-b7ae-6d0722e0ab03
+  scheme: openstates
 given_name: Carolyn
 family_name: Laine

--- a/data/mn/people/Erik-Simonson-2f94f2ac-3097-4ed6-89bf-66bfe2c36f42.yml
+++ b/data/mn/people/Erik-Simonson-2f94f2ac-3097-4ed6-89bf-66bfe2c36f42.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000575
   scheme: legacy_openstates
+- identifier: ocd-person/377f12f8-5c31-4144-8927-b55144c0f102
+  scheme: openstates
 given_name: Erik
 family_name: Simonson

--- a/data/mn/people/Jason-Isaacson-d32312d3-1b72-470d-bc1a-cd0c3359b224.yml
+++ b/data/mn/people/Jason-Isaacson-d32312d3-1b72-470d-bc1a-cd0c3359b224.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000600
   scheme: legacy_openstates
+- identifier: ocd-person/d336484a-ea08-4aaf-bda6-d080a4ad4378
+  scheme: openstates
 given_name: Jason
 family_name: Isaacson

--- a/data/mn/people/Jerry-Newton-9ec4bda3-571f-4d6d-85f1-39a2d54d106a.yml
+++ b/data/mn/people/Jerry-Newton-9ec4bda3-571f-4d6d-85f1-39a2d54d106a.yml
@@ -36,5 +36,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000635
   scheme: legacy_openstates
+- identifier: ocd-person/3a342b25-cd1e-4061-b70c-c171dc3d5bc7
+  scheme: openstates
 given_name: Jerry
 family_name: Newton

--- a/data/mn/people/Jim-Abeler-fc189dd9-b597-4744-86d3-ac315b93a3f3.yml
+++ b/data/mn/people/Jim-Abeler-fc189dd9-b597-4744-86d3-ac315b93a3f3.yml
@@ -36,5 +36,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000370
   scheme: legacy_openstates
+- identifier: ocd-person/c9dd9cd4-1e64-4cb9-b02e-fa02075f7058
+  scheme: openstates
 given_name: Jim
 family_name: Abeler

--- a/data/mn/people/John-Persell-c41534ef-17ef-4e1f-a7df-c6d0ebd57f91.yml
+++ b/data/mn/people/John-Persell-c41534ef-17ef-4e1f-a7df-c6d0ebd57f91.yml
@@ -33,3 +33,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000593
   scheme: legacy_openstates
+- identifier: ocd-person/5be01674-a330-4d12-9746-f16a6432caef
+  scheme: openstates

--- a/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
+++ b/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000180
   scheme: legacy_openstates
+- identifier: ocd-person/b5d151c8-33f6-441d-ba5b-5069ae39dc87
+  scheme: openstates
 given_name: Karla
 family_name: Bigham

--- a/data/mn/people/Ryan-Winkler-01002bdd-9ced-4bd2-bf6e-7235ca9a60f9.yml
+++ b/data/mn/people/Ryan-Winkler-01002bdd-9ced-4bd2-bf6e-7235ca9a60f9.yml
@@ -33,3 +33,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MNL000638
   scheme: legacy_openstates
+- identifier: ocd-person/8eb5e1e5-f824-429a-99fb-87275de28846
+  scheme: openstates

--- a/data/mo/people/Andrew-Koenig-2effb0e6-3648-4cc7-8738-8f2cb8373b30.yml
+++ b/data/mo/people/Andrew-Koenig-2effb0e6-3648-4cc7-8738-8f2cb8373b30.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000285
   scheme: legacy_openstates
+- identifier: ocd-person/a17525e8-26ee-43b4-9185-f1b020d177fa
+  scheme: openstates
 given_name: Andrew
 family_name: Koenig

--- a/data/mo/people/Caleb-Rowden-b65e8aa2-23c4-4ad4-8550-510d8ba82cfc.yml
+++ b/data/mo/people/Caleb-Rowden-b65e8aa2-23c4-4ad4-8550-510d8ba82cfc.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000339
   scheme: legacy_openstates
+- identifier: ocd-person/7521d3b9-1f7c-4ff0-ad3c-06b38c200caf
+  scheme: openstates
 given_name: Caleb
 family_name: Rowden

--- a/data/mo/people/Chris-Carter-91b85143-6ba4-42d1-970c-8dfbb7140fbd.yml
+++ b/data/mo/people/Chris-Carter-91b85143-6ba4-42d1-970c-8dfbb7140fbd.yml
@@ -27,3 +27,5 @@ extras:
 other_identifiers:
 - identifier: MOL000052
   scheme: legacy_openstates
+- identifier: ocd-person/4b738c76-6d31-4e1c-a4e5-cbea4bef2bc1
+  scheme: openstates

--- a/data/mo/people/Denny-Hoskins-9f04b7ea-bd98-4f8e-ad76-8a5bf7b5917a.yml
+++ b/data/mo/people/Denny-Hoskins-9f04b7ea-bd98-4f8e-ad76-8a5bf7b5917a.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000272
   scheme: legacy_openstates
+- identifier: ocd-person/dac9b1a2-57a3-4e58-a962-b42d36e5ac6e
+  scheme: openstates
 given_name: Denny
 family_name: Hoskins

--- a/data/mo/people/Eric-Burlison-dc0f12ea-0f93-4d75-ae28-51a053368188.yml
+++ b/data/mo/people/Eric-Burlison-dc0f12ea-0f93-4d75-ae28-51a053368188.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000222
   scheme: legacy_openstates
+- identifier: ocd-person/0127e9f2-4e8e-4f15-84c0-f268950ced9f
+  scheme: openstates

--- a/data/mo/people/John-Rizzo-9f51689c-7d78-4e84-8a13-8bcd0d8b10ad.yml
+++ b/data/mo/people/John-Rizzo-9f51689c-7d78-4e84-8a13-8bcd0d8b10ad.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000336
   scheme: legacy_openstates
+- identifier: ocd-person/24c3e135-6889-4bdb-92f9-f9b9b20021e9
+  scheme: openstates
 given_name: John
 family_name: Rizzo

--- a/data/mo/people/Lauren-Arthur-d7beefb2-2b4f-490a-b1f3-b83840c663ff.yml
+++ b/data/mo/people/Lauren-Arthur-d7beefb2-2b4f-490a-b1f3-b83840c663ff.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000404
   scheme: legacy_openstates
+- identifier: ocd-person/4ee5c374-a4e2-4758-acaa-a5ba0c75ae61
+  scheme: openstates
 given_name: Lauren
 family_name: Arthur

--- a/data/mo/people/Lincoln-Hough-934fdfca-5cdf-4c67-a3b0-b23e433f87f6.yml
+++ b/data/mo/people/Lincoln-Hough-934fdfca-5cdf-4c67-a3b0-b23e433f87f6.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000273
   scheme: legacy_openstates
+- identifier: ocd-person/2139579b-ad7c-42c1-8240-ea32a0bf782f
+  scheme: openstates

--- a/data/mo/people/Ron-Hicks-79763e96-3489-411e-b379-243f76edeab6.yml
+++ b/data/mo/people/Ron-Hicks-79763e96-3489-411e-b379-243f76edeab6.yml
@@ -27,3 +27,5 @@ extras:
 other_identifiers:
 - identifier: MOL000268
   scheme: legacy_openstates
+- identifier: ocd-person/58a810dc-507f-4f34-81ee-71c5ca56a029
+  scheme: openstates

--- a/data/mo/people/Sheila-Solon-8b5f5917-7799-4d2e-bbe7-ac9e27ccd039.yml
+++ b/data/mo/people/Sheila-Solon-8b5f5917-7799-4d2e-bbe7-ac9e27ccd039.yml
@@ -34,3 +34,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MOL000351
   scheme: legacy_openstates
+- identifier: ocd-person/8f7e37e3-8011-4479-b4b0-e732b8181e10
+  scheme: openstates

--- a/data/ms/people/David-Parker-18630d08-6afc-4892-ac2f-e13f0d9932f6.yml
+++ b/data/ms/people/David-Parker-18630d08-6afc-4892-ac2f-e13f0d9932f6.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MSL000228
   scheme: legacy_openstates
+- identifier: ocd-person/c998e641-4136-4595-a560-19804dc402cd
+  scheme: openstates
 given_name: David
 family_name: Parker

--- a/data/ms/people/Kevin-Horan-b339d980-af38-4e76-b53c-215c26191cc1.yml
+++ b/data/ms/people/Kevin-Horan-b339d980-af38-4e76-b53c-215c26191cc1.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MSL000212
   scheme: legacy_openstates
+- identifier: ocd-person/c3741045-e044-490e-8186-43149d8ec505
+  scheme: openstates
 given_name: Kevin
 family_name: Horan

--- a/data/ms/people/Michael-T-Evans-d247f852-5545-40b2-b974-757b73b1e807.yml
+++ b/data/ms/people/Michael-T-Evans-d247f852-5545-40b2-b974-757b73b1e807.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MSL000222
   scheme: legacy_openstates
+- identifier: ocd-person/5cf40f42-b33a-40c3-8631-8c89d0bca827
+  scheme: openstates
 given_name: Michael T.
 family_name: Evans

--- a/data/mt/people/Albert-Olszewski-65fc9478-1d40-4b00-b434-52a0a737c067.yml
+++ b/data/mt/people/Albert-Olszewski-65fc9478-1d40-4b00-b434-52a0a737c067.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000261
   scheme: legacy_openstates
+- identifier: ocd-person/c384f2cb-98db-4a30-9e4d-d57fe2164e40
+  scheme: openstates
 given_name: Albert
 family_name: Olszewski

--- a/data/mt/people/Bradley-Maxon-Hamlett-80af2c89-f455-4599-966c-2ab147376959.yml
+++ b/data/mt/people/Bradley-Maxon-Hamlett-80af2c89-f455-4599-966c-2ab147376959.yml
@@ -41,5 +41,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000353
   scheme: legacy_openstates
+- identifier: ocd-person/f7b84b6b-837b-451d-98d4-437df3ac8cb8
+  scheme: openstates
 given_name: Bradley Maxon
 family_name: Hamlett

--- a/data/mt/people/Bryce-Bennett-24ce8d6f-c716-409b-85bb-dfafb267e62d.yml
+++ b/data/mt/people/Bryce-Bennett-24ce8d6f-c716-409b-85bb-dfafb267e62d.yml
@@ -23,3 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000331
   scheme: legacy_openstates
+- identifier: ocd-person/3fcdaa21-3606-4b5e-a01c-e3c48b4b84cb
+  scheme: openstates

--- a/data/mt/people/Casey-Schreiner-86c48c35-9757-4d9d-941f-c97d0abb8e49.yml
+++ b/data/mt/people/Casey-Schreiner-86c48c35-9757-4d9d-941f-c97d0abb8e49.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000306
   scheme: legacy_openstates
+- identifier: ocd-person/d65df0ae-22cd-4289-b1bc-ea37ee35ad1e
+  scheme: openstates
 given_name: Casey
 family_name: Schreiner

--- a/data/mt/people/Daniel-Salomon-c6641ba3-7be7-4286-9ade-3445b4d6a08f.yml
+++ b/data/mt/people/Daniel-Salomon-c6641ba3-7be7-4286-9ade-3445b4d6a08f.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000258
   scheme: legacy_openstates
+- identifier: ocd-person/cb1013bc-4e8b-4409-baad-b4f19db68802
+  scheme: openstates
 given_name: Daniel
 family_name: Salomon

--- a/data/mt/people/Dennis-Lenz-0fd1ad64-349c-42d9-ae46-4ff7d3eb9495.yml
+++ b/data/mt/people/Dennis-Lenz-0fd1ad64-349c-42d9-ae46-4ff7d3eb9495.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000197
   scheme: legacy_openstates
+- identifier: ocd-person/e2c67964-f21a-4675-b168-b5521e2b5bff
+  scheme: openstates
 given_name: Dennis
 family_name: Lenz

--- a/data/mt/people/Derek-Skees-c5702661-6e26-4cc3-afa1-167d49b393df.yml
+++ b/data/mt/people/Derek-Skees-c5702661-6e26-4cc3-afa1-167d49b393df.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000135
   scheme: legacy_openstates
+- identifier: ocd-person/ac936409-36d2-49ab-94e8-d0d8c96b3c85
+  scheme: openstates
 given_name: Derek
 family_name: Skees

--- a/data/mt/people/Edie-Mcclafferty-3a40e354-8436-4755-8668-30c6d3f14c1b.yml
+++ b/data/mt/people/Edie-Mcclafferty-3a40e354-8436-4755-8668-30c6d3f14c1b.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000337
   scheme: legacy_openstates
+- identifier: ocd-person/83346184-2d5c-4903-8caa-42ca0c4453b1
+  scheme: openstates
 given_name: Edie
 family_name: Mcclafferty

--- a/data/mt/people/Edward-Buttrey-29b81d32-dc72-49d8-8bef-ca4b60fe9c87.yml
+++ b/data/mt/people/Edward-Buttrey-29b81d32-dc72-49d8-8bef-ca4b60fe9c87.yml
@@ -23,3 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000296
   scheme: legacy_openstates
+- identifier: ocd-person/62a09e8b-f80f-4c3f-80b3-4de9866300d3
+  scheme: openstates

--- a/data/mt/people/Janet-Ellis-2062cc82-e160-435d-ab16-c57305a13db4.yml
+++ b/data/mt/people/Janet-Ellis-2062cc82-e160-435d-ab16-c57305a13db4.yml
@@ -21,3 +21,5 @@ contact_details:
 other_identifiers:
 - identifier: MTL000303
   scheme: legacy_openstates
+- identifier: ocd-person/ccadc5eb-1278-4d9e-bcaa-85137d5e380e
+  scheme: openstates

--- a/data/mt/people/Jeffrey-Welborn-1ceb0d0c-ddd6-43b9-9e74-86f75519030d.yml
+++ b/data/mt/people/Jeffrey-Welborn-1ceb0d0c-ddd6-43b9-9e74-86f75519030d.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000147
   scheme: legacy_openstates
+- identifier: ocd-person/c2dfdaca-da80-4e6f-88a6-fe3bdce2d69a
+  scheme: openstates
 given_name: Jeffrey
 family_name: Welborn

--- a/data/mt/people/Jim-Keane-fe5ed291-e056-4ad3-aec9-3a10da720910.yml
+++ b/data/mt/people/Jim-Keane-fe5ed291-e056-4ad3-aec9-3a10da720910.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000023
   scheme: legacy_openstates
+- identifier: ocd-person/86f4bc9f-cdcd-4d9e-bf04-bab9685e2a21
+  scheme: openstates
 given_name: Jim
 family_name: Keane

--- a/data/mt/people/Joe-Read-21e604a6-9cd0-49e7-b2b6-9dffd4419bee.yml
+++ b/data/mt/people/Joe-Read-21e604a6-9cd0-49e7-b2b6-9dffd4419bee.yml
@@ -22,3 +22,5 @@ contact_details:
 other_identifiers:
 - identifier: MTL000124
   scheme: legacy_openstates
+- identifier: ocd-person/64520404-5d31-450b-b980-023d75c78c08
+  scheme: openstates

--- a/data/mt/people/John-Esp-a936c9c8-0a8d-4bcf-8da0-1a9b9ac80ab2.yml
+++ b/data/mt/people/John-Esp-a936c9c8-0a8d-4bcf-8da0-1a9b9ac80ab2.yml
@@ -22,3 +22,5 @@ contact_details:
 other_identifiers:
 - identifier: MTL000073
   scheme: legacy_openstates
+- identifier: ocd-person/751bb306-ce27-4995-9b54-bc383a937f60
+  scheme: openstates

--- a/data/mt/people/Keith-Regier-d21c0b57-3b30-4cfc-895d-461eebd97461.yml
+++ b/data/mt/people/Keith-Regier-d21c0b57-3b30-4cfc-895d-461eebd97461.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000267
   scheme: legacy_openstates
+- identifier: ocd-person/09f471c6-e46b-40ab-81f8-2948ab178858
+  scheme: openstates
 given_name: Keith
 family_name: Regier

--- a/data/mt/people/Llew-Jones-ed3e498d-5160-4f6a-8580-ee2a4d877b5d.yml
+++ b/data/mt/people/Llew-Jones-ed3e498d-5160-4f6a-8580-ee2a4d877b5d.yml
@@ -23,3 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000238
   scheme: legacy_openstates
+- identifier: ocd-person/cbe3d754-5e22-4006-a3c7-c65eefc292b1
+  scheme: openstates

--- a/data/mt/people/Mary-Caferro-c2eda1fb-6dc5-4326-a4b5-a295f26ee399.yml
+++ b/data/mt/people/Mary-Caferro-c2eda1fb-6dc5-4326-a4b5-a295f26ee399.yml
@@ -23,3 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000254
   scheme: legacy_openstates
+- identifier: ocd-person/4d78e49e-5e30-4c22-8c16-d3e7c31b0d45
+  scheme: openstates

--- a/data/mt/people/Mike-Cuffe-54c93c1b-968f-4b39-a17f-26ebcb266f69.yml
+++ b/data/mt/people/Mike-Cuffe-54c93c1b-968f-4b39-a17f-26ebcb266f69.yml
@@ -21,3 +21,5 @@ contact_details:
 other_identifiers:
 - identifier: MTL000069
   scheme: legacy_openstates
+- identifier: ocd-person/c841e01f-4518-4bb0-a791-d421d9c9d360
+  scheme: openstates

--- a/data/mt/people/Mike-Lang-191d61f0-fa51-4588-8cb3-5d05d227d776.yml
+++ b/data/mt/people/Mike-Lang-191d61f0-fa51-4588-8cb3-5d05d227d776.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000321
   scheme: legacy_openstates
+- identifier: ocd-person/cfd94df9-6689-4425-a3e4-c8f010c96fd8
+  scheme: openstates
 given_name: Mike
 family_name: Lang

--- a/data/mt/people/Ryan-Osmundson-0d6804fe-7977-4162-b1d8-e5b29cdc29f9.yml
+++ b/data/mt/people/Ryan-Osmundson-0d6804fe-7977-4162-b1d8-e5b29cdc29f9.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000329
   scheme: legacy_openstates
+- identifier: ocd-person/e8c36e08-a54c-4c5f-837a-049d284c4604
+  scheme: openstates
 given_name: Ryan
 family_name: Osmundson

--- a/data/mt/people/Steve-Fitzpatrick-afcd51eb-e3cf-4bc4-8093-80f884de54e2.yml
+++ b/data/mt/people/Steve-Fitzpatrick-afcd51eb-e3cf-4bc4-8093-80f884de54e2.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000075
   scheme: legacy_openstates
+- identifier: ocd-person/2f3bb43e-d868-41e0-970e-e0b482ab1c09
+  scheme: openstates
 given_name: Steve
 family_name: Fitzpatrick

--- a/data/mt/people/Susan-Webber-8a773a18-0be3-4292-9543-e6e5051e59f4.yml
+++ b/data/mt/people/Susan-Webber-8a773a18-0be3-4292-9543-e6e5051e59f4.yml
@@ -21,3 +21,5 @@ contact_details:
 other_identifiers:
 - identifier: MTL000316
   scheme: legacy_openstates
+- identifier: ocd-person/90e85427-a0fa-4a40-adca-c4a5a32dd016
+  scheme: openstates

--- a/data/mt/people/Tom-Richmond-664b4aa9-af1e-4df0-863d-2b692ba53705.yml
+++ b/data/mt/people/Tom-Richmond-664b4aa9-af1e-4df0-863d-2b692ba53705.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000290
   scheme: legacy_openstates
+- identifier: ocd-person/eb1e1113-08e5-4348-9500-ae929df89b2f
+  scheme: openstates
 given_name: Tom
 family_name: Richmond

--- a/data/mt/people/Wendy-Mckamey-8f827a3b-16fe-4e09-bad0-c3e29c73d9c8.yml
+++ b/data/mt/people/Wendy-Mckamey-8f827a3b-16fe-4e09-bad0-c3e29c73d9c8.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000276
   scheme: legacy_openstates
+- identifier: ocd-person/3b9dfb11-becb-4279-99f2-3896428d264b
+  scheme: openstates
 given_name: Wendy
 family_name: Mckamey

--- a/data/mt/people/Wylie-Galt-4b0e74d3-19ae-449e-b712-ac96d2c1a165.yml
+++ b/data/mt/people/Wylie-Galt-4b0e74d3-19ae-449e-b712-ac96d2c1a165.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: MTL000184
   scheme: legacy_openstates
+- identifier: ocd-person/0450b0af-b031-414c-b2ed-ed796ca1ee5a
+  scheme: openstates
 given_name: Wylie
 family_name: Galt

--- a/data/nc/people/Dan-Bishop-aeda3016-da15-448e-9ae4-62da790b3129.yml
+++ b/data/nc/people/Dan-Bishop-aeda3016-da15-448e-9ae4-62da790b3129.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NCL000343
   scheme: legacy_openstates
+- identifier: ocd-person/fbf9d1b7-4468-4c0f-8ef2-8c340428959e
+  scheme: openstates
 given_name: Dan
 family_name: Bishop

--- a/data/nc/people/Joe-Sam-Queen-418e28d6-6539-40c6-8e95-dd56e1e663a1.yml
+++ b/data/nc/people/Joe-Sam-Queen-418e28d6-6539-40c6-8e95-dd56e1e663a1.yml
@@ -35,3 +35,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NCL000294
   scheme: legacy_openstates
+- identifier: ocd-person/1d5fa241-9606-4410-ae6f-23f138317930
+  scheme: openstates

--- a/data/nd/people/Corey-Mock-33add2cf-dc7a-4da0-b60d-95faaad1f261.yml
+++ b/data/nd/people/Corey-Mock-33add2cf-dc7a-4da0-b60d-95faaad1f261.yml
@@ -21,6 +21,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NDL000369
   scheme: legacy_openstates
+- identifier: ocd-person/0c9cdb48-aa83-48df-892f-b38bf0a9b8e8
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/nd/people/Diane-Larson-9844a188-809c-4711-8147-2c30206721ee.yml
+++ b/data/nd/people/Diane-Larson-9844a188-809c-4711-8147-2c30206721ee.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NDL000425
   scheme: legacy_openstates
+- identifier: ocd-person/6a252b4a-e516-401f-8904-4b9f5f8b880e
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/nd/people/George-J-Keiser-5db91a7e-928c-40f4-aa90-62ae2c45a23b.yml
+++ b/data/nd/people/George-J-Keiser-5db91a7e-928c-40f4-aa90-62ae2c45a23b.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NDL000416
   scheme: legacy_openstates
+- identifier: ocd-person/64e8e803-2b1e-45c9-abec-93d7d6371694
+  scheme: openstates
 given_name: George J.
 family_name: Keiser

--- a/data/nd/people/Rick-C-Becker-02d00f0b-b88e-444f-ab65-adb352d5ae69.yml
+++ b/data/nd/people/Rick-C-Becker-02d00f0b-b88e-444f-ab65-adb352d5ae69.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NDL000168
   scheme: legacy_openstates
+- identifier: ocd-person/beab3176-e2c5-49f0-835f-f7e35ac90d66
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/ne/people/Steve-Lathrop-e8cdba62-b191-4fc8-ae40-3b7f23f98564.yml
+++ b/data/ne/people/Steve-Lathrop-e8cdba62-b191-4fc8-ae40-3b7f23f98564.yml
@@ -22,3 +22,5 @@ family_name: Lathrop
 other_identifiers:
 - identifier: NEL000012
   scheme: legacy_openstates
+- identifier: ocd-person/a77414eb-08fb-48a2-8924-f622365a03b7
+  scheme: openstates

--- a/data/nh/people/Andrew-Renzullo-b8aa741e-30b1-4d45-8f6a-7241f0d0eed2.yml
+++ b/data/nh/people/Andrew-Renzullo-b8aa741e-30b1-4d45-8f6a-7241f0d0eed2.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000701
   scheme: legacy_openstates
+- identifier: ocd-person/ca01a498-77ce-409a-a75d-93d6439e0f13
+  scheme: openstates
 given_name: Andrew
 family_name: Renzullo

--- a/data/nh/people/Andrew-S-OHearne-e21aaa1f-c784-46f1-a214-9372580fc45e.yml
+++ b/data/nh/people/Andrew-S-OHearne-e21aaa1f-c784-46f1-a214-9372580fc45e.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000963
   scheme: legacy_openstates
+- identifier: ocd-person/83149c2f-1487-4cbf-a7d4-cf1b4678c7b1
+  scheme: openstates

--- a/data/nh/people/Cindy-Rosenwald-f3e949ce-6d98-4826-bbca-08039cea4ea4.yml
+++ b/data/nh/people/Cindy-Rosenwald-f3e949ce-6d98-4826-bbca-08039cea4ea4.yml
@@ -29,3 +29,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000714
   scheme: legacy_openstates
+- identifier: ocd-person/3ca76f7b-e7c4-40c0-ab15-fe06d6b1cafd
+  scheme: openstates

--- a/data/nh/people/Dan-Feltes-e97501d7-4bef-403f-8d48-9fcecc980cf5.yml
+++ b/data/nh/people/Dan-Feltes-e97501d7-4bef-403f-8d48-9fcecc980cf5.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001290
   scheme: legacy_openstates
+- identifier: ocd-person/25c8ffc1-5dd6-4e74-a39c-929f5f34e389
+  scheme: openstates
 given_name: Dan
 family_name: Feltes

--- a/data/nh/people/David-B-Karrick-94f54bab-44a0-41ce-a766-0e0eb882f9bf.yml
+++ b/data/nh/people/David-B-Karrick-94f54bab-44a0-41ce-a766-0e0eb882f9bf.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000927
   scheme: legacy_openstates
+- identifier: ocd-person/687569cf-b9b0-4bdc-b596-3ccd88623d06
+  scheme: openstates

--- a/data/nh/people/David-H-Watters-cf24defe-6df3-49f3-88ca-c6774b144f19.yml
+++ b/data/nh/people/David-H-Watters-cf24defe-6df3-49f3-88ca-c6774b144f19.yml
@@ -46,5 +46,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001305
   scheme: legacy_openstates
+- identifier: ocd-person/05a8690d-2c83-45e0-a5fd-a1fdfa5d4746
+  scheme: openstates
 given_name: David H
 family_name: Watters

--- a/data/nh/people/David-O-Huot-1ca469eb-22a1-4c1c-af43-a0a5456f3a4f.yml
+++ b/data/nh/people/David-O-Huot-1ca469eb-22a1-4c1c-af43-a0a5456f3a4f.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000826
   scheme: legacy_openstates
+- identifier: ocd-person/a8389c79-79c5-458b-a6d1-1e35fe10d2a4
+  scheme: openstates
 given_name: David O.
 family_name: Huot

--- a/data/nh/people/David-Woodbury-149da0e1-39c6-4bd0-b290-5af40a15ea37.yml
+++ b/data/nh/people/David-Woodbury-149da0e1-39c6-4bd0-b290-5af40a15ea37.yml
@@ -26,3 +26,5 @@ extras:
 other_identifiers:
 - identifier: NHL000801
   scheme: legacy_openstates
+- identifier: ocd-person/3b781353-92db-4f5d-b8e8-8c78573ec06f
+  scheme: openstates

--- a/data/nh/people/Dennis-J-Malloy-d6200a81-3d99-4ff7-93e0-e2f3b49cfd65.yml
+++ b/data/nh/people/Dennis-J-Malloy-d6200a81-3d99-4ff7-93e0-e2f3b49cfd65.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000979
   scheme: legacy_openstates
+- identifier: ocd-person/cb3a99cb-a534-465b-8057-185175138d4f
+  scheme: openstates
 given_name: Dennis J.
 family_name: Malloy

--- a/data/nh/people/Donna-M-Soucy-bfbbacfd-e12a-4e07-970e-c2c2c006f4a2.yml
+++ b/data/nh/people/Donna-M-Soucy-bfbbacfd-e12a-4e07-970e-c2c2c006f4a2.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001304
   scheme: legacy_openstates
+- identifier: ocd-person/450cb308-6475-433d-be07-71156f8e6dad
+  scheme: openstates
 given_name: Donna M.
 family_name: Soucy

--- a/data/nh/people/George-L-Saunderson-633b7bd0-b605-42ae-837a-4d7d392e085e.yml
+++ b/data/nh/people/George-L-Saunderson-633b7bd0-b605-42ae-837a-4d7d392e085e.yml
@@ -26,3 +26,5 @@ extras:
 other_identifiers:
 - identifier: NHL001142
   scheme: legacy_openstates
+- identifier: ocd-person/8e5e92aa-d65c-4d57-bc81-6ca592399ab9
+  scheme: openstates

--- a/data/nh/people/Harold-F-French-ff11da65-174b-4fdc-b33c-e5d6d56602f0.yml
+++ b/data/nh/people/Harold-F-French-ff11da65-174b-4fdc-b33c-e5d6d56602f0.yml
@@ -36,5 +36,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001120
   scheme: legacy_openstates
+- identifier: ocd-person/f1064c53-331e-4fea-a8b9-05ca2077bc67
+  scheme: openstates
 given_name: Harold F.
 family_name: French

--- a/data/nh/people/James-P-Gray-e6443187-eb51-42eb-8bd7-349ed0ba9641.yml
+++ b/data/nh/people/James-P-Gray-e6443187-eb51-42eb-8bd7-349ed0ba9641.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001259
   scheme: legacy_openstates
+- identifier: ocd-person/ffa003e5-fad2-4bfa-9f98-bd77fcbed7e8
+  scheme: openstates
 given_name: James P.
 family_name: Gray

--- a/data/nh/people/Janice-E-Schmidt-ec374833-801f-4c21-9261-67cdefc1ba44.yml
+++ b/data/nh/people/Janice-E-Schmidt-ec374833-801f-4c21-9261-67cdefc1ba44.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000887
   scheme: legacy_openstates
+- identifier: ocd-person/a9db756e-9349-4167-9084-7d9808b0c1bc
+  scheme: openstates
 given_name: Janice E.
 family_name: Schmidt

--- a/data/nh/people/Jeb-Bradley-3f5455e8-256e-4442-9c13-bc14f62ce76f.yml
+++ b/data/nh/people/Jeb-Bradley-3f5455e8-256e-4442-9c13-bc14f62ce76f.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001292
   scheme: legacy_openstates
+- identifier: ocd-person/06e05075-d5ea-4ddf-9ce0-1c8340ec144b
+  scheme: openstates
 given_name: Jeb
 family_name: Bradley

--- a/data/nh/people/John-M-Potucek-433c67d6-bfdc-410e-87e2-463c93d55a17.yml
+++ b/data/nh/people/John-M-Potucek-433c67d6-bfdc-410e-87e2-463c93d55a17.yml
@@ -26,3 +26,5 @@ extras:
 other_identifiers:
 - identifier: NHL001168
   scheme: legacy_openstates
+- identifier: ocd-person/1dd2f3e4-a4e4-4130-949b-4b4c5e6b82cc
+  scheme: openstates

--- a/data/nh/people/Kendall-A-Snow-cfc39de4-1079-46cc-85d2-fa6382d4eafd.yml
+++ b/data/nh/people/Kendall-A-Snow-cfc39de4-1079-46cc-85d2-fa6382d4eafd.yml
@@ -30,3 +30,5 @@ extras:
 other_identifiers:
 - identifier: NHL001244
   scheme: legacy_openstates
+- identifier: ocd-person/85513460-62c7-43f7-ae49-404eab5802c5
+  scheme: openstates

--- a/data/nh/people/Lou-DAllesandro-87c48788-817d-408b-a1e1-ebe1c9fd893d.yml
+++ b/data/nh/people/Lou-DAllesandro-87c48788-817d-408b-a1e1-ebe1c9fd893d.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001293
   scheme: legacy_openstates
+- identifier: ocd-person/42278fcd-ce07-40dd-af45-15be073dd69e
+  scheme: openstates
 given_name: Lou
 family_name: D'Allesandro

--- a/data/nh/people/Mark-McLean-b089786f-4435-4822-a7d6-3725cca787bf.yml
+++ b/data/nh/people/Mark-McLean-b089786f-4435-4822-a7d6-3725cca787bf.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001152
   scheme: legacy_openstates
+- identifier: ocd-person/5333e418-cc89-4773-878f-578ddbb8ca0a
+  scheme: openstates
 given_name: Mark
 family_name: McLean

--- a/data/nh/people/Mark-Warden-01358592-fa6d-49bf-a933-ea2f223572d7.yml
+++ b/data/nh/people/Mark-Warden-01358592-fa6d-49bf-a933-ea2f223572d7.yml
@@ -36,3 +36,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000785
   scheme: legacy_openstates
+- identifier: ocd-person/d74f93e8-3b4f-45ac-af62-87f10c67e400
+  scheme: openstates

--- a/data/nh/people/Martha-Fuller-Clark-823e56cb-5c51-4a09-b060-93cdb7f7ac25.yml
+++ b/data/nh/people/Martha-Fuller-Clark-823e56cb-5c51-4a09-b060-93cdb7f7ac25.yml
@@ -39,5 +39,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001308
   scheme: legacy_openstates
+- identifier: ocd-person/00bd9ed7-ecdb-4a74-8328-9093b614c6b6
+  scheme: openstates
 given_name: Martha Fuller
 family_name: Clark

--- a/data/nh/people/Max-Abramson-a2248bc0-9253-48d8-9ee2-d9c0b6fbc800.yml
+++ b/data/nh/people/Max-Abramson-a2248bc0-9253-48d8-9ee2-d9c0b6fbc800.yml
@@ -26,3 +26,5 @@ extras:
 other_identifiers:
 - identifier: NHL001187
   scheme: legacy_openstates
+- identifier: ocd-person/30c4267e-4905-4e30-bac8-8669b1540ea0
+  scheme: openstates

--- a/data/nh/people/Shannon-E-Chandley-92b62a3f-15ef-4cd6-9073-14d32a3eb74b.yml
+++ b/data/nh/people/Shannon-E-Chandley-92b62a3f-15ef-4cd6-9073-14d32a3eb74b.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000913
   scheme: legacy_openstates
+- identifier: ocd-person/45968fc8-e07b-4690-87b8-d99479659c76
+  scheme: openstates
 given_name: Shannon E.
 family_name: Chandley

--- a/data/nh/people/Sharon-M-Carson-00964fc0-dd57-44c3-87bf-b6d5bbc34560.yml
+++ b/data/nh/people/Sharon-M-Carson-00964fc0-dd57-44c3-87bf-b6d5bbc34560.yml
@@ -38,5 +38,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001289
   scheme: legacy_openstates
+- identifier: ocd-person/2d0aaf0e-69ed-450d-93e0-353b4e58c4a5
+  scheme: openstates
 given_name: Sharon M
 family_name: Carson

--- a/data/nh/people/Steven-J-Woitkun-200bb305-1df9-483e-82f3-f88a1d921e9a.yml
+++ b/data/nh/people/Steven-J-Woitkun-200bb305-1df9-483e-82f3-f88a1d921e9a.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001171
   scheme: legacy_openstates
+- identifier: ocd-person/8f8ccaf6-0376-4fa4-819e-3fe17b253b41
+  scheme: openstates
 given_name: Steven J.
 family_name: Woitkun

--- a/data/nh/people/Susan-J-Ticehurst-1f3a9485-30e3-4cdf-8389-d8ad149dc881.yml
+++ b/data/nh/people/Susan-J-Ticehurst-1f3a9485-30e3-4cdf-8389-d8ad149dc881.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000972
   scheme: legacy_openstates
+- identifier: ocd-person/3a98885a-d505-41c5-9080-9da90c09db4e
+  scheme: openstates

--- a/data/nh/people/Susan-M-Ford-41f95cc7-7833-44f2-85c6-336d6fe53da4.yml
+++ b/data/nh/people/Susan-M-Ford-41f95cc7-7833-44f2-85c6-336d6fe53da4.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000965
   scheme: legacy_openstates
+- identifier: ocd-person/45cb1183-1f5d-4e68-94cc-28d1cfcd0479
+  scheme: openstates

--- a/data/nh/people/Suzanne-M-Vail-ce985799-268d-4190-b078-955fc63a8c3c.yml
+++ b/data/nh/people/Suzanne-M-Vail-ce985799-268d-4190-b078-955fc63a8c3c.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000856
   scheme: legacy_openstates
+- identifier: ocd-person/d0ec569c-bb65-4c42-8e27-ee4345b1ce8c
+  scheme: openstates

--- a/data/nh/people/Thomas-C-Schamberg-29eeecd3-79b7-489c-b1a5-ace913e619f2.yml
+++ b/data/nh/people/Thomas-C-Schamberg-29eeecd3-79b7-489c-b1a5-ace913e619f2.yml
@@ -26,3 +26,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000982
   scheme: legacy_openstates
+- identifier: ocd-person/466b13a7-cd53-47a8-ada8-fe75e39a8278
+  scheme: openstates

--- a/data/nh/people/Timothy-A-Soucy-edcefea3-7cd4-4128-92ef-b22bc4a7c0b4.yml
+++ b/data/nh/people/Timothy-A-Soucy-edcefea3-7cd4-4128-92ef-b22bc4a7c0b4.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL000931
   scheme: legacy_openstates
+- identifier: ocd-person/02e4d365-e1db-42b1-907e-0bc87ca7febb
+  scheme: openstates
 given_name: Timothy A.
 family_name: Soucy

--- a/data/nh/people/William-A-Pearson-7781641c-b716-4a21-ba1a-f29f6c928f2e.yml
+++ b/data/nh/people/William-A-Pearson-7781641c-b716-4a21-ba1a-f29f6c928f2e.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NHL001124
   scheme: legacy_openstates
+- identifier: ocd-person/4cc7477e-6a43-473d-81bf-b6119d0417aa
+  scheme: openstates
 given_name: William A.
 family_name: Pearson

--- a/data/nj/people/Chris-A-Brown-30a41595-e0b5-403a-a7cc-568983f8e327.yml
+++ b/data/nj/people/Chris-A-Brown-30a41595-e0b5-403a-a7cc-568983f8e327.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000149
   scheme: legacy_openstates
+- identifier: ocd-person/725d9a42-7fd3-4ba3-9fb8-de0b3be6b703
+  scheme: openstates
 given_name: Chris
 family_name: Brown

--- a/data/nj/people/Joseph-A-Lagana-90a0a109-2ce3-4a55-8761-1e07ff875703.yml
+++ b/data/nj/people/Joseph-A-Lagana-90a0a109-2ce3-4a55-8761-1e07ff875703.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000182
   scheme: legacy_openstates
+- identifier: ocd-person/da5fe30e-9819-40d3-9420-8e8c7fc2d53a
+  scheme: openstates
 given_name: Joseph
 family_name: Lagana

--- a/data/nj/people/Troy-Singleton-a1c9ec59-4127-4973-b100-f35c30bb817c.yml
+++ b/data/nj/people/Troy-Singleton-a1c9ec59-4127-4973-b100-f35c30bb817c.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NJL000129
   scheme: legacy_openstates
+- identifier: ocd-person/186fd811-86e9-4621-9791-bb9a73832ba7
+  scheme: openstates
 given_name: Troy
 family_name: Singleton

--- a/data/nm/people/Elizabeth-Liz-Thomson-13ad8eb1-a64f-4a08-8c68-a1488466128f.yml
+++ b/data/nm/people/Elizabeth-Liz-Thomson-13ad8eb1-a64f-4a08-8c68-a1488466128f.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NML000235
   scheme: legacy_openstates
+- identifier: ocd-person/c2a39132-53fb-4ada-80a1-df22466de94b
+  scheme: openstates
 given_name: Elizabeth "Liz"
 family_name: Thomson

--- a/data/nm/people/James-P-White-cabc1f3c-9806-4ae8-a896-c2224efa5976.yml
+++ b/data/nm/people/James-P-White-cabc1f3c-9806-4ae8-a896-c2224efa5976.yml
@@ -31,5 +31,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NML000231
   scheme: legacy_openstates
+- identifier: ocd-person/d158564e-ddf6-449e-b32b-e2281db6e8bc
+  scheme: openstates
 given_name: James P.
 family_name: White

--- a/data/nm/people/Jeff-Steinborn-601202fc-f916-4be1-ae20-8c437293817e.yml
+++ b/data/nm/people/Jeff-Steinborn-601202fc-f916-4be1-ae20-8c437293817e.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NML000290
   scheme: legacy_openstates
+- identifier: ocd-person/41161f0b-1c24-48ca-b33b-1ef68ccde213
+  scheme: openstates
 given_name: Jeff
 family_name: Steinborn

--- a/data/nv/people/Jason-Frierson-9124c41d-12ad-4803-aef6-3d8dd9c208f9.yml
+++ b/data/nv/people/Jason-Frierson-9124c41d-12ad-4803-aef6-3d8dd9c208f9.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NVL000249
   scheme: legacy_openstates
+- identifier: ocd-person/c6fa69b9-1a1b-4e44-9e4f-8738c6b7817c
+  scheme: openstates
 given_name: Jason
 family_name: Frierson

--- a/data/nv/people/Lesley-E-Cohen-0f7983ab-0a1f-435a-b8ae-f5f4a73e26c5.yml
+++ b/data/nv/people/Lesley-E-Cohen-0f7983ab-0a1f-435a-b8ae-f5f4a73e26c5.yml
@@ -22,5 +22,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NVL000263
   scheme: legacy_openstates
+- identifier: ocd-person/68c9893e-bba9-48f7-90f3-1931b8d1169e
+  scheme: openstates
 given_name: Lesley E.
 family_name: Cohen

--- a/data/nv/people/Marilyn-Dondero-Loop-0435a1f4-d8e4-43d9-9ac1-788a0aed92e4.yml
+++ b/data/nv/people/Marilyn-Dondero-Loop-0435a1f4-d8e4-43d9-9ac1-788a0aed92e4.yml
@@ -29,3 +29,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NVL000230
   scheme: legacy_openstates
+- identifier: ocd-person/a8534d64-df56-4c14-8ab7-7ba720aea74a
+  scheme: openstates

--- a/data/ny/people/James-Tedisco-975453b1-113a-40e9-8036-53e714a47b66.yml
+++ b/data/ny/people/James-Tedisco-975453b1-113a-40e9-8036-53e714a47b66.yml
@@ -36,5 +36,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NYL000314
   scheme: legacy_openstates
+- identifier: ocd-person/c024ab00-3817-4245-9ce7-0da06a1e1aab
+  scheme: openstates
 given_name: James
 family_name: Tedisco

--- a/data/ny/people/Shelley-Mayer-a9b13089-77fc-4e9d-a9e4-35933ea903a0.yml
+++ b/data/ny/people/Shelley-Mayer-a9b13089-77fc-4e9d-a9e4-35933ea903a0.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NYL000285
   scheme: legacy_openstates
+- identifier: ocd-person/f79f50df-9dba-4960-91be-d89c919b0fd6
+  scheme: openstates
 given_name: Shelley
 family_name: Mayer

--- a/data/ny/people/Todd-Kaminsky-1ef06373-79dc-4c90-b2ec-f0fa5218e77e.yml
+++ b/data/ny/people/Todd-Kaminsky-1ef06373-79dc-4c90-b2ec-f0fa5218e77e.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NYL000334
   scheme: legacy_openstates
+- identifier: ocd-person/f5d4089b-4c4f-41b0-b7a0-2d16c2e551c0
+  scheme: openstates
 given_name: Todd
 family_name: Kaminsky

--- a/data/oh/people/Matt-Huffman-23d51717-c6eb-4a2c-bd55-038c72593a61.yml
+++ b/data/oh/people/Matt-Huffman-23d51717-c6eb-4a2c-bd55-038c72593a61.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OHL000173
   scheme: legacy_openstates
+- identifier: ocd-person/a2d881a3-02fb-4141-bace-faf416ed41ac
+  scheme: openstates
 given_name: Matt
 family_name: Huffman

--- a/data/oh/people/Sandra-Williams-925ef313-4409-48dd-b1be-d37c6077b0af.yml
+++ b/data/oh/people/Sandra-Williams-925ef313-4409-48dd-b1be-d37c6077b0af.yml
@@ -22,5 +22,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OHL000282
   scheme: legacy_openstates
+- identifier: ocd-person/9dfcd179-e87c-4e20-8cf7-fe6f468dc9b8
+  scheme: openstates
 given_name: Sandra
 family_name: Williams

--- a/data/oh/people/Stephanie-Kunze-fd6110b8-258e-4f63-95e2-39ba11778cca.yml
+++ b/data/oh/people/Stephanie-Kunze-fd6110b8-258e-4f63-95e2-39ba11778cca.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OHL000193
   scheme: legacy_openstates
+- identifier: ocd-person/24d595dd-addd-48dd-a20b-0e02611f375d
+  scheme: openstates
 given_name: Stephanie
 family_name: Kunze

--- a/data/oh/people/Terry-Johnson-57300c34-0e2d-4e85-bdce-c4fb8c781541.yml
+++ b/data/oh/people/Terry-Johnson-57300c34-0e2d-4e85-bdce-c4fb8c781541.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OHL000259
   scheme: legacy_openstates
+- identifier: ocd-person/871f7df3-bff9-4f81-b951-401bfecb733a
+  scheme: openstates

--- a/data/oh/people/Vernon-Sykes-c91ca7db-c471-4d6d-8e6d-e78a6f238e8f.yml
+++ b/data/oh/people/Vernon-Sykes-c91ca7db-c471-4d6d-8e6d-e78a6f238e8f.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OHL000203
   scheme: legacy_openstates
+- identifier: ocd-person/a8685e9e-a78c-43d9-a06a-cb034ba9a858
+  scheme: openstates
 given_name: Vernon
 family_name: Sykes

--- a/data/ok/people/Casey-Murdock-8c8517c3-75ee-4b27-8d8c-3444c036ba78.yml
+++ b/data/ok/people/Casey-Murdock-8c8517c3-75ee-4b27-8d8c-3444c036ba78.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OKL000194
   scheme: legacy_openstates
+- identifier: ocd-person/b80f171a-cf10-485b-822d-06d7e98bbb8a
+  scheme: openstates
 given_name: Casey
 family_name: Murdock

--- a/data/ok/people/James-Leewright-7a8d705e-62eb-43a4-946f-b6a3c8cdaa6f.yml
+++ b/data/ok/people/James-Leewright-7a8d705e-62eb-43a4-946f-b6a3c8cdaa6f.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: OKL000197
   scheme: legacy_openstates
+- identifier: ocd-person/368a889d-52b3-4cda-8160-6283afa28283
+  scheme: openstates
 given_name: James
 family_name: Leewright

--- a/data/or/people/Dallas-Heard-3bad466e-d37c-4e67-b5c3-a0b740accf6b.yml
+++ b/data/or/people/Dallas-Heard-3bad466e-d37c-4e67-b5c3-a0b740accf6b.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ORL000354
   scheme: legacy_openstates
+- identifier: ocd-person/33c190ab-a9e9-46ec-998f-5f00f30f0ef0
+  scheme: openstates
 given_name: Dallas
 family_name: Heard

--- a/data/or/people/Denyc-Boles-5249bd1f-de9a-44c9-98c1-b7605e858090.yml
+++ b/data/or/people/Denyc-Boles-5249bd1f-de9a-44c9-98c1-b7605e858090.yml
@@ -22,5 +22,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ORL000258
   scheme: legacy_openstates
+- identifier: ocd-person/65a5ad33-7cfd-4994-8060-f3e731e5ba16
+  scheme: openstates
 given_name: Denyc
 family_name: Boles

--- a/data/or/people/Kathleen-Taylor-97c2b8fd-9e87-43b7-b202-6541af36bab7.yml
+++ b/data/or/people/Kathleen-Taylor-97c2b8fd-9e87-43b7-b202-6541af36bab7.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ORL000320
   scheme: legacy_openstates
+- identifier: ocd-person/dcbb32b3-b40e-4eec-b18a-0bf46ff8d776
+  scheme: openstates
 given_name: Kathleen
 family_name: Taylor

--- a/data/or/people/Lew-Frederick-2256d4a8-f19b-4e1d-ba35-771cc0349b0b.yml
+++ b/data/or/people/Lew-Frederick-2256d4a8-f19b-4e1d-ba35-771cc0349b0b.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ORL000291
   scheme: legacy_openstates
+- identifier: ocd-person/03706f4f-f01c-4255-91a8-f82b23e90720
+  scheme: openstates
 given_name: Lew
 family_name: Frederick

--- a/data/or/people/Shemia-Fagan-1156b920-81ee-496b-af60-09d5eed5752d.yml
+++ b/data/or/people/Shemia-Fagan-1156b920-81ee-496b-af60-09d5eed5752d.yml
@@ -30,3 +30,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ORL000279
   scheme: legacy_openstates
+- identifier: ocd-person/91dd91e8-6aa7-4d58-96fb-5bced3b59796
+  scheme: openstates

--- a/data/pa/people/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
+++ b/data/pa/people/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
@@ -23,6 +23,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PAL000390
   scheme: legacy_openstates
+- identifier: ocd-person/65229fa4-1d45-459f-b0da-a5912af47a8a
+  scheme: openstates
 party:
 - name: Democratic
 roles:

--- a/data/pa/people/Mike-Regan-ce0d90e3-b4dc-436f-a808-dc40946b6352.yml
+++ b/data/pa/people/Mike-Regan-ce0d90e3-b4dc-436f-a808-dc40946b6352.yml
@@ -27,6 +27,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PAL000464
   scheme: legacy_openstates
+- identifier: ocd-person/730cec72-892f-47ef-bef6-57572fadbcc0
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/pr/people/Anibal-J-Torres-Torres-581cc244-f938-4b8a-b0d5-76b7739471aa.yml
+++ b/data/pr/people/Anibal-J-Torres-Torres-581cc244-f938-4b8a-b0d5-76b7739471aa.yml
@@ -21,5 +21,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000160
   scheme: legacy_openstates
+- identifier: ocd-person/d6729bce-c401-46cf-8c40-d74c42a9a4f1
+  scheme: openstates
 given_name: Anibal
 family_name: Torres Torres

--- a/data/pr/people/Cirilo-Tirado-Rivera-f3a5a322-bb08-4276-ac9b-eb58ddee59cb.yml
+++ b/data/pr/people/Cirilo-Tirado-Rivera-f3a5a322-bb08-4276-ac9b-eb58ddee59cb.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000094
   scheme: legacy_openstates
+- identifier: ocd-person/486618d5-b237-4005-b29b-6012fcdfca37
+  scheme: openstates
 given_name: Cirilo
 family_name: Tirado Rivera

--- a/data/pr/people/Eduardo-Bhatia-Gautier-754f50eb-5659-4f92-871e-8e0cb2f31a27.yml
+++ b/data/pr/people/Eduardo-Bhatia-Gautier-754f50eb-5659-4f92-871e-8e0cb2f31a27.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000091
   scheme: legacy_openstates
+- identifier: ocd-person/6470dc35-c611-42ee-a358-81f1b17fc760
+  scheme: openstates
 given_name: Eduardo
 family_name: Bhatia Gautier

--- a/data/pr/people/Eric-Correa-Rivera-bf91070c-848c-4b96-b52a-c831a0372541.yml
+++ b/data/pr/people/Eric-Correa-Rivera-bf91070c-848c-4b96-b52a-c831a0372541.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000069
   scheme: legacy_openstates
+- identifier: ocd-person/05572fd1-32dd-4cea-84cb-9989504b6895
+  scheme: openstates
 given_name: Eric
 family_name: Correa Rivera

--- a/data/pr/people/Itzamar-Pea-Ramirez-913d5189-4745-482f-946f-669a6f6f7781.yml
+++ b/data/pr/people/Itzamar-Pea-Ramirez-913d5189-4745-482f-946f-669a6f6f7781.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000087
   scheme: legacy_openstates
+- identifier: ocd-person/9b3fd0f9-d15b-4338-ba29-dc6342226468
+  scheme: openstates
 given_name: Itzamar
 family_name: "Pe\xF1a Ramirez"

--- a/data/pr/people/Luis-A-Berdiel-Rivera-f758d383-32ce-4c16-83ed-23463586df2a.yml
+++ b/data/pr/people/Luis-A-Berdiel-Rivera-f758d383-32ce-4c16-83ed-23463586df2a.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000107
   scheme: legacy_openstates
+- identifier: ocd-person/d3127f89-9f71-4151-b9b7-438afe8d2014
+  scheme: openstates
 given_name: Luis
 family_name: Berdiel Rivera

--- a/data/pr/people/Migdalia-Padilla-Alvelo-b451e173-36b4-4664-ada7-ac5057ef8c9f.yml
+++ b/data/pr/people/Migdalia-Padilla-Alvelo-b451e173-36b4-4664-ada7-ac5057ef8c9f.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000198
   scheme: legacy_openstates
+- identifier: ocd-person/eb1375be-2215-42e9-82b2-18f8303802e8
+  scheme: openstates
 given_name: Migdalia
 family_name: Padilla Alvelo

--- a/data/pr/people/Miguel-A-Pereira-Castillo-6f7fd5c6-7b5e-4967-a9f2-3f1e8c6193bf.yml
+++ b/data/pr/people/Miguel-A-Pereira-Castillo-6f7fd5c6-7b5e-4967-a9f2-3f1e8c6193bf.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000205
   scheme: legacy_openstates
+- identifier: ocd-person/554ee61d-0386-4a0c-a3ec-e81dbc02df50
+  scheme: openstates
 given_name: Miguel
 family_name: Pereira Castillo

--- a/data/pr/people/Thomas-Rivera-Schatz-3caf98b9-5210-45ab-bbde-794edfc41451.yml
+++ b/data/pr/people/Thomas-Rivera-Schatz-3caf98b9-5210-45ab-bbde-794edfc41451.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000084
   scheme: legacy_openstates
+- identifier: ocd-person/372e0f0f-c6b9-40e0-86f3-3af30a61eb32
+  scheme: openstates
 given_name: Thomas
 family_name: Rivera Schatz

--- a/data/pr/people/Vctor-L-Pars-Otero-90109872-9f06-48fb-8118-25453deb69c7.yml
+++ b/data/pr/people/Vctor-L-Pars-Otero-90109872-9f06-48fb-8118-25453deb69c7.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: PRL000132
   scheme: legacy_openstates
+- identifier: ocd-person/dc63d9b5-fbb7-4e31-8ed7-0aac0c12e9ea
+  scheme: openstates
 given_name: "V\xEDctor"
 family_name: "Par\xE9s Otero"

--- a/data/sc/people/Mia-S-McLeod-9b4e7cb9-4e4e-484d-8ce9-4fe4a73b8c59.yml
+++ b/data/sc/people/Mia-S-McLeod-9b4e7cb9-4e4e-484d-8ce9-4fe4a73b8c59.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000194
   scheme: legacy_openstates
+- identifier: ocd-person/f5283ddc-7442-4170-80a2-248c485263cc
+  scheme: openstates
 given_name: Mia S.
 family_name: McLeod

--- a/data/sd/people/Al-Novstrup-02f0edff-2879-4fbb-9b23-796358690d07.yml
+++ b/data/sd/people/Al-Novstrup-02f0edff-2879-4fbb-9b23-796358690d07.yml
@@ -21,6 +21,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000256
   scheme: legacy_openstates
+- identifier: ocd-person/3e965e9a-8ea2-41b6-8d05-902d2c366bdc
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Jean-M-Hunhoff-487bbd05-7baf-40bf-81a5-cc9c9a4d8b8a.yml
+++ b/data/sd/people/Jean-M-Hunhoff-487bbd05-7baf-40bf-81a5-cc9c9a4d8b8a.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000019
   scheme: legacy_openstates
+- identifier: ocd-person/5a43f9cf-97ae-4111-8b59-c889801b1b36
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Jeffrey-D-Partridge-246a61b3-6c1d-4c22-aee8-a1e08a8e495a.yml
+++ b/data/sd/people/Jeffrey-D-Partridge-246a61b3-6c1d-4c22-aee8-a1e08a8e495a.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000216
   scheme: legacy_openstates
+- identifier: ocd-person/6202bd23-f609-4bdc-9b39-8798be44dd96
+  scheme: openstates
 given_name: Jeffrey D
 family_name: Partridge

--- a/data/sd/people/Jim-Bolin-02a43643-ce8a-41fa-a43b-5d5cbf33f1f0.yml
+++ b/data/sd/people/Jim-Bolin-02a43643-ce8a-41fa-a43b-5d5cbf33f1f0.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000037
   scheme: legacy_openstates
+- identifier: ocd-person/3c832d26-90e0-4c83-af96-47acf5013329
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Jim-Stalzer-b4220d52-fc9f-49e7-9802-ef2aa4e99baa.yml
+++ b/data/sd/people/Jim-Stalzer-b4220d52-fc9f-49e7-9802-ef2aa4e99baa.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000197
   scheme: legacy_openstates
+- identifier: ocd-person/30365f34-d2b0-4099-b80f-8d07806fef0e
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Jon-Hansen-912b0c53-5674-42b0-8f22-8ccd01c3264c.yml
+++ b/data/sd/people/Jon-Hansen-912b0c53-5674-42b0-8f22-8ccd01c3264c.yml
@@ -23,3 +23,5 @@ extras:
 other_identifiers:
 - identifier: SDL000128
   scheme: legacy_openstates
+- identifier: ocd-person/80835888-0f8e-4f66-a4e7-e82e5da1a1f5
+  scheme: openstates

--- a/data/sd/people/Justin-R-Cronin-911dd65f-e35c-4e37-bd0d-9a8edd953092.yml
+++ b/data/sd/people/Justin-R-Cronin-911dd65f-e35c-4e37-bd0d-9a8edd953092.yml
@@ -19,6 +19,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000043
   scheme: legacy_openstates
+- identifier: ocd-person/b927c0fd-5160-4f3c-981e-ce642f4f2304
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Kris-Langer-c6fa0ac3-5c66-4661-bc45-7575a173a741.yml
+++ b/data/sd/people/Kris-Langer-c6fa0ac3-5c66-4661-bc45-7575a173a741.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000206
   scheme: legacy_openstates
+- identifier: ocd-person/7f991cdc-87dc-4f03-8543-7dc6f2fcb660
+  scheme: openstates
 given_name: Kris
 family_name: Langer

--- a/data/sd/people/Lance-S-Russell-e1665a74-e2bc-4417-85c3-083d60acb007.yml
+++ b/data/sd/people/Lance-S-Russell-e1665a74-e2bc-4417-85c3-083d60acb007.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000088
   scheme: legacy_openstates
+- identifier: ocd-person/64eccdf0-8791-485c-bc7b-22d7accde8f6
+  scheme: openstates
 given_name: Lance S
 family_name: Russell

--- a/data/sd/people/Lee-Schoenbeck-a2152143-6b32-48e5-bda2-57eed76df09f.yml
+++ b/data/sd/people/Lee-Schoenbeck-a2152143-6b32-48e5-bda2-57eed76df09f.yml
@@ -27,3 +27,5 @@ extras:
 other_identifiers:
 - identifier: SDL000218
   scheme: legacy_openstates
+- identifier: ocd-person/591535fc-8a46-48af-aa80-359684a26917
+  scheme: openstates

--- a/data/sd/people/Manny-Steele-1d1ed545-3272-4e67-a646-09e08da7809c.yml
+++ b/data/sd/people/Manny-Steele-1d1ed545-3272-4e67-a646-09e08da7809c.yml
@@ -23,3 +23,5 @@ extras:
 other_identifiers:
 - identifier: SDL000095
   scheme: legacy_openstates
+- identifier: ocd-person/8d4b95f0-2a06-432f-aedd-c6d1b7064b49
+  scheme: openstates

--- a/data/sd/people/Ryan-Maher-d1329f2b-43b5-4276-ba13-b4ceced4f0b0.yml
+++ b/data/sd/people/Ryan-Maher-d1329f2b-43b5-4276-ba13-b4ceced4f0b0.yml
@@ -22,5 +22,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000023
   scheme: legacy_openstates
+- identifier: ocd-person/810b318b-7a27-4bc0-935c-51643510ff39
+  scheme: openstates
 given_name: Ryan
 family_name: Maher

--- a/data/sd/people/Stace-Nelson-98ea6441-d833-4464-b132-d1e0943f4a46.yml
+++ b/data/sd/people/Stace-Nelson-98ea6441-d833-4464-b132-d1e0943f4a46.yml
@@ -21,6 +21,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SDL000186
   scheme: legacy_openstates
+- identifier: ocd-person/be9e17a2-850e-4fdb-b5d1-80b04ab409b2
+  scheme: openstates
 party:
 - name: Republican
 roles:

--- a/data/sd/people/Susan-Wismer-530465d6-d53e-4da9-b8af-22f92ebf0e28.yml
+++ b/data/sd/people/Susan-Wismer-530465d6-d53e-4da9-b8af-22f92ebf0e28.yml
@@ -35,5 +35,7 @@ other_identifiers:
   scheme: openstates
 - identifier: SDL000105
   scheme: legacy_openstates
+- identifier: ocd-person/f3b8b0f8-f15e-4006-ac1c-0b99a4b10b8c
+  scheme: openstates
 given_name: Susan
 family_name: Wismer

--- a/data/tn/people/Gloria-Johnson-4dbbf89b-69ab-459f-97ee-c53866e81296.yml
+++ b/data/tn/people/Gloria-Johnson-4dbbf89b-69ab-459f-97ee-c53866e81296.yml
@@ -28,3 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TNL000441
   scheme: legacy_openstates
+- identifier: ocd-person/0690e446-0f2f-4f65-8acc-0180634600c7
+  scheme: openstates

--- a/data/tn/people/Jon-Lundberg-98424377-d7d3-4c6d-b511-b63e4fd548e4.yml
+++ b/data/tn/people/Jon-Lundberg-98424377-d7d3-4c6d-b511-b63e4fd548e4.yml
@@ -33,5 +33,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TNL000322
   scheme: legacy_openstates
+- identifier: ocd-person/20752630-6523-454b-b696-0e77c3ec7cee
+  scheme: openstates
 given_name: Jon
 family_name: Lundberg

--- a/data/tx/people/Borris-L-Miles-3475b324-1c9b-4513-90e6-063aba5ac04e.yml
+++ b/data/tx/people/Borris-L-Miles-3475b324-1c9b-4513-90e6-063aba5ac04e.yml
@@ -37,6 +37,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TXL000648
   scheme: legacy_openstates
+- identifier: ocd-person/619d2cdd-788c-4582-ae13-85a44c32ae48
+  scheme: openstates
 given_name: Borris
 family_name: Miles
 image: https://senate.texas.gov/members/d13/img/miles-initial.jpg

--- a/data/tx/people/Bryan-Hughes-8326538c-c907-43b2-a6db-76434036afd7.yml
+++ b/data/tx/people/Bryan-Hughes-8326538c-c907-43b2-a6db-76434036afd7.yml
@@ -39,6 +39,8 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TXL000630
   scheme: legacy_openstates
+- identifier: ocd-person/0b0da34f-1c89-4a82-a00a-4975695ec367
+  scheme: openstates
 given_name: Bryan
 family_name: Hughes
 image: https://senate.texas.gov/members/d01/img/hughes-initial.jpg

--- a/data/tx/people/Philip-Cortez-12d67093-ab4c-425d-afa3-e5777db09d1c.yml
+++ b/data/tx/people/Philip-Cortez-12d67093-ab4c-425d-afa3-e5777db09d1c.yml
@@ -26,5 +26,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TXL000432
   scheme: legacy_openstates
+- identifier: ocd-person/171dd255-22ce-4ad5-86af-1ee81d340a60
+  scheme: openstates
 given_name: Philip
 family_name: Cortez

--- a/data/tx/people/Steve-Toth-6c80914d-b07b-4d27-95e2-0e5aa2b0c7d9.yml
+++ b/data/tx/people/Steve-Toth-6c80914d-b07b-4d27-95e2-0e5aa2b0c7d9.yml
@@ -25,3 +25,5 @@ family_name: Toth
 other_identifiers:
 - identifier: TXL000467
   scheme: legacy_openstates
+- identifier: ocd-person/a3f30715-ff61-45cf-9194-3620f3558480
+  scheme: openstates

--- a/data/tx/people/Trey-Martinez-Fischer-07f5e898-8d5d-435a-bf97-7bfb26fce5ac.yml
+++ b/data/tx/people/Trey-Martinez-Fischer-07f5e898-8d5d-435a-bf97-7bfb26fce5ac.yml
@@ -27,3 +27,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: TXL000526
   scheme: legacy_openstates
+- identifier: ocd-person/fdb3e834-8737-493b-bfda-b5bf5da8ff8b
+  scheme: openstates

--- a/data/ut/people/Christine-F-Watkins-052622aa-50ab-47c7-84b8-175d144a9d59.yml
+++ b/data/ut/people/Christine-F-Watkins-052622aa-50ab-47c7-84b8-175d144a9d59.yml
@@ -28,5 +28,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: UTL000096
   scheme: legacy_openstates
+- identifier: ocd-person/8812b204-ef5f-49ba-82ba-a47026c0ed63
+  scheme: openstates
 given_name: Christine
 family_name: Watkins

--- a/data/ut/people/Jacob-L-Anderegg-29fd7869-2422-4f28-a978-11e5783f51b1.yml
+++ b/data/ut/people/Jacob-L-Anderegg-29fd7869-2422-4f28-a978-11e5783f51b1.yml
@@ -34,5 +34,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: UTL000234
   scheme: legacy_openstates
+- identifier: ocd-person/86119565-decb-43e1-add4-07bc45543b33
+  scheme: openstates
 given_name: Jacob
 family_name: Anderegg

--- a/data/ut/people/Keith-Grover-7634ce2b-d172-4852-919c-7089eaa38db8.yml
+++ b/data/ut/people/Keith-Grover-7634ce2b-d172-4852-919c-7089eaa38db8.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: UTL000272
   scheme: legacy_openstates
+- identifier: ocd-person/c17b9ece-b750-4eb1-befb-591757513771
+  scheme: openstates
 given_name: Keith
 family_name: Grover

--- a/data/ut/people/Stewart-E-Barlow-b5285658-1e71-48a2-8641-a2bc75957b24.yml
+++ b/data/ut/people/Stewart-E-Barlow-b5285658-1e71-48a2-8641-a2bc75957b24.yml
@@ -37,5 +37,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: UTL000235
   scheme: legacy_openstates
+- identifier: ocd-person/ec84c19b-e975-4bb1-9999-912421f000b3
+  scheme: openstates
 given_name: Stewart
 family_name: Barlow

--- a/data/vt/people/Avram-Patt-419b4d42-7a60-4ced-b361-1f344263a856.yml
+++ b/data/vt/people/Avram-Patt-419b4d42-7a60-4ced-b361-1f344263a856.yml
@@ -27,3 +27,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: VTL000708
   scheme: legacy_openstates
+- identifier: ocd-person/6066765f-9228-47df-b0a5-9a297e1784eb
+  scheme: openstates

--- a/data/wa/people/Andrew-Barkis-9c1fefff-fa5a-49aa-90ca-a9ca80b6f669.yml
+++ b/data/wa/people/Andrew-Barkis-9c1fefff-fa5a-49aa-90ca-a9ca80b6f669.yml
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000238
   scheme: legacy_openstates
+- identifier: ocd-person/976ed594-851e-4dc7-8d36-84983fdb974e
+  scheme: openstates
 given_name: Andrew
 family_name: Barkis

--- a/data/wa/people/Brad-Hawkins-11de0f04-3a78-49cf-a5a9-7d7f59bf94b3.yml
+++ b/data/wa/people/Brad-Hawkins-11de0f04-3a78-49cf-a5a9-7d7f59bf94b3.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000177
   scheme: legacy_openstates
+- identifier: ocd-person/87934228-89fc-495f-a396-becd7b913b31
+  scheme: openstates
 given_name: Brad
 family_name: Hawkins

--- a/data/wa/people/Hans-Zeiger-fca9e52d-7200-4b31-9090-7326fcc444cd.yml
+++ b/data/wa/people/Hans-Zeiger-fca9e52d-7200-4b31-9090-7326fcc444cd.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000147
   scheme: legacy_openstates
+- identifier: ocd-person/f69ceac4-0124-4e6e-bd22-5e1f20e4e4a3
+  scheme: openstates
 given_name: Hans
 family_name: Zeiger

--- a/data/wa/people/Kevin-Van-De-Wege-18f36c55-d647-4041-a989-50440b2d977a.yml
+++ b/data/wa/people/Kevin-Van-De-Wege-18f36c55-d647-4041-a989-50440b2d977a.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000143
   scheme: legacy_openstates
+- identifier: ocd-person/f6411b5f-860a-466e-ac1a-3dbe5e25297a
+  scheme: openstates
 given_name: Kevin
 family_name: Van De Wege

--- a/data/wa/people/Lynda-Wilson-29e84b77-1702-4eb9-970b-4089bea31b21.yml
+++ b/data/wa/people/Lynda-Wilson-29e84b77-1702-4eb9-970b-4089bea31b21.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000214
   scheme: legacy_openstates
+- identifier: ocd-person/3790f0eb-5d15-43ba-ba19-4d180f4771c6
+  scheme: openstates
 given_name: Lynda
 family_name: Wilson

--- a/data/wa/people/Maureen-Walsh-56ba5b89-41b7-4215-a632-e0ed6f3012af.yml
+++ b/data/wa/people/Maureen-Walsh-56ba5b89-41b7-4215-a632-e0ed6f3012af.yml
@@ -30,5 +30,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000144
   scheme: legacy_openstates
+- identifier: ocd-person/5cb1b55b-fae6-4691-9d58-23d9fe34262b
+  scheme: openstates
 given_name: Maureen
 family_name: Walsh

--- a/data/wa/people/Patty-Kuderer-ef6a28f2-da94-4a3f-850a-b005cffa884d.yml
+++ b/data/wa/people/Patty-Kuderer-ef6a28f2-da94-4a3f-850a-b005cffa884d.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000232
   scheme: legacy_openstates
+- identifier: ocd-person/84c9ebce-40db-47ff-ad39-d3c588113c1f
+  scheme: openstates
 given_name: Patty
 family_name: Kuderer

--- a/data/wa/people/Sam-Hunt-917d24db-26e0-4ba4-8f98-26c7940327f9.yml
+++ b/data/wa/people/Sam-Hunt-917d24db-26e0-4ba4-8f98-26c7940327f9.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000089
   scheme: legacy_openstates
+- identifier: ocd-person/7a2e1a22-5736-4747-884a-26bd93132455
+  scheme: openstates
 given_name: Sam
 family_name: Hunt

--- a/data/wa/people/Shelly-Short-a45d8fe7-d052-4d18-bc5f-b5911948d42c.yml
+++ b/data/wa/people/Shelly-Short-a45d8fe7-d052-4d18-bc5f-b5911948d42c.yml
@@ -27,5 +27,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WAL000134
   scheme: legacy_openstates
+- identifier: ocd-person/bca66fde-c372-4788-9ccd-069a2f01e670
+  scheme: openstates
 given_name: Shelly
 family_name: Short

--- a/data/wi/people/Andr-Jacque-b0101cd0-ad49-466b-a46e-8bb8671cb709.yml
+++ b/data/wi/people/Andr-Jacque-b0101cd0-ad49-466b-a46e-8bb8671cb709.yml
@@ -25,3 +25,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WIL000549
   scheme: legacy_openstates
+- identifier: ocd-person/0e27c35e-f9fc-483e-80fa-0718735e8451
+  scheme: openstates

--- a/data/wi/people/David-Craig-f2288133-a8cf-48d2-abaa-5d59fa3a41ea.yml
+++ b/data/wi/people/David-Craig-f2288133-a8cf-48d2-abaa-5d59fa3a41ea.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WIL000484
   scheme: legacy_openstates
+- identifier: ocd-person/37ea3772-779e-4147-abbf-7be983580d9c
+  scheme: openstates
 given_name: David
 family_name: Craig

--- a/data/wi/people/Jeff-Smith-8a1ee7b3-8450-45b4-a1cf-5e05788c0653.yml
+++ b/data/wi/people/Jeff-Smith-8a1ee7b3-8450-45b4-a1cf-5e05788c0653.yml
@@ -23,3 +23,5 @@ sources:
 other_identifiers:
 - identifier: WIL000421
   scheme: legacy_openstates
+- identifier: ocd-person/51aa4699-b7c1-428a-a72d-2b90a6545409
+  scheme: openstates

--- a/data/wi/people/Kathleen-Bernier-6ce09502-b5ab-4529-b3ec-3e8cc2b80900.yml
+++ b/data/wi/people/Kathleen-Bernier-6ce09502-b5ab-4529-b3ec-3e8cc2b80900.yml
@@ -25,3 +25,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WIL000503
   scheme: legacy_openstates
+- identifier: ocd-person/af637369-6a69-47f1-87e8-d7baac37adad
+  scheme: openstates

--- a/data/wi/people/LaTonya-Johnson-eba6f26b-65c9-42fe-a8a5-09e11c8d089a.yml
+++ b/data/wi/people/LaTonya-Johnson-eba6f26b-65c9-42fe-a8a5-09e11c8d089a.yml
@@ -32,5 +32,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WIL000515
   scheme: legacy_openstates
+- identifier: ocd-person/87999884-0aa3-4b05-8bbf-0118ead14994
+  scheme: openstates
 given_name: LaTonya
 family_name: Johnson

--- a/data/wv/people/Doug-Skaff-39be9160-4cf2-4290-b3b9-ca33e4dcfffe.yml
+++ b/data/wv/people/Doug-Skaff-39be9160-4cf2-4290-b3b9-ca33e4dcfffe.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000253
   scheme: legacy_openstates
+- identifier: ocd-person/be2cdf7d-9229-4ea1-bed8-df7abd5e1eb7
+  scheme: openstates

--- a/data/wv/people/Jason-Barrett-bcbe03de-3df0-4c07-8973-0304dafa2cb8.yml
+++ b/data/wv/people/Jason-Barrett-bcbe03de-3df0-4c07-8973-0304dafa2cb8.yml
@@ -25,5 +25,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000222
   scheme: legacy_openstates
+- identifier: ocd-person/f7b54755-f78c-4184-b167-570673e07710
+  scheme: openstates
 given_name: Jason
 family_name: Barrett

--- a/data/wv/people/John-Doyle-bfe2ce7b-af36-4542-9455-2ab56ab62653.yml
+++ b/data/wv/people/John-Doyle-bfe2ce7b-af36-4542-9455-2ab56ab62653.yml
@@ -27,3 +27,5 @@ family_name: Doyle
 other_identifiers:
 - identifier: WVL000133
   scheme: legacy_openstates
+- identifier: ocd-person/e261e802-778b-4642-ba70-c498ac16114a
+  scheme: openstates

--- a/data/wv/people/Larry-Kump-17ae499e-4b87-4631-851d-5e55185da510.yml
+++ b/data/wv/people/Larry-Kump-17ae499e-4b87-4631-851d-5e55185da510.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000267
   scheme: legacy_openstates
+- identifier: ocd-person/24eb7532-0d81-4397-960d-efca08b7af96
+  scheme: openstates

--- a/data/wv/people/Margaret-Staggers-3c4a05fd-6b2f-44bc-824d-496b3df197bd.yml
+++ b/data/wv/people/Margaret-Staggers-3c4a05fd-6b2f-44bc-824d-496b3df197bd.yml
@@ -31,3 +31,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000255
   scheme: legacy_openstates
+- identifier: ocd-person/42cc0267-98ae-4647-afb6-6c6ce4e9ee58
+  scheme: openstates

--- a/data/wv/people/Mike-Azinger-8fe81e26-b0ce-4349-a3e3-91d25247b980.yml
+++ b/data/wv/people/Mike-Azinger-8fe81e26-b0ce-4349-a3e3-91d25247b980.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000318
   scheme: legacy_openstates
+- identifier: ocd-person/1d07e116-08cb-4077-a8df-6a33f0b50150
+  scheme: openstates
 given_name: Mike
 family_name: Azinger

--- a/data/wv/people/Randy-Swartzmiller-ef3d710b-324f-45bf-8c61-45fa98cd003d.yml
+++ b/data/wv/people/Randy-Swartzmiller-ef3d710b-324f-45bf-8c61-45fa98cd003d.yml
@@ -22,3 +22,5 @@ family_name: Swartzmiller
 other_identifiers:
 - identifier: WVL000036
   scheme: legacy_openstates
+- identifier: ocd-person/43e69a38-e82d-42c3-b5b0-2c30257d6b21
+  scheme: openstates

--- a/data/wv/people/Ryan-Weld-680aa2ce-6408-4047-a36b-0b3badc82851.yml
+++ b/data/wv/people/Ryan-Weld-680aa2ce-6408-4047-a36b-0b3badc82851.yml
@@ -29,5 +29,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WVL000313
   scheme: legacy_openstates
+- identifier: ocd-person/5532c060-4f50-4777-8998-335c23c6aefd
+  scheme: openstates
 given_name: Ryan
 family_name: Weld

--- a/data/wv/people/Scott-Cadle-2b3d3cdb-e0c4-44f6-b847-0e192244970f.yml
+++ b/data/wv/people/Scott-Cadle-2b3d3cdb-e0c4-44f6-b847-0e192244970f.yml
@@ -22,3 +22,5 @@ family_name: Cadle
 other_identifiers:
 - identifier: WVL000151
   scheme: legacy_openstates
+- identifier: ocd-person/8fc8aa21-0673-4a33-9c3e-d3d43a9206c3
+  scheme: openstates

--- a/data/wv/people/Terry-Waxman-58918c86-9ef2-455c-9877-0cab2628a902.yml
+++ b/data/wv/people/Terry-Waxman-58918c86-9ef2-455c-9877-0cab2628a902.yml
@@ -25,3 +25,5 @@ family_name: Waxman
 other_identifiers:
 - identifier: WVL000331
   scheme: legacy_openstates
+- identifier: ocd-person/636eb554-89e9-44a7-9f8f-94eb473f8e0c
+  scheme: openstates

--- a/data/wv/people/Tom-Azinger-5fd04803-80d7-46be-996e-736c40850487.yml
+++ b/data/wv/people/Tom-Azinger-5fd04803-80d7-46be-996e-736c40850487.yml
@@ -22,3 +22,5 @@ contact_details:
 other_identifiers:
 - identifier: WVL000048
   scheme: legacy_openstates
+- identifier: ocd-person/82648120-acd6-41fd-9392-2f44c8eeafbf
+  scheme: openstates

--- a/data/wy/people/Fred-Baldwin-d3aae123-a4f8-4882-9313-ba6a400c43fb.yml
+++ b/data/wy/people/Fred-Baldwin-d3aae123-a4f8-4882-9313-ba6a400c43fb.yml
@@ -53,3 +53,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WYL000128
   scheme: legacy_openstates
+- identifier: ocd-person/1727ae1d-3ddd-4949-aa1b-cfa25e093fbd
+  scheme: openstates

--- a/data/wy/people/Glenn-Moniz-3451b137-cd87-43dc-b157-00acef74c33a.yml
+++ b/data/wy/people/Glenn-Moniz-3451b137-cd87-43dc-b157-00acef74c33a.yml
@@ -46,3 +46,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WYL000072
   scheme: legacy_openstates
+- identifier: ocd-person/4879d612-ec7b-4cfd-a4ec-0c870454d113
+  scheme: openstates

--- a/data/wy/people/Jim-Anderson-f40c41d5-b371-49c5-a597-db8435e613a0.yml
+++ b/data/wy/people/Jim-Anderson-f40c41d5-b371-49c5-a597-db8435e613a0.yml
@@ -52,3 +52,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: WYL000135
   scheme: legacy_openstates
+- identifier: ocd-person/263445d8-aeb6-45ed-9aa6-63a05d932a53
+  scheme: openstates

--- a/data/wy/people/Jim-Roscoe-613ae8ab-aab5-4667-ba4f-3736b39df437.yml
+++ b/data/wy/people/Jim-Roscoe-613ae8ab-aab5-4667-ba4f-3736b39df437.yml
@@ -34,3 +34,5 @@ extras:
 other_identifiers:
 - identifier: WYL000081
   scheme: legacy_openstates
+- identifier: ocd-person/95af8fbd-7114-4aea-a10a-da9e96b55247
+  scheme: openstates

--- a/data/wy/people/Lynn-Hutchings-b91459e7-2049-4cf9-8b0b-f769ce373613.yml
+++ b/data/wy/people/Lynn-Hutchings-b91459e7-2049-4cf9-8b0b-f769ce373613.yml
@@ -36,3 +36,5 @@ extras:
 other_identifiers:
 - identifier: WYL000101
   scheme: legacy_openstates
+- identifier: ocd-person/f2828e56-955b-419f-9ae3-a35439c3e867
+  scheme: openstates


### PR DESCRIPTION
It appears the proper way to deal with duplicate legislators is to add their old IDs to other_identifiers. This change adds the old IDs for all legislators deleted in #251.