### PR TITLE
WI: Replace Peter Barca with Tip McGuire

### DIFF
--- a/data/wi/people/Tip-McGuire-c66ed13a-e5a7-49e0-9cce-02d677c5da15.yml
+++ b/data/wi/people/Tip-McGuire-c66ed13a-e5a7-49e0-9cce-02d677c5da15.yml
@@ -1,0 +1,22 @@
+id: ocd-person/c66ed13a-e5a7-49e0-9cce-02d677c5da15
+name: Tip McGuire
+party:
+- name: Democratic
+roles:
+- district: '64'
+  jurisdiction: ocd-jurisdiction/country:us/state:wi/government
+  type: lower
+  start_date: 2019-05-13
+contact_details:
+- address: Room 15 West;State Capitol;PO Box 8953;Madison, WI 53708
+  email: Rep.McGuire@legis.wisconsin.gov
+  fax: 608-282-3664
+  note: Capitol Office
+  voice: 608-266-5504
+links:
+- url: https://docs.legis.wisconsin.gov/2019/legislators/assembly/2075
+sources:
+- url: https://docs.legis.wisconsin.gov/2019/legislators/assembly/2075
+image: https://docs.legis.wisconsin.gov/2019/legislators/assembly/2075.jpg
+given_name: Tip
+family_name: McGuire

--- a/data/wi/retired/Peter-Barca-5e70f623-ae29-4013-ac58-b86c2616a9eb.yml
+++ b/data/wi/retired/Peter-Barca-5e70f623-ae29-4013-ac58-b86c2616a9eb.yml
@@ -6,6 +6,7 @@ roles:
 - district: '64'
   jurisdiction: ocd-jurisdiction/country:us/state:wi/government
   type: lower
+  end_date: '2019-01-08'
 contact_details:
 - address: Room 109 North;State Capitol;PO Box 8952;Madison, WI 53708
   email: Rep.Barca@legis.wisconsin.gov


### PR DESCRIPTION
Peter Barca resigned last year, and Tip McGuire was elected to replace him.