### PR TITLE
CT: Update legislators

### DIFF
--- a/data/ct/organizations/Aging-e8231bb4-edf2-4bb2-b09d-1df2e08c92be.yml
+++ b/data/ct/organizations/Aging-e8231bb4-edf2-4bb2-b09d-1df2e08c92be.yml
@@ -24,7 +24,7 @@ memberships:
   role: vice chair
   end_date: '2018-12-31'
 - id: ocd-person/ee35378a-f19c-4edf-a6ed-826d62adcced
-  name: Michael Winkler
+  name: Michael A. Winkler
 - id: ocd-person/5bdec6fb-c316-43f7-aa65-38b0ffa83efe
   name: Anthony J. D'Amelio
 - id: ocd-person/0185c242-1a49-4731-841f-9df14573fa7f

--- a/data/ct/organizations/Appropriations-adc6d631-9248-4298-a181-7ec6f562a2ff.yml
+++ b/data/ct/organizations/Appropriations-adc6d631-9248-4298-a181-7ec6f562a2ff.yml
@@ -95,6 +95,7 @@ memberships:
 - id: ocd-person/b56ac685-dc65-4583-9209-e8fd129455e2
   name: Ezequiel Santiago
   role: vice chair
+  end_date: '2019-03-15'
 - id: ocd-person/15f3df31-84bc-4ae6-b399-c9b9c58ecec6
   name: Chris Perone
 - id: ocd-person/2d99a0ff-740d-4c97-8d0c-524842f99f73
@@ -119,7 +120,7 @@ memberships:
   name: Joe Markley
   end_date: '2018-12-31'
 - id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-  name: Heather B. Somers
+  name: Heather S. Somers
 - id: ocd-person/aec1fe1b-02ac-4802-be69-8714ec0b848e
   name: Catherine A. Osten
   role: chair

--- a/data/ct/organizations/Commerce-a109a14a-d843-436e-b36c-e10ce37948ce.yml
+++ b/data/ct/organizations/Commerce-a109a14a-d843-436e-b36c-e10ce37948ce.yml
@@ -42,6 +42,7 @@ memberships:
   role: chair
 - id: ocd-person/7a5474af-535a-42e5-8653-0edf8311cdfb
   name: Fred Camillo
+  end_date: '2019-12-02'
 - id: ocd-person/39edf512-e705-4617-ad71-53405a15eb48
   name: Timothy D. Larson
   role: vice chair

--- a/data/ct/organizations/Education-a979d83d-84e9-42dd-b4b6-8c74e2fabb78.yml
+++ b/data/ct/organizations/Education-a979d83d-84e9-42dd-b4b6-8c74e2fabb78.yml
@@ -86,7 +86,7 @@ memberships:
 - id: ocd-person/97acf3e4-5fa9-4cb9-af7d-d3d2c69f7213
   name: George S. Logan
 - id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-  name: Heather B. Somers
+  name: Heather S. Somers
   role: vice chair
 - id: ocd-person/41d83b98-d5ab-48db-b847-3a3e08194b4c
   name: Marilyn V. Moore

--- a/data/ct/organizations/Environment-40b808d7-fb07-49cb-a10b-f8fa5fc8c9e0.yml
+++ b/data/ct/organizations/Environment-40b808d7-fb07-49cb-a10b-f8fa5fc8c9e0.yml
@@ -60,6 +60,7 @@ memberships:
   name: Ben McGorty
 - id: ocd-person/b56ac685-dc65-4583-9209-e8fd129455e2
   name: Ezequiel Santiago
+  end_date: '2019-03-15'
 - id: ocd-person/2fbfcce7-6315-4961-8b07-58052346bc36
   name: Adam Dunsby
   end_date: '2018-12-31'
@@ -73,7 +74,7 @@ memberships:
   role: chair
   end_date: '2018-12-31'
 - id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-  name: Heather B. Somers
+  name: Heather S. Somers
   role: vice chair
 - id: ocd-person/77713b68-e8ef-455e-80a6-1614488fb71a
   name: Mae Flexer

--- a/data/ct/organizations/Executive-and-Legislative-Nominations-9c2080fa-67cd-436f-9736-303141fc1770.yml
+++ b/data/ct/organizations/Executive-and-Legislative-Nominations-9c2080fa-67cd-436f-9736-303141fc1770.yml
@@ -32,6 +32,7 @@ memberships:
   role: ranking member
 - id: ocd-person/7a5474af-535a-42e5-8653-0edf8311cdfb
   name: Fred Camillo
+  end_date: '2019-12-02'
 - id: ocd-person/77479a85-ce39-422f-9094-bbdbce7d5276
   name: Kevin D. Witkos
   role: vice chair

--- a/data/ct/organizations/Finance-Revenue-and-Bonding-78b07b72-322d-449a-9749-3f2e5a6c242c.yml
+++ b/data/ct/organizations/Finance-Revenue-and-Bonding-78b07b72-322d-449a-9749-3f2e5a6c242c.yml
@@ -37,7 +37,7 @@ memberships:
 - id: ocd-person/e7f7ad52-69a8-4306-8dfe-02368f74d75b
   name: John E. Piscopo
 - id: ocd-person/e1473778-00e1-4e12-bf11-01631a32bc0a
-  name: Emil Altobello
+  name: Emil "Buddy" Altobello
 - id: ocd-person/568f232d-2133-4eee-a886-c1927f7f88bc
   name: Hilda E. Santiago
 - id: ocd-person/817e17bf-a01c-4bf1-b70f-3e16aeef088e
@@ -76,6 +76,7 @@ memberships:
   name: Steven J. Stafstrom
 - id: ocd-person/d9f16dc8-f123-451a-a1cf-191706553a25
   name: Brenda L. Kupchick
+  end_date: '2019-11-22'
 - id: ocd-person/c1eb186b-4a6d-4a5f-9afe-a52005a4bc62
   name: Laura M. Devlin
 - id: ocd-person/2fbfcce7-6315-4961-8b07-58052346bc36

--- a/data/ct/organizations/General-Law-01d631ae-f451-41de-b619-580ebc7f8c89.yml
+++ b/data/ct/organizations/General-Law-01d631ae-f451-41de-b619-580ebc7f8c89.yml
@@ -14,13 +14,14 @@ memberships:
   end_date: '2018-12-31'
 - id: ocd-person/053aa93e-b38d-424d-a9fc-43088529068f
   name: Linda A. Orange
+  end_date: '2019-11-20'
 - id: ocd-person/78e8ae56-d8e3-4a8f-b4b0-516bec4b03e6
   name: Daniel S. Rovero
   end_date: '2018-12-31'
 - id: ocd-person/5bdec6fb-c316-43f7-aa65-38b0ffa83efe
   name: Anthony J. D'Amelio
 - id: ocd-person/e1473778-00e1-4e12-bf11-01631a32bc0a
-  name: Emil Altobello
+  name: Emil "Buddy" Altobello
 - id: ocd-person/1d02baaa-ab25-4607-b33f-40948893f928
   name: Vincent J. Candelora
 - id: ocd-person/62869ad5-5744-4a50-95f5-56ecf5549e31
@@ -36,6 +37,7 @@ memberships:
   name: David Rutigliano
 - id: ocd-person/d9f16dc8-f123-451a-a1cf-191706553a25
   name: Brenda L. Kupchick
+  end_date: '2019-11-22'
 - id: ocd-person/b0817ed7-2898-4824-934c-c49615c8b1ea
   name: Daniel J. Fox
 - id: ocd-person/39edf512-e705-4617-ad71-53405a15eb48

--- a/data/ct/organizations/Government-Administration-and-Elections-8c398887-bd19-4ff0-beb1-e88b6ae29200.yml
+++ b/data/ct/organizations/Government-Administration-and-Elections-8c398887-bd19-4ff0-beb1-e88b6ae29200.yml
@@ -12,10 +12,10 @@ memberships:
 - id: ocd-person/63a8e4ab-dfcd-4a69-8317-53b8e9a69729
   name: Gregory Haddad
 - id: ocd-person/ee35378a-f19c-4edf-a6ed-826d62adcced
-  name: Michael Winkler
+  name: Michael A. Winkler
   role: vice chair
 - id: ocd-person/0f203a11-5ba7-452a-89b4-720a617973fb
-  name: Rosa C. Rebimbas Esq.
+  name: Rosa C. Rebimbas
 - id: ocd-person/bfd8433a-289a-4de1-b112-53dce2153fe8
   name: Stephanie E. Cummings
 - id: ocd-person/d26f841d-8703-4035-bfbc-323404c44de6

--- a/data/ct/organizations/Higher-Education-and-Employment-Advancement-2e5567bc-3113-464e-8211-c779fc56b36a.yml
+++ b/data/ct/organizations/Higher-Education-and-Employment-Advancement-2e5567bc-3113-464e-8211-c779fc56b36a.yml
@@ -50,12 +50,13 @@ memberships:
   name: Caroline Simmons
 - id: ocd-person/7a5474af-535a-42e5-8653-0edf8311cdfb
   name: Fred Camillo
+  end_date: '2019-12-02'
 - id: ocd-person/e6953ec1-9931-41fa-8db0-ea4ed56c42b9
   name: Beth Bye
   role: chair
   end_date: '2018-12-31'
 - id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-  name: Heather B. Somers
+  name: Heather S. Somers
   role: vice chair
 - id: ocd-person/77713b68-e8ef-455e-80a6-1614488fb71a
   name: Mae Flexer

--- a/data/ct/organizations/Housing-a6612721-271f-48c2-a110-66ef5f7163f1.yml
+++ b/data/ct/organizations/Housing-a6612721-271f-48c2-a110-66ef5f7163f1.yml
@@ -27,6 +27,7 @@ memberships:
 - id: ocd-person/d9f16dc8-f123-451a-a1cf-191706553a25
   name: Brenda L. Kupchick
   role: ranking member
+  end_date: '2019-11-22'
 - id: ocd-person/a8f6288b-0c1f-40c5-b257-0f0c922ccff7
   name: Mike Bocchino
   end_date: '2018-12-31'

--- a/data/ct/organizations/Judiciary-cf27a212-0cc9-483c-8cf1-e8fa9ff1c4f8.yml
+++ b/data/ct/organizations/Judiciary-cf27a212-0cc9-483c-8cf1-e8fa9ff1c4f8.yml
@@ -30,7 +30,7 @@ memberships:
 - id: ocd-person/695f61b5-0fe0-47db-b0ba-30cd70e1223b
   name: Arthur J. O'Neill
 - id: ocd-person/0f203a11-5ba7-452a-89b4-720a617973fb
-  name: Rosa C. Rebimbas Esq.
+  name: Rosa C. Rebimbas
   role: ranking member
 - id: ocd-person/e081f8cd-223d-4c6f-b3bb-10bf2162eb38
   name: Jeffrey J. Berger

--- a/data/ct/organizations/Legislative-Management-2dce6105-c1ba-45fa-b83b-12b1b0e239a8.yml
+++ b/data/ct/organizations/Legislative-Management-2dce6105-c1ba-45fa-b83b-12b1b0e239a8.yml
@@ -21,12 +21,13 @@ memberships:
   name: Emmett D. Riley
 - id: ocd-person/053aa93e-b38d-424d-a9fc-43088529068f
   name: Linda A. Orange
+  end_date: '2019-11-20'
 - id: ocd-person/daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6
   name: Michelle L. Cook
 - id: ocd-person/695f61b5-0fe0-47db-b0ba-30cd70e1223b
   name: Arthur J. O'Neill
 - id: ocd-person/0f203a11-5ba7-452a-89b4-720a617973fb
-  name: Rosa C. Rebimbas Esq.
+  name: Rosa C. Rebimbas
 - id: ocd-person/e7f7ad52-69a8-4306-8dfe-02368f74d75b
   name: John E. Piscopo
 - id: ocd-person/1d02baaa-ab25-4607-b33f-40948893f928

--- a/data/ct/organizations/Planning-and-Development-e9888c4f-bb7a-4fb7-839a-18efeb2720f8.yml
+++ b/data/ct/organizations/Planning-and-Development-e9888c4f-bb7a-4fb7-839a-18efeb2720f8.yml
@@ -44,6 +44,7 @@ memberships:
   name: Steven J. Stafstrom
 - id: ocd-person/b56ac685-dc65-4583-9209-e8fd129455e2
   name: Ezequiel Santiago
+  end_date: '2019-03-15'
 - id: ocd-person/194f23a9-142e-4f6e-906e-680854414805
   name: Fred Wilms
   end_date: '2018-12-31'

--- a/data/ct/organizations/Public-Health-e9a0948d-b751-4599-b4d4-be55e5320a07.yml
+++ b/data/ct/organizations/Public-Health-e9a0948d-b751-4599-b4d4-be55e5320a07.yml
@@ -28,7 +28,7 @@ memberships:
 - id: ocd-person/81708fd7-b28e-4c83-b972-80e77a91da3c
   name: Emmett D. Riley
 - id: ocd-person/ee35378a-f19c-4edf-a6ed-826d62adcced
-  name: Michael Winkler
+  name: Michael A. Winkler
 - id: ocd-person/daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6
   name: Michelle L. Cook
 - id: ocd-person/bfd8433a-289a-4de1-b112-53dce2153fe8
@@ -70,7 +70,7 @@ memberships:
   name: George S. Logan
   role: vice chair
 - id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-  name: Heather B. Somers
+  name: Heather S. Somers
   role: chair
 - id: ocd-person/41d83b98-d5ab-48db-b847-3a3e08194b4c
   name: Marilyn V. Moore

--- a/data/ct/organizations/Public-Safety-and-Security-5e44b086-56c3-4b60-a18a-134da9e545b3.yml
+++ b/data/ct/organizations/Public-Safety-and-Security-5e44b086-56c3-4b60-a18a-134da9e545b3.yml
@@ -23,6 +23,7 @@ memberships:
 - id: ocd-person/053aa93e-b38d-424d-a9fc-43088529068f
   name: Linda A. Orange
   role: vice chair
+  end_date: '2019-11-20'
 - id: ocd-person/50e78f89-a9e7-43f5-9566-a9f2cb23a5c9
   name: Patrick S. Boyd
 - id: ocd-person/78e8ae56-d8e3-4a8f-b4b0-516bec4b03e6

--- a/data/ct/organizations/Transportation-c547bec3-54cc-4da6-91db-c658825b53d8.yml
+++ b/data/ct/organizations/Transportation-c547bec3-54cc-4da6-91db-c658825b53d8.yml
@@ -34,7 +34,7 @@ memberships:
 - id: ocd-person/b57c3599-c0b0-4fd3-a48c-2bfd32d95071
   name: Tami Zawistowski
 - id: ocd-person/e1473778-00e1-4e12-bf11-01631a32bc0a
-  name: Emil Altobello
+  name: Emil "Buddy" Altobello
 - id: ocd-person/b56af509-8913-42b4-85bc-3df186448b01
   name: Sean Scanlon
 - id: ocd-person/d2a3535f-bdff-414c-8aaa-c3f3f203bc14

--- a/data/ct/people/Alexandra-Bergstein-4d30d22f-4e3f-46b1-802f-cb689cac7fb5.yml
+++ b/data/ct/people/Alexandra-Bergstein-4d30d22f-4e3f-46b1-802f-cb689cac7fb5.yml
@@ -1,5 +1,5 @@
 id: ocd-person/4d30d22f-4e3f-46b1-802f-cb689cac7fb5
-name: Alexandra Bergstein
+name: Alex Kasser
 party:
 - name: Democratic
 roles:
@@ -7,10 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3300;Hartford, CT 06106
+- address: Legislative Office Building;Room 2402;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
+  voice: 860-240-0393
 links:
-- url: http://www.senatedems.ct.gov/bergstein
+- url: http://www.senatedems.ct.gov/kasser
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Alex
+family_name: Kasser

--- a/data/ct/people/Alphonse-Paolillo-Jr-3e0a00e8-0ec8-418d-a2e3-a7eef0a5d186.yml
+++ b/data/ct/people/Alphonse-Paolillo-Jr-3e0a00e8-0ec8-418d-a2e3-a7eef0a5d186.yml
@@ -7,13 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4100;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8557
+- address: Legislative Office Building;Room 5008;Hartford, CT 06106
   email: Alphonse.Paolillo@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8500
 - address: 151 Huntington Road;New Haven, CT 06492
   note: District Office
-  voice: 203-469-1823
 links:
 - url: http://www.housedems.ct.gov/Paolillo
 sources:

--- a/data/ct/people/Andre-F-Baker-Jr-e823b0bf-1132-4ed8-b860-e0febf9a275a.yml
+++ b/data/ct/people/Andre-F-Baker-Jr-e823b0bf-1132-4ed8-b860-e0febf9a275a.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4037;Hartford, CT 06106
+  email: Andre.Baker@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0141
-  email: Andre.Baker@cga.ct.gov
 - address: 985 Stratford Avenue;Bridgeport, CT 06607
   note: District Office
   voice: 203-334-3876
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000304
   scheme: legacy_openstates
-given_name: Andre F.
+given_name: Andre
 family_name: Baker

--- a/data/ct/people/Anne-Dauphinais-087a813d-b14a-4205-a08f-cec795647318.yml
+++ b/data/ct/people/Anne-Dauphinais-087a813d-b14a-4205-a08f-cec795647318.yml
@@ -7,14 +7,14 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4200;Hartford, CT 06106
+- address: Legislative Office Building;Room 4063;Hartford, CT 06106
+  email: Anne.Dauphinais@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Anne.Dauphinais@housegop.ct.gov
 - address: 204 Wright Road;Danielson, CT 06239
   note: District Office
 links:
-- url: http://www.cthousegop.com/Dauphinais/main/
+- url: http://www.cthousegop.com/Dauphinais/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Anne-Hughes-ce2070f7-9487-4856-976b-9bbd6a2f1617.yml
+++ b/data/ct/people/Anne-Hughes-ce2070f7-9487-4856-976b-9bbd6a2f1617.yml
@@ -1,5 +1,5 @@
 id: ocd-person/ce2070f7-9487-4856-976b-9bbd6a2f1617
-name: Anne Hughes
+name: Anne M. Hughes
 party:
 - name: Democratic
 roles:
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Anne.Hughes@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 67 North Street;Easton, CT 06612
   note: District Office
   voice: 203-613-4040
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/hughes
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Anne
+family_name: Hughes

--- a/data/ct/people/Anthony-J-DAmelio-5bdec6fb-c316-43f7-aa65-38b0ffa83efe.yml
+++ b/data/ct/people/Anthony-J-DAmelio-5bdec6fb-c316-43f7-aa65-38b0ffa83efe.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4085;Hartford, CT 06106
+  email: Anthony.DAmelio@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Anthony.DAmelio@housegop.ct.gov
 - address: 64 Wellington Avenue;Waterbury, CT 06708
   note: District Office
 links:
-- url: http://www.cthousegop.com/DAmelio/main/
+- url: http://www.cthousegop.com/DAmelio/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000107
   scheme: legacy_openstates
-given_name: Anthony J.
+given_name: Anthony
 family_name: D'Amelio

--- a/data/ct/people/Anthony-L-Nolan-c7160abf-d376-484d-b87e-600a398ab503.yml
+++ b/data/ct/people/Anthony-L-Nolan-c7160abf-d376-484d-b87e-600a398ab503.yml
@@ -1,0 +1,23 @@
+id: ocd-person/c7160abf-d376-484d-b87e-600a398ab503
+name: Anthony L. Nolan
+party:
+- name: Democratic
+roles:
+- district: '39'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2019-03-01
+contact_details:
+- address: Legislative Office Building;Room 4043;Hartford, CT 06106
+  email: Anthony.Nolan@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 105 Blackhall Street;New London, CT 06320
+  note: District Office
+  voice: 860-437-8868
+links:
+- url: http://www.housedems.ct.gov/nolan
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Anthony
+family_name: Nolan

--- a/data/ct/people/Antonio-Felipe-caaba025-7a5a-401d-8714-73f627651196.yml
+++ b/data/ct/people/Antonio-Felipe-caaba025-7a5a-401d-8714-73f627651196.yml
@@ -1,0 +1,23 @@
+id: ocd-person/caaba025-7a5a-401d-8714-73f627651196
+name: Antonio Felipe
+party:
+- name: Democratic
+roles:
+- district: '130'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2019-05-13
+contact_details:
+- address: Legislative Office Bldg;Room 4000;Hartford, CT 06106
+  email: antonio.felipe@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 666 Iranistan Avenue;Bridgeport, CT 06604
+  note: District Office
+  voice: 203-726-6398
+links:
+- url: http://www.housedems.ct.gov/felipe
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Antonio
+family_name: Felipe

--- a/data/ct/people/Arthur-J-ONeill-695f61b5-0fe0-47db-b0ba-30cd70e1223b.yml
+++ b/data/ct/people/Arthur-J-ONeill-695f61b5-0fe0-47db-b0ba-30cd70e1223b.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4204;Hartford, CT 06106
+  email: Arthur.ONeill@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Arthur.ONeill@housegop.ct.gov
-- address: 617 Bucks Hills Road;Southbury, CT 06488
+- address: 177 Tepi Drive;Southbury, CT 06488
   note: District Office
 links:
-- url: http://www.cthousegop.com/ONeill/main/
+- url: http://www.cthousegop.com/ONeill/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000105
   scheme: legacy_openstates
-given_name: Arthur J.
+given_name: Arthur
 family_name: O'Neill

--- a/data/ct/people/Ben-McGorty-240d52a3-33df-495c-b1a0-142cc43f3fce.yml
+++ b/data/ct/people/Ben-McGorty-240d52a3-33df-495c-b1a0-142cc43f3fce.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4062;Hartford, CT 06106
+  email: Ben.McGorty@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Ben.McGorty@housegop.ct.gov
 - address: 30 Wigwam Drive;Shelton, CT 06484
   note: District Office
 links:
-- url: http://www.cthousegop.com/McGorty/main/
+- url: http://www.cthousegop.com/McGorty/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Bill-Buckbee-1c270bf3-7cc6-4e11-93fb-e35f5d9a1774.yml
+++ b/data/ct/people/Bill-Buckbee-1c270bf3-7cc6-4e11-93fb-e35f5d9a1774.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4041;Hartford, CT 06106
+  email: Bill.Buckbee@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8723
-  email: Bill.Buckbee@housegop.ct.gov
 - address: 64A Lanesville Road;New Milford, CT 06776
   note: District Office
 links:
-- url: http://www.cthousegop.com/Buckbee/main/
+- url: http://www.cthousegop.com/Buckbee/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Bill-Simanski-16a9c87b-8381-4c80-9c15-5d1babe6b673.yml
+++ b/data/ct/people/Bill-Simanski-16a9c87b-8381-4c80-9c15-5d1babe6b673.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2404;Hartford, CT 06106
+  email: bill.simanski@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: bill.simanski@housegop.ct.gov
 - address: 12 Kilmer Lane;Granby, CT 06035
   note: District Office
   voice: 860-653-0686
 links:
-- url: http://www.cthousegop.com/Simanski/main/
+- url: http://www.cthousegop.com/Simanski/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Bob-Duff-7836916c-08a2-430a-99eb-580f7cf50e81.yml
+++ b/data/ct/people/Bob-Duff-7836916c-08a2-430a-99eb-580f7cf50e81.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
+  email: Bob.Duff@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0414
-  email: Bob.Duff@cga.ct.gov
 - address: 50 Toilsome Avenue;Norwalk, CT 06851
   note: District Office
   voice: 203-840-1333

--- a/data/ct/people/Bob-Godfrey-97e1ed70-218e-41d6-abad-73cf8c717c5b.yml
+++ b/data/ct/people/Bob-Godfrey-97e1ed70-218e-41d6-abad-73cf8c717c5b.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4107;Hartford, CT 06106
+  email: Bob.Godfrey@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Bob.Godfrey@cga.ct.gov
 - address: 13 Stillman Avenue;Danbury, CT 06810
   note: District Office
   voice: 203-778-5127

--- a/data/ct/people/Bobby-G-Gibson-Jr-6e4977fe-2ed9-4e1c-93ce-c837766d2896.yml
+++ b/data/ct/people/Bobby-G-Gibson-Jr-6e4977fe-2ed9-4e1c-93ce-c837766d2896.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Bobby.Gibson@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Bobby.Gibson@cga.ct.gov
 - address: 5 Greenbrier Drive;Bloomfield, CT 06002
   note: District Office
   voice: 860-306-6638
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000364
   scheme: legacy_openstates
-given_name: Bobby G.
+given_name: Bobby
 family_name: Gibson

--- a/data/ct/people/Brandon-L-McGee-Jr-b2d80201-bab4-424e-aa42-cc8d2902cadb.yml
+++ b/data/ct/people/Brandon-L-McGee-Jr-b2d80201-bab4-424e-aa42-cc8d2902cadb.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 5009;Hartford, CT 06106
+  email: Brandon.McGee@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Brandon.McGee@cga.ct.gov
 - address: 43 Warren Street;Hartford, CT 06120
   note: District Office
   voice: 860-578-2979
@@ -27,5 +27,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000249
   scheme: legacy_openstates
-given_name: Brandon L.
+given_name: Brandon
 family_name: McGee

--- a/data/ct/people/Brian-Farnen-a5013946-a51e-4a95-a1f1-cfd62c72ac80.yml
+++ b/data/ct/people/Brian-Farnen-a5013946-a51e-4a95-a1f1-cfd62c72ac80.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a5013946-a51e-4a95-a1f1-cfd62c72ac80
+name: Brian Farnen
+party:
+- name: Republican
+roles:
+- district: '132'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2020-01-22
+contact_details:
+- address: 300 Capitol Avenue;Room 4200;Hartford, CT 06106
+  email: brian.farnen@housegop.ct.gov
+  note: Capitol Office
+  voice: 860-240-8700
+- address: 394 Rowland Road;Fairfield, CT 06824
+  note: District Office
+links:
+- url: http://cthousegop.com/farnen
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Brian
+family_name: Farnen

--- a/data/ct/people/Brian-Lanoue-fc3ba144-870e-4603-b2a4-26d3e80b5c70.yml
+++ b/data/ct/people/Brian-Lanoue-fc3ba144-870e-4603-b2a4-26d3e80b5c70.yml
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Brian.Lanoue@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Brian.Lanoue@housegop.ct.gov
 - address: 35 Kenwood Estates;Griswold, CT 06351
   note: District Office
   voice: 860-376-9354
 links:
-- url: http://www.replanoue.com
+- url: http://www.cthousegop.com/lanoue/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Brian
+family_name: Lanoue

--- a/data/ct/people/Brian-T-Smith-8abc69af-2775-4342-9191-6902690d03ed.yml
+++ b/data/ct/people/Brian-T-Smith-8abc69af-2775-4342-9191-6902690d03ed.yml
@@ -1,0 +1,23 @@
+id: ocd-person/8abc69af-2775-4342-9191-6902690d03ed
+name: Brian T. Smith
+party:
+- name: Democratic
+roles:
+- district: '48'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2020-01-22
+contact_details:
+- address: 300 Capitol Avenue;Room;Hartford, CT 06106
+  email: brian.smith@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 12 Broadway;Colchester, CT 06415
+  note: District Office
+  voice: 860-537-1925
+links:
+- url: http://www.housedems.ct.gov/smith
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Brian
+family_name: Smith

--- a/data/ct/people/Cara-Christine-Pavalock-DAmato-e9c9ef28-807a-4efe-983f-d194c54ed41a.yml
+++ b/data/ct/people/Cara-Christine-Pavalock-DAmato-e9c9ef28-807a-4efe-983f-d194c54ed41a.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4063;Hartford, CT 06106
+  email: Cara.Pavalock-DAmato@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Cara.Pavalock-DAmato@housegop.ct.gov
 - address: 182 Rossi Drive;Bristol, CT 06010
   note: District Office
 links:
-- url: http://www.cthousegop.com/Pavalock/main/
+- url: http://www.cthousegop.com/Pavalock/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000322
   scheme: legacy_openstates
-given_name: Cara Christine
+given_name: Cara
 family_name: Pavalock-D'Amato

--- a/data/ct/people/Carlo-Leone-5223bdb7-4dfc-4fba-b83e-be5b8368f9a0.yml
+++ b/data/ct/people/Carlo-Leone-5223bdb7-4dfc-4fba-b83e-be5b8368f9a0.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3503;Hartford, CT 06106
+- address: Legislative Office Building;Room 2300;Hartford, CT 06106
   note: Capitol Office
   voice: 860-240-8600
 - address: 88 Houston Terrace;Stamford, CT 06902

--- a/data/ct/people/Carol-Hall-5e47f657-ab56-4673-bebb-5a7c1a0410db.yml
+++ b/data/ct/people/Carol-Hall-5e47f657-ab56-4673-bebb-5a7c1a0410db.yml
@@ -7,12 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4200;Hartford, CT 06106
+- address: Legislative Office Building;Room 1803;Hartford, CT 06106
+  email: Carol.Hall@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Carol.Hall@housegop.ct.gov
 links:
-- url: http://www.cthousegop.com/Hall/main/
+- url: http://www.cthousegop.com/Hall/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Caroline-Simmons-ad606d1d-4567-41b6-8087-534555de2828.yml
+++ b/data/ct/people/Caroline-Simmons-ad606d1d-4567-41b6-8087-534555de2828.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Capitol Building;Room 407;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-0380
   email: Caroline.Simmons@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-0388
 - address: 48 Lakeview Drive;Stamford, CT 06905
   note: District Office
 links:

--- a/data/ct/people/Catherine-A-Osten-aec1fe1b-02ac-4802-be69-8714ec0b848e.yml
+++ b/data/ct/people/Catherine-A-Osten-aec1fe1b-02ac-4802-be69-8714ec0b848e.yml
@@ -19,5 +19,5 @@ sources:
 other_identifiers:
 - identifier: CTL000222
   scheme: legacy_openstates
-given_name: Catherine A.
+given_name: Catherine
 family_name: Osten

--- a/data/ct/people/Catherine-F-Abercrombie-85ce898d-f0fc-499d-9b09-1238b29f152c.yml
+++ b/data/ct/people/Catherine-F-Abercrombie-85ce898d-f0fc-499d-9b09-1238b29f152c.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2002;Hartford, CT 06106
+  email: Catherine.Abercrombie@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0492
-  email: Catherine.Abercrombie@cga.ct.gov
 - address: 230 Westfort Drive;Meriden, CT 06451
   note: District Office
   voice: 203-634-8770
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000119
   scheme: legacy_openstates
-given_name: Catherine F.
+given_name: Catherine
 family_name: Abercrombie

--- a/data/ct/people/Charles-J-Ferraro-bc0526f4-43f7-4ad1-b518-ceb1680771f8.yml
+++ b/data/ct/people/Charles-J-Ferraro-bc0526f4-43f7-4ad1-b518-ceb1680771f8.yml
@@ -7,18 +7,18 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4055;Hartford, CT 06106
+- address: Legislative Office Building;Room 3904;Hartford, CT 06106
+  email: Charles.Ferraro@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Charles.Ferraro@housegop.ct.gov
 - address: 13 Twin Circle Road;West Haven, CT 06516
   note: District Office
 links:
-- url: http://www.cthousegop.com/Ferraro/main/
+- url: http://www.cthousegop.com/Ferraro/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000296
   scheme: legacy_openstates
-given_name: Charles J.
+given_name: Charles
 family_name: Ferraro

--- a/data/ct/people/Charlie-L-Stallworth-ddbee7da-746c-4fd1-8ee2-21ec3c6672d1.yml
+++ b/data/ct/people/Charlie-L-Stallworth-ddbee7da-746c-4fd1-8ee2-21ec3c6672d1.yml
@@ -8,12 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 5005;Hartford, CT 06106
+  email: Charlie.Stallworth@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0141
-  email: Charlie.Stallworth@cga.ct.gov
 - address: 35 Wickliffe Circle;Bridgeport, CT 06606
   note: District Office
-  voice: 203-449-8301
+  voice: 203-257-5281
 links:
 - url: http://www.housedems.ct.gov/stallworth
 sources:
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000162
   scheme: legacy_openstates
-given_name: Charlie L.
+given_name: Charlie
 family_name: Stallworth

--- a/data/ct/people/Chris-Perone-15f3df31-84bc-4ae6-b399-c9b9c58ecec6.yml
+++ b/data/ct/people/Chris-Perone-15f3df31-84bc-4ae6-b399-c9b9c58ecec6.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4100;Hartford, CT 06106
+- address: Legislative Office Building;Room 4109;Hartford, CT 06106
+  email: Chris.Perone@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Chris.Perone@cga.ct.gov
 - address: 8 East Rocks Road;Norwalk, CT 06851
   note: District Office
   voice: 203-840-1643

--- a/data/ct/people/Christie-M-Carpino-88d052d8-3d97-4e23-8abd-53311294acfd.yml
+++ b/data/ct/people/Christie-M-Carpino-88d052d8-3d97-4e23-8abd-53311294acfd.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4065;Hartford, CT 06106
+  email: christie.carpino@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: christie.carpino@housegop.ct.gov
 - address: 29 Sovereign Ridge;Cromwell, CT 06416
   note: District Office
   voice: 860-635-8725
 links:
-- url: http://www.cthousegop.com/Carpino/main/
+- url: http://www.cthousegop.com/Carpino/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000068
   scheme: legacy_openstates
-given_name: Christie M.
+given_name: Christie
 family_name: Carpino

--- a/data/ct/people/Christine-Cohen-5e2acad1-d976-4a7d-997b-52b5b400a654.yml
+++ b/data/ct/people/Christine-Cohen-5e2acad1-d976-4a7d-997b-52b5b400a654.yml
@@ -7,10 +7,12 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3300;Hartford, CT 06106
+- address: Legislative Office Building;Room 3200;Hartford, CT 06106
   note: Capitol Office
   voice: 860-240-8600
 links:
 - url: http://www.senatedems.ct.gov/cohen
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Christine
+family_name: Cohen

--- a/data/ct/people/Christine-Conley-276eaeb3-5dae-40f3-acbb-3effe375988b.yml
+++ b/data/ct/people/Christine-Conley-276eaeb3-5dae-40f3-acbb-3effe375988b.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4100;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 4009;Hartford, CT 06106
   email: Christine.Conley@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 33 Toll Gate Road;Groton, CT 06340
   note: District Office
   voice: 860-916-3333

--- a/data/ct/people/Christine-Palm-d125d3d7-3ad3-487e-a993-c0e3107c9202.yml
+++ b/data/ct/people/Christine-Palm-d125d3d7-3ad3-487e-a993-c0e3107c9202.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 4045;Hartford, CT 06106
   email: Christine.Palm@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 29 East Liberty Street;Chester, CT 06412
   note: District Office
   voice: 860-836-2145
@@ -18,3 +18,5 @@ links:
 - url: http:////www.housedems.ct.gov/palm
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Christine
+family_name: Palm

--- a/data/ct/people/Christopher-Davis-e9445cd3-45fb-421c-af28-c59f48bff8cb.yml
+++ b/data/ct/people/Christopher-Davis-e9445cd3-45fb-421c-af28-c59f48bff8cb.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3703;Hartford, CT 06106
+  email: christopher.davis@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: christopher.davis@housegop.ct.gov
 - address: 123 Snipsic Lake Road;Ellington, CT 06029
   note: District Office
   voice: 860-292-0041
 links:
-- url: http://www.cthousegop.com/Davis/main/
+- url: http://www.cthousegop.com/Davis/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Christopher-Rosario-ea0027a9-6952-4b74-a771-a14ced4e647e.yml
+++ b/data/ct/people/Christopher-Rosario-ea0027a9-6952-4b74-a771-a14ced4e647e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4115;Hartford, CT 06106
+- address: Legislative Office Building;Room 4013;Hartford, CT 06106
+  email: Christopher.Rosario@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Christopher.Rosario@cga.ct.gov
 - address: 195 French Street;Bridgeport, CT 06606
   note: District Office
 links:

--- a/data/ct/people/Christopher-Ziogas-506de26d-cebf-48cf-a0e0-3f7f8efb6a6a.yml
+++ b/data/ct/people/Christopher-Ziogas-506de26d-cebf-48cf-a0e0-3f7f8efb6a6a.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Chris.Ziogas@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Chris.Ziogas@cga.ct.gov
 - address: P.O. Box 1399;Bristol, CT 06010
   note: District Office
 links:

--- a/data/ct/people/Craig-C-Fishbein-02ce0fa3-ac25-42dd-9f5e-ee44b7e9d542.yml
+++ b/data/ct/people/Craig-C-Fishbein-02ce0fa3-ac25-42dd-9f5e-ee44b7e9d542.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Craig.Fishbein@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Craig.Fishbein@housegop.ct.gov
 - address: 179 Grieb Road;Wallingford, CT 06492
   note: District Office
 links:
-- url: http://www.cthousegop.com/Fishbein/main/
+- url: http://www.cthousegop.com/Fishbein/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000341
   scheme: legacy_openstates
-given_name: Craig C.
+given_name: Craig
 family_name: Fishbein

--- a/data/ct/people/Craig-Miner-9b22e360-54e1-4e6a-a733-d2c0a7e94d5a.yml
+++ b/data/ct/people/Craig-Miner-9b22e360-54e1-4e6a-a733-d2c0a7e94d5a.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: Craig.Miner@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Craig.Miner@cga.ct.gov
 - address: 230 E. Chestnut Hill Road;Litchfield, CT 06759
   note: District Office
 links:

--- a/data/ct/people/Cristin-McCarthy-Vahey-dfc1bead-50cd-4c34-9dc6-5d80c7a09589.yml
+++ b/data/ct/people/Cristin-McCarthy-Vahey-dfc1bead-50cd-4c34-9dc6-5d80c7a09589.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4001;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8760
+- address: Legislative Office Building;Room 2103;Hartford, CT 06106
   email: Cristin.McCarthyVahey@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8362
 - address: 1625 Melville Avenue;Fairfield, CT 06825
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000281
   scheme: legacy_openstates
-given_name: Cristin McCarthy
-family_name: Vahey
+given_name: Cristin
+family_name: McCarthy Vahey

--- a/data/ct/people/Dan-Champagne-9e96a931-c06f-4245-859b-dbe02d3e2342.yml
+++ b/data/ct/people/Dan-Champagne-9e96a931-c06f-4245-859b-dbe02d3e2342.yml
@@ -8,12 +8,14 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: Dan.Champagne@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Dan.Champagne@cga.ct.gov
 - address: 30 Lawler Road;Vernon, CT 06066
   note: District Office
 links:
 - url: http://www.ctsenaterepublicans.com/home-champagne
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Dan
+family_name: Champagne

--- a/data/ct/people/Daniel-J-Fox-b0817ed7-2898-4824-934c-c49615c8b1ea.yml
+++ b/data/ct/people/Daniel-J-Fox-b0817ed7-2898-4824-934c-c49615c8b1ea.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2202;Hartford, CT 06106
+  email: Dan.Fox@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Dan.Fox@cga.ct.gov
 - address: 28 Pierce Place;Stamford, CT 06906
   note: District Office
   voice: 203-569-6290
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000184
   scheme: legacy_openstates
-given_name: Daniel J.
+given_name: Daniel
 family_name: Fox

--- a/data/ct/people/Dave-W-Yaccarino-12835342-bb95-428a-ace3-78c51c3e8443.yml
+++ b/data/ct/people/Dave-W-Yaccarino-12835342-bb95-428a-ace3-78c51c3e8443.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4057;Hartford, CT 06106
+  email: dave.yaccarino@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: dave.yaccarino@housegop.ct.gov
 - address: 1804 Hartford Tpke;North Haven, CT 06473
   note: District Office
   voice: 203-980-0030
 links:
-- url: http://www.cthousegop.com/Yaccarino/main/
+- url: http://www.cthousegop.com/Yaccarino/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000123
   scheme: legacy_openstates
-given_name: Dave W.
+given_name: Dave
 family_name: Yaccarino

--- a/data/ct/people/David-Arconti-Jr-586dc1fb-0c17-412b-964a-f5de187d4158.yml
+++ b/data/ct/people/David-Arconti-Jr-586dc1fb-0c17-412b-964a-f5de187d4158.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4034;Hartford, CT 06106
+- address: Legislative Office Building;Room 3902;Hartford, CT 06106
+  email: David.Arconti@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: David.Arconti@cga.ct.gov
 - address: 141 Great Plain Road;Danbury, CT 06811
   note: District Office
   voice: 203-313-4407

--- a/data/ct/people/David-K-Labriola-0d2a3f7f-31d4-4e47-ba1f-7bfce484f6f9.yml
+++ b/data/ct/people/David-K-Labriola-0d2a3f7f-31d4-4e47-ba1f-7bfce484f6f9.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4084;Hartford, CT 06106
+  email: David.Labriola@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: David.Labriola@housegop.ct.gov
 - address: 185 Riggs Street;Oxford, CT 06478
   note: District Office
   voice: 203-828-6154
 links:
-- url: http://www.cthousegop.com/Labriola/main/
+- url: http://www.cthousegop.com/Labriola/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000167
   scheme: legacy_openstates
-given_name: David K.
+given_name: David
 family_name: Labriola

--- a/data/ct/people/David-Michel-2e21841e-7d65-4010-a0b2-c3bb779523c5.yml
+++ b/data/ct/people/David-Michel-2e21841e-7d65-4010-a0b2-c3bb779523c5.yml
@@ -7,14 +7,16 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 4037;Hartford, CT 06106
   email: David.Michel@cga.ct.gov
-- address: 40 Rockledge Drive;Stamford, CT 06902
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 4 Rockledge Drive;Stamford, CT 06902
   note: District Office
   voice: 860-240-8500
 links:
 - url: http://www.housedems.ct.gov/michel
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: David
+family_name: Michel

--- a/data/ct/people/David-Rutigliano-01bfbaf3-d536-45f0-8478-96cd8fbd4518.yml
+++ b/data/ct/people/David-Rutigliano-01bfbaf3-d536-45f0-8478-96cd8fbd4518.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3801;Hartford, CT 06106
+  email: David.Rutigliano@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: David.Rutigliano@housegop.ct.gov
 - address: 52 Stemway Road;Trumbull, CT 06611
   note: District Office
 links:
-- url: http://www.cthousegop.com/Rutigliano/main/
+- url: http://www.cthousegop.com/Rutigliano/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/David-T-Wilson-520fc855-8f97-4698-9521-039c9ea9918c.yml
+++ b/data/ct/people/David-T-Wilson-520fc855-8f97-4698-9521-039c9ea9918c.yml
@@ -7,19 +7,19 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4039;Hartford, CT 06106
+- address: Legislative Office Building;Room 4054;Hartford, CT 06106
+  email: David.Wilson@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: David.Wilson@housegop.ct.gov
 - address: 42 Wheeler Road;Litchfield, CT 06759
   note: District Office
   voice: 860-489-9673
 links:
-- url: http://www.cthousegop.com/Wilson/main/
+- url: http://www.cthousegop.com/Wilson/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000337
   scheme: legacy_openstates
-given_name: David T.
+given_name: David
 family_name: Wilson

--- a/data/ct/people/Dennis-Bradley-fa722794-9212-4794-b381-04d0f1d65cff.yml
+++ b/data/ct/people/Dennis-Bradley-fa722794-9212-4794-b381-04d0f1d65cff.yml
@@ -1,5 +1,5 @@
 id: ocd-person/fa722794-9212-4794-b381-04d0f1d65cff
-name: Dennis Bradley
+name: Dennis A. Bradley
 party:
 - name: Democratic
 roles:
@@ -9,7 +9,7 @@ roles:
 contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
+  voice: 860-240-0591
 - address: 853 Fairfield Avenue;Bridgeport, CT 06604
   note: District Office
   voice: 203-212-3617
@@ -17,3 +17,5 @@ links:
 - url: http://www.senatedems.ct.gov/bradley
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Dennis
+family_name: Bradley

--- a/data/ct/people/Derek-Slap-a33a2113-e60b-4000-9dc7-eb58a775d986.yml
+++ b/data/ct/people/Derek-Slap-a33a2113-e60b-4000-9dc7-eb58a775d986.yml
@@ -6,16 +6,19 @@ roles:
 - district: '19'
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
+  end_date: 2019-03-01
+- district: '5'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: upper
+  start_date: 2019-03-01
 contact_details:
-- address: Legislative Office Building;Room 4036;Hartford, CT 06106
+- address: Legislative Office Building;Room 1000;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8500
-  email: Derek.Slap@cga.ct.gov
+  voice: 860-240-1436
 - address: 51 Fairlee Road;West Hartford, CT 06107
   note: District Office
-  voice: 860-503-3599
 links:
-- url: http://www.housedems.ct.gov/Slap
+- url: http://www.senatedems.ct.gov/slap
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Devin-R-Carney-79d4059c-5faa-443f-a842-7b494ea2d57e.yml
+++ b/data/ct/people/Devin-R-Carney-79d4059c-5faa-443f-a842-7b494ea2d57e.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2304;Hartford, CT 06106
+  email: Devin.Carney@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Devin.Carney@housegop.ct.gov
 - address: 99 Grassy Hill Road;Old Lyme, CT 06371
   note: District Office
 links:
-- url: http://www.cthousegop.com/Carney/main/
+- url: http://www.cthousegop.com/Carney/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
@@ -22,5 +22,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000300
   scheme: legacy_openstates
-given_name: Devin R.
+given_name: Devin
 family_name: Carney

--- a/data/ct/people/Dorinda-Borer-4868bf1f-ad1d-4cad-96fa-040ede0d1641.yml
+++ b/data/ct/people/Dorinda-Borer-4868bf1f-ad1d-4cad-96fa-040ede0d1641.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Dorinda.Borer@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Dorinda.Borer@cga.ct.gov
 links:
 - url: http://www.housedems.ct.gov/Borer
 sources:

--- a/data/ct/people/Doug-Dubitsky-2342cde8-078f-4dd8-8879-f9fdaa036a94.yml
+++ b/data/ct/people/Doug-Dubitsky-2342cde8-078f-4dd8-8879-f9fdaa036a94.yml
@@ -7,14 +7,14 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4050;Hartford, CT 06106
+- address: Legislative Office Building;Room 4047;Hartford, CT 06106
+  email: Doug.Dubitsky@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Doug.Dubitsky@housegop.ct.gov
 - address: P.O. Box 140;Chaplin, CT 06235
   note: District Office
 links:
-- url: http://www.cthousegop.com/Dubitsky/main/
+- url: http://www.cthousegop.com/Dubitsky/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Douglas-McCrory-83a4e876-4df7-48ef-8a84-7d7940585af9.yml
+++ b/data/ct/people/Douglas-McCrory-83a4e876-4df7-48ef-8a84-7d7940585af9.yml
@@ -7,7 +7,8 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3300;Hartford, CT 06106
+- address: Legislative Office Building;Room 3105;Hartford, CT 06106
+  email: douglas.mccrory@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8600
 - address: 235 Blue Hills Avenue;Hartford, CT 06112

--- a/data/ct/people/Edwin-Vargas-7689046b-7757-475e-ba24-1e20ecf169b4.yml
+++ b/data/ct/people/Edwin-Vargas-7689046b-7757-475e-ba24-1e20ecf169b4.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 1003;Hartford, CT 06106
+  email: Edwin.Vargas@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0454
-  email: Edwin.Vargas@cga.ct.gov
 - address: 141 Douglas Street;Hartford, CT 06114
   note: District Office
   voice: 860-956-1503

--- a/data/ct/people/Emil-Altobello-e1473778-00e1-4e12-bf11-01631a32bc0a.yml
+++ b/data/ct/people/Emil-Altobello-e1473778-00e1-4e12-bf11-01631a32bc0a.yml
@@ -1,5 +1,5 @@
 id: ocd-person/e1473778-00e1-4e12-bf11-01631a32bc0a
-name: Emil Altobello
+name: Emil "Buddy" Altobello
 party:
 - name: Democratic
 roles:
@@ -8,12 +8,11 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4015;Hartford, CT 06106
+  email: Emil.Altobello@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Emil.Altobello@cga.ct.gov
 - address: 555 Preston Avenue;Meriden, CT 06450
   note: District Office
-  voice: 203-634-1692
 links:
 - url: http://www.housedems.ct.gov/Altobello
 sources:

--- a/data/ct/people/Emmett-D-Riley-81708fd7-b28e-4c83-b972-80e77a91da3c.yml
+++ b/data/ct/people/Emmett-D-Riley-81708fd7-b28e-4c83-b972-80e77a91da3c.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4003;Hartford, CT 06106
+- address: Legislative Office Building;Room 4112;Hartford, CT 06106
+  email: Emmett.Riley@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8382
-  email: Emmett.Riley@cga.ct.gov
 - address: 25 Sherwood Lane;Norwich, CT 06360
   note: District Office
   voice: 860-887-6228
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000202
   scheme: legacy_openstates
-given_name: Emmett D.
+given_name: Emmett
 family_name: Riley

--- a/data/ct/people/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
+++ b/data/ct/people/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: Eric.Berthel@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Eric.Berthel@cga.ct.gov
 - address: 92 Malvern Hill Road;Watertown, CT 06795
   note: District Office
 links:
@@ -22,5 +22,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000358
   scheme: legacy_openstates
-given_name: Eric C.
+given_name: Eric
 family_name: Berthel

--- a/data/ct/people/Gail-Lavielle-5c5388d9-80b5-4951-b91e-0fa4c42b7f6c.yml
+++ b/data/ct/people/Gail-Lavielle-5c5388d9-80b5-4951-b91e-0fa4c42b7f6c.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 3103;Hartford, CT 06106
+- address: Legislative Office Building;Room 2703;Hartford, CT 06106
+  email: gail.lavielle@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: gail.lavielle@housegop.ct.gov
 - address: 109 Hickory Hill;Wilton, CT 06897
   note: District Office
   voice: 203-762-7373
 links:
-- url: http://www.cthousegop.com/Lavielle/main/
+- url: http://www.cthousegop.com/Lavielle/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Gale-L-Mastrofrancesco-c60ec8d2-fcc3-414e-a122-cca6aeef901d.yml
+++ b/data/ct/people/Gale-L-Mastrofrancesco-c60ec8d2-fcc3-414e-a122-cca6aeef901d.yml
@@ -8,13 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Gale.Mastrofrancesco@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Gale.Mastrofrancesco@housegop.ct.gov
-- address: 16 Spindle Hill Road;Wolcott, CT 06716
-  note: District Office
-  voice: 203-879-6270
 links:
-- url: http://www.repmastrofrancesco.com
+- url: http://www.cthousegop.com/mastrofrancesco/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Gale
+family_name: Mastrofrancesco

--- a/data/ct/people/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
+++ b/data/ct/people/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
@@ -7,9 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 2400;Hartford, CT 06106
+- address: Legislative Office Building;Room 2500;Hartford, CT 06106
+  email: gary.winfield@cga.ct.gov
   note: Capitol Office
-  voice: 860-240-0422
+  voice: 860-240-0475
 - address: 480 Winchester Avenue;New Haven, CT 06511
   note: District Office
   voice: 203-676-8167
@@ -20,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000279
   scheme: legacy_openstates
-given_name: Gary A.
+given_name: Gary
 family_name: Winfield

--- a/data/ct/people/Gary-Turco-36b9eb8c-9fd8-4f6e-ba6b-fddb03bf3be3.yml
+++ b/data/ct/people/Gary-Turco-36b9eb8c-9fd8-4f6e-ba6b-fddb03bf3be3.yml
@@ -1,5 +1,5 @@
 id: ocd-person/36b9eb8c-9fd8-4f6e-ba6b-fddb03bf3be3
-name: Gary Turco
+name: Gary A. Turco Jr.
 party:
 - name: Democratic
 roles:
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Gary.Turco@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 98 Williamstown Court;Newington, CT 06111
   note: District Office
   voice: 860-335-6122
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/turco
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Gary
+family_name: Turco

--- a/data/ct/people/Gennaro-Bizzarro-1abaa8f6-bece-4166-b523-bacd09fd76ef.yml
+++ b/data/ct/people/Gennaro-Bizzarro-1abaa8f6-bece-4166-b523-bacd09fd76ef.yml
@@ -1,0 +1,23 @@
+id: ocd-person/1abaa8f6-bece-4166-b523-bacd09fd76ef
+name: Gennaro Bizzarro
+party:
+- name: Republican
+roles:
+- district: '6'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: upper
+  start_date: 2019-03-04
+contact_details:
+- address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: Gennaro.Bizzarro@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8800
+- address: 440 Shuttle Meadow Avenue;New Britain, CT 06052
+  note: District Office
+  voice: 203-536-6178
+links:
+- url: http://www.ctsenaterepublicans.com/home-bizzarro
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Gennaro
+family_name: Bizzarro

--- a/data/ct/people/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
+++ b/data/ct/people/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
@@ -9,9 +9,9 @@ roles:
   start_date: 2011-01-01
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Geoff.Luxenberg@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 56 Elizabeth Drive;Manchester, CT 06042
   note: District Office
   voice: 860-335-2023
@@ -24,3 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ocd-person/d36d807e-c27c-4085-97a8-9a98898d84d6
   scheme: openstates
+given_name: Geoff
+family_name: Luxenberg

--- a/data/ct/people/George-S-Logan-97acf3e4-5fa9-4cb9-af7d-d3d2c69f7213.yml
+++ b/data/ct/people/George-S-Logan-97acf3e4-5fa9-4cb9-af7d-d3d2c69f7213.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 2102;Hartford, CT 06106
+  email: George.Logan@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: George.Logan@cga.ct.gov
 - address: 10 LaRovera Terrace;Ansonia, CT 06401
   note: District Office
   voice: 203-734-8658
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000352
   scheme: legacy_openstates
-given_name: George S.
+given_name: George
 family_name: Logan

--- a/data/ct/people/Geraldo-C-Reyes-Jr-f11b5a17-e613-4aa8-9b91-7e2583e1ced5.yml
+++ b/data/ct/people/Geraldo-C-Reyes-Jr-f11b5a17-e613-4aa8-9b91-7e2583e1ced5.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4024;Hartford, CT 06106
+  email: Geraldo.Reyes@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Geraldo.Reyes@cga.ct.gov
 - address: 30 Madison Street;Waterbury, CT 06706
   note: District Office
   voice: 203-753-4930
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000312
   scheme: legacy_openstates
-given_name: Geraldo C.
+given_name: Geraldo
 family_name: Reyes

--- a/data/ct/people/Gregory-Haddad-63a8e4ab-dfcd-4a69-8317-53b8e9a69729.yml
+++ b/data/ct/people/Gregory-Haddad-63a8e4ab-dfcd-4a69-8317-53b8e9a69729.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 1804;Hartford, CT 06106
+  email: Gregory.Haddad@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Gregory.Haddad@cga.ct.gov
 - address: 28 Storrs Heights Road;Storrs, CT 06268
   note: District Office
   voice: 860-429-8517

--- a/data/ct/people/Harry-Arora-2253e194-1b93-4973-a76e-7fc39ad1727b.yml
+++ b/data/ct/people/Harry-Arora-2253e194-1b93-4973-a76e-7fc39ad1727b.yml
@@ -1,0 +1,23 @@
+id: ocd-person/2253e194-1b93-4973-a76e-7fc39ad1727b
+name: Harry Arora
+party:
+- name: Republican
+roles:
+- district: '151'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2020-01-29
+contact_details:
+- address: 300 Capitol Ave., LOB;Room 1002;Hartford, CT 06106
+  email: harry.arora@housegop.ct.gov
+  note: Capitol Office
+  voice: 860-240-8700
+- address: 300 Capitol Ave., LOB;Hartford, CT 06106
+  note: District Office
+  voice: 860-240-8700
+links:
+- url: http://www.cthousegop.com/arora
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Harry
+family_name: Arora

--- a/data/ct/people/Heather-B-Somers-a648c360-3b9e-408d-ba2a-c171edada365.yml
+++ b/data/ct/people/Heather-B-Somers-a648c360-3b9e-408d-ba2a-c171edada365.yml
@@ -1,5 +1,5 @@
 id: ocd-person/a648c360-3b9e-408d-ba2a-c171edada365
-name: Heather B. Somers
+name: Heather S. Somers
 party:
 - name: Republican
 roles:
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3400;Hartford, CT 06106
+- address: Legislative Office Building;Room 3501;Hartford, CT 06106
+  email: Heather.Somers@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Heather.Somers@cga.ct.gov
 links:
 - url: http://www.ctsenaterepublicans.com/home-Somers
 sources:
@@ -18,5 +18,5 @@ sources:
 other_identifiers:
 - identifier: CTL000330
   scheme: legacy_openstates
-given_name: Heather B.
+given_name: Heather
 family_name: Somers

--- a/data/ct/people/Henri-Martin-ca8be710-988a-4415-bc37-6d3a92d1afcd.yml
+++ b/data/ct/people/Henri-Martin-ca8be710-988a-4415-bc37-6d3a92d1afcd.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-0022
   email: Henri.Martin@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-0529
 - address: 7 Ipswitch Road;Bristol, CT 06010
   note: District Office
 links:

--- a/data/ct/people/Henry-J-Genga-c07f613b-b79d-4e11-b959-589c8cefac41.yml
+++ b/data/ct/people/Henry-J-Genga-c07f613b-b79d-4e11-b959-589c8cefac41.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4030;Hartford, CT 06106
+  email: henry.genga@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8534
-  email: henry.genga@cga.ct.gov
 - address: 5 Elaine Drive;East Hartford, CT 06118
   note: District Office
   voice: 860-568-6395
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000046
   scheme: legacy_openstates
-given_name: Henry J.
+given_name: Henry
 family_name: Genga

--- a/data/ct/people/Hilda-E-Santiago-568f232d-2133-4eee-a886-c1927f7f88bc.yml
+++ b/data/ct/people/Hilda-E-Santiago-568f232d-2133-4eee-a886-c1927f7f88bc.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4111;Hartford, CT 06106
+- address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Hilda.Santiago@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Hilda.Santiago@cga.ct.gov
 - address: 86 South Avenue;Meriden, CT 06451
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000209
   scheme: legacy_openstates
-given_name: Hilda E.
+given_name: Hilda
 family_name: Santiago

--- a/data/ct/people/Holly-H-Cheeseman-4382243c-e60c-4b2a-b41b-cd3b6d658f9d.yml
+++ b/data/ct/people/Holly-H-Cheeseman-4382243c-e60c-4b2a-b41b-cd3b6d658f9d.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Holly.Cheeseman@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Holly.Cheeseman@housegop.ct.gov
 - address: 16 Mitchell Drive;Niantic, CT 06357
   note: District Office
   voice: 860-739-5429
 links:
-- url: http://www.cthousegop.com/Cheeseman/main/
+- url: http://www.cthousegop.com/Cheeseman/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000324
   scheme: legacy_openstates
-given_name: Holly H.
+given_name: Holly
 family_name: Cheeseman

--- a/data/ct/people/Irene-Haines-02cd12d5-6a88-4834-b9b5-11fb491f6b4b.yml
+++ b/data/ct/people/Irene-Haines-02cd12d5-6a88-4834-b9b5-11fb491f6b4b.yml
@@ -1,5 +1,5 @@
 id: ocd-person/02cd12d5-6a88-4834-b9b5-11fb491f6b4b
-name: Irene Haines
+name: Irene M. Haines
 party:
 - name: Republican
 roles:
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Irene.Haines@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Irene.Haines@housegop.ct.gov
 - address: 112 Shanaghan Road;East Haddam, CT 06423
   note: District Office
-  voice: 860-240-8700
+  voice: 860-608-8931
 links:
-- url: http://www.rephaines.com
+- url: http://www.cthousegop.com/haines/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Irene
+family_name: Haines

--- a/data/ct/people/JP-Sredzinski-5706d598-bbcc-43cb-82d2-d657a42e2259.yml
+++ b/data/ct/people/JP-Sredzinski-5706d598-bbcc-43cb-82d2-d657a42e2259.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3601;Hartford, CT 06106
+  email: JP.Sredzinski@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: JP.Sredzinski@housegop.ct.gov
 - address: 280 Shelton Road;Monroe, CT 06468
   note: District Office
 links:
-- url: http://www.cthousegop.com/Sredzinski/main/
+- url: http://www.cthousegop.com/Sredzinski/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/James-J-Maroney-f37ce303-e106-4972-b453-4287b7915762.yml
+++ b/data/ct/people/James-J-Maroney-f37ce303-e106-4972-b453-4287b7915762.yml
@@ -10,10 +10,12 @@ contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
   note: Capitol Office
   voice: 860-240-8600
-- address: 22 Saranal Road;Milford, CT 06461
+- address: 22 Saranac Road;Milford, CT 06461
   note: District Office
   voice: 203-214-9133
 links:
 - url: http://www.senatedems.ct.gov/maroney
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: James
+family_name: Maroney

--- a/data/ct/people/Jane-M-Garibay-fee3a7d8-7e51-4c5a-af29-190694152ccc.yml
+++ b/data/ct/people/Jane-M-Garibay-fee3a7d8-7e51-4c5a-af29-190694152ccc.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Jane.Garibay@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 409 Broad Street;Windsor, CT 06095
   note: District Office
   voice: 860-882-8842
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/garibay
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Jane
+family_name: Garibay

--- a/data/ct/people/Jason-Doucette-33a50ad7-61f8-4e5a-92fc-a24efddc15f1.yml
+++ b/data/ct/people/Jason-Doucette-33a50ad7-61f8-4e5a-92fc-a24efddc15f1.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Jason.Doucette@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 85 Stephanie's Way;Manchester, CT 06040
   note: District Office
   voice: 860-490-3490
@@ -18,3 +18,5 @@ links:
 - url: http://housedems.ct.gov/doucette
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Jason
+family_name: Doucette

--- a/data/ct/people/Jason-Perillo-78bb88a9-cde1-4691-aa7a-e423ee16a147.yml
+++ b/data/ct/people/Jason-Perillo-78bb88a9-cde1-4691-aa7a-e423ee16a147.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4078;Hartford, CT 06106
+  email: jason.perillo@housegop.ct.gov
   note: Capitol Office
   voice: 800-842-1423
-  email: jason.perillo@housegop.ct.gov
 - address: 454 Coram Avenue;Shelton, CT 06484
   note: District Office
 links:
-- url: http://www.cthousegop.com/Perillo/main/
+- url: http://www.cthousegop.com/Perillo/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Jason-Rojas-94b3daf5-cbc7-4016-9297-8c0b8bc54944.yml
+++ b/data/ct/people/Jason-Rojas-94b3daf5-cbc7-4016-9297-8c0b8bc54944.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4023;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-0549
+- address: Legislative Office Building;Room 3704;Hartford, CT 06106
   email: Jason.Rojas@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8586
 - address: 169 Langford Lane;East Hartford, CT 06118
   note: District Office
   voice: 860-895-8374

--- a/data/ct/people/Jay-M-Case-fc3cb4e1-f784-46ac-9d54-1dd44cb817b0.yml
+++ b/data/ct/people/Jay-M-Case-fc3cb4e1-f784-46ac-9d54-1dd44cb817b0.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2004;Hartford, CT 06106
+  email: Jay.Case@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Jay.Case@housegop.ct.gov
 - address: P.O. Box 573;Winsted, CT 06098
   note: District Office
 links:
-- url: http://www.cthousegop.com/Case/main/
+- url: http://www.cthousegop.com/Case/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000205
   scheme: legacy_openstates
-given_name: Jay M.
+given_name: Jay
 family_name: Case

--- a/data/ct/people/Jeff-Currey-0589b926-29e0-4281-b0f9-73369fe7f989.yml
+++ b/data/ct/people/Jeff-Currey-0589b926-29e0-4281-b0f9-73369fe7f989.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4010;Hartford, CT 06106
+  email: Jeff.Currey@cga.ct.gov
   note: Capitol Office
   voice: 860-240-1378
-  email: Jeff.Currey@cga.ct.gov
 - address: 50 McKee Street;East Hartford, CT 06108
   note: District Office
 links:

--- a/data/ct/people/Jesse-MacLachlan-0e290496-8a84-4ed5-9167-9ac95679c692.yml
+++ b/data/ct/people/Jesse-MacLachlan-0e290496-8a84-4ed5-9167-9ac95679c692.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4044;Hartford, CT 06106
+  email: Jesse.MacLachlan@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Jesse.MacLachlan@housegop.ct.gov
 - address: 121 Plymouth Road;Westbrook, CT 06498
   note: District Office
 links:
-- url: http://www.cthousegop.com/MacLachlan/main/
+- url: http://www.cthousegop.com/MacLachlan/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Jill-Barry-629f89a2-138d-43b1-a39f-b420bd7bc061.yml
+++ b/data/ct/people/Jill-Barry-629f89a2-138d-43b1-a39f-b420bd7bc061.yml
@@ -8,13 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Jill.Barry@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 199 Cavan Lane;Glastonbury, CT 06033
   note: District Office
-  voice: 860-652-8326
 links:
 - url: http://www.housedems.ct.gov/barry
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Jill
+family_name: Barry

--- a/data/ct/people/Jillian-Gilchrest-26149cc4-f15a-46fb-a9a5-7bc0544dc287.yml
+++ b/data/ct/people/Jillian-Gilchrest-26149cc4-f15a-46fb-a9a5-7bc0544dc287.yml
@@ -8,12 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Jillian.Gilchrest@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 329 Fern Street;West Hartford, CT 06119
   note: District Office
 links:
 - url: http://www.housedems.ct.gov/gilchrest
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Jillian
+family_name: Gilchrest

--- a/data/ct/people/Joan-V-Hartley-2c22d680-9e92-423b-a943-20571186c91a.yml
+++ b/data/ct/people/Joan-V-Hartley-2c22d680-9e92-423b-a943-20571186c91a.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 1805;Hartford, CT 06106
+  email: Hartley@senatedems.ct.gov
   note: Capitol Office
   voice: 860-240-0006
-  email: Hartley@senatedems.ct.gov
 - address: 206 Columbia Blvd.;Waterbury, CT 06710
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000015
   scheme: legacy_openstates
-given_name: Joan V.
+given_name: Joan
 family_name: Hartley

--- a/data/ct/people/Joe-Aresimowicz-b6fce1b4-fecf-4983-a015-08a49fb9c41c.yml
+++ b/data/ct/people/Joe-Aresimowicz-b6fce1b4-fecf-4983-a015-08a49fb9c41c.yml
@@ -8,10 +8,10 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4105;Hartford, CT 06106
+  email: Joe.Aresimowicz@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8489
-  email: Joe.Aresimowicz@cga.ct.gov
-- address: 33 Langdon Court;Berlin, CT 06037
+- address: 33 Langdon Court F-3;Berlin, CT 06037
   note: District Office
   voice: 860-371-6887
 links:

--- a/data/ct/people/Joe-Polletta-df318645-047c-46a5-be61-682a7272e6b6.yml
+++ b/data/ct/people/Joe-Polletta-df318645-047c-46a5-be61-682a7272e6b6.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Joe.Polletta@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Joe.Polletta@housegop.ct.gov
 - address: 25 Lakeview Drive;Watertown, CT 06795
   note: District Office
   voice: 203-509-0340
 links:
-- url: http://www.cthousegop.com/Polletta/main/
+- url: http://www.cthousegop.com/Polletta/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Joe-Verrengia-ea273311-92f8-4930-adff-c0220fb2b8d3.yml
+++ b/data/ct/people/Joe-Verrengia-ea273311-92f8-4930-adff-c0220fb2b8d3.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 3804;Hartford, CT 06106
+- address: Legislative Office Building;Room 3603;Hartford, CT 06106
+  email: Joe.Verrengia@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Joe.Verrengia@cga.ct.gov
 - address: 160 Colonial Street;West Hartford, CT 06110
   note: District Office
   voice: 860-982-5282

--- a/data/ct/people/Joe-de-la-Cruz-4361534b-c294-475d-b2d8-384bc355ad17.yml
+++ b/data/ct/people/Joe-de-la-Cruz-4361534b-c294-475d-b2d8-384bc355ad17.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Joe.delaCruz@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Joe.delaCruz@cga.ct.gov
 - address: 95 Corey Road;Groton, CT 06340
   note: District Office
   voice: 860-271-1834

--- a/data/ct/people/John-A-Kissel-da65a738-37c7-41c1-8cd4-abae65ef0167.yml
+++ b/data/ct/people/John-A-Kissel-da65a738-37c7-41c1-8cd4-abae65ef0167.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 2503;Hartford, CT 06106
+- address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: John.A.Kissel@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0531
-  email: John.A.Kissel@cga.ct.gov
 - address: 16 Frew Terrace;Enfield, CT 06082
   note: District Office
   voice: 860-745-0668
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000007
   scheme: legacy_openstates
-given_name: John A.
+given_name: John
 family_name: Kissel

--- a/data/ct/people/John-E-Piscopo-e7f7ad52-69a8-4306-8dfe-02368f74d75b.yml
+++ b/data/ct/people/John-E-Piscopo-e7f7ad52-69a8-4306-8dfe-02368f74d75b.yml
@@ -8,17 +8,17 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4086;Hartford, CT 06106
+  email: John.Piscopo@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: John.Piscopo@housegop.ct.gov
 - address: 50 Judson Street;Thomaston, CT 06787
   note: District Office
 links:
-- url: http://www.cthousegop.com/Piscopo/main/
+- url: http://www.cthousegop.com/Piscopo/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000112
   scheme: legacy_openstates
-given_name: John E.
+given_name: John
 family_name: Piscopo

--- a/data/ct/people/John-Fusco-0185c242-1a49-4731-841f-9df14573fa7f.yml
+++ b/data/ct/people/John-Fusco-0185c242-1a49-4731-841f-9df14573fa7f.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4046;Hartford, CT 06106
+  email: John.Fusco@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: John.Fusco@housegop.ct.gov
 - address: 178 West Center Street;Southington, CT 06489
   note: District Office
 links:
-- url: http://www.cthousegop.com/Fusco/main/
+- url: http://www.cthousegop.com/Fusco/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/John-H-Frey-a69bbf37-13c0-4cb7-a536-3eabe26a79b1.yml
+++ b/data/ct/people/John-H-Frey-a69bbf37-13c0-4cb7-a536-3eabe26a79b1.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4080;Hartford, CT 06106
+  email: John.Frey@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: John.Frey@housegop.ct.gov
 - address: 193 Wilton Road West;Ridgefield, CT 06877
   note: District Office
   voice: 203-431-6799
 links:
-- url: http://www.cthousegop.com/Frey/main/
+- url: http://www.cthousegop.com/Frey/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000147
   scheme: legacy_openstates
-given_name: John H.
+given_name: John
 family_name: Frey

--- a/data/ct/people/John-Jack-F-Hennessy-3d61a53f-2d06-4910-b6ae-943cc8741d9b.yml
+++ b/data/ct/people/John-Jack-F-Hennessy-3d61a53f-2d06-4910-b6ae-943cc8741d9b.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 5002;Hartford, CT 06106
+  email: Jack.Hennessy@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Jack.Hennessy@cga.ct.gov
 - address: 556 Savoy Street;Bridgeport, CT 06606
   note: District Office
 links:

--- a/data/ct/people/John-K-Hampton-f9ecbfe5-3d3b-4c2a-b58d-71083baf8c9d.yml
+++ b/data/ct/people/John-K-Hampton-f9ecbfe5-3d3b-4c2a-b58d-71083baf8c9d.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 5007;Hartford, CT 06106
+- address: Legislative Office Building;Room 4017;Hartford, CT 06106
+  email: John.Hampton@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8659
-  email: John.Hampton@cga.ct.gov
 - address: 9 Knoll Lane;Weatogue, CT 06089
   note: District Office
   voice: 860-803-4072
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000197
   scheme: legacy_openstates
-given_name: John K.
+given_name: John
 family_name: Hampton

--- a/data/ct/people/John-W-Fonfara-749be8b3-0b40-41ec-8670-7dfbfbc90b6e.yml
+++ b/data/ct/people/John-W-Fonfara-749be8b3-0b40-41ec-8670-7dfbfbc90b6e.yml
@@ -19,5 +19,5 @@ sources:
 other_identifiers:
 - identifier: CTL000001
   scheme: legacy_openstates
-given_name: John W.
+given_name: John
 family_name: Fonfara

--- a/data/ct/people/Jonathan-Steinberg-22b7b95d-3488-4c14-8365-c5157b3cb099.yml
+++ b/data/ct/people/Jonathan-Steinberg-22b7b95d-3488-4c14-8365-c5157b3cb099.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3004;Hartford, CT 06106
+  email: Jonathan.Steinberg@cga.ct.gov
   note: Capitol Office
   voice: 860-240-0562
-  email: Jonathan.Steinberg@cga.ct.gov
 - address: 1 Bushy Ridge Road;Westport, CT 06880
   note: District Office
   voice: 203-226-6749

--- a/data/ct/people/Joseph-C-Serra-04d33c13-4172-42f1-bbb7-af57db9546a6.yml
+++ b/data/ct/people/Joseph-C-Serra-04d33c13-4172-42f1-bbb7-af57db9546a6.yml
@@ -8,12 +8,11 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4021;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Joseph.Serra@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8420
 - address: P.O. Box 233;Middletown, CT 06457
   note: District Office
-  voice: 860-347-0119
 links:
 - url: http://www.housedems.ct.gov/Serra
 sources:
@@ -21,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000069
   scheme: legacy_openstates
-given_name: Joseph C.
+given_name: Joseph
 family_name: Serra

--- a/data/ct/people/Joseph-H-Zullo-391a83ee-0e23-4669-b3ae-b29bd9c77294.yml
+++ b/data/ct/people/Joseph-H-Zullo-391a83ee-0e23-4669-b3ae-b29bd9c77294.yml
@@ -1,0 +1,23 @@
+id: ocd-person/391a83ee-0e23-4669-b3ae-b29bd9c77294
+name: Joseph H. Zullo
+party:
+- name: Republican
+roles:
+- district: '99'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2019-03-01
+contact_details:
+- address: Legislative Office Building;Room;Hartford, CT 06106
+  email: joe.zullo@housegop.ct.gov
+  note: Capitol Office
+  voice: 860-240-8700
+- address: 2 Lisa Lane;East Haven, CT 06512
+  note: District Office
+  voice: 203-927-0871
+links:
+- url: http://www.cthousegop.com/zullo/
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Joseph
+family_name: Zullo

--- a/data/ct/people/Joseph-P-Gresko-06bb6ad8-3238-4ba7-8f83-47507541a300.yml
+++ b/data/ct/people/Joseph-P-Gresko-06bb6ad8-3238-4ba7-8f83-47507541a300.yml
@@ -8,12 +8,11 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4006;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Joseph.Gresko@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8582
 - address: 284 Mary Avenue;Stratford, CT 06614
   note: District Office
-  voice: 860-240-8582
 links:
 - url: http://www.housedems.ct.gov/Gresko
 sources:

--- a/data/ct/people/Josh-Elliott-57461c01-e706-4ce5-9dfd-8982e1f29021.yml
+++ b/data/ct/people/Josh-Elliott-57461c01-e706-4ce5-9dfd-8982e1f29021.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Josh.Elliott@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Josh.Elliott@cga.ct.gov
 - address: 59 McArthur Drive;Hamden, CT 06518
   note: District Office
 links:

--- a/data/ct/people/Joshua-M-Hall-acb9a83b-c921-4631-826e-ffd02e2203b9.yml
+++ b/data/ct/people/Joshua-M-Hall-acb9a83b-c921-4631-826e-ffd02e2203b9.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 5007;Hartford, CT 06106
+  email: Joshua.Hall@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Joshua.Hall@cga.ct.gov
 - address: 28 Canterbury Street;Hartford, CT 06112
   note: District Office
   voice: 860-810-0471
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000362
   scheme: legacy_openstates
-given_name: Joshua M.
+given_name: Joshua
 family_name: Hall

--- a/data/ct/people/Juan-R-Candelaria-6af561a7-e6d7-4a29-8f65-9a22a5734639.yml
+++ b/data/ct/people/Juan-R-Candelaria-6af561a7-e6d7-4a29-8f65-9a22a5734639.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4013;Hartford, CT 06106
+- address: Legislative Office Building;Room 4040;Hartford, CT 06106
+  email: Juan.Candelaria@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Juan.Candelaria@cga.ct.gov
 - address: 34 Sixth Street;New Haven, CT 06519
   note: District Office
   voice: 203-645-7905
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000131
   scheme: legacy_openstates
-given_name: Juan R.
+given_name: Juan
 family_name: Candelaria

--- a/data/ct/people/Julie-Kushner-34ca88f1-c2bc-430e-9f7c-93e8f3563e33.yml
+++ b/data/ct/people/Julie-Kushner-34ca88f1-c2bc-430e-9f7c-93e8f3563e33.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: Legislative Office Building;Room 3300;Hartford, CT 06106
+- address: Legislative Office Building;Room 3800;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
+  voice: 860-240-0509
 - address: 75 Old Ridgebury Road;Danbury, CT 06810
   note: District Office
   voice: 203-470-7957
@@ -17,3 +17,5 @@ links:
 - url: http://www.senatedems.ct.gov/kushner
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Julie
+family_name: Kushner

--- a/data/ct/people/Julio-A-Concepcion-d44bd84a-b02c-4c1b-94ee-05c8b1008e57.yml
+++ b/data/ct/people/Julio-A-Concepcion-d44bd84a-b02c-4c1b-94ee-05c8b1008e57.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2303;Hartford, CT 06106
+  email: julio.concepcion@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: julio.concepcion@cga.ct.gov
 - address: 3 Linden Place;Hartford, CT 06106
   note: District Office
   voice: 860-922-0768
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000366
   scheme: legacy_openstates
-given_name: Julio A.
+given_name: Julio
 family_name: Concepcion

--- a/data/ct/people/Kara-Rochelle-3969673d-4a3e-487e-a572-42ce9f79e6dd.yml
+++ b/data/ct/people/Kara-Rochelle-3969673d-4a3e-487e-a572-42ce9f79e6dd.yml
@@ -8,10 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-4100
   email: Kara.Rochelle@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/rochelle
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Kara
+family_name: Rochelle

--- a/data/ct/people/Kate-Rotella-652e43d4-1325-4a4a-9161-f2970b7f2ecd.yml
+++ b/data/ct/people/Kate-Rotella-652e43d4-1325-4a4a-9161-f2970b7f2ecd.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Kate.Rotella@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8543
 - address: 170 Long Wharf Drive;Mystic, CT 06355
   note: District Office
   voice: 860-885-6225
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/rotella
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Kate
+family_name: Rotella

--- a/data/ct/people/Kathleen-M-McCarty-f04c3831-624c-49a1-a7c2-3185a43de06f.yml
+++ b/data/ct/people/Kathleen-M-McCarty-f04c3831-624c-49a1-a7c2-3185a43de06f.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4046;Hartford, CT 06106
+  email: Kathleen.McCarty@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Kathleen.McCarty@housegop.ct.gov
 - address: 226 Great Neck Road;Waterford, CT 06385
   note: District Office
   voice: 860-442-2903
 links:
-- url: http://www.cthousegop.com/McCarty/main/
+- url: http://www.cthousegop.com/McCarty/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000277
   scheme: legacy_openstates
-given_name: Kathleen M.
+given_name: Kathleen
 family_name: McCarty

--- a/data/ct/people/Kathy-Kennedy-f0517411-fc60-49ad-86e6-1f025ab4579b.yml
+++ b/data/ct/people/Kathy-Kennedy-f0517411-fc60-49ad-86e6-1f025ab4579b.yml
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Kathy.Kennedy@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Kathy.Kennedy@housegop.ct.gov
 - address: 265 New Haven Ave.;Milford, CT 06460
   note: District Office
   voice: 203-530-3322
 links:
-- url: http://www.repkennedy.com
+- url: http://www.cthousegop.com/kennedy/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Kathy
+family_name: Kennedy

--- a/data/ct/people/Kenneth-M-Gucker-1d3bcf34-6da4-4392-aead-077d833fa7fb.yml
+++ b/data/ct/people/Kenneth-M-Gucker-1d3bcf34-6da4-4392-aead-077d833fa7fb.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Kenneth.Gucker@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 89 Padanaram Road;Danbury, CT 06811
   note: District Office
   voice: 203-733-4400
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/gucker
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Kenneth
+family_name: Gucker

--- a/data/ct/people/Kerry-S-Wood-d71060b1-2bb9-4239-ab9b-fad7d1a4d903.yml
+++ b/data/ct/people/Kerry-S-Wood-d71060b1-2bb9-4239-ab9b-fad7d1a4d903.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Kerry.Wood@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 260 France Street;Rocky Hill, CT 06067
   note: District Office
   voice: 860-531-8322
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/wood
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Kerry
+family_name: Wood

--- a/data/ct/people/Kevin-C-Kelly-5acf728f-8ec5-4db5-b7eb-8dec668d0626.yml
+++ b/data/ct/people/Kevin-C-Kelly-5acf728f-8ec5-4db5-b7eb-8dec668d0626.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 2803;Hartford, CT 06106
+  email: Kevin.Kelly@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Kevin.Kelly@cga.ct.gov
 - address: 240 York Street;Stratford, CT 06615
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000021
   scheme: legacy_openstates
-given_name: Kevin C.
+given_name: Kevin
 family_name: Kelly

--- a/data/ct/people/Kevin-D-Witkos-77479a85-ce39-422f-9094-bbdbce7d5276.yml
+++ b/data/ct/people/Kevin-D-Witkos-77479a85-ce39-422f-9094-bbdbce7d5276.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: Kevin.Witkos@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Kevin.Witkos@cga.ct.gov
 - address: 15 High Ledge Road;Canton, CT 06019
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000008
   scheme: legacy_openstates
-given_name: Kevin D.
+given_name: Kevin
 family_name: Witkos

--- a/data/ct/people/Kevin-Ryan-2d99a0ff-740d-4c97-8d0c-524842f99f73.yml
+++ b/data/ct/people/Kevin-Ryan-2d99a0ff-740d-4c97-8d0c-524842f99f73.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4108;Hartford, CT 06106
+  email: Kevin.Ryan@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8504
-  email: Kevin.Ryan@cga.ct.gov
 - address: 21 Terrace Drive;Oakdale, CT 06370
   note: District Office
   voice: 860-848-0790

--- a/data/ct/people/Kim-Rose-dd3c678c-7361-4e83-8123-0a1140da1823.yml
+++ b/data/ct/people/Kim-Rose-dd3c678c-7361-4e83-8123-0a1140da1823.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4002;Hartford, CT 06106
+  email: Kim.Rose@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Kim.Rose@cga.ct.gov
 - address: 292 Naugatuck Avenue;Milford, CT 06460
   note: District Office
   voice: 203-701-6098

--- a/data/ct/people/Kurt-Vail-ffa361d0-7471-450e-aee8-cb0c32ee2742.yml
+++ b/data/ct/people/Kurt-Vail-ffa361d0-7471-450e-aee8-cb0c32ee2742.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3802;Hartford, CT 06106
+  email: Kurt.Vail@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Kurt.Vail@housegop.ct.gov
 - address: 90 Main Street;Stafford Springs, CT 06076
   note: District Office
 links:
-- url: http://www.cthousegop.com/Vail/main/
+- url: http://www.cthousegop.com/Vail/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Larry-B-Butler-47282285-14de-4306-b33f-a82754702ec5.yml
+++ b/data/ct/people/Larry-B-Butler-47282285-14de-4306-b33f-a82754702ec5.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 5001;Hartford, CT 06106
+  email: Larry.Butler@cga.ct.gov
   note: Capitol Office
   voice: 800-842-8876
-  email: Larry.Butler@cga.ct.gov
 - address: 70 Blackman Road;Waterbury, CT 06704
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000108
   scheme: legacy_openstates
-given_name: Larry B.
+given_name: Larry
 family_name: Butler

--- a/data/ct/people/Laura-M-Devlin-c1eb186b-4a6d-4a5f-9afe-a52005a4bc62.yml
+++ b/data/ct/people/Laura-M-Devlin-c1eb186b-4a6d-4a5f-9afe-a52005a4bc62.yml
@@ -7,14 +7,14 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4061;Hartford, CT 06106
+- address: Legislative Office Building;Room 2304;Hartford, CT 06106
+  email: Laura.Devlin@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Laura.Devlin@housegop.ct.gov
 - address: 85 Brett Lane;Fairfield, CT 06824
   note: District Office
 links:
-- url: http://www.cthousegop.com/Devlin/main/
+- url: http://www.cthousegop.com/Devlin/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
@@ -22,5 +22,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000360
   scheme: legacy_openstates
-given_name: Laura M.
+given_name: Laura
 family_name: Devlin

--- a/data/ct/people/Leonard-A-Fasano-8dc933e2-8f6e-4a85-b32a-725d9b5a6e2a.yml
+++ b/data/ct/people/Leonard-A-Fasano-8dc933e2-8f6e-4a85-b32a-725d9b5a6e2a.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3402;Hartford, CT 06106
+  email: Len.Fasano@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Len.Fasano@cga.ct.gov
 - address: 7 Sycamore Lane;North Haven, CT 06473
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000034
   scheme: legacy_openstates
-given_name: Leonard A.
+given_name: Leonard
 family_name: Fasano

--- a/data/ct/people/Leslee-Hill-442151b9-e2d2-4e09-8090-14e37ccbdb72.yml
+++ b/data/ct/people/Leslee-Hill-442151b9-e2d2-4e09-8090-14e37ccbdb72.yml
@@ -1,5 +1,5 @@
 id: ocd-person/442151b9-e2d2-4e09-8090-14e37ccbdb72
-name: Leslee Hill
+name: Leslee B. Hill
 party:
 - name: Republican
 roles:
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Leslee.Hill@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Leslee.Hill@housegop.ct.gov
 - address: 91 Andrew Drive;Canton, CT 06019
   note: District Office
   voice: 860-989-8151
 links:
-- url: http://www.replesleehill.com
+- url: http://www.cthousegop.com/hill/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Leslee
+family_name: Hill

--- a/data/ct/people/Lezlye-Zupkus-cddc0b8f-51e5-4ed1-af05-41de718801f3.yml
+++ b/data/ct/people/Lezlye-Zupkus-cddc0b8f-51e5-4ed1-af05-41de718801f3.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4083;Hartford, CT 06106
+  email: Lezlye.Zupkus@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Lezlye.Zupkus@housegop.ct.gov
 - address: 38 Colonial Drive;Prospect, CT 06712
   note: District Office
   voice: 203-758-0029
 links:
-- url: http://www.cthousegop.com/Zupkus/main/
+- url: http://www.cthousegop.com/Zupkus/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Livvy-R-Floren-366f34da-e089-474b-9615-a8d5ea18bb2e.yml
+++ b/data/ct/people/Livvy-R-Floren-366f34da-e089-474b-9615-a8d5ea18bb2e.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4071;Hartford, CT 06106
+  email: Livvy.Floren@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Livvy.Floren@housegop.ct.gov
 - address: 210 Round Hill Road;Greenwich, CT 06831
   note: District Office
   voice: 203-661-5758
 links:
-- url: http://www.cthousegop.com/Floren/main/
+- url: http://www.cthousegop.com/Floren/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000185
   scheme: legacy_openstates
-given_name: Livvy R.
+given_name: Livvy
 family_name: Floren

--- a/data/ct/people/Liz-Linehan-96e6350e-71c4-4031-8af8-a989d0ec3a01.yml
+++ b/data/ct/people/Liz-Linehan-96e6350e-71c4-4031-8af8-a989d0ec3a01.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: Liz.Linehan@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Liz.Linehan@cga.ct.gov
 links:
 - url: http://www.housedems.ct.gov/Linehan
 sources:

--- a/data/ct/people/Lucy-Dathan-2ed1f7b0-a1e3-4754-93a5-46b5a3fb9836.yml
+++ b/data/ct/people/Lucy-Dathan-2ed1f7b0-a1e3-4754-93a5-46b5a3fb9836.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 5005;Hartford, CT 06106
   email: Lucy.Dathan@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8376
 - address: 950 Silvermine Road;New Canaan, CT 06840
   note: District Office
   voice: 650-223-4045
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/dathan
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Lucy
+family_name: Dathan

--- a/data/ct/people/Mae-Flexer-77713b68-e8ef-455e-80a6-1614488fb71a.yml
+++ b/data/ct/people/Mae-Flexer-77713b68-e8ef-455e-80a6-1614488fb71a.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: Legislative Office Building;Room 1805;Hartford, CT 06106
   note: Capitol Office
   voice: 860-240-8634
-- address: 452 Main Street;Danielson, CT 06239
+- address: 300 Capitol Avenue, Legislative Office Bldg;Hartford, CT 06106
   note: District Office
   voice: 860-208-0429
 links:

--- a/data/ct/people/Maria-P-Horn-283ad876-68be-4235-a108-e0aedbadde40.yml
+++ b/data/ct/people/Maria-P-Horn-283ad876-68be-4235-a108-e0aedbadde40.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
+  email: Maria.Horn@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Maria.Horn@cga.ct.gov
 - address: 137 Salmon Kill Road;Salisbury, CT 06068
   note: District Office
   voice: 860-671-1026
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/horn
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Maria
+family_name: Horn

--- a/data/ct/people/Marilyn-V-Moore-41d83b98-d5ab-48db-b847-3a3e08194b4c.yml
+++ b/data/ct/people/Marilyn-V-Moore-41d83b98-d5ab-48db-b847-3a3e08194b4c.yml
@@ -19,5 +19,5 @@ sources:
 other_identifiers:
 - identifier: CTL000329
   scheme: legacy_openstates
-given_name: Marilyn V.
+given_name: Marilyn
 family_name: Moore

--- a/data/ct/people/Martin-M-Looney-2d21e401-cb76-4001-b836-e57f667f550f.yml
+++ b/data/ct/people/Martin-M-Looney-2d21e401-cb76-4001-b836-e57f667f550f.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
+  email: Looney@senatedems.ct.gov
   note: Capitol Office
   voice: 860-240-8614
-  email: Looney@senatedems.ct.gov
 - address: 132 Fort Hale Road;New Haven, CT 06512
   note: District Office
   voice: 203-468-8829
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000011
   scheme: legacy_openstates
-given_name: Martin M.
+given_name: Martin
 family_name: Looney

--- a/data/ct/people/Mary-D-Abrams-9b559d02-1ab6-4a26-ba08-5445cb703037.yml
+++ b/data/ct/people/Mary-D-Abrams-9b559d02-1ab6-4a26-ba08-5445cb703037.yml
@@ -1,5 +1,5 @@
 id: ocd-person/9b559d02-1ab6-4a26-ba08-5445cb703037
-name: Mary D. Abrams
+name: Mary Daugherty Abrams
 party:
 - name: Democratic
 roles:
@@ -7,12 +7,14 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: upper
 contact_details:
-- address: State Capitol;Room 3300;Hartford, CT 06106
+- address: State Capitol;Room 3000;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
-- address: 158 Hillcrest Terrace;Meriden, CT 06450
+  voice: 860-240-0584
+- address: 300 Capitol Avenue;Hartford, CT 06106
   note: District Office
 links:
 - url: http://www.senatedems.ct.gov/abrams
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Mary
+family_name: Abrams

--- a/data/ct/people/Mary-M-Mushinsky-817e17bf-a01c-4bf1-b70f-3e16aeef088e.yml
+++ b/data/ct/people/Mary-M-Mushinsky-817e17bf-a01c-4bf1-b70f-3e16aeef088e.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4038;Hartford, CT 06106
+  email: Mary.Mushinsky@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Mary.Mushinsky@cga.ct.gov
 - address: 188 South Cherry Street;Wallingford, CT 06492
   note: District Office
   voice: 203-269-8378
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000121
   scheme: legacy_openstates
-given_name: Mary M.
+given_name: Mary
 family_name: Mushinsky

--- a/data/ct/people/Matt-Blumenthal-9c5e5d75-a622-41d2-b607-2adbc12ee11f.yml
+++ b/data/ct/people/Matt-Blumenthal-9c5e5d75-a622-41d2-b607-2adbc12ee11f.yml
@@ -7,13 +7,13 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 2504;Hartford, CT 06106
   email: Matt.Blumenthal@cga.ct.gov
-- address: ';, CT '
-  note: District Office
+  note: Capitol Office
+  voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/blumenthal
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Matt
+family_name: Blumenthal

--- a/data/ct/people/Matt-Lesser-f55ef0f9-f0ed-48ba-80b9-23ac643626cc.yml
+++ b/data/ct/people/Matt-Lesser-f55ef0f9-f0ed-48ba-80b9-23ac643626cc.yml
@@ -1,5 +1,5 @@
 id: ocd-person/f55ef0f9-f0ed-48ba-80b9-23ac643626cc
-name: Matt Lesser
+name: Matthew L. Lesser
 party:
 - name: Democratic
 roles:
@@ -9,11 +9,10 @@ roles:
 contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
-  email: Matthew.Lesser@cga.ct.gov
-- address: ';, CT '
-  note: District Office
+  voice: 860-240-0511
 links:
 - url: http://www.senatedems.ct.gov/lesser
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Matthew
+family_name: Lesser

--- a/data/ct/people/Matthew-Ritter-2a91c3d6-433a-4e8f-b5a5-38fc80b8ea57.yml
+++ b/data/ct/people/Matthew-Ritter-2a91c3d6-433a-4e8f-b5a5-38fc80b8ea57.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4106;Hartford, CT 06106
+  email: Matthew.Ritter@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Matthew.Ritter@cga.ct.gov
 - address: 169 N. Beacon Street;Hartford, CT 06105
   note: District Office
   voice: 860-519-5685

--- a/data/ct/people/Michael-A-DiMassa-ad0dd078-9756-4d8a-ba91-dcdf9dbd007b.yml
+++ b/data/ct/people/Michael-A-DiMassa-ad0dd078-9756-4d8a-ba91-dcdf9dbd007b.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 5006;Hartford, CT 06106
+- address: Legislative Office Building;Room 2704;Hartford, CT 06106
+  email: Michael.DiMassa@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Michael.DiMassa@cga.ct.gov
 - address: 136 Putney Drive;West Haven, CT 06516
   note: District Office
   voice: 203-710-8915
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000332
   scheme: legacy_openstates
-given_name: Michael A.
+given_name: Michael
 family_name: DiMassa

--- a/data/ct/people/Michael-DAgostino-62869ad5-5744-4a50-95f5-56ecf5549e31.yml
+++ b/data/ct/people/Michael-DAgostino-62869ad5-5744-4a50-95f5-56ecf5549e31.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4022;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-2731
+- address: Legislative Office Building;Room 3504;Hartford, CT 06106
   email: Michael.DAgostino@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 575 Ridge Road;Hamden, CT 06517
   note: District Office
 links:

--- a/data/ct/people/Michael-Winkler-ee35378a-f19c-4edf-a6ed-826d62adcced.yml
+++ b/data/ct/people/Michael-Winkler-ee35378a-f19c-4edf-a6ed-826d62adcced.yml
@@ -1,5 +1,5 @@
 id: ocd-person/ee35378a-f19c-4edf-a6ed-826d62adcced
-name: Michael Winkler
+name: Michael A. Winkler
 party:
 - name: Democratic
 roles:
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4026;Hartford, CT 06106
+  email: Michael.Winkler@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8771
-  email: Michael.Winkler@cga.ct.gov
 - address: 20 Gottier Drive;Vernon, CT 06066
   note: District Office
   voice: 860-875-3149

--- a/data/ct/people/Michelle-L-Cook-daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6.yml
+++ b/data/ct/people/Michelle-L-Cook-daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4035;Hartford, CT 06106
+  email: Michelle.Cook@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8547
-  email: Michelle.Cook@cga.ct.gov
 - address: 499 Charles Street;Torrington, CT 06790
   note: District Office
   voice: 860-489-8038
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000101
   scheme: legacy_openstates
-given_name: Michelle L.
+given_name: Michelle
 family_name: Cook

--- a/data/ct/people/Mike-Demicco-ca9357d4-dffa-456a-a715-d4a7671c1f84.yml
+++ b/data/ct/people/Mike-Demicco-ca9357d4-dffa-456a-a715-d4a7671c1f84.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 3201;Hartford, CT 06106
+  email: Mike.Demicco@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Mike.Demicco@cga.ct.gov
 - address: 6 Deborah Lane;Farmington, CT 06032
   note: District Office
 links:

--- a/data/ct/people/Mike-France-f9285869-efa5-474f-86b4-9cd79867ed7f.yml
+++ b/data/ct/people/Mike-France-f9285869-efa5-474f-86b4-9cd79867ed7f.yml
@@ -7,15 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4049;Hartford, CT 06106
+- address: Legislative Office Building;Room 2205;Hartford, CT 06106
+  email: Mike.France@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Mike.France@housegop.ct.gov
 - address: 17 Garden Drive;Gales Ferry, CT 06335
   note: District Office
   voice: 860-464-9229
 links:
-- url: http://www.cthousegop.com/France/main/
+- url: http://www.cthousegop.com/France/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Minnie-Gonzalez-57900db1-ade5-4107-8025-a0c664f41a32.yml
+++ b/data/ct/people/Minnie-Gonzalez-57900db1-ade5-4107-8025-a0c664f41a32.yml
@@ -8,12 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4031;Hartford, CT 06106
+  email: Minnie.Gonzalez@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Minnie.Gonzalez@cga.ct.gov
 - address: 97 Amity Street;Hartford, CT 06106
   note: District Office
-  voice: 860-236-9654
+  voice: 860-655-5907
 links:
 - url: http://www.housedems.ct.gov/Gonzalez
 sources:

--- a/data/ct/people/Mitch-Bolinsky-5af50689-4e90-49b1-8544-7a00048dad99.yml
+++ b/data/ct/people/Mitch-Bolinsky-5af50689-4e90-49b1-8544-7a00048dad99.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4053;Hartford, CT 06106
+  email: Mitch.Bolinsky@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Mitch.Bolinsky@housegop.ct.gov
 - address: 3 Wiley Lane;Newtown, CT 06470
   note: District Office
 links:
-- url: http://www.cthousegop.com/Bolinsky/main/
+- url: http://www.cthousegop.com/Bolinsky/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Nicole-Klarides-Ditria-71c15656-a6f4-4b95-9537-69a82b2cb54c.yml
+++ b/data/ct/people/Nicole-Klarides-Ditria-71c15656-a6f4-4b95-9537-69a82b2cb54c.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Nicole.Klarides-Ditria@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Nicole.Klarides-Ditria@housegop.ct.gov
 - address: 23 Osprey Drive;Seymour, CT 06483
   note: District Office
 links:
-- url: http://www.cthousegop.com/Klarides-Ditria/main/
+- url: http://www.cthousegop.com/Klarides-Ditria/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Noreen-S-Kokoruda-0e82440f-868b-4955-9494-3f78a7661e9b.yml
+++ b/data/ct/people/Noreen-S-Kokoruda-0e82440f-868b-4955-9494-3f78a7661e9b.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4067;Hartford, CT 06106
+  email: Noreen.Kokoruda@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Noreen.Kokoruda@housegop.ct.gov
 - address: 85 Liberty Street;Madison, CT 06443
   note: District Office
   voice: 203-245-9054
 links:
-- url: http://www.cthousegop.com/Kokoruda/main/
+- url: http://www.cthousegop.com/Kokoruda/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000137
   scheme: legacy_openstates
-given_name: Noreen S.
+given_name: Noreen
 family_name: Kokoruda

--- a/data/ct/people/Norman-Needleman-109295ad-521f-463a-b0af-66c9f0598a97.yml
+++ b/data/ct/people/Norman-Needleman-109295ad-521f-463a-b0af-66c9f0598a97.yml
@@ -9,10 +9,10 @@ roles:
 contact_details:
 - address: Legislative Office Building;Room 3300;Hartford, CT 06106
   note: Capitol Office
-  voice: 860-240-8600
-- address: ';, CT '
-  note: District Office
+  voice: 860-240-0428
 links:
 - url: http://www.senatedems.ct.gov/needleman
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Norman
+family_name: Needleman

--- a/data/ct/people/Pat-Wilson-Pheanious-7bda6ebb-86fc-4bb7-87c6-23958f372c40.yml
+++ b/data/ct/people/Pat-Wilson-Pheanious-7bda6ebb-86fc-4bb7-87c6-23958f372c40.yml
@@ -7,11 +7,13 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
+- address: Legislative Office Building;Room 4044;Hartford, CT 06106
   email: Pat.WilsonPheanious@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/wilsonpheanious
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Pat
+family_name: Wilson Pheanious

--- a/data/ct/people/Patricia-A-Dillon-23d08488-597c-4c35-b41a-f8aef1c264c4.yml
+++ b/data/ct/people/Patricia-A-Dillon-23d08488-597c-4c35-b41a-f8aef1c264c4.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4019;Hartford, CT 06106
+  email: Patricia.Dillon@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Patricia.Dillon@cga.ct.gov
 - address: 68 West Rock Avenue;New Haven, CT 06515
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000128
   scheme: legacy_openstates
-given_name: Patricia A.
+given_name: Patricia
 family_name: Dillon

--- a/data/ct/people/Patricia-Billie-Miller-fcf63a22-3979-4cbf-a719-0d414d13e1ac.yml
+++ b/data/ct/people/Patricia-Billie-Miller-fcf63a22-3979-4cbf-a719-0d414d13e1ac.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4033;Hartford, CT 06106
+  email: Patricia.Miller@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8591
-  email: Patricia.Miller@cga.ct.gov
 - address: 95 Liberty Street;Stamford, CT 06902
   note: District Office
   voice: 203-325-3315
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000181
   scheme: legacy_openstates
-given_name: Patricia Billie
+given_name: Patricia
 family_name: Miller

--- a/data/ct/people/Patrick-S-Boyd-50e78f89-a9e7-43f5-9566-a9f2cb23a5c9.yml
+++ b/data/ct/people/Patrick-S-Boyd-50e78f89-a9e7-43f5-9566-a9f2cb23a5c9.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4005;Hartford, CT 06106
+  email: Pat.Boyd@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Pat.Boyd@cga.ct.gov
 - address: PO Box 153;Pomfret, CT 06258
   note: District Office
   voice: 860-963-5202
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000350
   scheme: legacy_openstates
-given_name: Patrick S.
+given_name: Patrick
 family_name: Boyd

--- a/data/ct/people/Paul-M-Formica-bdea553b-35fa-4076-88e8-fd995d2d7631.yml
+++ b/data/ct/people/Paul-M-Formica-bdea553b-35fa-4076-88e8-fd995d2d7631.yml
@@ -8,10 +8,10 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 2705;Hartford, CT 06106
+  email: Paul.Formica@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: Paul.Formica@cga.ct.gov
-- address: 20-A Bush Hill Road;Niantic, CT 06357
+- address: 20-A Bush Hill Drive;Niantic, CT 06357
   note: District Office
 links:
 - url: http://www.ctsenaterepublicans.com/home-Formica
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000298
   scheme: legacy_openstates
-given_name: Paul M.
+given_name: Paul
 family_name: Formica

--- a/data/ct/people/Peter-A-Tercyak-0a4ae3cc-c2dc-4ef4-8ba8-95be03126a02.yml
+++ b/data/ct/people/Peter-A-Tercyak-0a4ae3cc-c2dc-4ef4-8ba8-95be03126a02.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4017;Hartford, CT 06106
+- address: Legislative Office Building;Room 4025;Hartford, CT 06106
+  email: Peter.Tercyak@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Peter.Tercyak@cga.ct.gov
 - address: 150 Belridge Road;New Britain, CT 06053
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000062
   scheme: legacy_openstates
-given_name: Peter A.
+given_name: Peter
 family_name: Tercyak

--- a/data/ct/people/Philip-L-Young-III-d2a3535f-bdff-414c-8aaa-c3f3f203bc14.yml
+++ b/data/ct/people/Philip-L-Young-III-d2a3535f-bdff-414c-8aaa-c3f3f203bc14.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4100;Hartford, CT 06106
+  email: phil.young@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: phil.young@cga.ct.gov
 - address: 88 Wood Avenue;Stratford, CT 06614
   note: District Office
   voice: 203-502-1458
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000365
   scheme: legacy_openstates
-given_name: Philip L.
+given_name: Philip
 family_name: Young

--- a/data/ct/people/Quentin-W-Phipps-46678375-9195-4d3a-8aef-6476397f1491.yml
+++ b/data/ct/people/Quentin-W-Phipps-46678375-9195-4d3a-8aef-6476397f1491.yml
@@ -8,10 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Quentin.Phipps@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 89 Bretton Road;Middletown, CT 06457
+  note: District Office
+  voice: 860-830-5407
 links:
 - url: http://www.housedems.ct.gov/phipps
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Quentin
+family_name: Phipps

--- a/data/ct/people/Raghib-Allie-Brennan-1a01451b-8c85-4bde-9cef-ab083d99ae84.yml
+++ b/data/ct/people/Raghib-Allie-Brennan-1a01451b-8c85-4bde-9cef-ab083d99ae84.yml
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Raghib.Allie-Brennan@cga.ct.gov
-- address: 26 Grassy Plain Street;Bethel, CT 06801
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 26 Grassy Plain Street, Unit 106;Bethel, CT 06801
   note: District Office
   voice: 203-241-6034
 links:
 - url: http://www.housedems.ct.gov/allie-brennan
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Raghib
+family_name: Allie-Brennan

--- a/data/ct/people/Richard-A-Smith-ddd31749-fc54-4b8f-9a93-6f08edd9d87f.yml
+++ b/data/ct/people/Richard-A-Smith-ddd31749-fc54-4b8f-9a93-6f08edd9d87f.yml
@@ -7,18 +7,18 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 3502;Hartford, CT 06106
+- address: Legislative Office Building;Room 4073;Hartford, CT 06106
+  email: richard.smith@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: richard.smith@housegop.ct.gov
 - address: 25 Jeremy Drive;New Fairfield, CT 06812
   note: District Office
 links:
-- url: http://www.cthousegop.com/Smith/main/
+- url: http://www.cthousegop.com/Smith/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000144
   scheme: legacy_openstates
-given_name: Richard A.
+given_name: Richard
 family_name: Smith

--- a/data/ct/people/Rick-L-Hayes-c30bb3b3-de40-4c0a-89a5-da36532694c9.yml
+++ b/data/ct/people/Rick-L-Hayes-c30bb3b3-de40-4c0a-89a5-da36532694c9.yml
@@ -8,13 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: rick.hayes@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: rick.hayes@housegop.ct.gov
 - address: 78 S. Prospect Street;Putnam, CT 06260
   note: District Office
   voice: 860-933-3022
 links:
-- url: http://www.rephayes.com
+- url: http://www.cthousegop.com/hayes/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Rick
+family_name: Hayes

--- a/data/ct/people/Rick-Lopes-bdc5f5a0-0285-45d2-a6fd-d29d8b31cd43.yml
+++ b/data/ct/people/Rick-Lopes-bdc5f5a0-0285-45d2-a6fd-d29d8b31cd43.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 1802;Hartford, CT 06106
+  email: Rick.Lopes@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Rick.Lopes@cga.ct.gov
 - address: 208 South Mountain Drive;New Britain, CT 06052
   note: District Office
   voice: 860-229-7721

--- a/data/ct/people/Rob-Sampson-0cdb540d-c360-4981-b7a9-2a67e2f91121.yml
+++ b/data/ct/people/Rob-Sampson-0cdb540d-c360-4981-b7a9-2a67e2f91121.yml
@@ -8,12 +8,12 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3400;Hartford, CT 06106
+  email: rob.sampson@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8800
-  email: rob.sampson@cga.ct.gov
-- address: ';, CT '
-  note: District Office
 links:
 - url: http://www.ctsenaterepublicans.com/home-sampson
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Rob
+family_name: Sampson

--- a/data/ct/people/Robert-Sanchez-8703dbac-ef19-414d-afe4-1081451f124e.yml
+++ b/data/ct/people/Robert-Sanchez-8703dbac-ef19-414d-afe4-1081451f124e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4018;Hartford, CT 06106
+- address: Legislative Office Building;Room 3100;Hartford, CT 06106
+  email: Bobby.Sanchez@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Bobby.Sanchez@cga.ct.gov
 - address: 269 Washington Street;New Britain, CT 06051
   note: District Office
   voice: 860-225-4807

--- a/data/ct/people/Robin-E-Comey-5d963d6d-74c1-4282-9ad4-592c3760bead.yml
+++ b/data/ct/people/Robin-E-Comey-5d963d6d-74c1-4282-9ad4-592c3760bead.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Robin.Comey@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
 - address: 109 Shore Drive;Branford, CT 06405
   note: District Office
   voice: 203-415-5613
@@ -18,3 +18,5 @@ links:
 - url: http://housedems.ct.gov/comey
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Robin
+family_name: Comey

--- a/data/ct/people/Robin-Green-f664d091-23ab-46d0-a019-6009e0480a81.yml
+++ b/data/ct/people/Robin-Green-f664d091-23ab-46d0-a019-6009e0480a81.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Robin.Green@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Robin.Green@housegop.ct.gov
 - address: 63 Highpoint Commons;Marlborough, CT 06447
   note: District Office
 links:
-- url: http://www.cthousegop.com/Green/main/
+- url: http://www.cthousegop.com/Green/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Robyn-A-Porter-c78a6285-02a8-4b73-bac9-9f5807c2aacf.yml
+++ b/data/ct/people/Robyn-A-Porter-c78a6285-02a8-4b73-bac9-9f5807c2aacf.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2704;Hartford, CT 06106
+  email: robyn.porter@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: robyn.porter@cga.ct.gov
 - address: 99 Division Street;New Haven, CT 06511
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000260
   scheme: legacy_openstates
-given_name: Robyn A.
+given_name: Robyn
 family_name: Porter

--- a/data/ct/people/Roland-J-Lemar-273e9a65-2254-43f1-ae88-744e1fa3738a.yml
+++ b/data/ct/people/Roland-J-Lemar-273e9a65-2254-43f1-ae88-744e1fa3738a.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4041;Hartford, CT 06106
+- address: Legislative Office Building;Room 2300;Hartford, CT 06106
+  email: roland.lemar@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: roland.lemar@cga.ct.gov
 - address: 552 Chapel Street;New Haven, CT 06511
   note: District Office
   voice: 203-903-5003
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000132
   scheme: legacy_openstates
-given_name: Roland J.
+given_name: Roland
 family_name: Lemar

--- a/data/ct/people/Ronald-A-Napoli-Jr-71fb3504-679f-419d-86bf-d1ae7d573244.yml
+++ b/data/ct/people/Ronald-A-Napoli-Jr-71fb3504-679f-419d-86bf-d1ae7d573244.yml
@@ -8,12 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Ron.Napoli@cga.ct.gov
-- address: ';, CT '
+  note: Capitol Office
+  voice: 860-240-8585
+- address: 334 Gaylord Drive;Waterbury, CT 06708
   note: District Office
 links:
 - url: http://www.housedems.ct.gov/napoli
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Ronald
+family_name: Napoli

--- a/data/ct/people/Rosa-C-Rebimbas-Esq-0f203a11-5ba7-452a-89b4-720a617973fb.yml
+++ b/data/ct/people/Rosa-C-Rebimbas-Esq-0f203a11-5ba7-452a-89b4-720a617973fb.yml
@@ -1,5 +1,5 @@
 id: ocd-person/0f203a11-5ba7-452a-89b4-720a617973fb
-name: Rosa C. Rebimbas Esq.
+name: Rosa C. Rebimbas
 party:
 - name: Republican
 roles:
@@ -7,18 +7,18 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4064;Hartford, CT 06106
+- address: Legislative Office Building;Room 4067;Hartford, CT 06106
+  email: Rosa.Rebimbas@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Rosa.Rebimbas@housegop.ct.gov
 - address: 54 Woodlawn Avenue;Naugatuck, CT 06770
   note: District Office
 links:
-- url: http://www.cthousegop.com/Rebimbas/main/
+- url: http://www.cthousegop.com/Rebimbas/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000106
   scheme: legacy_openstates
-given_name: Rosa C.
+given_name: Rosa
 family_name: Rebimbas

--- a/data/ct/people/Russell-A-Morin-c4a7704b-a054-4f1c-89c9-1bfc8b4bde1a.yml
+++ b/data/ct/people/Russell-A-Morin-c4a7704b-a054-4f1c-89c9-1bfc8b4bde1a.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4110;Hartford, CT 06106
+  email: Russell.Morin@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Russell.Morin@cga.ct.gov
 - address: 495 Brimfield Road;Wethersfield, CT 06109
   note: District Office
   voice: 860-257-3876
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000064
   scheme: legacy_openstates
-given_name: Russell A.
+given_name: Russell
 family_name: Morin

--- a/data/ct/people/Saud-Anwar-686df3d6-3199-4d48-a27e-7b3e7c65de66.yml
+++ b/data/ct/people/Saud-Anwar-686df3d6-3199-4d48-a27e-7b3e7c65de66.yml
@@ -1,0 +1,21 @@
+id: ocd-person/686df3d6-3199-4d48-a27e-7b3e7c65de66
+name: Saud Anwar
+party:
+- name: Democratic
+roles:
+- district: '3'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: upper
+  start_date: 2019-03-01
+contact_details:
+- address: Legislative Office Building;Room 3300;Hartford, CT 06106
+  note: Capitol Office
+  voice: 860-240-8600
+- address: 93 Rockledge Drive;South Windsor, CT 06074
+  note: District Office
+links:
+- url: http://www.senatedems.ct.gov/anwar
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Saud
+family_name: Anwar

--- a/data/ct/people/Sean-Scanlon-b56af509-8913-42b4-85bc-3df186448b01.yml
+++ b/data/ct/people/Sean-Scanlon-b56af509-8913-42b4-85bc-3df186448b01.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2800;Hartford, CT 06106
+  email: Sean.Scanlon@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Sean.Scanlon@cga.ct.gov
 - address: 405 North River Street;Guilford, CT 06437
   note: District Office
 links:

--- a/data/ct/people/Stephanie-E-Cummings-bfd8433a-289a-4de1-b112-53dce2153fe8.yml
+++ b/data/ct/people/Stephanie-E-Cummings-bfd8433a-289a-4de1-b112-53dce2153fe8.yml
@@ -8,15 +8,15 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Stephanie.Cummings@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Stephanie.Cummings@housegop.ct.gov
 links:
-- url: http://www.cthousegop.com/Cummings/main/
+- url: http://www.cthousegop.com/Cummings/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000333
   scheme: legacy_openstates
-given_name: Stephanie E.
+given_name: Stephanie
 family_name: Cummings

--- a/data/ct/people/Stephen-G-Harding-Jr-f0f89d15-9682-4a2e-8096-57700ac5b8dc.yml
+++ b/data/ct/people/Stephen-G-Harding-Jr-f0f89d15-9682-4a2e-8096-57700ac5b8dc.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4044;Hartford, CT 06106
+  email: Stephen.Harding@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Stephen.Harding@housegop.ct.gov
 - address: 21 Brookfield Meadows;Brookfield, CT 06804
   note: District Office
 links:
-- url: http://www.cthousegop.com/Harding/main/
+- url: http://www.cthousegop.com/Harding/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
@@ -22,5 +22,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000308
   scheme: legacy_openstates
-given_name: Stephen G.
+given_name: Stephen
 family_name: Harding

--- a/data/ct/people/Stephen-R-Meskers-77dbf0fd-d45c-445c-9966-0135fff8feaa.yml
+++ b/data/ct/people/Stephen-R-Meskers-77dbf0fd-d45c-445c-9966-0135fff8feaa.yml
@@ -8,12 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Stephen.Meskers@cga.ct.gov
-- address: 'meskers4greenwich@gmail.com;, CT '
-  note: District Office
+  note: Capitol Office
+  voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/meskers
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Stephen
+family_name: Meskers

--- a/data/ct/people/Steven-J-Stafstrom-cb252e7b-fffb-4bda-b951-d2b54a3c37e3.yml
+++ b/data/ct/people/Steven-J-Stafstrom-cb252e7b-fffb-4bda-b951-d2b54a3c37e3.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 3104;Hartford, CT 06106
+- address: Legislative Office Building;Room 2500;Hartford, CT 06106
+  email: Steven.Stafstrom@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Steven.Stafstrom@cga.ct.gov
 - address: 120 Sailors Lane;Bridgeport, CT 06605
   note: District Office
   voice: 203-258-6878
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000356
   scheme: legacy_openstates
-given_name: Steven J.
+given_name: Steven
 family_name: Stafstrom

--- a/data/ct/people/Susan-M-Johnson-454e5979-c5bb-4f4e-9f3d-dc11f5e5b6ca.yml
+++ b/data/ct/people/Susan-M-Johnson-454e5979-c5bb-4f4e-9f3d-dc11f5e5b6ca.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4029;Hartford, CT 06106
+  email: Susan.Johnson@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Susan.Johnson@cga.ct.gov
 - address: 120 Bolivia Street;Willimantic, CT 06226
   note: District Office
   voice: 860-423-2085
@@ -21,5 +21,5 @@ sources:
 other_identifiers:
 - identifier: CTL000085
   scheme: legacy_openstates
-given_name: Susan M.
+given_name: Susan
 family_name: Johnson

--- a/data/ct/people/Tami-Zawistowski-b57c3599-c0b0-4fd3-a48c-2bfd32d95071.yml
+++ b/data/ct/people/Tami-Zawistowski-b57c3599-c0b0-4fd3-a48c-2bfd32d95071.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2105;Hartford, CT 06106
+  email: Tami.Zawistowski@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Tami.Zawistowski@housegop.ct.gov
 - address: 11 Seymour Road;East Granby, CT 06026
   note: District Office
   voice: 860-658-1191
 links:
-- url: http://www.cthousegop.com/Zawistowski/main/
+- url: http://www.cthousegop.com/Zawistowski/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Tammy-R-Exum-8872e78b-25b4-406b-84b2-949c700f7b56.yml
+++ b/data/ct/people/Tammy-R-Exum-8872e78b-25b4-406b-84b2-949c700f7b56.yml
@@ -1,0 +1,20 @@
+id: ocd-person/8872e78b-25b4-406b-84b2-949c700f7b56
+name: Tammy R. Exum
+party:
+- name: Democratic
+roles:
+- district: '19'
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+  type: lower
+  start_date: 2019-04-23
+contact_details:
+- address: Legislative Office Building;Room 4014;Hartford, CT 06106
+  email: Tammy.Exum@cga.ct.gov
+  note: Capitol Office
+  voice: 860-240-8585
+links:
+- url: http://www.housedems.ct.gov/exum
+sources:
+- url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Tammy
+family_name: Exum

--- a/data/ct/people/Terrie-E-Wood-fd57836a-b0bd-4ff9-8490-5ba5903d52a5.yml
+++ b/data/ct/people/Terrie-E-Wood-fd57836a-b0bd-4ff9-8490-5ba5903d52a5.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2005;Hartford, CT 06106
+  email: Terrie.Wood@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Terrie.Wood@housegop.ct.gov
 - address: 50 St. Nicholas Road;Darien, CT 06820
   note: District Office
   voice: 203-655-4452
 links:
-- url: http://www.cthousegop.com/Wood/main/
+- url: http://www.cthousegop.com/Wood/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
@@ -23,5 +23,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: CTL000353
   scheme: legacy_openstates
-given_name: Terrie E.
+given_name: Terrie
 family_name: Wood

--- a/data/ct/people/Themis-Klarides-8d85499f-d434-466f-a859-e6c5c40e33fa.yml
+++ b/data/ct/people/Themis-Klarides-8d85499f-d434-466f-a859-e6c5c40e33fa.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4202;Hartford, CT 06106
+  email: Themis.Klarides@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Themis.Klarides@housegop.ct.gov
 - address: 23 East Court;Derby, CT 06418
   note: District Office
   voice: 203-735-5911
 links:
-- url: http://www.cthousegop.com/Klarides/main/
+- url: http://www.cthousegop.com/Klarides/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Tim-Ackert-d458d504-9053-4709-bf43-d955083a18ab.yml
+++ b/data/ct/people/Tim-Ackert-d458d504-9053-4709-bf43-d955083a18ab.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4066;Hartford, CT 06106
+  email: tim.ackert@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: tim.ackert@housegop.ct.gov
 - address: 67 Deer Hill Lane;Coventry, CT 06238
   note: District Office
   voice: 860-742-5287
 links:
-- url: http://www.cthousegop.com/Ackert/main/
+- url: http://www.cthousegop.com/Ackert/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Tom-Arnone-ea621753-2aca-412d-a221-d4fc5e48ba80.yml
+++ b/data/ct/people/Tom-Arnone-ea621753-2aca-412d-a221-d4fc5e48ba80.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
+  email: Tom.Arnone@cga.ct.gov
   note: Capitol Office
-  voice: 860-240-8500
-  email: Thomas.Arnone@cga.ct.gov
+  voice: 860-240-8585
 - address: 5 Cartier Road;Enfield, CT 06082
   note: District Office
   voice: 860-745-3125
@@ -18,3 +18,5 @@ links:
 - url: http://www.housedems.ct.gov/arnone
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Tom
+family_name: Arnone

--- a/data/ct/people/Tom-Delnicki-8bf7e55e-afc1-4f5c-99c3-9b7a1356fbc3.yml
+++ b/data/ct/people/Tom-Delnicki-8bf7e55e-afc1-4f5c-99c3-9b7a1356fbc3.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4200;Hartford, CT 06106
+  email: Tom.Delnicki@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Tom.Delnicki@housegop.ct.gov
 - address: 130 Felt Road;South Windsor, CT 06074
   note: District Office
   voice: 860-644-0026
 links:
-- url: http://www.cthousegop.com/Delnicki/main/
+- url: http://www.cthousegop.com/Delnicki/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Tom-ODea-03642345-7acb-4294-91b5-84dcc3c18cc7.yml
+++ b/data/ct/people/Tom-ODea-03642345-7acb-4294-91b5-84dcc3c18cc7.yml
@@ -8,13 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4206;Hartford, CT 06106
+  email: Tom.ODea@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Tom.ODea@housegop.ct.gov
 - address: 37 Holly Road;New Canaan, CT 06840
   note: District Office
 links:
-- url: http://www.cthousegop.com/ODea/main/
+- url: http://www.cthousegop.com/ODea/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Toni-E-Walker-59460c80-5324-423f-a06c-158d69a30b02.yml
+++ b/data/ct/people/Toni-E-Walker-59460c80-5324-423f-a06c-158d69a30b02.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 2702;Hartford, CT 06106
+  email: Toni.Walker@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8500
-  email: Toni.Walker@cga.ct.gov
 - address: 1643 Ella Grasso Blvd.;New Haven, CT 06511
   note: District Office
 links:
@@ -20,5 +20,5 @@ sources:
 other_identifiers:
 - identifier: CTL000129
   scheme: legacy_openstates
-given_name: Toni E.
+given_name: Toni
 family_name: Walker

--- a/data/ct/people/Tony-Hwang-b1ab473b-e7ff-4c53-96af-ee796c89f4dd.yml
+++ b/data/ct/people/Tony-Hwang-b1ab473b-e7ff-4c53-96af-ee796c89f4dd.yml
@@ -8,9 +8,9 @@ roles:
   type: upper
 contact_details:
 - address: Legislative Office Building;Room 3602;Hartford, CT 06106
+  email: Tony.Hwang@cga.ct.gov
   note: Capitol Office
   voice: 860-240-8805
-  email: Tony.Hwang@cga.ct.gov
 - address: 80 Martingale Lane;Fairfield, CT 06824
   note: District Office
   voice: 203-255-5555

--- a/data/ct/people/Travis-Simms-9e9d6f02-ee29-4ff3-a6fe-1b8a0cec0612.yml
+++ b/data/ct/people/Travis-Simms-9e9d6f02-ee29-4ff3-a6fe-1b8a0cec0612.yml
@@ -8,13 +8,12 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4000;Hartford, CT 06106
-  note: Capitol Office
-  voice: 860-240-8500
   email: Travis.Simms@cga.ct.gov
-- address: 28 Dr. Martin Luther King Jr. Drive;Norwalk, CT 06854
-  note: District Office
-  voice: 203-820-3845
+  note: Capitol Office
+  voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/simms
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Travis
+family_name: Simms

--- a/data/ct/people/Vincent-J-Candelora-1d02baaa-ab25-4607-b33f-40948893f928.yml
+++ b/data/ct/people/Vincent-J-Candelora-1d02baaa-ab25-4607-b33f-40948893f928.yml
@@ -8,18 +8,18 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 4203;Hartford, CT 06106
+  email: Vincent.Candelora@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: Vincent.Candelora@housegop.ct.gov
 - address: 405 Sea Hill Road;North Branford, CT 06471
   note: District Office
   voice: 203-481-4463
 links:
-- url: http://www.cthousegop.com/Candelora/main/
+- url: http://www.cthousegop.com/Candelora/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000122
   scheme: legacy_openstates
-given_name: Vincent J.
+given_name: Vincent
 family_name: Candelora

--- a/data/ct/people/Whit-Betts-ed8c3238-f1f8-451c-8906-8feca116a025.yml
+++ b/data/ct/people/Whit-Betts-ed8c3238-f1f8-451c-8906-8feca116a025.yml
@@ -8,14 +8,14 @@ roles:
   type: lower
 contact_details:
 - address: Legislative Office Building;Room 1803;Hartford, CT 06106
+  email: whit.betts@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: whit.betts@housegop.ct.gov
 - address: 1924 Perkins Street;Bristol, CT 06010
   note: District Office
   voice: 860-582-7105
 links:
-- url: http://www.cthousegop.com/Betts/main/
+- url: http://www.cthousegop.com/Betts/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:

--- a/data/ct/people/Will-Haskell-982f8478-39ab-44d8-8322-6807a26e25e4.yml
+++ b/data/ct/people/Will-Haskell-982f8478-39ab-44d8-8322-6807a26e25e4.yml
@@ -16,3 +16,5 @@ links:
 - url: http://www.senatedems.ct.gov/haskell
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+given_name: Will
+family_name: Haskell

--- a/data/ct/people/William-A-Petit-Jr-MD-3ee72607-8d51-4752-af90-dd669611187b.yml
+++ b/data/ct/people/William-A-Petit-Jr-MD-3ee72607-8d51-4752-af90-dd669611187b.yml
@@ -7,18 +7,18 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
 contact_details:
-- address: Legislative Office Building;Room 4040;Hartford, CT 06106
+- address: Legislative Office Building;Room 3003;Hartford, CT 06106
+  email: William.Petit@housegop.ct.gov
   note: Capitol Office
   voice: 860-240-8700
-  email: William.Petit@housegop.ct.gov
 - address: PO Box 310;Plainville, CT 06062
   note: District Office
 links:
-- url: http://www.cthousegop.com/Petit/main/
+- url: http://www.cthousegop.com/Petit/
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 other_identifiers:
 - identifier: CTL000346
   scheme: legacy_openstates
-given_name: William A.
+given_name: William
 family_name: Petit

--- a/data/ct/retired/Brenda-L-Kupchick-d9f16dc8-f123-451a-a1cf-191706553a25.yml
+++ b/data/ct/retired/Brenda-L-Kupchick-d9f16dc8-f123-451a-a1cf-191706553a25.yml
@@ -6,6 +6,7 @@ roles:
 - district: '132'
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
+  end_date: '2019-11-22'
 contact_details:
 - address: Legislative Office Building;Room 4068;Hartford, CT 06106
   note: Capitol Office

--- a/data/ct/retired/Ezequiel-Santiago-b56ac685-dc65-4583-9209-e8fd129455e2.yml
+++ b/data/ct/retired/Ezequiel-Santiago-b56ac685-dc65-4583-9209-e8fd129455e2.yml
@@ -6,6 +6,8 @@ roles:
 - district: '130'
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
+  end_date: '2019-03-15'
+  end_reason: Deceased
 contact_details:
 - address: Legislative Office Building;Room 5003;Hartford, CT 06106
   note: Capitol Office
@@ -22,3 +24,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Ezequiel
 family_name: Santiago
+death_date: '2019-03-15'

--- a/data/ct/retired/Fred-Camillo-7a5474af-535a-42e5-8653-0edf8311cdfb.yml
+++ b/data/ct/retired/Fred-Camillo-7a5474af-535a-42e5-8653-0edf8311cdfb.yml
@@ -6,6 +6,7 @@ roles:
 - district: '151'
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
+  end_date: '2019-12-02'
 contact_details:
 - address: Legislative Office Building;Room 1002;Hartford, CT 06106
   note: Capitol Office

--- a/data/ct/retired/Linda-A-Orange-053aa93e-b38d-424d-a9fc-43088529068f.yml
+++ b/data/ct/retired/Linda-A-Orange-053aa93e-b38d-424d-a9fc-43088529068f.yml
@@ -6,6 +6,8 @@ roles:
 - district: '48'
   jurisdiction: ocd-jurisdiction/country:us/state:ct/government
   type: lower
+  end_date: '2019-11-20'
+  end_reason: Deceased
 contact_details:
 - address: Legislative Office Building;Room 4012;Hartford, CT 06106
   note: Capitol Office
@@ -23,3 +25,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Linda A.
 family_name: Orange
+death_date: '2019-11-20'

--- a/settings.yml
+++ b/settings.yml
@@ -1,20 +1,3 @@
-ct:
-  vacancies:
-    - chamber: lower
-      district: 39
-      vacant_until: 2021-01-01
-    - chamber: lower
-      district: 99
-      vacant_until: 2021-01-01
-    - chamber: upper
-      district: 3
-      vacant_until: 2021-01-01
-    - chamber: upper
-      district: 5
-      vacant_until: 2021-01-01
-    - chamber: upper
-      district: 6
-      vacant_until: 2021-01-01
 ma:
   vacancies:
     - chamber: upper


### PR DESCRIPTION
Add 9 new legislators, with 5 existing vacancies, 2 deaths, 2 resignations, and one member moving from the House to the Senate. Also update given/family names, contact information, and sort the email attribute within `contact_details`.