### PR TITLE
VT: Update legislators

### DIFF
--- a/data/vt/organizations/Energy-and-Technology-8ad3f19f-e2ab-4172-950a-e1da498593da.yml
+++ b/data/vt/organizations/Energy-and-Technology-8ad3f19f-e2ab-4172-950a-e1da498593da.yml
@@ -25,6 +25,7 @@ memberships:
 - id: ocd-person/dcfb27c5-ea5c-4de1-b542-440f60904e83
   name: Robert Forguites
   role: Clerk
+  end_date: '2019-04-09'
 - name: Mr. Mike Ferrant
   role: Committee Assistant
 - id: ocd-person/46cebde2-6c9e-4d8f-a272-a36615efa80f

--- a/data/vt/organizations/Health-Care-4f0f6711-8755-4c0d-b043-ed9dbaf30e29.yml
+++ b/data/vt/organizations/Health-Care-4f0f6711-8755-4c0d-b043-ed9dbaf30e29.yml
@@ -13,6 +13,7 @@ memberships:
   name: Annmarie Christensen
 - id: ocd-person/763aec16-22cc-4851-84cc-454183e2449a
   name: Benjamin Jickling
+  end_date: '2019-09-01'
 - id: ocd-person/122c1791-f3f9-45be-8966-dad77757a541
   name: Elizabeth "Betsy" Dunn
   end_date: '2019-01-08'

--- a/data/vt/organizations/Legislative-Information-Technology-Committee-d413458a-45fc-4eb8-9491-d69c4a1238c3.yml
+++ b/data/vt/organizations/Legislative-Information-Technology-Committee-d413458a-45fc-4eb8-9491-d69c4a1238c3.yml
@@ -21,6 +21,7 @@ memberships:
   name: Curt Taylor
 - id: ocd-person/763aec16-22cc-4851-84cc-454183e2449a
   name: Benjamin Jickling
+  end_date: '2019-09-01'
 - id: ocd-person/85843bdd-2b1d-4dd9-8201-ed2fa4ef1d0a
   name: Gabrielle Lucke
   end_date: '2019-01-08'

--- a/data/vt/people/Alice-M-Emmons-24194dba-4d25-4b8c-be33-8ff50fcd8a8f.yml
+++ b/data/vt/people/Alice-M-Emmons-24194dba-4d25-4b8c-be33-8ff50fcd8a8f.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14512
-image: https://legislature.vermont.gov/assets/Documents/Legislators/AEmmons.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/AEmmons.jpg
 other_identifiers:
 - identifier: VTL000067
   scheme: legacy_openstates

--- a/data/vt/people/Alice-W-Nitka-c28e9c1f-b40f-48ef-943f-dfe03317b7d3.yml
+++ b/data/vt/people/Alice-W-Nitka-c28e9c1f-b40f-48ef-943f-dfe03317b7d3.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14612
-image: https://legislature.vermont.gov/assets/Documents/Legislators/ANitka.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/ANitka.jpg
 other_identifiers:
 - identifier: VTL000023
   scheme: legacy_openstates

--- a/data/vt/people/Alison-Clarkson-a366bc32-20d8-41a8-a2cf-939650b7a2c2.yml
+++ b/data/vt/people/Alison-Clarkson-a366bc32-20d8-41a8-a2cf-939650b7a2c2.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27152
-image: https://legislature.vermont.gov/assets/Documents/Legislators/AClarkson.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Clarkson.Alison.jpg
 other_identifiers:
 - identifier: VTL000825
   scheme: legacy_openstates

--- a/data/vt/people/Amy-Sheldon-f490d01d-80b7-40ae-9577-572bd1c8567a.yml
+++ b/data/vt/people/Amy-Sheldon-f490d01d-80b7-40ae-9577-572bd1c8567a.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24022
-image: https://legislature.vermont.gov/assets/Documents/Legislators/ASheldon.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Sheldon.Amy.jpg
 other_identifiers:
 - identifier: VTL000422
   scheme: legacy_openstates

--- a/data/vt/people/Andrew-Perchlik-1463485e-f279-44f6-a368-f75f213dc7cd.yml
+++ b/data/vt/people/Andrew-Perchlik-1463485e-f279-44f6-a368-f75f213dc7cd.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: aperchlik@leg.state.vt.us
   note: Capitol Office
-- address: 29 Franklin St.;Montpelier, VT 05602
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-279-0471
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30982
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Perchlik.Andrew.jpg
 given_name: Andrew
 family_name: Perchlik

--- a/data/vt/people/Ann-Cummings-c34f492a-7cdf-4830-a28a-0ff2fe7c8f71.yml
+++ b/data/vt/people/Ann-Cummings-c34f492a-7cdf-4830-a28a-0ff2fe7c8f71.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14604
-image: https://legislature.vermont.gov/assets/Documents/Legislators/ACummings.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Cummings.Ann.jpg
 other_identifiers:
 - identifier: VTL000008
   scheme: legacy_openstates

--- a/data/vt/people/Ann-Pugh-db18c970-e1a3-4084-b7f9-32798050fe1f.yml
+++ b/data/vt/people/Ann-Pugh-db18c970-e1a3-4084-b7f9-32798050fe1f.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14530
-image: https://legislature.vermont.gov/assets/Documents/Legislators/APugh.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Pugh.Ann.jpg
 other_identifiers:
 - identifier: VTL000148
   scheme: legacy_openstates

--- a/data/vt/people/Anne-B-Donahue-5321cd58-caae-4d94-8ba0-f1df47d4e75b.yml
+++ b/data/vt/people/Anne-B-Donahue-5321cd58-caae-4d94-8ba0-f1df47d4e75b.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14557
-image: https://legislature.vermont.gov/assets/Documents/Legislators/ADonahue.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Donahue.Anne.jpg
 other_identifiers:
 - identifier: VTL000064
   scheme: legacy_openstates

--- a/data/vt/people/Annmarie-Christensen-5379d433-655f-416c-af15-7aebd404d37a.yml
+++ b/data/vt/people/Annmarie-Christensen-5379d433-655f-416c-af15-7aebd404d37a.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27181
-image: https://legislature.vermont.gov/assets/Documents/Legislators/AChristensen.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Christensen.A.jpg
 other_identifiers:
 - identifier: VTL000824
   scheme: legacy_openstates

--- a/data/vt/people/Anthony-Pollina-1fdc7a2d-288f-419b-be84-e748a9b8a68e.yml
+++ b/data/vt/people/Anthony-Pollina-1fdc7a2d-288f-419b-be84-e748a9b8a68e.yml
@@ -11,7 +11,7 @@ contact_details:
   email: apollina@leg.state.vt.us
   note: Capitol Office
 - address: 93 Story Rd.;North Middlesex, VT 05682
-  email: apollina@sover.net
+  email: apollinavt@gmail.com
   note: District Office
   voice: 802-229-5809
 links:
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15795
-image: https://legislature.vermont.gov/assets/Documents/Legislators/APollina.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Pollina.Anthony.jpg
 other_identifiers:
 - identifier: VTL000184
   scheme: legacy_openstates

--- a/data/vt/people/Avram-Patt-419b4d42-7a60-4ced-b361-1f344263a856.yml
+++ b/data/vt/people/Avram-Patt-419b4d42-7a60-4ced-b361-1f344263a856.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30962
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Patt.Avram.jpg
 given_name: Avram
 family_name: Patt
 other_identifiers:

--- a/data/vt/people/Barbara-Murphy-3e83f231-bd4f-49ae-a292-c362d99863f9.yml
+++ b/data/vt/people/Barbara-Murphy-3e83f231-bd4f-49ae-a292-c362d99863f9.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24017
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BMurphy.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Murphy.Barbara.jpg
 other_identifiers:
 - identifier: VTL000469
   scheme: legacy_openstates

--- a/data/vt/people/Barbara-Rachelson-26b89cd1-55b7-49ef-b47b-d3b21ed81635.yml
+++ b/data/vt/people/Barbara-Rachelson-26b89cd1-55b7-49ef-b47b-d3b21ed81635.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20377
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BRachelson.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Rachelson.Barb.jpg
 other_identifiers:
 - identifier: VTL000302
   scheme: legacy_openstates

--- a/data/vt/people/Becca-Balint-db106e21-ebc0-46a9-8081-bddfd769afb2.yml
+++ b/data/vt/people/Becca-Balint-db106e21-ebc0-46a9-8081-bddfd769afb2.yml
@@ -13,12 +13,13 @@ contact_details:
 - address: 271 South Main St.;Brattleboro, VT 05301
   email: beccabalint@gmail.com
   note: District Office
+  voice: 802-365-1060
 links:
 - url: http://legislature.vermont.gov/people/single/2020/24029
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24029
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BBalint.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Balint.Becca.jpg
 other_identifiers:
 - identifier: VTL000511
   scheme: legacy_openstates

--- a/data/vt/people/Brian-Campion-5e6451d0-e410-48e5-854a-bcd0a0a5b3c0.yml
+++ b/data/vt/people/Brian-Campion-5e6451d0-e410-48e5-854a-bcd0a0a5b3c0.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24030
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BCampion.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Campion.Brian.jpg
 other_identifiers:
 - identifier: VTL000191
   scheme: legacy_openstates

--- a/data/vt/people/Brian-Cina-35504508-c008-4ecd-869f-6d8e33a4ad56.yml
+++ b/data/vt/people/Brian-Cina-35504508-c008-4ecd-869f-6d8e33a4ad56.yml
@@ -2,6 +2,7 @@ id: ocd-person/35504508-c008-4ecd-869f-6d8e33a4ad56
 name: Brian Cina
 party:
 - name: Progressive
+- name: Progressive/Democratic
 roles:
 - district: Chittenden-6-4
   jurisdiction: ocd-jurisdiction/country:us/state:vt/government
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27162
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BCina.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Cina.Brian.jpg
 other_identifiers:
 - identifier: VTL000848
   scheme: legacy_openstates

--- a/data/vt/people/Brian-Collamore-d4ead076-6425-4ab7-ad32-b10dce660170.yml
+++ b/data/vt/people/Brian-Collamore-d4ead076-6425-4ab7-ad32-b10dce660170.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24031
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BCollamore.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Collamore.Brian.jpg
 other_identifiers:
 - identifier: VTL000443
   scheme: legacy_openstates

--- a/data/vt/people/Brian-K-Savage-3ab79a25-b3cb-494a-b36c-9bdba1cfba7a.yml
+++ b/data/vt/people/Brian-K-Savage-3ab79a25-b3cb-494a-b36c-9bdba1cfba7a.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14679
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BSavage.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Savage.Brian.jpg
 other_identifiers:
 - identifier: VTL000152
   scheme: legacy_openstates

--- a/data/vt/people/Brian-Smith-a118c779-cb90-4746-8930-cfba85045430.yml
+++ b/data/vt/people/Brian-Smith-a118c779-cb90-4746-8930-cfba85045430.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27176
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BSmith.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Smith.Brian.jpg
 other_identifiers:
 - identifier: VTL000828
   scheme: legacy_openstates

--- a/data/vt/people/Caleb-Elder-9c460746-5296-40dc-bad6-273f38574c1a.yml
+++ b/data/vt/people/Caleb-Elder-9c460746-5296-40dc-bad6-273f38574c1a.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: celder@leg.state.vt.us
   note: Capitol Office
-- address: 580 Ruby Brace Rd.;Starksboro, VT 05487
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-373-6465
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30940
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Elder.Caleb.jpg
 given_name: Caleb
 family_name: Elder

--- a/data/vt/people/Carl-Demrow-8e48ba22-bc5e-4986-b335-9a621a97e6b5.yml
+++ b/data/vt/people/Carl-Demrow-8e48ba22-bc5e-4986-b335-9a621a97e6b5.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30963
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Demrow.Carl.jpg
 given_name: Carl
 family_name: Demrow

--- a/data/vt/people/Carl-Rosenquist-74979e65-09c0-4bf9-b917-6cca42c32333.yml
+++ b/data/vt/people/Carl-Rosenquist-74979e65-09c0-4bf9-b917-6cca42c32333.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27168
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CRosenquist.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Rosenquist.Carl.jpg
 other_identifiers:
 - identifier: VTL000833
   scheme: legacy_openstates

--- a/data/vt/people/Carol-Ode-e9036574-9eac-4f0c-9bd2-1b425e96bb8c.yml
+++ b/data/vt/people/Carol-Ode-e9036574-9eac-4f0c-9bd2-1b425e96bb8c.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27161
-image: https://legislature.vermont.gov/assets/Documents/Legislators/COde.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Ode.Carol.jpg
 other_identifiers:
 - identifier: VTL000849
   scheme: legacy_openstates

--- a/data/vt/people/Carolyn-W-Partridge-e9561021-9f48-4c96-bbe7-9714ae7ca61c.yml
+++ b/data/vt/people/Carolyn-W-Partridge-e9561021-9f48-4c96-bbe7-9714ae7ca61c.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14527
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CPartridge.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Partridge.C.jpg
 other_identifiers:
 - identifier: VTL000140
   scheme: legacy_openstates

--- a/data/vt/people/Casey-Toof-704de547-43b6-4dfa-bf95-c4137f263e00.yml
+++ b/data/vt/people/Casey-Toof-704de547-43b6-4dfa-bf95-c4137f263e00.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: ctoof@leg.state.vt.us
   note: Capitol Office
-- address: 16 Clyde Allen Dr.;St. Albans, VT 05478
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-309-3522
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30955
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Toof.Casey.jpg
 given_name: Casey
 family_name: Toof

--- a/data/vt/people/Catherine-Toll-6fb5b1e3-6932-425b-96e2-5b3c365006ad.yml
+++ b/data/vt/people/Catherine-Toll-6fb5b1e3-6932-425b-96e2-5b3c365006ad.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14693
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CToll.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CToll.jpg
 other_identifiers:
 - identifier: VTL000166
   scheme: legacy_openstates

--- a/data/vt/people/Charen-Fegard-43ec38be-fb28-4f98-82bb-9e3033b48b3e.yml
+++ b/data/vt/people/Charen-Fegard-43ec38be-fb28-4f98-82bb-9e3033b48b3e.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: cfegard@leg.state.vt.us
   note: Capitol Office
-- address: 1570 Lost Nation Rd.;Enosburg Falls, VT 05450
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-848-7303
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30957
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Fegard.Charen.jpg
 given_name: Charen
 family_name: Fegard

--- a/data/vt/people/Charles-Butch-Shaw-6783c18b-dfdc-4b50-a27a-6457ba1a811c.yml
+++ b/data/vt/people/Charles-Butch-Shaw-6783c18b-dfdc-4b50-a27a-6457ba1a811c.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15553
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CShaw.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Shaw.Butch.jpg
 other_identifiers:
 - identifier: VTL000156
   scheme: legacy_openstates

--- a/data/vt/people/Charles-Conquest-6d7dffb4-9301-44a8-8d62-bf2d4bab53a5.yml
+++ b/data/vt/people/Charles-Conquest-6d7dffb4-9301-44a8-8d62-bf2d4bab53a5.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14695
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CConquest.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CConquest.jpg
 other_identifiers:
 - identifier: VTL000053
   scheme: legacy_openstates

--- a/data/vt/people/Charles-Kimbell-5f41ed36-d168-489a-bc2a-8eacbb9d82cd.yml
+++ b/data/vt/people/Charles-Kimbell-5f41ed36-d168-489a-bc2a-8eacbb9d82cd.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27184
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CKimbell.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CKimbell.jpg
 other_identifiers:
 - identifier: VTL000852
   scheme: legacy_openstates

--- a/data/vt/people/Cheryl-Hooker-cd8c58d6-11a5-4af0-a3db-3a939e60c8fa.yml
+++ b/data/vt/people/Cheryl-Hooker-cd8c58d6-11a5-4af0-a3db-3a939e60c8fa.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: chooker@leg.state.vt.us
   note: Capitol Office
-- address: 11 Royce St.;Rutland, VT 05701
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-353-7288
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30979
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Hooker.Cheryl.jpg
 given_name: Cheryl
 family_name: Hooker

--- a/data/vt/people/Christopher-A-Pearson-48d31a41-0a4a-4fd4-997c-220b93c28881.yml
+++ b/data/vt/people/Christopher-A-Pearson-48d31a41-0a4a-4fd4-997c-220b93c28881.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27150
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CPearson.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CPearson.jpg
 other_identifiers:
 - identifier: VTL000817
   scheme: legacy_openstates

--- a/data/vt/people/Christopher-Bates-fd7942c2-1d2d-4776-9930-beb6a66ac30b.yml
+++ b/data/vt/people/Christopher-Bates-fd7942c2-1d2d-4776-9930-beb6a66ac30b.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: cbates@leg.state.vt.us
   note: Capitol Office
-- address: 425 N. Branch St.;Bennington, VT 05201
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-681-6914
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30942
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Bates.Chris.jpg
 given_name: Christopher
 family_name: Bates

--- a/data/vt/people/Christopher-Bray-932e6a17-d8a5-4573-b2a4-8f5ae59300c6.yml
+++ b/data/vt/people/Christopher-Bray-932e6a17-d8a5-4573-b2a4-8f5ae59300c6.yml
@@ -10,16 +10,15 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: cbray@leg.state.vt.us
   note: Capitol Office
-- address: 829 South St.;New Haven, VT 05472
-  email: cbray@sover.net
+- address: 115 State St;Montpelier, VT 05633
   note: District Office
-  voice: 802-453-4424
+  voice: 802-453-3444
 links:
 - url: http://legislature.vermont.gov/people/single/2020/20396
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20396
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CBray.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Bray.Christopher.jpg
 other_identifiers:
 - identifier: VTL000043
   scheme: legacy_openstates

--- a/data/vt/people/Christopher-Mattos-1526326f-c2a8-4103-af27-1805f9a8e32a.yml
+++ b/data/vt/people/Christopher-Mattos-1526326f-c2a8-4103-af27-1805f9a8e32a.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/29153
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CMattos.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CMattos.jpg
 other_identifiers:
 - identifier: VTL000875
   scheme: legacy_openstates

--- a/data/vt/people/Constance-Quimby-75c87cc9-da65-46de-8082-23774bf01b75.yml
+++ b/data/vt/people/Constance-Quimby-75c87cc9-da65-46de-8082-23774bf01b75.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20380
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CQuimby.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Quimby.Constance.jpg
 other_identifiers:
 - identifier: VTL000301
   scheme: legacy_openstates

--- a/data/vt/people/Corey-Parent-cd9ee450-f261-4516-bb09-3263b54a4a21.yml
+++ b/data/vt/people/Corey-Parent-cd9ee450-f261-4516-bb09-3263b54a4a21.yml
@@ -13,8 +13,9 @@ roles:
   start_date: '2019-01-09'
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: CParent@leg.state.vt.us
   note: Capitol Office
-- address: 5 Potter Ave.;St. Albans, VT 05478
+- address: 21 Bluff Lane;St. Albans, VT 05478
   note: District Office
   voice: 802-370-0494
 links:
@@ -22,7 +23,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30980
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Parent.Corey.jpg
 other_identifiers:
 - identifier: VTL000369
   scheme: legacy_openstates

--- a/data/vt/people/Curt-Taylor-e4fb0d53-dde1-4035-a648-b2bf19eb4919.yml
+++ b/data/vt/people/Curt-Taylor-e4fb0d53-dde1-4035-a648-b2bf19eb4919.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: CTaylor@leg.state.vt.us
   note: Capitol Office
-- address: 436 Sunderland Woods;Colchester, VT 05446
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-324-7188
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27167
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CTaylor.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Taylor.Curt.jpg
 other_identifiers:
 - identifier: VTL000846
   scheme: legacy_openstates

--- a/data/vt/people/Curtis-McCormack-1ed40d71-5b90-4371-a930-3ead6989a1cb.yml
+++ b/data/vt/people/Curtis-McCormack-1ed40d71-5b90-4371-a930-3ead6989a1cb.yml
@@ -1,5 +1,5 @@
 id: ocd-person/1ed40d71-5b90-4371-a930-3ead6989a1cb
-name: Curtis McCormack
+name: Curt McCormack
 party:
 - name: Democratic
 roles:
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20376
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CMccormack.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CMccormack.jpg
 other_identifiers:
 - identifier: VTL000285
   scheme: legacy_openstates
@@ -35,5 +35,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: VTL000860
   scheme: legacy_openstates
-given_name: Curtis
+given_name: Curt
 family_name: McCormack

--- a/data/vt/people/Cynthia-Browning-2e7d9438-5abb-4515-9164-93835e516862.yml
+++ b/data/vt/people/Cynthia-Browning-2e7d9438-5abb-4515-9164-93835e516862.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: cbrowning@leg.state.vt.us
   note: Capitol Office
-- address: P.O. Box 389;Arlington, VT 05250
+- address: 115 State St.;Montpelier, VT 05633
   email: cynthiab@sover.net
   note: District Office
   voice: 802-375-9019
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14585
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CBrowning.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/CBrowning.jpg
 other_identifiers:
 - identifier: VTL000045
   scheme: legacy_openstates

--- a/data/vt/people/Daniel-Noyes-95cd4184-c07f-48a5-993a-e924ad71184f.yml
+++ b/data/vt/people/Daniel-Noyes-95cd4184-c07f-48a5-993a-e924ad71184f.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27171
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DNoyes.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Noyes.Daniel.jpg
 other_identifiers:
 - identifier: VTL000816
   scheme: legacy_openstates

--- a/data/vt/people/David-Durfee-500ffe66-07b0-4ebd-9084-d017872daa84.yml
+++ b/data/vt/people/David-Durfee-500ffe66-07b0-4ebd-9084-d017872daa84.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30944
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Durfee.David.jpg
 given_name: David
 family_name: Durfee

--- a/data/vt/people/David-Potter-307f5efe-e6df-4a53-8877-02b9d8c8e85f.yml
+++ b/data/vt/people/David-Potter-307f5efe-e6df-4a53-8877-02b9d8c8e85f.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14577
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DPotter.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Potter.Dave.jpg
 other_identifiers:
 - identifier: VTL000147
   scheme: legacy_openstates

--- a/data/vt/people/David-Yacovone-79f88a73-229c-4036-b97c-67a44927b969.yml
+++ b/data/vt/people/David-Yacovone-79f88a73-229c-4036-b97c-67a44927b969.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27172
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DYacovone.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Yacovone.David.jpg
 other_identifiers:
 - identifier: VTL000829
   scheme: legacy_openstates

--- a/data/vt/people/Debbie-Ingram-fb1f7f03-8d57-4a27-acfe-75c797c775a5.yml
+++ b/data/vt/people/Debbie-Ingram-fb1f7f03-8d57-4a27-acfe-75c797c775a5.yml
@@ -10,15 +10,15 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: DIngram@leg.state.vt.us
   note: Capitol Office
-- address: 2120 South Rd.;Williston, VT 05495
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
-  voice: 802-879-0054
+  voice: 802-622-4394
 links:
 - url: http://legislature.vermont.gov/people/single/2020/27149
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27149
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DIngram.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Ingram.Debbie.jpg
 other_identifiers:
 - identifier: VTL000820
   scheme: legacy_openstates

--- a/data/vt/people/Diana-Gonzalez-4a26e77f-a3aa-4e50-930a-f8c80d54ed9e.yml
+++ b/data/vt/people/Diana-Gonzalez-4a26e77f-a3aa-4e50-930a-f8c80d54ed9e.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24007
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DGonzalez.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Gonzalez.Diana.jpg
 other_identifiers:
 - identifier: VTL000450
   scheme: legacy_openstates

--- a/data/vt/people/Diane-Lanpher-a072e1d3-94fe-4327-b3b0-14f033457e0a.yml
+++ b/data/vt/people/Diane-Lanpher-a072e1d3-94fe-4327-b3b0-14f033457e0a.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: dlanpher@leg.state.vt.us
   note: Capitol Office
-- address: 194 So. Maple St.;P.O. Box 165;Vergennes, VT 05491
+- address: P.O. Box 165;Vergennes, VT 05491
   note: District Office
   voice: 802-877-2230
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14667
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DLanpher.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Lanpher.Diane.jpg
 other_identifiers:
 - identifier: VTL000100
   scheme: legacy_openstates

--- a/data/vt/people/Dick-Mazza-1acec5ba-9c21-4166-9307-d6958608fb41.yml
+++ b/data/vt/people/Dick-Mazza-1acec5ba-9c21-4166-9307-d6958608fb41.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: rmazza@leg.state.vt.us
   note: Capitol Office
 - address: 777 West Lakeshore Dr.;Colchester, VT 05446
   note: District Office
@@ -17,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14610
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RMazza.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Mazza.Dick.jpg
 other_identifiers:
 - identifier: VTL000019
   scheme: legacy_openstates

--- a/data/vt/people/Dick-McCormack-3287ebb4-7592-484d-8194-d44d886e0d41.yml
+++ b/data/vt/people/Dick-McCormack-3287ebb4-7592-484d-8194-d44d886e0d41.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rmccormack@leg.state.vt.us
   note: Capitol Office
-- address: 127 Cleveland Brook Rd.;Bethel, VT 05032
+- address: 115 State St.;Montpelier, VT 05633
   email: dmccormack127@gmail.com
   note: District Office
   voice: 802-793-6417
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14625
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RMccormack.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RMccormack.jpg
 other_identifiers:
 - identifier: VTL000020
   scheme: legacy_openstates

--- a/data/vt/people/Dick-Sears-ffba43ff-20d1-492d-a5f7-22855c1fbba4.yml
+++ b/data/vt/people/Dick-Sears-ffba43ff-20d1-492d-a5f7-22855c1fbba4.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14613
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RSears.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RSears.jpg
 other_identifiers:
 - identifier: VTL000026
   scheme: legacy_openstates

--- a/data/vt/people/Dylan-Giambatista-17dcafb9-c63a-4a32-8e3b-71bcf59b1a59.yml
+++ b/data/vt/people/Dylan-Giambatista-17dcafb9-c63a-4a32-8e3b-71bcf59b1a59.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27165
-image: https://legislature.vermont.gov/assets/Documents/Legislators/DGiambatista.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Giambatista.D.jpg
 other_identifiers:
 - identifier: VTL000835
   scheme: legacy_openstates

--- a/data/vt/people/Eileen-Dickinson-d0698c2f-d5fb-475b-abc9-042971d26a5f.yml
+++ b/data/vt/people/Eileen-Dickinson-d0698c2f-d5fb-475b-abc9-042971d26a5f.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14677
-image: https://legislature.vermont.gov/assets/Documents/Legislators/EDickinson.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/EDickinson.jpg
 other_identifiers:
 - identifier: VTL000062
   scheme: legacy_openstates

--- a/data/vt/people/Emilie-Kornheiser-cb033790-7578-41c3-87b6-c9794b289c77.yml
+++ b/data/vt/people/Emilie-Kornheiser-cb033790-7578-41c3-87b6-c9794b289c77.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30972
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Kornheiser.E.jpg
 given_name: Emilie
 family_name: Kornheiser

--- a/data/vt/people/Emily-Long-36bd1884-fd78-46b4-9ac3-318ca6358a67.yml
+++ b/data/vt/people/Emily-Long-36bd1884-fd78-46b4-9ac3-318ca6358a67.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24012
-image: https://legislature.vermont.gov/assets/Documents/Legislators/ELong.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Long.Emily.jpg
 other_identifiers:
 - identifier: VTL000505
   scheme: legacy_openstates

--- a/data/vt/people/Felisha-Leffler-7e9172a4-27b7-455f-a226-e251a6503fef.yml
+++ b/data/vt/people/Felisha-Leffler-7e9172a4-27b7-455f-a226-e251a6503fef.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30959
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Leffler.Felisha.jpg
 given_name: Felisha
 family_name: Leffler

--- a/data/vt/people/Francis-McFaun-a7c7d0f6-8795-4f50-928b-15b6c3831ac4.yml
+++ b/data/vt/people/Francis-McFaun-a7c7d0f6-8795-4f50-928b-15b6c3831ac4.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14579
-image: https://legislature.vermont.gov/assets/Documents/Legislators/FMcfaun.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/FMcfaun.jpg
 other_identifiers:
 - identifier: VTL000121
   scheme: legacy_openstates

--- a/data/vt/people/George-W-Till-54c2dd5b-136a-4fac-a617-b54576095dea.yml
+++ b/data/vt/people/George-W-Till-54c2dd5b-136a-4fac-a617-b54576095dea.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14676
-image: https://legislature.vermont.gov/assets/Documents/Legislators/GTill.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Till.George.jpg
 other_identifiers:
 - identifier: VTL000165
   scheme: legacy_openstates

--- a/data/vt/people/Harold-Colston-7fae5f96-31f0-4dba-af52-f14537de5263.yml
+++ b/data/vt/people/Harold-Colston-7fae5f96-31f0-4dba-af52-f14537de5263.yml
@@ -1,5 +1,5 @@
 id: ocd-person/7fae5f96-31f0-4dba-af52-f14537de5263
-name: Harold Colston
+name: Harold "Hal" Colston
 given_name: Harold
 family_name: Colston
 image: https://legislature.vermont.gov/Documents/Legislators/Colston.Hal.jpg
@@ -14,11 +14,11 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: hcolston@leg.state.vt.us
   note: Capitol Office
-- address: 20 West Canal Street \#214, Winooski, VT 05404
-  email: smith45@together.net
+- address: '20 West Canal Street #214;Winooski, VT 05404'
   note: District Office
-  voice: 802-828-2228
+  voice: 802-922-2908
 links:
-- url: https://legislature.vermont.gov/people/single/2020/31249
+- url: http://legislature.vermont.gov/people/single/2020/31249
 sources:
-- url: https://legislature.vermont.gov/people/single/2020/31249
+- url: http://legislature.vermont.gov/people/loadAll/2020
+- url: http://legislature.vermont.gov/people/single/2020/31249

--- a/data/vt/people/Harvey-Smith-77cacaa2-54e4-4031-b054-803da94303d8.yml
+++ b/data/vt/people/Harvey-Smith-77cacaa2-54e4-4031-b054-803da94303d8.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15785
-image: https://legislature.vermont.gov/assets/Documents/Legislators/HSmith.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Smith.Harvey.jpg
 other_identifiers:
 - identifier: VTL000203
   scheme: legacy_openstates

--- a/data/vt/people/Heidi-E-Scheuermann-773ff1e9-6e60-4a0b-88cf-27f732ebed08.yml
+++ b/data/vt/people/Heidi-E-Scheuermann-773ff1e9-6e60-4a0b-88cf-27f732ebed08.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14592
-image: https://legislature.vermont.gov/assets/Documents/Legislators/HScheuermann.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Scheuerman.Heidi.jpg
 other_identifiers:
 - identifier: VTL000153
   scheme: legacy_openstates

--- a/data/vt/people/James-Carroll-439f6541-dcf9-4661-9088-fa7dd39734be.yml
+++ b/data/vt/people/James-Carroll-439f6541-dcf9-4661-9088-fa7dd39734be.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30943
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Carroll.Jim.jpg
 given_name: James
 family_name: Carroll

--- a/data/vt/people/James-Gregoire-2219c217-1804-40be-8183-ae139cd93f1c.yml
+++ b/data/vt/people/James-Gregoire-2219c217-1804-40be-8183-ae139cd93f1c.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30958
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Gregoire.James.jpg
 given_name: James
 family_name: Gregoire

--- a/data/vt/people/James-Harrison-bd5d142d-90c3-41f6-b8af-7591316951da.yml
+++ b/data/vt/people/James-Harrison-bd5d142d-90c3-41f6-b8af-7591316951da.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/28878
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JHarrison.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JHarrison.jpg
 other_identifiers:
 - identifier: VTL000873
   scheme: legacy_openstates

--- a/data/vt/people/James-Masland-5342eafc-7f58-4ebe-ad1e-0ec4aefe82fe.yml
+++ b/data/vt/people/James-Masland-5342eafc-7f58-4ebe-ad1e-0ec4aefe82fe.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14523
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JMasland.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Masland.James.jpg
 other_identifiers:
 - identifier: VTL000117
   scheme: legacy_openstates

--- a/data/vt/people/James-McCullough-5f407e79-1d08-4d58-9003-26ff270e21e5.yml
+++ b/data/vt/people/James-McCullough-5f407e79-1d08-4d58-9003-26ff270e21e5.yml
@@ -8,8 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: jmccullough@leg.state.vt.us
   note: Capitol Office
-- address: 592 Governor Chittenden Rd.;Williston, VT 05495
+- address: 115 State St.;Montpelier, VT 05633
   email: jim_mccullough@myfairpoint.net
   note: District Office
   voice: 802-878-2180
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14547
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JMccullough.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/McCullough.James.jpg
 other_identifiers:
 - identifier: VTL000119
   scheme: legacy_openstates

--- a/data/vt/people/James-McNeil-30371e70-1e68-49c1-9355-528eea771d4c.yml
+++ b/data/vt/people/James-McNeil-30371e70-1e68-49c1-9355-528eea771d4c.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30981
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/McNeil.James.jpg
 given_name: James
 family_name: McNeil

--- a/data/vt/people/Jane-Kitchel-34b76b5d-83b0-4e3e-9152-8ba48800399b.yml
+++ b/data/vt/people/Jane-Kitchel-34b76b5d-83b0-4e3e-9152-8ba48800399b.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14622
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MKitchel.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Kitchel.Jane.jpg
 other_identifiers:
 - identifier: VTL000015
   scheme: legacy_openstates

--- a/data/vt/people/Janet-Ancel-e5cedfce-36a4-42b3-aed0-a9e0c5416dfe.yml
+++ b/data/vt/people/Janet-Ancel-e5cedfce-36a4-42b3-aed0-a9e0c5416dfe.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14580
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JAncel.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JAncel.jpg
 other_identifiers:
 - identifier: VTL000034
   scheme: legacy_openstates

--- a/data/vt/people/Jean-OSullivan-018d5646-5e49-4d4c-98fb-1955295e7e6c.yml
+++ b/data/vt/people/Jean-OSullivan-018d5646-5e49-4d4c-98fb-1955295e7e6c.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/18342
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JOsullivan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/O'Sullivan.Jean.jpg
 other_identifiers:
 - identifier: VTL000213
   scheme: legacy_openstates

--- a/data/vt/people/Jeanette-K-White-19d7d2c5-d3f9-423b-8bf0-e1ba621b5fd8.yml
+++ b/data/vt/people/Jeanette-K-White-19d7d2c5-d3f9-423b-8bf0-e1ba621b5fd8.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14620
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JWhite.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JWhite.jpg
 other_identifiers:
 - identifier: VTL000030
   scheme: legacy_openstates

--- a/data/vt/people/Jessica-Brumsted-f45bc8b4-9df5-40f6-9e14-1acc6987e058.yml
+++ b/data/vt/people/Jessica-Brumsted-f45bc8b4-9df5-40f6-9e14-1acc6987e058.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27160
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JBrumsted.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JBrumsted.jpg
 other_identifiers:
 - identifier: VTL000842
   scheme: legacy_openstates

--- a/data/vt/people/Jill-Krowinski-ca098cac-17de-4e6b-ac7c-178d77998970.yml
+++ b/data/vt/people/Jill-Krowinski-ca098cac-17de-4e6b-ac7c-178d77998970.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: jkrowinski@leg.state.vt.us
   note: Capitol Office
-- address: 27 Spring Street;Burlington, VT 05401
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-363-3907
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/19342
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JKrowinski.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JKrowinski.jpg
 other_identifiers:
 - identifier: VTL000214
   scheme: legacy_openstates

--- a/data/vt/people/Joe-Benning-d7b6abac-fce9-4a80-82b6-cfba0a066803.yml
+++ b/data/vt/people/Joe-Benning-d7b6abac-fce9-4a80-82b6-cfba0a066803.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: jbenning@leg.state.vt.us
   note: Capitol Office
-- address: 291 Happy Hill Rd.;Lyndonville, VT 05851
+- address: P.O. Box 142;Lyndonville, VT 05851
   email: beaner77@myfairpoint.net
   note: District Office
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15792
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JBenning.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JBenning.jpg
 other_identifiers:
 - identifier: VTL000181
   scheme: legacy_openstates

--- a/data/vt/people/Johannah-Donovan-d0bd965b-63c4-4d51-9205-5c8a2235c580.yml
+++ b/data/vt/people/Johannah-Donovan-d0bd965b-63c4-4d51-9205-5c8a2235c580.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14534
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JDonovan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Donovan.Johanna.jpg
 other_identifiers:
 - identifier: VTL000065
   scheme: legacy_openstates

--- a/data/vt/people/John-Gannon-ee18fdb0-ff48-4dc4-8c48-3a16b7998b4e.yml
+++ b/data/vt/people/John-Gannon-ee18fdb0-ff48-4dc4-8c48-3a16b7998b4e.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27179
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JGannon.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/JGannon.jpg
 other_identifiers:
 - identifier: VTL000819
   scheme: legacy_openstates

--- a/data/vt/people/John-Killacky-5aeaad29-f713-4990-a6d4-33bc5c48b549.yml
+++ b/data/vt/people/John-Killacky-5aeaad29-f713-4990-a6d4-33bc5c48b549.yml
@@ -12,6 +12,7 @@ contact_details:
   email: jkillacky@leg.state.vt.us
   note: Capitol Office
 - address: 72 Woodthrush Cir.;South Burlington, VT 05403
+  email: jrkillacky52@gmail,com
   note: District Office
   voice: 802-862-2254
 links:
@@ -19,6 +20,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30949
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Killacky.John.jpg
 given_name: John
 family_name: Killacky

--- a/data/vt/people/John-L-Bartholomew-d12670e1-fd0b-4e78-a471-ec5d4ddfafb8.yml
+++ b/data/vt/people/John-L-Bartholomew-d12670e1-fd0b-4e78-a471-ec5d4ddfafb8.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: jbartholomew@leg.state.vt.us
   note: Capitol Office
-- address: 23 Linden Rd.;Hartland, VT 05048
+- address: 115 State St.;Montpelier, VT 05633
   email: barthoj@vermontel.net
   note: District Office
   voice: 802-436-2151
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15769
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JBartholomew.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Bartholomew.John.jpg
 other_identifiers:
 - identifier: VTL000186
   scheme: legacy_openstates

--- a/data/vt/people/John-OBrien-6b0c1c32-609e-4d13-a9c5-699b73bd1470.yml
+++ b/data/vt/people/John-OBrien-6b0c1c32-609e-4d13-a9c5-699b73bd1470.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30977
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/O'Brien.John.jpg
 given_name: John
 family_name: O'Brien

--- a/data/vt/people/John-Palasik-9ed42856-4db2-48a7-b656-6e7578aa720e.yml
+++ b/data/vt/people/John-Palasik-9ed42856-4db2-48a7-b656-6e7578aa720e.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30953
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Palasik.John.jpg
 given_name: John
 family_name: Palasik

--- a/data/vt/people/John-Rodgers-2cb218ea-52a4-4d1f-9732-217940ba260e.yml
+++ b/data/vt/people/John-Rodgers-2cb218ea-52a4-4d1f-9732-217940ba260e.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: jrodgers@leg.state.vt.us
   note: Capitol Office
-- address: P.O. Box 217;Glover, VT 05839
+- address: 642 Daniels Pond Rd.;Glover, VT 05839
   note: District Office
   voice: 802-525-4182
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20398
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JRodgers.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Rodgers.John.jpg
 other_identifiers:
 - identifier: VTL000151
   scheme: legacy_openstates

--- a/data/vt/people/Joseph-Chip-Troiano-0ae074ad-454d-4c05-98f2-d118fd5841d4.yml
+++ b/data/vt/people/Joseph-Chip-Troiano-0ae074ad-454d-4c05-98f2-d118fd5841d4.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: ctroiano@leg.state.vt.us
   note: Capitol Office
-- address: 261 Hutchins Farm Rd.;East Hardwick, VT 05836
+- address: 115 State St.;Montpelier, VT 05633
   email: chiptroiano@gmail.com
   note: District Office
   voice: 802-533-7712
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24026
-image: https://legislature.vermont.gov/assets/Documents/Legislators/CTroiano.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Troiano.Chip.jpg
 other_identifiers:
 - identifier: VTL000481
   scheme: legacy_openstates

--- a/data/vt/people/Katherine-Kari-Dolan-d2eb927f-91d2-48e3-ba49-71cf02e69ed5.yml
+++ b/data/vt/people/Katherine-Kari-Dolan-d2eb927f-91d2-48e3-ba49-71cf02e69ed5.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: kdolan@leg.state.vt.us
   note: Capitol Office
-- address: 214 Joslin HIll Rd.;Waitsfield, VT 05673
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-496-5020
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30970
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Dolan.Kari.jpg
 given_name: Katherine
 family_name: Dolan

--- a/data/vt/people/Kathleen-James-8b47b675-97d4-4cdc-a3ae-d44c05594b5c.yml
+++ b/data/vt/people/Kathleen-James-8b47b675-97d4-4cdc-a3ae-d44c05594b5c.yml
@@ -13,12 +13,12 @@ contact_details:
   note: Capitol Office
 - address: P.O. Box 1044;Manchester Center, VT 05255
   note: District Office
-  voice: 802-366-1158
+  voice: 802-828-2228
 links:
 - url: http://legislature.vermont.gov/people/single/2020/30945
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30945
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/James.Kath.jpg
 given_name: Kathleen
 family_name: James

--- a/data/vt/people/Kathryn-Webb-a1831f4c-2d2f-40c1-89cf-735eb93171db.yml
+++ b/data/vt/people/Kathryn-Webb-a1831f4c-2d2f-40c1-89cf-735eb93171db.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: kwebb@leg.state.vt.us
   note: Capitol Office
-- address: 1611 Harbor Rd.;Shelburne, VT 05482
+- address: 115 State St.;Montpelier, VT 05633
   email: katewebbvt@gmail.com
   note: District Office
   voice: 802-233-7798
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14675
-image: https://legislature.vermont.gov/assets/Documents/Legislators/KWebb.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/KWebb.jpg
 other_identifiers:
 - identifier: VTL000170
   scheme: legacy_openstates

--- a/data/vt/people/Kelly-Pajala-bc95d135-723c-4f4d-8519-ed8800b3aa57.yml
+++ b/data/vt/people/Kelly-Pajala-bc95d135-723c-4f4d-8519-ed8800b3aa57.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/29214
-image: https://legislature.vermont.gov/assets/Documents/Legislators/KPajala.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/KPajala.jpg
 other_identifiers:
 - identifier: VTL000877
   scheme: legacy_openstates

--- a/data/vt/people/Kenneth-Goslant-723a6dd0-9f92-4fdf-b506-f6947a3ccfe7.yml
+++ b/data/vt/people/Kenneth-Goslant-723a6dd0-9f92-4fdf-b506-f6947a3ccfe7.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30968
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Goslant.Kenneth.jpg
 given_name: Kenneth
 family_name: Goslant

--- a/data/vt/people/Kevin-Coach-Christie-dfe297f7-6d88-48d5-8b81-f2605f791de0.yml
+++ b/data/vt/people/Kevin-Coach-Christie-dfe297f7-6d88-48d5-8b81-f2605f791de0.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15774
-image: https://legislature.vermont.gov/assets/Documents/Legislators/KChristie.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/KChristie.jpg
 other_identifiers:
 - identifier: VTL000192
   scheme: legacy_openstates

--- a/data/vt/people/Kimberly-Jessup-694ae2a2-8d7d-4b5e-9c1b-322009c9d437.yml
+++ b/data/vt/people/Kimberly-Jessup-694ae2a2-8d7d-4b5e-9c1b-322009c9d437.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: kjessup@leg.state.vt.us
   note: Capitol Office
-- address: 126 Wood Rd.;N. Middlesex, VT 05682
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-223-0767
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27178
-image: https://legislature.vermont.gov/assets/Documents/Legislators/KJessup.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/KJessup.jpg
 other_identifiers:
 - identifier: VTL000823
   scheme: legacy_openstates

--- a/data/vt/people/Kristi-Morris-aa90c35b-88cb-4f97-9d66-70d777f7cae4.yml
+++ b/data/vt/people/Kristi-Morris-aa90c35b-88cb-4f97-9d66-70d777f7cae4.yml
@@ -1,0 +1,24 @@
+id: ocd-person/aa90c35b-88cb-4f97-9d66-70d777f7cae4
+name: Kristi Morris
+party:
+- name: Democratic
+roles:
+- district: Windsor-3-2
+  jurisdiction: ocd-jurisdiction/country:us/state:vt/government
+  type: lower
+  start_date: 2020-01-07
+contact_details:
+- address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: kmorris2@leg.state.vt.us
+  note: Capitol Office
+- address: 59 Coolidge Rd.;Springfield, VT 05156
+  email: kmorris2@leg.state.vt.us
+  note: District Office
+links:
+- url: http://legislature.vermont.gov/people/single/2020/33012
+sources:
+- url: http://legislature.vermont.gov/people/loadAll/2020
+- url: http://legislature.vermont.gov/people/single/2020/33012
+image: https://legislature.vermont.gov/Documents/Legislators/KristiMorris.jpg
+given_name: Kristi
+family_name: Morris

--- a/data/vt/people/Laura-Sibilia-57c62cd8-8701-4af6-9627-b89e735b5632.yml
+++ b/data/vt/people/Laura-Sibilia-57c62cd8-8701-4af6-9627-b89e735b5632.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24023
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LSibilia.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/LSibilia.jpg
 other_identifiers:
 - identifier: VTL000398
   scheme: legacy_openstates

--- a/data/vt/people/Lawrence-Cupoli-e37abeb6-6600-4393-b2d0-38af1e4ad2b9.yml
+++ b/data/vt/people/Lawrence-Cupoli-e37abeb6-6600-4393-b2d0-38af1e4ad2b9.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20387
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LCupoli.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Cupoli.Larry.jpg
 other_identifiers:
 - identifier: VTL000239
   scheme: legacy_openstates

--- a/data/vt/people/Leland-Morgan-5b8b4c48-b09c-4669-a145-c733ae32e293.yml
+++ b/data/vt/people/Leland-Morgan-5b8b4c48-b09c-4669-a145-c733ae32e293.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30960
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Morgan.Leland.jpg
 given_name: Leland
 family_name: Morgan

--- a/data/vt/people/Linda-Joy-Sullivan-bf91c530-54d5-4984-93ea-e12113eb975b.yml
+++ b/data/vt/people/Linda-Joy-Sullivan-bf91c530-54d5-4984-93ea-e12113eb975b.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: LSullivan@leg.state.vt.us
   note: Capitol Office
-- address: 932 McNamara Rd.;Dorset, VT 05251
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-768-8668
 links:
@@ -18,11 +18,11 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27157
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LSullivan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Sullivan.Linda.jpg
 other_identifiers:
 - identifier: VTL000839
   scheme: legacy_openstates
 - identifier: VTL000857
   scheme: legacy_openstates
-given_name: Linda Joy
+given_name: Linda
 family_name: Sullivan

--- a/data/vt/people/Linda-K-Myers-5322e928-070b-4a59-81ad-020ad92ccb7c.yml
+++ b/data/vt/people/Linda-K-Myers-5322e928-070b-4a59-81ad-020ad92ccb7c.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14541
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LMyers.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Myers.Linda.jpg
 other_identifiers:
 - identifier: VTL000132
   scheme: legacy_openstates

--- a/data/vt/people/Lisa-Hango-99b59993-b8ed-4046-b343-2958d25a58a4.yml
+++ b/data/vt/people/Lisa-Hango-99b59993-b8ed-4046-b343-2958d25a58a4.yml
@@ -11,10 +11,13 @@ roles:
   start_date: '2019-02-14'
   type: lower
 links:
-- url: https://legislature.vermont.gov/people/single/2020/31854
+- url: http://legislature.vermont.gov/people/single/2020/31854
 sources:
-- url: https://legislature.vermont.gov/people/single/2020/31854
+- url: http://legislature.vermont.gov/people/loadAll/2020
+- url: http://legislature.vermont.gov/people/single/2020/31854
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: LHango@leg.state.vt.us
   note: Capitol Office
-  voice: 802-828-2228
+- address: 115 State St.;Montpelier, VT 05633
+  note: District Office

--- a/data/vt/people/Logan-Nicoll-33459ac0-b2b3-4dde-8f2d-85fcd37cd691.yml
+++ b/data/vt/people/Logan-Nicoll-33459ac0-b2b3-4dde-8f2d-85fcd37cd691.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30967
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Nicoll.Logan.jpg
 given_name: Logan
 family_name: Nicoll

--- a/data/vt/people/Lori-Houghton-acf44b62-a884-4de2-8deb-055363849c5b.yml
+++ b/data/vt/people/Lori-Houghton-acf44b62-a884-4de2-8deb-055363849c5b.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: LHoughton@leg.state.vt.us
   note: Capitol Office
-- address: 40 School St.;Essex Jct., VT 05452
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-373-0599
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27166
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LHoughton.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Houghton.Lori.jpg
 other_identifiers:
 - identifier: VTL000838
   scheme: legacy_openstates

--- a/data/vt/people/Lucy-Rogers-802b3e65-8f4c-4575-9e45-3bf26cf8c00c.yml
+++ b/data/vt/people/Lucy-Rogers-802b3e65-8f4c-4575-9e45-3bf26cf8c00c.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: lrogers@leg.state.vt.us
   note: Capitol Office
-- address: 446 Rogers Rd.;Waterville, VT 05492
+- address: P.O. Box 23;Waterville, VT 05492
   note: District Office
   voice: 802-730-0604
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30961
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Rogers.Lucy.jpg
 given_name: Lucy
 family_name: Rogers

--- a/data/vt/people/Lynn-Batchelor-aab8e6b9-929b-42ff-8af8-d5529e76ba6d.yml
+++ b/data/vt/people/Lynn-Batchelor-aab8e6b9-929b-42ff-8af8-d5529e76ba6d.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15770
-image: https://legislature.vermont.gov/assets/Documents/Legislators/LBatchelor.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Batchelor.Lynn.jpg
 other_identifiers:
 - identifier: VTL000187
   scheme: legacy_openstates

--- a/data/vt/people/Maida-Townsend-8e1bc0f9-1cfa-4ebf-8f40-f1ebe81f01b1.yml
+++ b/data/vt/people/Maida-Townsend-8e1bc0f9-1cfa-4ebf-8f40-f1ebe81f01b1.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20379
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MTownsend.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MTownsend.jpg
 other_identifiers:
 - identifier: VTL000319
   scheme: legacy_openstates

--- a/data/vt/people/Marcia-Gardner-8fc64d68-513d-467a-b121-4c4bc0755125.yml
+++ b/data/vt/people/Marcia-Gardner-8fc64d68-513d-467a-b121-4c4bc0755125.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27158
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MGardner.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MGardner.jpg
 other_identifiers:
 - identifier: VTL000826
   scheme: legacy_openstates

--- a/data/vt/people/Marcia-Martel-0e222a6e-5125-4645-b2f3-5ab5bb2a8fe9.yml
+++ b/data/vt/people/Marcia-Martel-0e222a6e-5125-4645-b2f3-5ab5bb2a8fe9.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24014
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MMartel.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MMartel.jpg
 other_identifiers:
 - identifier: VTL000462
   scheme: legacy_openstates

--- a/data/vt/people/Mari-Cordes-1f501dde-37ba-49b3-ac83-0c77102ed8c3.yml
+++ b/data/vt/people/Mari-Cordes-1f501dde-37ba-49b3-ac83-0c77102ed8c3.yml
@@ -2,6 +2,7 @@ id: ocd-person/1f501dde-37ba-49b3-ac83-0c77102ed8c3
 name: Mari Cordes
 party:
 - name: Democratic/Progressive
+- name: Democratic
 roles:
 - district: Addison-4
   jurisdiction: ocd-jurisdiction/country:us/state:vt/government
@@ -19,6 +20,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30939
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Cordes.Mari.jpg
 given_name: Mari
 family_name: Cordes

--- a/data/vt/people/Marianna-Gamache-ac6908c4-c3d5-4260-a562-e21e9e79443e.yml
+++ b/data/vt/people/Marianna-Gamache-ac6908c4-c3d5-4260-a562-e21e9e79443e.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24006
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MGamache.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MGamache.jpg
 other_identifiers:
 - identifier: VTL000376
   scheme: legacy_openstates

--- a/data/vt/people/Mark-A-MacDonald-a2922c8e-7f90-44ec-a5e6-63daf45d9c25.yml
+++ b/data/vt/people/Mark-A-MacDonald-a2922c8e-7f90-44ec-a5e6-63daf45d9c25.yml
@@ -13,13 +13,13 @@ contact_details:
 - address: 404 MacDonald Rd.;Williamstown, VT 05679
   email: senatormark@aol.com
   note: District Office
-  voice: 802-433-5867
+  voice: 802-272-1101
 links:
 - url: http://legislature.vermont.gov/people/single/2020/14608
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14608
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MMacdonald.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MacDonald.Mark.jpg
 other_identifiers:
 - identifier: VTL000018
   scheme: legacy_openstates

--- a/data/vt/people/Mark-Higley-67ac8d03-20fe-47a8-9997-61467b4a8e30.yml
+++ b/data/vt/people/Mark-Higley-67ac8d03-20fe-47a8-9997-61467b4a8e30.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14681
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MHigley.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MHigley.jpg
 other_identifiers:
 - identifier: VTL000082
   scheme: legacy_openstates

--- a/data/vt/people/Martha-Feltus-2bcf3474-dc8a-4872-86b9-abac634f1a1e.yml
+++ b/data/vt/people/Martha-Feltus-2bcf3474-dc8a-4872-86b9-abac634f1a1e.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: mfeltus@leg.state.vt.us
   note: Capitol Office
 - address: P.O. Box 963;Lyndonville, VT 05851
   email: martyfeltus@gmail.com
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20375
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MFeltus.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MFeltus.jpg
 other_identifiers:
 - identifier: VTL000251
   scheme: legacy_openstates

--- a/data/vt/people/Martin-LaLonde-73ee356a-069a-4f2c-938d-2bab3d81b49a.yml
+++ b/data/vt/people/Martin-LaLonde-73ee356a-069a-4f2c-938d-2bab3d81b49a.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24010
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MLaLonde.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MLaLonde.jpg
 other_identifiers:
 - identifier: VTL000401
   scheme: legacy_openstates

--- a/data/vt/people/Mary-A-Morrissey-337fe4da-28df-42bf-82b1-e806bb50e8f3.yml
+++ b/data/vt/people/Mary-A-Morrissey-337fe4da-28df-42bf-82b1-e806bb50e8f3.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14525
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MMorrissey.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MMorrissey.jpg
 other_identifiers:
 - identifier: VTL000130
   scheme: legacy_openstates

--- a/data/vt/people/Mary-E-Howard-3d835c85-50e3-4a02-8891-baa377f63fa5.yml
+++ b/data/vt/people/Mary-E-Howard-3d835c85-50e3-4a02-8891-baa377f63fa5.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: MHoward@leg.state.vt.us
   note: Capitol Office
-- address: 17 Griswold Dr.;Rutland, VT 05701
+- address: P.O. Box 6295;Rutland, VT 05702
   note: District Office
   voice: 802-775-1125
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27177
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MHoward.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Howard.Mary.jpg
 other_identifiers:
 - identifier: VTL000821
   scheme: legacy_openstates

--- a/data/vt/people/Mary-S-Hooper-44376e30-fbe7-4cae-8989-c7f59518e3ed.yml
+++ b/data/vt/people/Mary-S-Hooper-44376e30-fbe7-4cae-8989-c7f59518e3ed.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14688
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/MHooper.jpg
 other_identifiers:
 - identifier: VTL000083
   scheme: legacy_openstates

--- a/data/vt/people/Mary-Sullivan-b081e822-b989-4766-bb71-4133603fd77c.yml
+++ b/data/vt/people/Mary-Sullivan-b081e822-b989-4766-bb71-4133603fd77c.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24024
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MSullivan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MSullivan.jpg
 other_identifiers:
 - identifier: VTL000491
   scheme: legacy_openstates

--- a/data/vt/people/Marybeth-Redmond-7e538487-faff-4b1f-8f32-e5cb69ff3003.yml
+++ b/data/vt/people/Marybeth-Redmond-7e538487-faff-4b1f-8f32-e5cb69ff3003.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30950
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Redmond.Marybeth.jpg
 given_name: Marybeth
 family_name: Redmond

--- a/data/vt/people/Matthew-Birong-e3e3144c-e166-4b0f-a7e7-e3e24cd40039.yml
+++ b/data/vt/people/Matthew-Birong-e3e3144c-e166-4b0f-a7e7-e3e24cd40039.yml
@@ -11,13 +11,13 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: mbirong@leg.state.vt.us
   note: Capitol Office
-- address: P.O. Box 54;Vergennes, VT 05491
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
 links:
 - url: http://legislature.vermont.gov/people/single/2020/30938
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30938
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Birong.Matt.jpg
 given_name: Matthew
 family_name: Birong

--- a/data/vt/people/Matthew-Hill-3dbe981d-1add-4181-a3ea-0cbfa4f39483.yml
+++ b/data/vt/people/Matthew-Hill-3dbe981d-1add-4181-a3ea-0cbfa4f39483.yml
@@ -10,15 +10,14 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: MHill@leg.state.vt.us
   note: Capitol Office
-- address: P.O. Box 561;Johnson, VT 05656
-  note: District Office
+- note: District Office
   voice: 802-760-7089
 links:
 - url: http://legislature.vermont.gov/people/single/2020/27170
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27170
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MHill.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MHill.jpg
 other_identifiers:
 - identifier: VTL000822
   scheme: legacy_openstates

--- a/data/vt/people/Matthew-Trieber-045c76e9-246f-4d61-b1a0-5c4a36003d00.yml
+++ b/data/vt/people/Matthew-Trieber-045c76e9-246f-4d61-b1a0-5c4a36003d00.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: mtrieber@leg.state.vt.us
   note: Capitol Office
 - address: 82 Atkinson St.;Bellows Falls, VT 05101
   email: matrieber@gmail.com
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/16361
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MTrieber.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MTrieber.jpg
 other_identifiers:
 - identifier: VTL000209
   scheme: legacy_openstates

--- a/data/vt/people/Maxine-Grad-d8fc81d3-ada4-4643-acd8-980167e31ae5.yml
+++ b/data/vt/people/Maxine-Grad-d8fc81d3-ada4-4643-acd8-980167e31ae5.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: mgrad@leg.state.vt.us
   note: Capitol Office
-- address: 301 Paddy Hill Rd.;Moretown, VT 05660
+- address: 115 State St.;Montpelier, VT 05633
   email: maxjg@wcvt.com
   note: District Office
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14536
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MGrad.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Grad.Maxine.jpg
 other_identifiers:
 - identifier: VTL000076
   scheme: legacy_openstates

--- a/data/vt/people/Michael-Marcotte-cffd5316-4723-43a2-bd54-2d41a9e61e16.yml
+++ b/data/vt/people/Michael-Marcotte-cffd5316-4723-43a2-bd54-2d41a9e61e16.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14568
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MMarcotte.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Marcotte.Michael.jpg
 other_identifiers:
 - identifier: VTL000113
   scheme: legacy_openstates

--- a/data/vt/people/Michael-McCarthy-31ea201b-86e9-4222-8840-cd787f477361.yml
+++ b/data/vt/people/Michael-McCarthy-31ea201b-86e9-4222-8840-cd787f477361.yml
@@ -9,7 +9,7 @@ roles:
   start_date: '2019-01-09'
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
-  email: mmcarthy@leg.state.vt.us
+  email: mmccarthy@leg.state.vt.us
   note: Capitol Office
 - address: 113 Bank St.;St. Albans, VT 05478
   note: District Office
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30954
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/McCarthy.Mike.jpg
 given_name: Michael
 family_name: McCarthy

--- a/data/vt/people/Michael-Mrowicki-4258ac6c-c453-4faf-b15c-4cbd8ea91ebd.yml
+++ b/data/vt/people/Michael-Mrowicki-4258ac6c-c453-4faf-b15c-4cbd8ea91ebd.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14598
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MMrowicki.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Mrowicki.Michael.jpg
 other_identifiers:
 - identifier: VTL000131
   scheme: legacy_openstates

--- a/data/vt/people/Michael-Sirotkin-7e9d0e3b-91e0-46d8-bebb-0b47d3c2ff59.yml
+++ b/data/vt/people/Michael-Sirotkin-7e9d0e3b-91e0-46d8-bebb-0b47d3c2ff59.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23179
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MSirotkin.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MSirotkin.jpg
 other_identifiers:
 - identifier: VTL000336
   scheme: legacy_openstates

--- a/data/vt/people/Michael-Yantachka-eec489a4-377e-4487-a05a-7cf8edda9f36.yml
+++ b/data/vt/people/Michael-Yantachka-eec489a4-377e-4487-a05a-7cf8edda9f36.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15788
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MYantachka.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MYantachka.jpg
 other_identifiers:
 - identifier: VTL000206
   scheme: legacy_openstates

--- a/data/vt/people/Mitzi-Johnson-8550aa35-5c5a-4e50-adae-17a1e5ba6a10.yml
+++ b/data/vt/people/Mitzi-Johnson-8550aa35-5c5a-4e50-adae-17a1e5ba6a10.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14552
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MJohnson.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/MJohnson.jpg
 other_identifiers:
 - identifier: VTL000090
   scheme: legacy_openstates

--- a/data/vt/people/Mollie-S-Burke-2bf6abc2-667f-494f-896a-812721ee77d3.yml
+++ b/data/vt/people/Mollie-S-Burke-2bf6abc2-667f-494f-896a-812721ee77d3.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14690
-image: https://legislature.vermont.gov/assets/Documents/Legislators/MBurke.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Burke.Mollie.jpg
 other_identifiers:
 - identifier: VTL000046
   scheme: legacy_openstates

--- a/data/vt/people/Nader-Hashim-4cae5971-93ee-4029-b5ef-4c69574256da.yml
+++ b/data/vt/people/Nader-Hashim-4cae5971-93ee-4029-b5ef-4c69574256da.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: nhashim@leg.state.vt.us
   note: Capitol Office
-- address: 655 Canoe Brook Rd.;Dummerston, VT 05346
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-490-5823
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30973
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Hashim.Nadar.jpg
 given_name: Nader
 family_name: Hashim

--- a/data/vt/people/Nelson-Brownell-805deeb4-55c0-4f3c-a01f-3fd3c6096f21.yml
+++ b/data/vt/people/Nelson-Brownell-805deeb4-55c0-4f3c-a01f-3fd3c6096f21.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30941
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Brownell.Nelson.jpg
 given_name: Nelson
 family_name: Brownell

--- a/data/vt/people/Patricia-McCoy-599c54f9-34b6-4e31-bb50-e36708c3509b.yml
+++ b/data/vt/people/Patricia-McCoy-599c54f9-34b6-4e31-bb50-e36708c3509b.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: pmccoy@leg.state.vt.us
   note: Capitol Office
-- address: 1392 High Rd.;Poultney, VT 05764
+- address: 115 State St.;Montpelier, VT 05633
   email: pattie.mccoy5@gmail.com
   note: District Office
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24015
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PMccoy.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/McCoy.Patricia.jpg
 other_identifiers:
 - identifier: VTL000381
   scheme: legacy_openstates

--- a/data/vt/people/Patrick-Brennan-44bcd67b-5b5f-4fca-a61a-20f91072c5e7.yml
+++ b/data/vt/people/Patrick-Brennan-44bcd67b-5b5f-4fca-a61a-20f91072c5e7.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14549
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PBrennan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Brennan.Patrick.jpg
 other_identifiers:
 - identifier: VTL000044
   scheme: legacy_openstates

--- a/data/vt/people/Patrick-Seymour-b8424d22-9924-49dc-951f-f542b8de1860.yml
+++ b/data/vt/people/Patrick-Seymour-b8424d22-9924-49dc-951f-f542b8de1860.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30947
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Seymour.Patrick.jpg
 given_name: Patrick
 family_name: Seymour

--- a/data/vt/people/Paul-Lefebvre-dab673f8-4a06-4563-b1ed-6180675cd37c.yml
+++ b/data/vt/people/Paul-Lefebvre-dab673f8-4a06-4563-b1ed-6180675cd37c.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24011
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PLefebvre.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/PLefebvre.jpg
 other_identifiers:
 - identifier: VTL000343
   scheme: legacy_openstates

--- a/data/vt/people/Peter-Anthony-681ff7d0-07df-4aa7-bd84-89b5dfb9d377.yml
+++ b/data/vt/people/Peter-Anthony-681ff7d0-07df-4aa7-bd84-89b5dfb9d377.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: panthony@leg.state.vt.us
   note: Capitol Office
-- address: 25 Scampini Sq.;Barre, VT 05641
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-479-2420
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30969
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Anthony.Peter.jpg
 given_name: Peter
 family_name: Anthony

--- a/data/vt/people/Peter-Conlon-842ac286-38fb-428e-af54-1176d06b6144.yml
+++ b/data/vt/people/Peter-Conlon-842ac286-38fb-428e-af54-1176d06b6144.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27155
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PConlon.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/PConlon.jpg
 other_identifiers:
 - identifier: VTL000850
   scheme: legacy_openstates

--- a/data/vt/people/Peter-J-Fagan-e80e92df-7a9c-44ee-b0be-6b3bedc1f35d.yml
+++ b/data/vt/people/Peter-J-Fagan-e80e92df-7a9c-44ee-b0be-6b3bedc1f35d.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14686
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PFagan.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/PFagan.jpg
 other_identifiers:
 - identifier: VTL000069
   scheme: legacy_openstates

--- a/data/vt/people/Peter-Reed-b243a6b5-78ce-4d69-9a3f-6967632a225d.yml
+++ b/data/vt/people/Peter-Reed-b243a6b5-78ce-4d69-9a3f-6967632a225d.yml
@@ -1,0 +1,24 @@
+id: ocd-person/b243a6b5-78ce-4d69-9a3f-6967632a225d
+name: Peter Reed
+party:
+- name: Independent
+roles:
+- district: Orange-Washington-Addison
+  jurisdiction: ocd-jurisdiction/country:us/state:vt/government
+  type: lower
+  start_date: 2020-01-07
+contact_details:
+- address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: preed@leg.state.vt.us
+  note: Capitol Office
+- address: 115 State St;Montpelier, VT 05633
+  email: preed@leg.state.vt.us
+  note: District Office
+links:
+- url: http://legislature.vermont.gov/people/single/2020/33259
+sources:
+- url: http://legislature.vermont.gov/people/loadAll/2020
+- url: http://legislature.vermont.gov/people/single/2020/33259
+image: https://legislature.vermont.gov/Documents/Legislators/PReed.jpg
+given_name: Peter
+family_name: Reed

--- a/data/vt/people/Philip-Baruth-aa1d85e0-761b-4729-a7a3-194abb25fa30.yml
+++ b/data/vt/people/Philip-Baruth-aa1d85e0-761b-4729-a7a3-194abb25fa30.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15791
-image: https://legislature.vermont.gov/assets/Documents/Legislators/PBaruth.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/PBaruth.jpg
 other_identifiers:
 - identifier: VTL000180
   scheme: legacy_openstates

--- a/data/vt/people/Philip-Jay-Hooper-fe86164f-d4c6-4ed6-b9f4-db9a7fb70f6a.yml
+++ b/data/vt/people/Philip-Jay-Hooper-fe86164f-d4c6-4ed6-b9f4-db9a7fb70f6a.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27174
-image: https://legislature.vermont.gov/assets/Documents/Legislators/JHooper.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Hooper.Philip.jpg
 other_identifiers:
 - identifier: VTL000854
   scheme: legacy_openstates

--- a/data/vt/people/R-Scott-Campbell-b64a9bcc-5c1d-4e8b-931f-81f89ea5137e.yml
+++ b/data/vt/people/R-Scott-Campbell-b64a9bcc-5c1d-4e8b-931f-81f89ea5137e.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: scampbell@leg.state.vt.us
   note: Capitol Office
-- address: 761 Crow Hill Rd.;St. Johnsbury, VT 05819
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-595-5580
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30946
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Campbell.Scott.jpg
 given_name: Scott
 family_name: Campbell

--- a/data/vt/people/Randall-Szott-9ebdd2c4-7aa3-4ea2-b70a-bf9c8f21cf7f.yml
+++ b/data/vt/people/Randall-Szott-9ebdd2c4-7aa3-4ea2-b70a-bf9c8f21cf7f.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rszott@leg.state.vt.us
   note: Capitol Office
-- address: P.O. Box 4;Barnard, VT 05031
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-392-3039
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30975
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Szott.Randall.jpg
 given_name: Randall
 family_name: Szott

--- a/data/vt/people/Randy-Brock-e8028cf6-fe46-49bf-b8fc-6c9bcd1fa020.yml
+++ b/data/vt/people/Randy-Brock-e8028cf6-fe46-49bf-b8fc-6c9bcd1fa020.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rbrock@leg.state.vt.us
   note: Capitol Office
-- address: ';, '
+- address: 2396 Highgate Rd.;St. Albans, VT 05478
   note: District Office
   voice: 802-868-2300
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/29338
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RBrock.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RBrock.jpg
 other_identifiers:
 - identifier: VTL000004
   scheme: legacy_openstates

--- a/data/vt/people/Rebecca-White-d798a240-afe8-451d-8b56-9d2badd4820c.yml
+++ b/data/vt/people/Rebecca-White-d798a240-afe8-451d-8b56-9d2badd4820c.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rwhite@leg.state.vt.us
   note: Capitol Office
-- address: 159 Hazen St.;White River Jct., VT 05001
+- address: P.O. Box 4177;White River Jct., VT 05001
   note: District Office
   voice: 802-777-4517
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30976
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/White.Becca.jpg
 given_name: Rebecca
 family_name: White

--- a/data/vt/people/Richard-Westman-9a4f5d0d-7c71-4f80-bcf0-da9b4882d0d7.yml
+++ b/data/vt/people/Richard-Westman-9a4f5d0d-7c71-4f80-bcf0-da9b4882d0d7.yml
@@ -8,6 +8,7 @@ roles:
   type: upper
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
+  email: rwestman@leg.state.vt.us
   note: Capitol Office
 - address: 2439 Iron Gate Rd.;Cambridge, VT 05444
   email: rawestman@gmail.com
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15796
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RWestman.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RWestman.jpg
 other_identifiers:
 - identifier: VTL000185
   scheme: legacy_openstates

--- a/data/vt/people/Robert-Bancroft-21040f34-fb6d-49e3-ada3-e7a2ee0b1331.yml
+++ b/data/vt/people/Robert-Bancroft-21040f34-fb6d-49e3-ada3-e7a2ee0b1331.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rbancroft@leg.state.vt.us
   note: Capitol Office
-- address: 405 Brookside Rd.;Westford, VT 05494
+- address: 115 State St.;Montpelier, VT 05633
   email: bancroft.vt@gmail.com
   note: District Office
   voice: 802-879-7386
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23994
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RBancroft.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Bancroft.Robert.jpg
 other_identifiers:
 - identifier: VTL000435
   scheme: legacy_openstates

--- a/data/vt/people/Robert-Helm-5ebbf863-295c-4d2e-ae33-18565159e705.yml
+++ b/data/vt/people/Robert-Helm-5ebbf863-295c-4d2e-ae33-18565159e705.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14515
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BHelm.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/BHelm.jpg
 other_identifiers:
 - identifier: VTL000081
   scheme: legacy_openstates

--- a/data/vt/people/Robert-Hooper-dec4c236-1cd1-465f-969c-0bb4b8a04992.yml
+++ b/data/vt/people/Robert-Hooper-dec4c236-1cd1-465f-969c-0bb4b8a04992.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rhooper@leg.state.vt.us
   note: Capitol Office
-- address: 3 Grey Meadow Dr.;Burlington, VT 05408
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-363-5842
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30948
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Hooper.Robert.jpg
 given_name: Robert
 family_name: Hooper

--- a/data/vt/people/Robert-LaClair-373129a2-be62-4afa-a4ec-225c4c6f3199.yml
+++ b/data/vt/people/Robert-LaClair-373129a2-be62-4afa-a4ec-225c4c6f3199.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24009
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RLaClair.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/LaCLair.Robert.jpg
 other_identifiers:
 - identifier: VTL000423
   scheme: legacy_openstates

--- a/data/vt/people/Robert-Starr-0a318106-59a2-45a3-9d33-27043d5b9277.yml
+++ b/data/vt/people/Robert-Starr-0a318106-59a2-45a3-9d33-27043d5b9277.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14614
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RStarr.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Starr.Bobby.jpg
 other_identifiers:
 - identifier: VTL000029
   scheme: legacy_openstates

--- a/data/vt/people/Robin-Chesnut-Tangerman-46cebde2-6c9e-4d8f-a272-a36615efa80f.yml
+++ b/data/vt/people/Robin-Chesnut-Tangerman-46cebde2-6c9e-4d8f-a272-a36615efa80f.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23999
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RChesnutangerman.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RChesnutangerman.jpg
 other_identifiers:
 - identifier: VTL000488
   scheme: legacy_openstates

--- a/data/vt/people/Robin-Scheu-b463b201-086b-4f98-ab96-75a136e8be35.yml
+++ b/data/vt/people/Robin-Scheu-b463b201-086b-4f98-ab96-75a136e8be35.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: RScheu@leg.state.vt.us
   note: Capitol Office
-- address: 1459 Munger St.;Middlebury, VT 05753
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-388-1460
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27154
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RScheu.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Scheu.Robin.jpg
 other_identifiers:
 - identifier: VTL000840
   scheme: legacy_openstates

--- a/data/vt/people/Rodney-Graham-1a110b8d-4a65-4070-a674-3c3316b3087d.yml
+++ b/data/vt/people/Rodney-Graham-1a110b8d-4a65-4070-a674-3c3316b3087d.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24008
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RGraham.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Graham.Rodney.jpg
 other_identifiers:
 - identifier: VTL000358
   scheme: legacy_openstates

--- a/data/vt/people/Ruth-Hardy-84f2c6bd-5fe7-486c-b2ad-555bf69654e8.yml
+++ b/data/vt/people/Ruth-Hardy-84f2c6bd-5fe7-486c-b2ad-555bf69654e8.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30978
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Hardy.Ruth.jpg
 given_name: Ruth
 family_name: Hardy

--- a/data/vt/people/Samuel-Young-12be5a3d-e1f9-448d-946b-931aec6152ae.yml
+++ b/data/vt/people/Samuel-Young-12be5a3d-e1f9-448d-946b-931aec6152ae.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15789
-image: https://legislature.vermont.gov/assets/Documents/Legislators/SYoung.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Young.Sam.jpg
 other_identifiers:
 - identifier: VTL000207
   scheme: legacy_openstates

--- a/data/vt/people/Sandy-Haas-3f237d26-9bda-41c0-85cd-1b2581d4b282.yml
+++ b/data/vt/people/Sandy-Haas-3f237d26-9bda-41c0-85cd-1b2581d4b282.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14573
-image: https://legislature.vermont.gov/assets/Documents/Legislators/SHaas.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Haas.Sandy.jpg
 other_identifiers:
 - identifier: VTL000078
   scheme: legacy_openstates

--- a/data/vt/people/Sara-Coffey-64c5c421-b168-478c-ba1e-70991679eb39.yml
+++ b/data/vt/people/Sara-Coffey-64c5c421-b168-478c-ba1e-70991679eb39.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30971
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Coffey.Sara.jpg
 given_name: Sara
 family_name: Coffey

--- a/data/vt/people/Sarah-Austin-c028faa3-479d-440c-b2a5-e4320933c10f.yml
+++ b/data/vt/people/Sarah-Austin-c028faa3-479d-440c-b2a5-e4320933c10f.yml
@@ -1,5 +1,5 @@
 id: ocd-person/c028faa3-479d-440c-b2a5-e4320933c10f
-name: Sarah Austin
+name: Sarah "Sarita" Austin
 party:
 - name: Democratic
 roles:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30952
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Austin.Sarah.jpg
 given_name: Sarah
 family_name: Austin

--- a/data/vt/people/Sarah-Copeland-Hanzas-389f6327-715a-47b2-b833-9869bb69074f.yml
+++ b/data/vt/people/Sarah-Copeland-Hanzas-389f6327-715a-47b2-b833-9869bb69074f.yml
@@ -1,5 +1,5 @@
 id: ocd-person/389f6327-715a-47b2-b833-9869bb69074f
-name: Sarah Copeland-Hanzas
+name: Sarah Copeland Hanzas
 party:
 - name: Democratic
 roles:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14567
-image: https://legislature.vermont.gov/assets/Documents/Legislators/SCopelandhanzas.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Copeland.Sarah.jpg
 other_identifiers:
 - identifier: VTL000055
   scheme: legacy_openstates
@@ -27,4 +27,4 @@ other_identifiers:
 - identifier: VTL000564
   scheme: legacy_openstates
 given_name: Sarah
-family_name: Copeland-Hanzas
+family_name: Copeland Hanzas

--- a/data/vt/people/Scott-Beck-d626c3d1-769d-456c-a073-f1efb326fe1d.yml
+++ b/data/vt/people/Scott-Beck-d626c3d1-769d-456c-a073-f1efb326fe1d.yml
@@ -17,7 +17,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23996
-image: https://legislature.vermont.gov/assets/Documents/Legislators/SBeck.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/SBeck.jpg
 other_identifiers:
 - identifier: VTL000346
   scheme: legacy_openstates

--- a/data/vt/people/Selene-Colburn-70b0e909-0154-4071-86ac-c5fd4f96299f.yml
+++ b/data/vt/people/Selene-Colburn-70b0e909-0154-4071-86ac-c5fd4f96299f.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: SColburn@leg.state.vt.us
   note: Capitol Office
-- address: 49 Latham Court;Burlington, VT 05401
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-540-0546
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27163
-image: https://legislature.vermont.gov/assets/Documents/Legislators/SColburn.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/SColburn.jpg
 other_identifiers:
 - identifier: VTL000853
   scheme: legacy_openstates

--- a/data/vt/people/Seth-Chase-e6fefc15-f4c0-449f-a34a-9116f656bfb8.yml
+++ b/data/vt/people/Seth-Chase-e6fefc15-f4c0-449f-a34a-9116f656bfb8.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30951
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Chase.Seth.jpg
 given_name: Seth
 family_name: Chase

--- a/data/vt/people/Stephanie-Jerome-7ad3e2d3-1251-4af4-858d-4a168274fa9b.yml
+++ b/data/vt/people/Stephanie-Jerome-7ad3e2d3-1251-4af4-858d-4a168274fa9b.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30966
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Jerome.Stephanie.jpg
 given_name: Stephanie
 family_name: Jerome

--- a/data/vt/people/Terence-Macaig-401b3d1d-d61e-40c1-9081-b97bac74c714.yml
+++ b/data/vt/people/Terence-Macaig-401b3d1d-d61e-40c1-9081-b97bac74c714.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14670
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TMacaig.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Macaig.Terence.jpg
 other_identifiers:
 - identifier: VTL000109
   scheme: legacy_openstates

--- a/data/vt/people/Terry-Norris-b1717a89-58e1-4f7a-8fe3-ac407a7a0357.yml
+++ b/data/vt/people/Terry-Norris-b1717a89-58e1-4f7a-8fe3-ac407a7a0357.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: tnorris@leg.state.vt.us
   note: Capitol Office
-- address: 525 Palmer Road;Shoreham, VT 05770
+- address: 115 State St.;Montpelier, VT 05633
   email: tnorris@shoreham.net
   note: District Office
   voice: 802-897-7014
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/28072
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TNorris.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Norris.Terry.jpg
 other_identifiers:
 - identifier: VTL000869
   scheme: legacy_openstates

--- a/data/vt/people/Theresa-Wood-f68d3f17-24ca-4b87-8837-6a30737d21d8.yml
+++ b/data/vt/people/Theresa-Wood-f68d3f17-24ca-4b87-8837-6a30737d21d8.yml
@@ -10,14 +10,14 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: twood@leg.state.vt.us
   note: Capitol Office
-- address: 1461 Perry Hill Rd.;Waterbury, VT 05676
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
 links:
 - url: http://legislature.vermont.gov/people/single/2020/25699
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/25699
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TWood.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Wood.Theresa.jpg
 other_identifiers:
 - identifier: VTL000814
   scheme: legacy_openstates

--- a/data/vt/people/Thomas-Bock-eda485ce-19de-4b39-87ee-6c3274a7fa6c.yml
+++ b/data/vt/people/Thomas-Bock-eda485ce-19de-4b39-87ee-6c3274a7fa6c.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27182
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TBock.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Bock.Thomas.jpg
 other_identifiers:
 - identifier: VTL000845
   scheme: legacy_openstates

--- a/data/vt/people/Thomas-Burditt-68d53f5e-f99c-4167-9dff-3c802fc6e857.yml
+++ b/data/vt/people/Thomas-Burditt-68d53f5e-f99c-4167-9dff-3c802fc6e857.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15771
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TBurditt.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/TBurditt.jpg
 other_identifiers:
 - identifier: VTL000189
   scheme: legacy_openstates

--- a/data/vt/people/Thomas-Stevens-0acb9a2c-6cbb-44b3-828c-4c7ad3fd8ce6.yml
+++ b/data/vt/people/Thomas-Stevens-0acb9a2c-6cbb-44b3-828c-4c7ad3fd8ce6.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14689
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TStevens.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Stevens.Thomas.jpg
 other_identifiers:
 - identifier: VTL000161
   scheme: legacy_openstates

--- a/data/vt/people/Thomas-Terenzini-7d9ac18f-f504-4e26-adff-9b33dd492997.yml
+++ b/data/vt/people/Thomas-Terenzini-7d9ac18f-f504-4e26-adff-9b33dd492997.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20386
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TTerenzini.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Terenzini.Thomas.jpg
 other_identifiers:
 - identifier: VTL000314
   scheme: legacy_openstates

--- a/data/vt/people/Tim-Ashe-9d216dcc-3db0-4a0f-82c2-68ddc6bca247.yml
+++ b/data/vt/people/Tim-Ashe-9d216dcc-3db0-4a0f-82c2-68ddc6bca247.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14665
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TAshe.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/TAshe.jpg
 other_identifiers:
 - identifier: VTL000001
   scheme: legacy_openstates

--- a/data/vt/people/Timothy-Briglin-17cc176e-d66a-4b43-b2ba-96920736cb39.yml
+++ b/data/vt/people/Timothy-Briglin-17cc176e-d66a-4b43-b2ba-96920736cb39.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23998
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TBriglin.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/TBriglin.jpg
 other_identifiers:
 - identifier: VTL000442
   scheme: legacy_openstates

--- a/data/vt/people/Timothy-R-Corcoran-bd42ebbc-3e03-4929-bbd8-f2fe5141d604.yml
+++ b/data/vt/people/Timothy-R-Corcoran-bd42ebbc-3e03-4929-bbd8-f2fe5141d604.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14546
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TCorcoran.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/TCorcoran.jpg
 other_identifiers:
 - identifier: VTL000056
   scheme: legacy_openstates

--- a/data/vt/people/Tommy-Walz-e6be2352-e080-40a9-b364-8ed12de6853d.yml
+++ b/data/vt/people/Tommy-Walz-e6be2352-e080-40a9-b364-8ed12de6853d.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: twalz@leg.state.vt.us
   note: Capitol Office
-- address: 157 Camp St.;Barre, VT 05641
+- address: 115 State St.;Montpelier, VT 05633
   email: twalz@aol.com
   note: District Office
   voice: 802-476-7819
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/23826
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TWalz.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Walz.Tommy.jpg
 other_identifiers:
 - identifier: VTL000339
   scheme: legacy_openstates

--- a/data/vt/people/Trevor-Squirrell-7e019459-6d2e-4c45-8092-72cb8334bf25.yml
+++ b/data/vt/people/Trevor-Squirrell-7e019459-6d2e-4c45-8092-72cb8334bf25.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27159
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TSquirrell.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Squirrell.Trevor.jpg
 other_identifiers:
 - identifier: VTL000847
   scheme: legacy_openstates

--- a/data/vt/people/Tristan-Toleno-e4716ff3-5ee2-4fe4-9822-4db560d0c8d8.yml
+++ b/data/vt/people/Tristan-Toleno-e4716ff3-5ee2-4fe4-9822-4db560d0c8d8.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/20391
-image: https://legislature.vermont.gov/assets/Documents/Legislators/TToleno.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Toleno.Tristan.jpg
 other_identifiers:
 - identifier: VTL000316
   scheme: legacy_openstates

--- a/data/vt/people/Vicki-Strong-5b95da41-7af4-4bdb-9db7-d1bca974e962.yml
+++ b/data/vt/people/Vicki-Strong-5b95da41-7af4-4bdb-9db7-d1bca974e962.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/15786
-image: https://legislature.vermont.gov/assets/Documents/Legislators/VStrong.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Strong.Vicki.jpg
 other_identifiers:
 - identifier: VTL000204
   scheme: legacy_openstates

--- a/data/vt/people/Virginia-Ginny-Lyons-91dafbcc-d313-4ef3-a506-0113d4ce1975.yml
+++ b/data/vt/people/Virginia-Ginny-Lyons-91dafbcc-d313-4ef3-a506-0113d4ce1975.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14616
-image: https://legislature.vermont.gov/assets/Documents/Legislators/VLyons.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Lyons.Ginny.jpg
 other_identifiers:
 - identifier: VTL000017
   scheme: legacy_openstates

--- a/data/vt/people/Warren-F-Kitzmiller-a4dc898f-42ae-4947-b579-6be505193924.yml
+++ b/data/vt/people/Warren-F-Kitzmiller-a4dc898f-42ae-4947-b579-6be505193924.yml
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14540
-image: https://legislature.vermont.gov/assets/Documents/Legislators/WKitzmiller.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Kitzmiller.W.jpg
 other_identifiers:
 - identifier: VTL000094
   scheme: legacy_openstates

--- a/data/vt/people/William-Canfield-c66f104c-310a-40a1-9222-6d366b42e576.yml
+++ b/data/vt/people/William-Canfield-c66f104c-310a-40a1-9222-6d366b42e576.yml
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14569
-image: https://legislature.vermont.gov/assets/Documents/Legislators/WCanfield.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Canfield.William.jpg
 other_identifiers:
 - identifier: VTL000047
   scheme: legacy_openstates

--- a/data/vt/people/William-J-Lippert-16743083-ce0d-464a-b1ea-be80e94dacb0.yml
+++ b/data/vt/people/William-J-Lippert-16743083-ce0d-464a-b1ea-be80e94dacb0.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: wlippert@leg.state.vt.us
   note: Capitol Office
-- address: 2751 Baldwin Rd.;Hinesburg, VT 05461
+- address: 2751 Baldwin Road;Hinesburg, VT 05461
   note: District Office
   voice: 802-482-3528
 links:
@@ -18,7 +18,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/14522
-image: https://legislature.vermont.gov/assets/Documents/Legislators/WLippert.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/Lippert.William.jpg
 other_identifiers:
 - identifier: VTL000107
   scheme: legacy_openstates

--- a/data/vt/people/William-Notte-bcff864b-5660-4a36-a6c1-e16a732fae97.yml
+++ b/data/vt/people/William-Notte-bcff864b-5660-4a36-a6c1-e16a732fae97.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30965
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Notte.William.jpg
 given_name: William
 family_name: Notte

--- a/data/vt/people/Woodman-Page-0c2d8e34-55f1-4b34-a6a3-bd7708d2578c.yml
+++ b/data/vt/people/Woodman-Page-0c2d8e34-55f1-4b34-a6a3-bd7708d2578c.yml
@@ -11,7 +11,7 @@ contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: wpage@leg.state.vt.us
   note: Capitol Office
-- address: 299 Highland Ave.;Newport, VT 05855
+- address: 115 State St.;Montpelier, VT 05633
   note: District Office
   voice: 802-334-6988
 links:
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30964
-image: https://legislature.vermont.gov/mysite/images/profile.png
-given_name: ''
+image: https://legislature.vermont.gov/Documents/Legislators/Page.Woodman.jpg
+given_name: Woodman
 family_name: Page

--- a/data/vt/people/Zachariah-Ralph-240011e7-4903-4474-befe-feef95390fe5.yml
+++ b/data/vt/people/Zachariah-Ralph-240011e7-4903-4474-befe-feef95390fe5.yml
@@ -19,6 +19,6 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/30974
-image: https://legislature.vermont.gov/mysite/images/profile.png
+image: https://legislature.vermont.gov/Documents/Legislators/Ralph.Zachariah.jpg
 given_name: Zachariah
 family_name: Ralph

--- a/data/vt/retired/Benjamin-Jickling-763aec16-22cc-4851-84cc-454183e2449a.yml
+++ b/data/vt/retired/Benjamin-Jickling-763aec16-22cc-4851-84cc-454183e2449a.yml
@@ -6,6 +6,7 @@ roles:
 - district: Orange-Washington-Addison
   jurisdiction: ocd-jurisdiction/country:us/state:vt/government
   type: lower
+  end_date: '2019-09-01'
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: BJickling@leg.state.vt.us
@@ -18,7 +19,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/27175
-image: https://legislature.vermont.gov/assets/Documents/Legislators/BJickling.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/BJickling.jpg
 other_identifiers:
 - identifier: VTL000843
   scheme: legacy_openstates

--- a/data/vt/retired/Robert-Forguites-dcfb27c5-ea5c-4de1-b542-440f60904e83.yml
+++ b/data/vt/retired/Robert-Forguites-dcfb27c5-ea5c-4de1-b542-440f60904e83.yml
@@ -6,6 +6,8 @@ roles:
 - district: Windsor-3-2
   jurisdiction: ocd-jurisdiction/country:us/state:vt/government
   type: lower
+  end_date: '2019-04-09'
+  end_reason: Deceased
 contact_details:
 - address: Vermont State House;115 State Street;Montpelier, VT 05633
   email: rforguites@leg.state.vt.us
@@ -18,7 +20,7 @@ links:
 sources:
 - url: http://legislature.vermont.gov/people/loadAll/2020
 - url: http://legislature.vermont.gov/people/single/2020/24005
-image: https://legislature.vermont.gov/assets/Documents/Legislators/RForguites.jpg
+image: https://legislature.vermont.gov/Documents/Legislators/RForguites.jpg
 other_identifiers:
 - identifier: VTL000380
   scheme: legacy_openstates
@@ -26,3 +28,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Robert
 family_name: Forguites
+death_date: '2019-04-09'


### PR DESCRIPTION
Two new legislators, as a result of one death and one resignation. Also update some contact details and the image links for each legislator.