### PR TITLE
GA: Update legislators

### DIFF
--- a/data/ga/organizations/Appropriations-107fab84-ceaa-44d6-9554-dfe835a0aa04.yml
+++ b/data/ga/organizations/Appropriations-107fab84-ceaa-44d6-9554-dfe835a0aa04.yml
@@ -64,6 +64,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Secretary
+  end_date: '2019-09-05'
 - id: ocd-person/80f4bbdf-02f3-4233-8456-e550e7e745af
   name: Steve Tarvin
   role: Vice-Chairman of Subcommittee
@@ -213,6 +214,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Ex-Officio
+  end_date: '2019-11-26'
 - id: ocd-person/a53e6bbd-a5b8-436b-94ae-bebf957c5b61
   name: Brian Prince
   role: Member

--- a/data/ga/organizations/Appropriations-f3fb218c-97d1-45ee-9337-f19220bbf282.yml
+++ b/data/ga/organizations/Appropriations-f3fb218c-97d1-45ee-9337-f19220bbf282.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Chairman
+  end_date: '2020-04-06'
 - name: Renee Unterman
   role: Vice Chairman
 - id: ocd-person/e2c141e9-9e04-4e2b-8e5b-57db594c7abc

--- a/data/ga/organizations/Energy-Utilities--Telecommunications-b726e312-90ba-4c24-9406-c9046023960e.yml
+++ b/data/ga/organizations/Energy-Utilities--Telecommunications-b726e312-90ba-4c24-9406-c9046023960e.yml
@@ -67,6 +67,7 @@ memberships:
 - id: ocd-person/fd10b3ca-8271-42c6-b4fc-c0a6b46cde03
   name: David Stover
   role: Member
+  end_date: '2019-06-25'
 - id: ocd-person/4710c402-ebc0-4b6c-b399-87124e9966e9
   name: Sam Teasley
   role: Member

--- a/data/ga/organizations/Finance-8f11c490-84d9-4db9-8523-8812019171d8.yml
+++ b/data/ga/organizations/Finance-8f11c490-84d9-4db9-8523-8812019171d8.yml
@@ -17,7 +17,7 @@ memberships:
 - name: Hunter Hill
   role: Vice Chairman
 - id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-  name: 'Chuck  Payne '
+  name: Chuck  Payne
   role: Secretary
 - id: ocd-person/0c7848ee-f32c-4f6b-ac5d-6b311fed6605
   name: Ellis Black
@@ -34,6 +34,7 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Ex-Officio
+  end_date: '2020-04-06'
 - name: Judson Hill
   role: Member
 - name: Lester Jackson

--- a/data/ga/organizations/Governmental-Affairs-c6304e5c-9021-4e34-9693-d062c6f8271a.yml
+++ b/data/ga/organizations/Governmental-Affairs-c6304e5c-9021-4e34-9693-d062c6f8271a.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Chairman
+  end_date: '2019-09-05'
 - id: ocd-person/7ea227b9-339a-485a-bfc8-467206ad2457
   name: Barry Fleming
   role: Vice Chairman
@@ -27,7 +28,7 @@ memberships:
 - name: Amy Carter
   role: Member
 - id: ocd-person/bda95ef9-7054-4100-ab95-498abe8b892f
-  name: J. Collins
+  name: J Collins
   role: Member
 - id: ocd-person/f33d979c-554c-433e-ad0f-837eef1da589
   name: Eddie Lumsden
@@ -51,6 +52,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Member
+  end_date: '2019-11-26'
 - id: ocd-person/11d98077-e98f-45ff-8613-aad9a645d8ae
   name: Betty Price
   role: Member

--- a/data/ga/organizations/Health--Human-Services-6aef8991-22f6-4cc5-a01c-13f1bc6079bf.yml
+++ b/data/ga/organizations/Health--Human-Services-6aef8991-22f6-4cc5-a01c-13f1bc6079bf.yml
@@ -17,6 +17,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Secretary
+  end_date: '2019-09-05'
 - id: ocd-person/555d218d-1720-401c-a77f-124937c5b184
   name: Timothy Barr
   role: Member

--- a/data/ga/organizations/Health-and-Human-Services-a26c1786-dc5e-43fa-af71-31f6198e7470.yml
+++ b/data/ga/organizations/Health-and-Human-Services-a26c1786-dc5e-43fa-af71-31f6198e7470.yml
@@ -35,6 +35,7 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Member
+  end_date: '2019-12-22'
 - id: ocd-person/fc31ab02-026c-4173-86db-570c0b297c64
   name: Kay Kirkpatrick
   role: Member

--- a/data/ga/organizations/Insurance-and-Labor-c43116ed-e889-494e-9925-c88c758e83d0.yml
+++ b/data/ga/organizations/Insurance-and-Labor-c43116ed-e889-494e-9925-c88c758e83d0.yml
@@ -27,6 +27,7 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Member
+  end_date: '2019-12-22'
 - id: ocd-person/f644a410-f4c7-4014-bf80-bedce34f7d5d
   name: Joshua McKoon
   role: Member

--- a/data/ga/organizations/Intragovernmental-Coordination-1f877751-f62f-4e68-8328-c0c3ecd82dd2.yml
+++ b/data/ga/organizations/Intragovernmental-Coordination-1f877751-f62f-4e68-8328-c0c3ecd82dd2.yml
@@ -66,6 +66,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Member
+  end_date: '2019-09-05'
 - id: ocd-person/53d6aec0-12cb-4201-bf23-22ed40c4a089
   name: Pam Stephenson
   role: Member

--- a/data/ga/organizations/Judiciary-cd3e884b-e4ad-42b8-8685-5f1a0bc2143e.yml
+++ b/data/ga/organizations/Judiciary-cd3e884b-e4ad-42b8-8685-5f1a0bc2143e.yml
@@ -28,6 +28,7 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Member
+  end_date: '2019-12-22'
 - name: William Ligon, Jr.
   role: Member
 - id: ocd-person/f644a410-f4c7-4014-bf80-bedce34f7d5d

--- a/data/ga/organizations/Judiciary-d1daa6b8-014a-4dd1-90c4-776942450b21.yml
+++ b/data/ga/organizations/Judiciary-d1daa6b8-014a-4dd1-90c4-776942450b21.yml
@@ -53,6 +53,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Member
+  end_date: '2019-11-26'
 - name: Roger Rutledge
   role: Member
 - id: ocd-person/53d6aec0-12cb-4201-bf23-22ed40c4a089

--- a/data/ga/organizations/Juvenile-Justice-f2ca82fc-59d0-4a8d-ad2e-408ab97eb841.yml
+++ b/data/ga/organizations/Juvenile-Justice-f2ca82fc-59d0-4a8d-ad2e-408ab97eb841.yml
@@ -26,7 +26,7 @@ memberships:
   role: Member
   end_date: '2018-12-31'
 - id: ocd-person/bda95ef9-7054-4100-ab95-498abe8b892f
-  name: J. Collins
+  name: J Collins
   role: Member
 - id: ocd-person/f9e3bbf7-fb45-4bd4-ac4e-61f65e28e2f6
   name: Christian Coomer

--- a/data/ga/organizations/Legislative--Congressional-Reapportionment-aa8f879e-8221-4d59-be96-1cbeb8685e16.yml
+++ b/data/ga/organizations/Legislative--Congressional-Reapportionment-aa8f879e-8221-4d59-be96-1cbeb8685e16.yml
@@ -53,6 +53,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Member
+  end_date: '2019-09-05'
 - id: ocd-person/21c6cae1-bcd2-4403-ad39-af04b64ce55c
   name: Sandra Scott
   role: Member

--- a/data/ga/organizations/MARTOC-2636f588-629f-4c62-9314-74538f3a0320.yml
+++ b/data/ga/organizations/MARTOC-2636f588-629f-4c62-9314-74538f3a0320.yml
@@ -29,6 +29,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Member
+  end_date: '2019-11-26'
 - id: ocd-person/0c45cc6b-8368-4ed0-a450-840309900a7d
   name: Jimmy Pruett
   role: Member

--- a/data/ga/organizations/MARTOC-dfa92a46-6f3c-4458-ad5c-96e85766caab.yml
+++ b/data/ga/organizations/MARTOC-dfa92a46-6f3c-4458-ad5c-96e85766caab.yml
@@ -24,6 +24,7 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Member
+  end_date: '2019-12-22'
 - id: ocd-person/9a8fc67a-f6b7-4e54-8d3e-8945750d3c84
   name: Butch Miller
   role: Member

--- a/data/ga/organizations/Motor-Vehicles-2bf0b787-727e-4bdd-830c-321b03091b87.yml
+++ b/data/ga/organizations/Motor-Vehicles-2bf0b787-727e-4bdd-830c-321b03091b87.yml
@@ -50,6 +50,7 @@ memberships:
 - id: ocd-person/fd10b3ca-8271-42c6-b4fc-c0a6b46cde03
   name: David Stover
   role: Member
+  end_date: '2019-06-25'
 - id: ocd-person/de14c9e7-f1f4-49af-b464-dec8424687a9
   name: Robert Trammell
   role: Member

--- a/data/ga/organizations/Natural-Resources-3611fb5d-be01-44c8-bd05-480640c0754a.yml
+++ b/data/ga/organizations/Natural-Resources-3611fb5d-be01-44c8-bd05-480640c0754a.yml
@@ -20,3 +20,4 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Member
+  end_date: '2020-04-06'

--- a/data/ga/organizations/Natural-Resources-and-the-Environment-cd4d69c0-27db-4625-804a-f680233d5139.yml
+++ b/data/ga/organizations/Natural-Resources-and-the-Environment-cd4d69c0-27db-4625-804a-f680233d5139.yml
@@ -31,6 +31,7 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Member
+  end_date: '2020-04-06'
 - name: Freddie Sims
   role: Member
 - id: ocd-person/9d2248b0-9364-4268-89b0-dcc6ac968eea

--- a/data/ga/organizations/Public-Safety-8c58397b-b5c4-4aef-a9d4-6000b350c319.yml
+++ b/data/ga/organizations/Public-Safety-8c58397b-b5c4-4aef-a9d4-6000b350c319.yml
@@ -31,7 +31,7 @@ memberships:
   name: Kay Kirkpatrick
   role: Member
 - id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-  name: 'Chuck  Payne '
+  name: Chuck  Payne
   role: Member
 - id: ocd-person/110cea65-4417-4b3a-aa39-3e7e6122073d
   name: Valencia Seay

--- a/data/ga/organizations/Public-Safety-and-Homeland-Security-7e918bd6-12a9-465c-870b-8d8ebacd8533.yml
+++ b/data/ga/organizations/Public-Safety-and-Homeland-Security-7e918bd6-12a9-465c-870b-8d8ebacd8533.yml
@@ -18,7 +18,7 @@ memberships:
   name: Jesse Petrea
   role: Secretary
 - id: ocd-person/bda95ef9-7054-4100-ab95-498abe8b892f
-  name: J. Collins
+  name: J Collins
   role: Member
 - id: ocd-person/cb40fb3e-53c2-428e-a525-6e993a1ea537
   name: Kevin Cooke

--- a/data/ga/organizations/Regulated-Industries-and-Utilities-8f0b7058-b904-4431-b4c0-cbca4ae3c1b6.yml
+++ b/data/ga/organizations/Regulated-Industries-and-Utilities-8f0b7058-b904-4431-b4c0-cbca4ae3c1b6.yml
@@ -35,6 +35,7 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Member
+  end_date: '2020-04-06'
 - name: John Kennedy
   role: Member
 - id: ocd-person/4b05e770-4423-4b64-8ae1-9600e8c73244

--- a/data/ga/organizations/Rules-1a61ca4b-f828-43fb-a8d0-93033db63c56.yml
+++ b/data/ga/organizations/Rules-1a61ca4b-f828-43fb-a8d0-93033db63c56.yml
@@ -14,6 +14,7 @@ memberships:
 - id: ocd-person/6c1ad7e8-650a-4b91-a358-8104e4945eca
   name: Jack Hill
   role: Vice Chairman
+  end_date: '2020-04-06'
 - id: ocd-person/277c2b0e-2986-48d6-9b2d-3e058fc9f699
   name: Fran Millar
   role: Secretary

--- a/data/ga/organizations/Rules-2f83745d-1a7b-4729-8835-bc4069d8826f.yml
+++ b/data/ga/organizations/Rules-2f83745d-1a7b-4729-8835-bc4069d8826f.yml
@@ -96,6 +96,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Member
+  end_date: '2019-11-26'
 - id: ocd-person/481b74d1-e0d8-4282-b768-98b660bb13c1
   name: Terry Rogers
   role: Member

--- a/data/ga/organizations/Sales-Tax-5ef3b033-89f0-47df-a10c-92921fa8de0f.yml
+++ b/data/ga/organizations/Sales-Tax-5ef3b033-89f0-47df-a10c-92921fa8de0f.yml
@@ -11,7 +11,7 @@ memberships:
 - name: Hunter Hill
   role: Vice Chairman
 - id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-  name: 'Chuck  Payne '
+  name: Chuck  Payne
   role: Secretary
 - id: ocd-person/0c7848ee-f32c-4f6b-ac5d-6b311fed6605
   name: Ellis Black

--- a/data/ga/organizations/Science-and-Technology-7589318c-1bdf-41cb-aa6a-1252a254a690.yml
+++ b/data/ga/organizations/Science-and-Technology-7589318c-1bdf-41cb-aa6a-1252a254a690.yml
@@ -18,6 +18,7 @@ memberships:
 - id: ocd-person/fd10b3ca-8271-42c6-b4fc-c0a6b46cde03
   name: David Stover
   role: Secretary
+  end_date: '2019-06-25'
 - id: ocd-person/184a243c-6357-4a30-a072-5ed3e0ea5ac0
   name: Heath Clark
   role: Member

--- a/data/ga/organizations/Scope-of-Practice-eb0ff0d8-bda8-48cd-b0c5-735569a1662d.yml
+++ b/data/ga/organizations/Scope-of-Practice-eb0ff0d8-bda8-48cd-b0c5-735569a1662d.yml
@@ -16,3 +16,4 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Member
+  end_date: '2019-12-22'

--- a/data/ga/organizations/Small-Business-Development-13c268cf-57af-4fb6-b821-f31eba4321e2.yml
+++ b/data/ga/organizations/Small-Business-Development-13c268cf-57af-4fb6-b821-f31eba4321e2.yml
@@ -105,6 +105,7 @@ memberships:
 - id: ocd-person/fd10b3ca-8271-42c6-b4fc-c0a6b46cde03
   name: David Stover
   role: Member
+  end_date: '2019-06-25'
 - id: ocd-person/80f4bbdf-02f3-4233-8456-e550e7e745af
   name: Steve Tarvin
   role: Member

--- a/data/ga/organizations/State-Institutions-and-Property-e03d32e3-1b8f-45d3-b905-02e28c28ff2f.yml
+++ b/data/ga/organizations/State-Institutions-and-Property-e03d32e3-1b8f-45d3-b905-02e28c28ff2f.yml
@@ -26,5 +26,5 @@ memberships:
   name: Steve Henson
   role: Member
 - id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-  name: 'Chuck  Payne '
+  name: Chuck  Payne
   role: Member

--- a/data/ga/organizations/State-and-Local-Governmental-Operations-a0ce129e-c3eb-4ba9-a8de-de7d91ee8736.yml
+++ b/data/ga/organizations/State-and-Local-Governmental-Operations-a0ce129e-c3eb-4ba9-a8de-de7d91ee8736.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/c3762f0c-6f6b-46bd-b92b-cfeb2978d16e
   name: Greg Kirk
   role: Chairman
+  end_date: '2019-12-22'
 - id: ocd-person/90751b67-4684-4528-a9a2-9d10b884ab78
   name: P. K. Martin IV
   role: Vice Chairman
@@ -23,7 +24,7 @@ memberships:
   name: Marty Harbin
   role: Member
 - id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-  name: 'Chuck  Payne '
+  name: Chuck  Payne
   role: Member
 - id: ocd-person/ab3f6dfa-f18d-4ac8-8dc5-a9ab25a1bfdf
   name: Horacena Tate

--- a/data/ga/organizations/Transportation-c751df62-b868-4288-8667-1abb09b9a973.yml
+++ b/data/ga/organizations/Transportation-c751df62-b868-4288-8667-1abb09b9a973.yml
@@ -92,6 +92,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Member
+  end_date: '2019-09-05'
 - id: ocd-person/777f58bb-9d6b-4755-ab7b-b94d11629cb5
   name: Ed Setzler
   role: Member

--- a/data/ga/organizations/Ways--Means-dd8ec2fd-6859-4567-90be-79e8949e929d.yml
+++ b/data/ga/organizations/Ways--Means-dd8ec2fd-6859-4567-90be-79e8949e929d.yml
@@ -11,6 +11,7 @@ memberships:
 - id: ocd-person/fa8116dd-1638-4a0c-86d2-f0d70d4a284c
   name: Jay Powell
   role: Chairman
+  end_date: '2019-11-26'
 - id: ocd-person/6ac8933e-8dde-4902-8eec-61cc5a91c844
   name: Trey Kelley
   role: Vice Chairman
@@ -79,6 +80,7 @@ memberships:
 - id: ocd-person/573a438f-ad34-43df-bdd0-7e28c499e1ef
   name: Ed Rynders
   role: Member
+  end_date: '2019-09-05'
 - id: ocd-person/ce7cb314-aa41-43a3-a875-9204f3a10beb
   name: Mickey Stephens
   role: Member

--- a/data/ga/people/Able-Mable-Thomas-78d8937f-740a-4f3a-a6a4-5a2884d7997e.yml
+++ b/data/ga/people/Able-Mable-Thomas-78d8937f-740a-4f3a-a6a4-5a2884d7997e.yml
@@ -1,5 +1,5 @@
 id: ocd-person/78d8937f-740a-4f3a-a6a4-5a2884d7997e
-name: '"Able" Mable Thomas'
+name: Mable Thomas
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Alan-Powell-bb48e87c-29db-4a4d-a278-fa299be2020e.yml
+++ b/data/ga/people/Alan-Powell-bb48e87c-29db-4a4d-a278-fa299be2020e.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 613-B Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: alanpowell23@hotmail.com
+  email: alan.powell@house.ga.gov
   fax: 404-463-1673
   note: Capitol Office
   voice: 404-463-3793

--- a/data/ga/people/Andrew-J-Welch-4ffa6984-145b-49bc-bdc2-988d3475470e.yml
+++ b/data/ga/people/Andrew-J-Welch-4ffa6984-145b-49bc-bdc2-988d3475470e.yml
@@ -1,5 +1,5 @@
 id: ocd-person/4ffa6984-145b-49bc-bdc2-988d3475470e
-name: Andrew J. Welch
+name: Andrew Welch
 party:
 - name: Republican
 roles:
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 220-B State Capitol;Atlanta, GA 30334
-  email: awelch@smithwelchlaw.com
+  email: andrew.welch@house.ga.gov
   note: Capitol Office
   voice: 404-656-5912
 - address: PO Box 2871;McDonough, GA 30253

--- a/data/ga/people/Bill-Hitchens-4a9ef816-9130-4510-a19e-3124e3f2aeed.yml
+++ b/data/ga/people/Bill-Hitchens-4a9ef816-9130-4510-a19e-3124e3f2aeed.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 401-D State Capitol;Atlanta, GA 30334
   email: bill.hitchens@house.ga.gov
   note: Capitol Office
-  voice: 404-463-7855
+  voice: 404-656-7855
 - address: 2440 Rincon-Stillwell Rd.;Rincon, GA 31326
   note: District Office
 links:

--- a/data/ga/people/Bill-Werkheiser-adefd0ba-43cd-4aae-9321-12f67e57ac8a.yml
+++ b/data/ga/people/Bill-Werkheiser-adefd0ba-43cd-4aae-9321-12f67e57ac8a.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 401-J State Capitol;Atlanta, GA 30334
+- address: 218-A State Capitol;Atlanta, GA 30334
   email: bill.werkheiser@house.ga.gov
   note: Capitol Office
-  voice: 404-463-7857
+  voice: 404-656-5132
 - address: P.O. Box 27;Glennville, GA 30427
   note: District Office
   voice: 912-237-0145

--- a/data/ga/people/Bill-Yearta-23dfc274-73d1-45df-b381-67e597cf0b84.yml
+++ b/data/ga/people/Bill-Yearta-23dfc274-73d1-45df-b381-67e597cf0b84.yml
@@ -1,0 +1,27 @@
+id: ocd-person/23dfc274-73d1-45df-b381-67e597cf0b84
+name: Bill Yearta
+party:
+- name: Republican
+roles:
+- district: '152'
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  type: lower
+  start_date: 2019-12-24
+contact_details:
+- address: 601-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: bill.yearta@house.ga.gov
+  note: Capitol Office
+  voice: 404-656-0254
+- address: 114 Carriage Lane;Sylvester, GA 31791
+  note: District Office
+  voice: 229-776-2047
+links:
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4969&Session=27
+sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4969&Session=27
+image: http://www.house.ga.gov/SiteCollectionImages/YeartaBill4969.jpg
+family_name: Yearta
+given_name: Bill
+extras:
+  guid: 4969

--- a/data/ga/people/Bonnie-Rich-08452f85-2530-4c39-8309-22ca020b848e.yml
+++ b/data/ga/people/Bonnie-Rich-08452f85-2530-4c39-8309-22ca020b848e.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 601-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 402 Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: bonnie.rich@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0254
+  voice: 404-656-5087
 - address: P.O. Box 663;Suwanee, GA 30024
   note: District Office
 links:

--- a/data/ga/people/Brenda-Lopez-d68d535c-67eb-4c96-a1a4-96a4d78c3709.yml
+++ b/data/ga/people/Brenda-Lopez-d68d535c-67eb-4c96-a1a4-96a4d78c3709.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 511-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
-  email: brenda.lopez@house.ga.gov
+  email: brenda.lopezromero@house.ga.gov
   note: Capitol Office
   voice: 404-656-6372
 - address: P.O. Box 886;Norcross, GA 30091
@@ -19,7 +19,7 @@ sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4900&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/Lopez RomeroBrenda4900.jpg
-family_name: Lopez
+family_name: Lopez Romero
 given_name: Brenda
 extras:
   guid: 4900

--- a/data/ga/people/Bruce-Thompson-4caaa1f0-95fb-4206-a65f-19e47ae5a509.yml
+++ b/data/ga/people/Bruce-Thompson-4caaa1f0-95fb-4206-a65f-19e47ae5a509.yml
@@ -12,7 +12,7 @@ contact_details:
   fax: 404-656-6484
   note: Capitol Office
   voice: 404-656-0065
-- address: 25 Hawks Branch Lane;White, GA 30184-3244
+- address: 25 Hawks Branch Lane;White, GA 30184
   note: District Office
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=844&Session=27

--- a/data/ga/people/Carden-Summers-98850c9f-1c37-4177-9ad8-17d2b4d3c8d4.yml
+++ b/data/ga/people/Carden-Summers-98850c9f-1c37-4177-9ad8-17d2b4d3c8d4.yml
@@ -1,0 +1,23 @@
+id: ocd-person/98850c9f-1c37-4177-9ad8-17d2b4d3c8d4
+name: Carden Summers
+party:
+- name: Republican
+roles:
+- district: '13'
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  type: upper
+  start_date: 2020-03-09
+contact_details:
+- address: 121-J State Capitol;Atlanta, GA 30334
+  note: Capitol Office
+  voice: 404-463-5258
+links:
+- url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4971&Session=27
+sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
+- url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4971&Session=27
+image: http://www.senate.ga.gov/SiteCollectionImages/SummersCarden4971.jpg
+family_name: Summers
+given_name: Carden
+extras:
+  guid: 4971

--- a/data/ga/people/Carl-Wayne-Gilliard-562e162f-2a60-441c-956b-11db12eef266.yml
+++ b/data/ga/people/Carl-Wayne-Gilliard-562e162f-2a60-441c-956b-11db12eef266.yml
@@ -1,5 +1,5 @@
 id: ocd-person/562e162f-2a60-441c-956b-11db12eef266
-name: Carl Wayne Gilliard
+name: Carl Gilliard
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Chuck-E-Martin-42517dd7-eccb-4d22-a795-cbd010b69ee6.yml
+++ b/data/ga/people/Chuck-E-Martin-42517dd7-eccb-4d22-a795-cbd010b69ee6.yml
@@ -1,5 +1,5 @@
 id: ocd-person/42517dd7-eccb-4d22-a795-cbd010b69ee6
-name: Chuck E. Martin
+name: Charles Martin
 party:
 - name: Republican
 roles:
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 417-A State Capitol;Atlanta, GA 30334
-  email: chuck@martinforgeorgia.com
+  email: chuck.martin@house.ga.gov
   note: Capitol Office
   voice: 404-656-5064
 - address: 11770 Haynes Bridge RoadSuite 205-544;Alpharetta, GA 30004
@@ -20,7 +20,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=164&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/MartinCharles164.jpg
 family_name: Martin
-given_name: Chuck
+given_name: Charles
 extras:
   guid: 164
 other_identifiers:

--- a/data/ga/people/Chuck-Payne--1ac93f89-f367-4de3-82ba-79fa78d4d134.yml
+++ b/data/ga/people/Chuck-Payne--1ac93f89-f367-4de3-82ba-79fa78d4d134.yml
@@ -1,5 +1,5 @@
 id: ocd-person/1ac93f89-f367-4de3-82ba-79fa78d4d134
-name: 'Chuck  Payne '
+name: Chuck  Payne
 party:
 - name: Republican
 roles:
@@ -12,7 +12,7 @@ contact_details:
   fax: 404-657-7266
   note: Capitol Office
   voice: 404-463-5402
-- address: 305 Point North Place Suite 4;Dalton, GA 30720
+- address: P.O. Box 1074;Dalton, GA 30722
   note: District Office
   voice: 706-529-6748
 links:
@@ -20,7 +20,7 @@ links:
 sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4909&Session=27
-image: http://www.senate.ga.gov/SiteCollectionImages/Payne Chuck 4909.jpg
+image: http://www.senate.ga.gov/SiteCollectionImages/PayneChuck 4909.jpg
 family_name: Payne
 given_name: Chuck
 extras:
@@ -28,3 +28,5 @@ extras:
 other_identifiers:
 - identifier: GAL000475
   scheme: legacy_openstates
+other_names:
+- name: 'Chuck  Payne '

--- a/data/ga/people/Dale-Rutledge-8796d4fe-da6a-4585-9bc3-a8391c74ef66.yml
+++ b/data/ga/people/Dale-Rutledge-8796d4fe-da6a-4585-9bc3-a8391c74ef66.yml
@@ -1,5 +1,5 @@
 id: ocd-person/8796d4fe-da6a-4585-9bc3-a8391c74ef66
-name: Dale Rutledge
+name: Roger Rutledge
 party:
 - name: Republican
 roles:
@@ -20,7 +20,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=830&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/RutledgeRoger830.jpg
 family_name: Rutledge
-given_name: Dale
+given_name: Roger
 extras:
   guid: 830
 other_identifiers:

--- a/data/ga/people/Dale-Washburn-ec6cf250-ebcc-4dda-89a5-12da9ebbe51a.yml
+++ b/data/ga/people/Dale-Washburn-ec6cf250-ebcc-4dda-89a5-12da9ebbe51a.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 401-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: dale.washburn@house.ga.gov
   note: Capitol Office
   voice: 404-656-0152
 - address: 3040 Riverside Dr, Suite C-2;Macon, GA 31210

--- a/data/ga/people/Danny-Mathis-1a9598cc-056f-4725-a3fb-64c3f0fd26ed.yml
+++ b/data/ga/people/Danny-Mathis-1a9598cc-056f-4725-a3fb-64c3f0fd26ed.yml
@@ -8,6 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 401-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: danny.mathis@house.ga.gov
   note: Capitol Office
   voice: 404-656-0152
 - address: P.O. Box 531;Cochran, GA 31014

--- a/data/ga/people/Darlene-K-Taylor-d00eb950-0fb6-41ab-ae22-8e9ce84d7cf0.yml
+++ b/data/ga/people/Darlene-K-Taylor-d00eb950-0fb6-41ab-ae22-8e9ce84d7cf0.yml
@@ -1,5 +1,5 @@
 id: ocd-person/d00eb950-0fb6-41ab-ae22-8e9ce84d7cf0
-name: Darlene K. Taylor
+name: Darlene Taylor
 party:
 - name: Republican
 roles:

--- a/data/ga/people/David-Dreyer-266d1cbc-21b7-47b1-ae97-ecddfe7c3746.yml
+++ b/data/ga/people/David-Dreyer-266d1cbc-21b7-47b1-ae97-ecddfe7c3746.yml
@@ -11,7 +11,7 @@ contact_details:
   email: david.dreyer@house.ga.gov
   note: Capitol Office
   voice: 404-656-0265
-- address: 505 Cherokee Avenue;Atlanta, GA 30312
+- address: 275 Memorial Dr Suite 415;Atlanta, GA 30312
   note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4888&Session=27

--- a/data/ga/people/Don-Hogan-ca34bbde-7f53-44eb-abdd-c5c12aebe591.yml
+++ b/data/ga/people/Don-Hogan-ca34bbde-7f53-44eb-abdd-c5c12aebe591.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 501-G Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: don.hogan@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4906&Session=27
 sources:

--- a/data/ga/people/Don-Parsons-81dde544-49e9-4fb0-9313-32eacaf6194b.yml
+++ b/data/ga/people/Don-Parsons-81dde544-49e9-4fb0-9313-32eacaf6194b.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 401-F State Capitol;Atlanta, GA 30334
-  email: repdon@donparsons.org
+  email: don.parsons@house.ga.gov
   note: Capitol Office
   voice: 404-463-7853
 - address: 3167 Sycamore Lane;Marietta, GA 30066

--- a/data/ga/people/Eddie-Lumsden-f33d979c-554c-433e-ad0f-837eef1da589.yml
+++ b/data/ga/people/Eddie-Lumsden-f33d979c-554c-433e-ad0f-837eef1da589.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 402 Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 220-A State Capitol;Atlanta, GA 30334
   email: eddie.lumsden@house.ga.gov
   note: Capitol Office
-  voice: 404-656-5087
+  voice: 404-656-7850
 - address: PO Box 122;Armuchee, GA 30105
   note: District Office
 links:

--- a/data/ga/people/Erick-E-Allen-7e50f680-943e-4952-b92b-bb8913f81f30.yml
+++ b/data/ga/people/Erick-E-Allen-7e50f680-943e-4952-b92b-bb8913f81f30.yml
@@ -1,5 +1,5 @@
 id: ocd-person/7e50f680-943e-4952-b92b-bb8913f81f30
-name: Erick E. Allen
+name: Erick Allen
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Freddie-Powell-Sims-a0bfdc0d-4110-4cd2-b83c-834bba4300f5.yml
+++ b/data/ga/people/Freddie-Powell-Sims-a0bfdc0d-4110-4cd2-b83c-834bba4300f5.yml
@@ -1,5 +1,5 @@
 id: ocd-person/a0bfdc0d-4110-4cd2-b83c-834bba4300f5
-name: Freddie Powell Sims
+name: Freddie Sims
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Gerald-E-Greene-570a213a-a475-4fd3-ac36-23e1bd1190be.yml
+++ b/data/ga/people/Gerald-E-Greene-570a213a-a475-4fd3-ac36-23e1bd1190be.yml
@@ -1,5 +1,5 @@
 id: ocd-person/570a213a-a475-4fd3-ac36-23e1bd1190be
-name: Gerald E Greene
+name: Gerald Greene
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Gloria-Frazier-8d2154d2-3401-4b8c-9173-9c895d014b79.yml
+++ b/data/ga/people/Gloria-Frazier-8d2154d2-3401-4b8c-9173-9c895d014b79.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 604-C Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: frazier26@comcast.net
+  email: gloria.frazier@house.ga.gov
   note: Capitol Office
   voice: 404-656-0265
 - address: 2717 Willis Foreman Road;Hephzibah, GA 30815

--- a/data/ga/people/Gloria-S-Butler-c02e2258-027d-4ef8-bed9-70619b4bc4da.yml
+++ b/data/ga/people/Gloria-S-Butler-c02e2258-027d-4ef8-bed9-70619b4bc4da.yml
@@ -1,5 +1,5 @@
 id: ocd-person/c02e2258-027d-4ef8-bed9-70619b4bc4da
-name: Gloria S. Butler
+name: Gloria Butler
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Harold-V-Jones-II-d7bfd125-d343-4acd-a4dc-480daf241af3.yml
+++ b/data/ga/people/Harold-V-Jones-II-d7bfd125-d343-4acd-a4dc-480daf241af3.yml
@@ -1,5 +1,5 @@
 id: ocd-person/d7bfd125-d343-4acd-a4dc-480daf241af3
-name: Harold V. Jones II
+name: Harold Jones II
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Henry-Wayne-Howard-dcd39a01-0e57-4181-9c51-21dd56d60e9c.yml
+++ b/data/ga/people/Henry-Wayne-Howard-dcd39a01-0e57-4181-9c51-21dd56d60e9c.yml
@@ -1,5 +1,5 @@
 id: ocd-person/dcd39a01-0e57-4181-9c51-21dd56d60e9c
-name: Henry "Wayne" Howard
+name: Wayne Howard
 party:
 - name: Democratic
 roles:
@@ -21,7 +21,7 @@ sources:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=131&Session=27
 image: http://www.house.ga.gov/SiteCollectionImages/HowardWayne131.jpg
 family_name: Howard
-given_name: Henry
+given_name: Wayne
 extras:
   guid: 131
 other_identifiers:

--- a/data/ga/people/J-Collins-bda95ef9-7054-4100-ab95-498abe8b892f.yml
+++ b/data/ga/people/J-Collins-bda95ef9-7054-4100-ab95-498abe8b892f.yml
@@ -1,5 +1,5 @@
 id: ocd-person/bda95ef9-7054-4100-ab95-498abe8b892f
-name: J. Collins
+name: J Collins
 party:
 - name: Republican
 roles:
@@ -10,7 +10,7 @@ contact_details:
 - address: 408-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: j.collins@house.ga.gov
   note: Capitol Office
-  voice: 404-656-1803
+  voice: 404-657-1803
 - address: 206 South Carroll Rd.;Villa Rica, GA 30180
   note: District Office
 links:
@@ -18,11 +18,13 @@ links:
 sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4892&Session=27
-image: http://www.house.ga.gov/SiteCollectionImages/CollinsJ.4892.jpg
+image: http://www.house.ga.gov/SiteCollectionImages/CollinsJ4892.jpg
 family_name: Collins
-given_name: J.
+given_name: J
 extras:
   guid: 4892
 other_identifiers:
 - identifier: GAL000470
   scheme: legacy_openstates
+other_names:
+- name: J. Collins

--- a/data/ga/people/James-Burchett-dbce462d-74e3-42d3-bd6c-3b9f8eeb69fe.yml
+++ b/data/ga/people/James-Burchett-dbce462d-74e3-42d3-bd6c-3b9f8eeb69fe.yml
@@ -13,11 +13,14 @@ roles:
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4967&Session=27
 sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4967&Session=27
 contact_details:
 - address: 504-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: james.burchett@house.ga.gov
   note: Capitol Office
   voice: 404-656-0188
-- address: 6810 Albany Hwy; Waycross, GA 31552
+- address: 6810 Albany Hwy;Waycross, GA 31552
   note: District Office
+extras:
+  guid: 4967

--- a/data/ga/people/Jasmine-Clark-0461f02b-df18-4984-8b3b-ada287879d0a.yml
+++ b/data/ga/people/Jasmine-Clark-0461f02b-df18-4984-8b3b-ada287879d0a.yml
@@ -11,6 +11,8 @@ contact_details:
   email: jasmine.clark@house.ga.gov
   note: Capitol Office
   voice: 404-656-0287
+- address: P.O. Box 1922;Lilburn, GA 30048
+  note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4953&Session=27
 sources:

--- a/data/ga/people/Jeff-Jones-7c54f126-a624-4ac2-939b-87a09f59585d.yml
+++ b/data/ga/people/Jeff-Jones-7c54f126-a624-4ac2-939b-87a09f59585d.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 501-H Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: jeff.jones@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: 139-358 Altama Connector;Brunswick, GA 31525
   note: District Office
 links:

--- a/data/ga/people/Joe-Campbell-c862c17f-ed00-41d7-97e5-1138f451a96c.yml
+++ b/data/ga/people/Joe-Campbell-c862c17f-ed00-41d7-97e5-1138f451a96c.yml
@@ -1,0 +1,27 @@
+id: ocd-person/c862c17f-ed00-41d7-97e5-1138f451a96c
+name: Joe Campbell
+party:
+- name: Republican
+roles:
+- district: '171'
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  type: lower
+  start_date: 2020-02-06
+contact_details:
+- address: 608-C Coverdell Legislative Office Bldg. 18 Capitol Square SW;Atlanta,
+    GA 30334
+  email: joe.campbell@house.ga.gov
+  note: Capitol Office
+  voice: 404-656-0298
+- address: 4556 Squirrel Haven Rd;Camilla, GA 31730
+  note: District Office
+links:
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4970&Session=27
+sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4970&Session=27
+image: http://www.house.ga.gov/SiteCollectionImages/CampbellJoe4970.jpg
+family_name: Campbell
+given_name: Joe
+extras:
+  guid: 4970

--- a/data/ga/people/John-Carson-713cac52-0a57-4baa-8273-6eeca5b491df.yml
+++ b/data/ga/people/John-Carson-713cac52-0a57-4baa-8273-6eeca5b491df.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 401-E State Capitol;Atlanta, GA 30334
   email: john.carson@house.ga.gov
   note: Capitol Office
-  voice: 404-463-7855
+  voice: 404-656-7855
 - address: 3605 Sandy Plains Road, Suite 240-123;Marietta, GA 30066
   note: District Office
   voice: 404-520-8826

--- a/data/ga/people/John-F-Kennedy-ffa17688-2ca9-40ba-9eb3-3991f930bf53.yml
+++ b/data/ga/people/John-F-Kennedy-ffa17688-2ca9-40ba-9eb3-3991f930bf53.yml
@@ -1,5 +1,5 @@
 id: ocd-person/ffa17688-2ca9-40ba-9eb3-3991f930bf53
-name: John F. Kennedy
+name: John Kennedy
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Jon-G-Burns-64012657-d026-411c-9525-3232524a5145.yml
+++ b/data/ga/people/Jon-G-Burns-64012657-d026-411c-9525-3232524a5145.yml
@@ -1,5 +1,5 @@
 id: ocd-person/64012657-d026-411c-9525-3232524a5145
-name: Jon G. Burns
+name: Jon Burns
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Joseph-Gullett-f36d2507-b19a-4ee5-b4f9-5c06df761edf.yml
+++ b/data/ga/people/Joseph-Gullett-f36d2507-b19a-4ee5-b4f9-5c06df761edf.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 501-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: joseph.gullett@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: 290 Hope Drive;Dallas, GA 30157
   note: District Office
 links:

--- a/data/ga/people/Karen-Mathiak-f8db50e0-08ab-406c-ac8b-39c7038ef5ca.yml
+++ b/data/ga/people/Karen-Mathiak-f8db50e0-08ab-406c-ac8b-39c7038ef5ca.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 608-C Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 608-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: karen.mathiak@house.ga.gov
   note: Capitol Office
   voice: 404-656-0298

--- a/data/ga/people/Kasey-Carpenter-97a40ea4-674f-4b84-8fd3-8bc2f3b4a35d.yml
+++ b/data/ga/people/Kasey-Carpenter-97a40ea4-674f-4b84-8fd3-8bc2f3b4a35d.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 408-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: kasey.carpenter@house.ga.gov
   note: Capitol Office
-  voice: 404-656-1803
+  voice: 404-657-1803
 - address: 1301 W. Morton Drive;Dalton, GA 30720
   note: District Office
 links:

--- a/data/ga/people/Katie-M-Dempsey-bf68b3dc-ca81-49f9-8e33-fe27317183d3.yml
+++ b/data/ga/people/Katie-M-Dempsey-bf68b3dc-ca81-49f9-8e33-fe27317183d3.yml
@@ -1,5 +1,5 @@
 id: ocd-person/bf68b3dc-ca81-49f9-8e33-fe27317183d3
-name: Katie M. Dempsey
+name: Katie Dempsey
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Kay-Kirkpatrick-fc31ab02-026c-4173-86db-570c0b297c64.yml
+++ b/data/ga/people/Kay-Kirkpatrick-fc31ab02-026c-4173-86db-570c0b297c64.yml
@@ -11,7 +11,8 @@ contact_details:
   email: kay.kirkpatrick@senate.ga.gov
   note: Capitol Office
   voice: 404-656-3932
-- note: District Office
+- address: 2926 Ashebrooke Dr;Marietta, GA 30068
+  note: District Office
   voice: 404-822-4719
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4910&Session=27

--- a/data/ga/people/Kevin-Cooke-cb40fb3e-53c2-428e-a525-6e993a1ea537.yml
+++ b/data/ga/people/Kevin-Cooke-cb40fb3e-53c2-428e-a525-6e993a1ea537.yml
@@ -11,7 +11,7 @@ contact_details:
   email: kevin.cooke@house.ga.gov
   note: Capitol Office
   voice: 404-656-0188
-- address: 141 Natures Pointe Trail;Carrollton, GA 30117-8371
+- address: 102 Cherry St.;Bremen, GA 30110
   note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=757&Session=27

--- a/data/ga/people/Larry-Walker-III-44a51125-9e82-41f6-8d4f-a646895b5994.yml
+++ b/data/ga/people/Larry-Walker-III-44a51125-9e82-41f6-8d4f-a646895b5994.yml
@@ -1,5 +1,5 @@
 id: ocd-person/44a51125-9e82-41f6-8d4f-a646895b5994
-name: Larry Walker III
+name: Larry Walker, III
 party:
 - name: Republican
 roles:
@@ -19,7 +19,7 @@ links:
 sources:
 - url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4878&Session=27
-image: http://www.senate.ga.gov/SiteCollectionImages/Walker IIILawrence4878.jpg
+image: http://www.senate.ga.gov/SiteCollectionImages/Walker, IIILarry4878.jpg
 family_name: Walker
 given_name: Larry
 extras:
@@ -27,3 +27,5 @@ extras:
 other_identifiers:
 - identifier: GAL000438
   scheme: legacy_openstates
+other_names:
+- name: Larry Walker III

--- a/data/ga/people/Lester-G-Jackson-db1107ac-a309-4e44-8ee4-a20454cfe1d4.yml
+++ b/data/ga/people/Lester-G-Jackson-db1107ac-a309-4e44-8ee4-a20454cfe1d4.yml
@@ -1,5 +1,5 @@
 id: ocd-person/db1107ac-a309-4e44-8ee4-a20454cfe1d4
-name: Lester G. Jackson
+name: Lester Jackson
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Mandi-L-Ballinger-d6a8848d-a637-4c2e-ae37-84440c614400.yml
+++ b/data/ga/people/Mandi-L-Ballinger-d6a8848d-a637-4c2e-ae37-84440c614400.yml
@@ -1,5 +1,5 @@
 id: ocd-person/d6a8848d-a637-4c2e-ae37-84440c614400
-name: Mandi L.  Ballinger
+name: Mandi Ballinger
 party:
 - name: Republican
 roles:
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 218-B State Capitol;Atlanta, GA 30334
+- address: 218-D State Capitol;Atlanta, GA 30334
   email: mandi.ballinger@house.ga.gov
   note: Capitol Office
   voice: 404-656-7153

--- a/data/ga/people/Marcus-A-Wiedower-ff24cea3-8582-4cfe-b015-74ee7c5ebeef.yml
+++ b/data/ga/people/Marcus-A-Wiedower-ff24cea3-8582-4cfe-b015-74ee7c5ebeef.yml
@@ -1,5 +1,5 @@
 id: ocd-person/ff24cea3-8582-4cfe-b015-74ee7c5ebeef
-name: Marcus A. Wiedower
+name: Marcus Wiedower
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Martin-Momtahan-6552dd8d-1020-4bbb-abfc-88975573ebd4.yml
+++ b/data/ga/people/Martin-Momtahan-6552dd8d-1020-4bbb-abfc-88975573ebd4.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 501-A Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: martin.momtahan@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: 215 Postell Rd;Dallas, GA 30157
   note: District Office
 links:

--- a/data/ga/people/Marty-Harbin-078246e9-90b8-43aa-bb92-d7016f517b8e.yml
+++ b/data/ga/people/Marty-Harbin-078246e9-90b8-43aa-bb92-d7016f517b8e.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: upper
 contact_details:
-- address: 302- A Coverdell Legislative Office Building;Atlanta, GA 30334
+- address: 302-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: marty.harbin@senate.ga.gov
   fax: 404-656-6484
   note: Capitol Office

--- a/data/ga/people/Mary-Margaret-Margaret-Oliver-1eac4f46-2c61-4f92-a18c-70bfdeb7fec1.yml
+++ b/data/ga/people/Mary-Margaret-Margaret-Oliver-1eac4f46-2c61-4f92-a18c-70bfdeb7fec1.yml
@@ -1,5 +1,5 @@
 id: ocd-person/1eac4f46-2c61-4f92-a18c-70bfdeb7fec1
-name: Mary Margaret Oliver
+name: Mary Oliver
 party:
 - name: Democratic
 roles:
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 604-E Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: mmo@mmolaw.com
+  email: mary.oliver@house.ga.gov
   fax: 404-463-2634
   note: Capitol Office
   voice: 404-656-0265

--- a/data/ga/people/Matt-Barton-9103b29e-964b-4637-9304-0e73216d7796.yml
+++ b/data/ga/people/Matt-Barton-9103b29e-964b-4637-9304-0e73216d7796.yml
@@ -13,11 +13,14 @@ roles:
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4966&Session=27
 sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4966&Session=27
 contact_details:
-- address: 612-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 612-E Coverdell Legislative Bldg.;Atlanta, GA 30334
   email: matt.barton@house.ga.gov
   note: Capitol Office
   voice: 404-656-0325
-- address: 135 Victory Ct.; Calhoun, GA 30701
+- address: 135 Victory Ct.;Calhoun, GA 30701
   note: District Office
+extras:
+  guid: 4966

--- a/data/ga/people/Micah-Gravley-b2f6bc11-2b2f-4b49-9d44-d07a89432688.yml
+++ b/data/ga/people/Micah-Gravley-b2f6bc11-2b2f-4b49-9d44-d07a89432688.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 415 State Capitol;Atlanta, GA 30334
   email: micah.gravley@house.ga.gov
   note: Capitol Office
-  voice: 404-463-8143
+  voice: 404-656-5025
 - address: 94 Bridge Place;Douglasville, GA 30134
   note: District Office
 links:

--- a/data/ga/people/Mike-Dugan-c6ffdd1c-8f58-47cb-8802-ed7a9d6dd49a.yml
+++ b/data/ga/people/Mike-Dugan-c6ffdd1c-8f58-47cb-8802-ed7a9d6dd49a.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: upper
 contact_details:
-- address: 206 Washington Street - 236 State Capitol;Atlanta, GA 30334
+- address: 236 State Capitol;Atlanta, GA 30334
   email: mike.dugan@senate.ga.gov
   note: Capitol Office
   voice: 404-463-2478

--- a/data/ga/people/Mitchell-Scoggins-7ac30a66-1649-4a8c-a72f-a4b9a7ab1534.yml
+++ b/data/ga/people/Mitchell-Scoggins-7ac30a66-1649-4a8c-a72f-a4b9a7ab1534.yml
@@ -11,7 +11,7 @@ contact_details:
   email: mitchell.scoggins@house.ga.gov
   note: Capitol Office
   voice: 404-656-0325
-- address: P.O. Box 1051;Cartersville, GA 30120
+- address: P.O. Box 18;Rydal, GA 30171
   note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4964&Session=27

--- a/data/ga/people/P-K-Martin-IV-90751b67-4684-4528-a9a2-9d10b884ab78.yml
+++ b/data/ga/people/P-K-Martin-IV-90751b67-4684-4528-a9a2-9d10b884ab78.yml
@@ -11,8 +11,7 @@ contact_details:
   email: p.k.martin@senate.ga.gov
   note: Capitol Office
   voice: 404-463-6598
-- address: 455 Pine Forest Dr;Lawrenceville, GA 30046
-  note: District Office
+- note: District Office
   voice: 770-378-2102
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=854&Session=27

--- a/data/ga/people/Pam-Stephenson-53d6aec0-12cb-4201-bf23-22ed40c4a089.yml
+++ b/data/ga/people/Pam-Stephenson-53d6aec0-12cb-4201-bf23-22ed40c4a089.yml
@@ -12,10 +12,6 @@ contact_details:
   fax: 404-656-4889
   note: Capitol Office
   voice: 404-656-0126
-- address: 4262 Clausell Court, Suite C;Decatur, GA 30035
-  fax: 404-289-8303
-  note: District Office
-  voice: 404-289-8300
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=220&Session=27
 sources:

--- a/data/ga/people/Pat-Gardner-1d508736-f7f1-4214-b6c0-b7eccede94d1.yml
+++ b/data/ga/people/Pat-Gardner-1d508736-f7f1-4214-b6c0-b7eccede94d1.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 604-G Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: pat@patgardner.org
+  email: pat.gardner@house.ga.gov
   fax: 404-463-2634
   note: Capitol Office
   voice: 404-656-0265

--- a/data/ga/people/Pedro-Pete-Marin-90ad4502-efa3-4e77-9aed-4ec3667f4352.yml
+++ b/data/ga/people/Pedro-Pete-Marin-90ad4502-efa3-4e77-9aed-4ec3667f4352.yml
@@ -1,5 +1,5 @@
 id: ocd-person/90ad4502-efa3-4e77-9aed-4ec3667f4352
-name: Pedro "Pete" Marin
+name: Pedro Marin
 party:
 - name: Democratic
 roles:
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 611-A Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: marinstatehouse@gmail.com
+  email: pedro.marin@house.ga.gov
   fax: 404-651-8086
   note: Capitol Office
   voice: 404-656-0314

--- a/data/ga/people/Philip-Singleton-a812424b-ab9f-41fc-89a0-4e92674b1ac2.yml
+++ b/data/ga/people/Philip-Singleton-a812424b-ab9f-41fc-89a0-4e92674b1ac2.yml
@@ -1,0 +1,26 @@
+id: ocd-person/a812424b-ab9f-41fc-89a0-4e92674b1ac2
+name: Philip Singleton
+party:
+- name: Republican
+roles:
+- district: '71'
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  type: lower
+  start_date: 2019-10-15
+contact_details:
+- address: 501-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: philip.singleton@house.ga.gov
+  note: Capitol Office
+  voice: 404-656-0178
+- address: 55 Hazelridge Lane;Sharpsburg, GA 30277
+  note: District Office
+links:
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4968&Session=27
+sources:
+- url: http://webservices.legis.ga.gov/GGAServices/Members/Service.svc?wsdl
+- url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4968&Session=27
+image: http://www.house.ga.gov/SiteCollectionImages/SingletonPhilip4968.jpg
+family_name: Singleton
+given_name: Philip
+extras:
+  guid: 4968

--- a/data/ga/people/Renee-S-Unterman-ed835a8e-0055-4607-9803-6dfccb346ab5.yml
+++ b/data/ga/people/Renee-S-Unterman-ed835a8e-0055-4607-9803-6dfccb346ab5.yml
@@ -1,5 +1,5 @@
 id: ocd-person/ed835a8e-0055-4607-9803-6dfccb346ab5
-name: Renee S Unterman
+name: Renee Unterman
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Richard-H-Smith-fa84bdc1-e9c1-4794-b6ad-b8e0564efd9d.yml
+++ b/data/ga/people/Richard-H-Smith-fa84bdc1-e9c1-4794-b6ad-b8e0564efd9d.yml
@@ -1,5 +1,5 @@
 id: ocd-person/fa84bdc1-e9c1-4794-b6ad-b8e0564efd9d
-name: Richard H. Smith
+name: Richard Smith
 party:
 - name: Republican
 roles:
@@ -7,12 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 220-A State Capitol;Atlanta, GA 30334
+- address: HM-1 State Capitol;Atlanta, GA 30334
   email: richard.smith@house.ga.gov
-  fax: 404-463-4221
   note: Capitol Office
-  voice: 404-656-6831
-- address: PO Box 2122;Columbus, GA 31902-2122
+  voice: 404-656-5141
+- address: PO Box 2122;Columbus, GA 319022122
   note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=213&Session=27

--- a/data/ga/people/Rick-Jasperse-4d1f5379-01e9-4f58-9868-42acc07ec7a8.yml
+++ b/data/ga/people/Rick-Jasperse-4d1f5379-01e9-4f58-9868-42acc07ec7a8.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 218-A State Capitol;Atlanta, GA 30334
+- address: 218-C State Capitol;Atlanta, GA 30334
   email: rick.jasperse@house.ga.gov
   note: Capitol Office
-  voice: 404-656-5943
+  voice: 404-656-7153
 - address: 89 Apple Valley Farm Lane;Jasper, GA 30143
   note: District Office
 links:

--- a/data/ga/people/Robert-Trammell-de14c9e7-f1f4-49af-b464-dec8424687a9.yml
+++ b/data/ga/people/Robert-Trammell-de14c9e7-f1f4-49af-b464-dec8424687a9.yml
@@ -7,9 +7,8 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 609-F Coverdell Legislative Office Bldg. 18 Capitol Square SW;Atlanta,
-    GA 30334
-  email: bob.trammell@house.ga.gov
+- address: 609-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+  email: robert.trammell@house.ga.gov
   note: Capitol Office
   voice: 404-656-5058
 - address: 128 North Main Street;Luthersville, GA 30251

--- a/data/ga/people/Roger-Bruce-d32a6c75-5527-443e-b8a1-2d2931da643a.yml
+++ b/data/ga/people/Roger-Bruce-d32a6c75-5527-443e-b8a1-2d2931da643a.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 512-A Coverdell Legislative Office Building;Atlanta, GA 30334
-  email: rbruce5347@aol.com
+  email: roger.bruce@house.ga.gov
   note: Capitol Office
   voice: 404-656-7859
 - address: 410 Stone Arbor Court;Atlanta, GA 30331

--- a/data/ga/people/Sam-Park-2ba0916f-40b1-4255-9496-94b12ccabd1e.yml
+++ b/data/ga/people/Sam-Park-2ba0916f-40b1-4255-9496-94b12ccabd1e.yml
@@ -11,7 +11,7 @@ contact_details:
   email: sam.park@house.ga.gov
   note: Capitol Office
   voice: 404-656-0314
-- address: 1409 Legrand Circle;Lawrenceville, GA 30043
+- address: 4850 Sugarloaf Pkwy Ste. 209-188;Lawrenceville, GA 30044
   note: District Office
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=4901&Session=27

--- a/data/ga/people/Sheikh-Rahman-5b6e0e37-802b-4103-b401-551532aba2e7.yml
+++ b/data/ga/people/Sheikh-Rahman-5b6e0e37-802b-4103-b401-551532aba2e7.yml
@@ -11,6 +11,8 @@ contact_details:
   email: sheikh.rahman@senate.ga.gov
   note: Capitol Office
   voice: 404-463-1318
+- address: 779 Simon Way;Lawrenceville, GA 30045
+  note: District Office
 links:
 - url: http://www.senate.ga.gov/SENATORS/en-US/member.aspx?Member=4924&Session=27
 sources:

--- a/data/ga/people/Sheila-Clark-Nelson-059c0e54-cc7b-4605-aee6-58388026a2fb.yml
+++ b/data/ga/people/Sheila-Clark-Nelson-059c0e54-cc7b-4605-aee6-58388026a2fb.yml
@@ -1,5 +1,5 @@
 id: ocd-person/059c0e54-cc7b-4605-aee6-58388026a2fb
-name: Sheila Clark Nelson
+name: Sheila Nelson
 party:
 - name: Democratic
 roles:

--- a/data/ga/people/Sheila-Jones-b278b399-5ca3-4cd7-bc19-4053166577a2.yml
+++ b/data/ga/people/Sheila-Jones-b278b399-5ca3-4cd7-bc19-4053166577a2.yml
@@ -11,10 +11,9 @@ contact_details:
   email: sheila.jones@house.ga.gov
   fax: 404-651-8086
   note: Capitol Office
-  voice: 404-656-0126
+  voice: 404-656-0132
 - address: 3246 Amhurst Dr., NW;Atlanta, GA 30318
   note: District Office
-  voice: 404-542-8683
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=143&Session=27
 sources:

--- a/data/ga/people/Steven-Meeks-3194a8e0-aaf8-4686-b2c9-a22521f85fff.yml
+++ b/data/ga/people/Steven-Meeks-3194a8e0-aaf8-4686-b2c9-a22521f85fff.yml
@@ -8,9 +8,9 @@ roles:
   type: lower
 contact_details:
 - address: 501-E Coverdell Legislative Office Bldg.;Atlanta, GA 30334
-  email: meekss@me.com
+  email: steven.meeks@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: P.O. Box 178;Screven, GA 31560
   note: District Office
 links:

--- a/data/ga/people/Steven-Sainz-99082062-acd6-4c6b-bb45-2cfa071f19fc.yml
+++ b/data/ga/people/Steven-Sainz-99082062-acd6-4c6b-bb45-2cfa071f19fc.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 501-F Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: steven.sainz@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: 203 E 5th St;Woodbine, GA 31569
   note: District Office
 links:

--- a/data/ga/people/Susan-Holmes-aaa374c2-a584-4e78-b2f3-f899efb2d568.yml
+++ b/data/ga/people/Susan-Holmes-aaa374c2-a584-4e78-b2f3-f899efb2d568.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 218-C State Capitol;Atlanta, GA 30334
+- address: 218-B State Capitol;Atlanta, GA 30334
   email: susan.holmes@house.ga.gov
   note: Capitol Office
   voice: 404-656-5132

--- a/data/ga/people/Terry-England-89d6e453-cec1-4f90-b7c4-7de117d62b5c.yml
+++ b/data/ga/people/Terry-England-89d6e453-cec1-4f90-b7c4-7de117d62b5c.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
 contact_details:
 - address: 245 State Capitol;Atlanta, GA 30334
-  email: englandhomeport2@windstream.net
+  email: terry.england@house.ga.gov
   note: Capitol Office
   voice: 404-463-2247
 links:

--- a/data/ga/people/Timothy-Barr-555d218d-1720-401c-a77f-124937c5b184.yml
+++ b/data/ga/people/Timothy-Barr-555d218d-1720-401c-a77f-124937c5b184.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
 contact_details:
-- address: 608-D Coverdell Legislative Office Bldg.;Atlanta, GA 30334
+- address: 401-J State Capitol;Atlanta, GA 30334
   email: timothy.barr@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0298
+  voice: 404-656-7857
 links:
 - url: http://www.house.ga.gov/Representatives/en-US/member.aspx?Member=809&Session=27
 sources:

--- a/data/ga/people/Tom-Kirby-bd5465c9-0276-4d9d-8b54-6bc860a778a0.yml
+++ b/data/ga/people/Tom-Kirby-bd5465c9-0276-4d9d-8b54-6bc860a778a0.yml
@@ -11,7 +11,7 @@ contact_details:
   email: tom.kirby@house.ga.gov
   fax: 404-651-8086
   note: Capitol Office
-  voice: 404-656-0177
+  voice: 404-656-0178
 - address: PO Box 1416;Loganville, GA 30052
   note: District Office
 links:

--- a/data/ga/people/Tonya-Anderson-d9f1ea57-7b90-484a-9664-927a36c87e0c.yml
+++ b/data/ga/people/Tonya-Anderson-d9f1ea57-7b90-484a-9664-927a36c87e0c.yml
@@ -12,7 +12,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: upper
 contact_details:
-- address: 319-A Coverdell Legislative Building;Atlanta, GA 30334
+- address: 319-A Coverdell Legislative Office Building;Atlanta, GA 30334
   email: tonya.anderson@senate.ga.gov
   note: Capitol Office
   voice: 404-463-2598

--- a/data/ga/people/William-Boddie-91d76496-2642-49d5-ac8f-1fd3cf187d9f.yml
+++ b/data/ga/people/William-Boddie-91d76496-2642-49d5-ac8f-1fd3cf187d9f.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 609 Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: william.boddie@house.ga.gov
   note: Capitol Office
-  voice: 404-656-0109
+  voice: 404-656-5058
 - address: P.O. Box 90787;East Point, GA 30364
   note: District Office
 links:

--- a/data/ga/people/William-T-Ligon-Jr-cb9e65cd-936b-4eef-b504-4e80c4512fec.yml
+++ b/data/ga/people/William-T-Ligon-Jr-cb9e65cd-936b-4eef-b504-4e80c4512fec.yml
@@ -1,5 +1,5 @@
 id: ocd-person/cb9e65cd-936b-4eef-b504-4e80c4512fec
-name: William T. Ligon, Jr.
+name: William Ligon, Jr.
 party:
 - name: Republican
 roles:

--- a/data/ga/people/Winfred-J-Dukes-15e1c977-35f5-4e57-a3bd-b904fba74def.yml
+++ b/data/ga/people/Winfred-J-Dukes-15e1c977-35f5-4e57-a3bd-b904fba74def.yml
@@ -1,5 +1,5 @@
 id: ocd-person/15e1c977-35f5-4e57-a3bd-b904fba74def
-name: Winfred J Dukes
+name: Winfred Dukes
 party:
 - name: Democratic
 roles:

--- a/data/ga/retired/David-Stover-fd10b3ca-8271-42c6-b4fc-c0a6b46cde03.yml
+++ b/data/ga/retired/David-Stover-fd10b3ca-8271-42c6-b4fc-c0a6b46cde03.yml
@@ -6,6 +6,7 @@ roles:
 - district: '71'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
+  end_date: '2019-06-25'
 contact_details:
 - address: 501-B Coverdell Legislative Office Bldg.;Atlanta, GA 30334
   email: david.stover@house.ga.gov

--- a/data/ga/retired/Ed-Rynders-573a438f-ad34-43df-bdd0-7e28c499e1ef.yml
+++ b/data/ga/retired/Ed-Rynders-573a438f-ad34-43df-bdd0-7e28c499e1ef.yml
@@ -6,6 +6,7 @@ roles:
 - district: '152'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
+  end_date: '2019-09-05'
 contact_details:
 - address: 218-D State Capitol;Atlanta, GA 30334
   email: erynders@bellsouth.net

--- a/data/ga/retired/Greg-Kirk-c3762f0c-6f6b-46bd-b92b-cfeb2978d16e.yml
+++ b/data/ga/retired/Greg-Kirk-c3762f0c-6f6b-46bd-b92b-cfeb2978d16e.yml
@@ -6,6 +6,8 @@ roles:
 - district: '13'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: upper
+  end_date: '2019-12-22'
+  end_reason: Deceased
 contact_details:
 - address: 121-J State Capitol;Atlanta, GA 30334
   email: greg.kirk@senate.ga.gov
@@ -27,3 +29,4 @@ extras:
 other_identifiers:
 - identifier: GAL000404
   scheme: legacy_openstates
+death_date: '2019-12-22'

--- a/data/ga/retired/Jack-Hill-6c1ad7e8-650a-4b91-a358-8104e4945eca.yml
+++ b/data/ga/retired/Jack-Hill-6c1ad7e8-650a-4b91-a358-8104e4945eca.yml
@@ -6,6 +6,8 @@ roles:
 - district: '4'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: upper
+  end_date: '2020-04-06'
+  end_reason: Deceased
 contact_details:
 - address: 234 State Capitol;Atlanta, GA 30334
   email: jack.hill@senate.ga.gov
@@ -29,3 +31,4 @@ extras:
 other_identifiers:
 - identifier: GAL000023
   scheme: legacy_openstates
+death_date: '2020-04-06'

--- a/data/ga/retired/Jay-Powell-fa8116dd-1638-4a0c-86d2-f0d70d4a284c.yml
+++ b/data/ga/retired/Jay-Powell-fa8116dd-1638-4a0c-86d2-f0d70d4a284c.yml
@@ -6,6 +6,8 @@ roles:
 - district: '171'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/government
   type: lower
+  end_date: '2019-11-26'
+  end_reason: Deceased
 contact_details:
 - address: HM-1 State Capitol;Atlanta, GA 30334
   email: jay.powell@house.ga.gov
@@ -27,3 +29,4 @@ extras:
 other_identifiers:
 - identifier: GAL000184
   scheme: legacy_openstates
+death_date: '2019-11-26'

--- a/settings.yml
+++ b/settings.yml
@@ -1,3 +1,8 @@
+ga:
+  vacancies:
+    - chamber: upper
+      district: 4
+      vacant_until: 2020-08-01
 ma:
   vacancies:
     - chamber: upper


### PR DESCRIPTION
Add four new legislators, as a result of two resignations and two deaths. There is additionally now a vacancy as a result of Jack Hill's death.

This also updates some names by removing nicknames and middle names, as these fail to match with the names found in bills and committees.