### PR TITLE
Update South Carolina legislators

### DIFF
--- a/data/sc/organizations/Banking-and-Insurance-eace1f94-9de6-4403-82a2-c841302f0fa1.yml
+++ b/data/sc/organizations/Banking-and-Insurance-eace1f94-9de6-4403-82a2-c841302f0fa1.yml
@@ -23,6 +23,7 @@ memberships:
   name: Kent M. Williams
 - id: ocd-person/f80f5cbc-aebf-462e-ae16-7e5d32e002a5
   name: William Timmons
+  end_date: '2018-11-09'
 - id: ocd-person/27fb6caf-f757-44a3-8973-6ce72aacd7e2
   name: Luke A. Rankin
 - id: ocd-person/cfe2d50f-0241-496c-9557-2a3d6edef4fd
@@ -30,7 +31,7 @@ memberships:
 - id: ocd-person/2b3fc123-0a9b-4324-b406-1421260f7ee6
   name: Gerald Malloy
 - id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-  name: Mike Gambrell
+  name: Michael W. Gambrell
 - id: ocd-person/e93ca357-56f3-453f-aacc-fdeb0f8a77e8
   name: Nikki G. Setzler
 - id: ocd-person/3265c6c1-e300-4fd3-9d61-1cef57279d67

--- a/data/sc/organizations/Corrections-and-Penology-4dc4af6d-d4d7-4829-9704-422dcb747f52.yml
+++ b/data/sc/organizations/Corrections-and-Penology-4dc4af6d-d4d7-4829-9704-422dcb747f52.yml
@@ -15,6 +15,7 @@ memberships:
   name: Floyd Nicholson
 - id: ocd-person/f80f5cbc-aebf-462e-ae16-7e5d32e002a5
   name: William Timmons
+  end_date: '2018-11-09'
 - id: ocd-person/9bd3d162-efdd-4c99-8cdd-cccd2ad40baa
   name: Sandy Senn
 - id: ocd-person/6409590b-b759-47e0-ba61-cfe5aee94228

--- a/data/sc/organizations/Education-and-Public-Works-6f6dc65c-cd1f-4ae8-882b-ca0c3b94934b.yml
+++ b/data/sc/organizations/Education-and-Public-Works-6f6dc65c-cd1f-4ae8-882b-ca0c3b94934b.yml
@@ -15,6 +15,7 @@ memberships:
 - id: ocd-person/79c3a2ca-d046-4fc6-bfae-04a1fdd08546
   name: Ronald "Ronnie" Young
   role: first vice-chair
+  end_date: '2019-05-19'
 - id: ocd-person/56f713aa-3887-4e45-996d-ca60006edd99
   name: Jerry N. Govan, Jr.
 - id: ocd-person/aa158d61-1373-4c4a-9ad3-ea74bf422cc3
@@ -61,19 +62,19 @@ memberships:
   name: Paula Rawl Calhoon
   start_date: '2018-11-12'
 - id: ocd-person/85b6c740-53c9-4231-aa87-161e816738a5
-  name: Converse A "Con" Chellis, IV
+  name: Converse A. "Con" Chellis, IV
   start_date: '2018-11-12'
 - id: ocd-person/083dd694-e9e1-43fb-a857-760acfb78ef8
   name: Bobby J. Cox
   start_date: '2018-11-12'
 - id: ocd-person/023895b1-aeb4-410a-84d0-0059b3f10ee3
-  name: Timothy A "Tim" McGinnis
+  name: Timothy A. "Tim" McGinnis
   start_date: '2018-11-12'
 - id: ocd-person/13c06705-600b-49d0-a5a0-393668a03e73
   name: Ivory Torrey Thigpen
   start_date: '2018-11-12'
 - id: ocd-person/728e5331-d2ec-4c21-a271-be37ae8843ff
-  name: Christopher Sloan "Chris" Wooten
+  name: Chris Wooten
   start_date: '2018-11-12'
 - id: ocd-person/ebfb814e-0b47-4d8f-be94-63718f71a96c
   name: Richard L. "Richie" Yow

--- a/data/sc/organizations/Ethics-956b1601-8bc7-4dea-81a4-86a79fd7b687.yml
+++ b/data/sc/organizations/Ethics-956b1601-8bc7-4dea-81a4-86a79fd7b687.yml
@@ -41,6 +41,7 @@ memberships:
 - id: ocd-person/9a28833a-867d-460f-b165-be02daf32093
   name: Peter M. McCoy, Jr.
   start_date: '2018-11-12'
+  end_date: '2020-03-30'
 - id: ocd-person/ad25d5ef-8d4f-425f-9dbd-0b018f1771cc
   name: J. Todd Rutherford
   start_date: '2018-11-12'

--- a/data/sc/organizations/Fish-Game-and-Forestry-228ed379-24a9-411a-96fe-2de33cdd4625.yml
+++ b/data/sc/organizations/Fish-Game-and-Forestry-228ed379-24a9-411a-96fe-2de33cdd4625.yml
@@ -38,6 +38,7 @@ memberships:
   role: chairman
 - id: ocd-person/f80f5cbc-aebf-462e-ae16-7e5d32e002a5
   name: William Timmons
+  end_date: '2018-11-09'
 - id: ocd-person/51171d8d-a51b-4684-8e45-a88ad5250314
   name: Scott Talley
 - id: ocd-person/f4d5a02c-1b98-4fd1-9db4-35b1b8a79d18

--- a/data/sc/organizations/General-300eb421-9747-491f-9301-9a5d2dc8ddfe.yml
+++ b/data/sc/organizations/General-300eb421-9747-491f-9301-9a5d2dc8ddfe.yml
@@ -21,7 +21,7 @@ memberships:
 - id: ocd-person/bf0e5259-d4e3-472c-a3a0-384eab1e8ae2
   name: Ross Turner
 - id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-  name: Mike Gambrell
+  name: Michael W. Gambrell
 - id: ocd-person/7bf37b05-cbd3-4aa6-b6d7-fd01aa27a045
   name: John L. Scott, Jr.
 - id: ocd-person/9837e1c5-5014-4306-9f78-1550b1a9a2c2
@@ -42,3 +42,4 @@ memberships:
   name: J. Thomas McElveen, III
 - id: ocd-person/f80f5cbc-aebf-462e-ae16-7e5d32e002a5
   name: William Timmons
+  end_date: '2018-11-09'

--- a/data/sc/organizations/Judiciary-c4ee3787-21c4-4fb5-89ce-495b1dc8519c.yml
+++ b/data/sc/organizations/Judiciary-c4ee3787-21c4-4fb5-89ce-495b1dc8519c.yml
@@ -35,6 +35,7 @@ memberships:
   name: George E. "Chip" Campsen, III
 - id: ocd-person/f80f5cbc-aebf-462e-ae16-7e5d32e002a5
   name: William Timmons
+  end_date: '2018-11-09'
 - id: ocd-person/bf0e5259-d4e3-472c-a3a0-384eab1e8ae2
   name: Ross Turner
 - id: ocd-person/9b4e7cb9-4e4e-484d-8ce9-4fe4a73b8c59
@@ -49,7 +50,7 @@ memberships:
 - id: ocd-person/340b7b78-4f07-49ef-8872-dab35cf48c5c
   name: A. Shane Massey
 - id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-  name: Mike Gambrell
+  name: Michael W. Gambrell
 - id: ocd-person/0a07f819-4966-4b86-8e1f-d6b66b447460
   name: Katrina Frye Shealy
 - id: ocd-person/9bd3d162-efdd-4c99-8cdd-cccd2ad40baa

--- a/data/sc/organizations/Judiciary-c539e7cc-6b38-422d-beb8-04e56cf521c3.yml
+++ b/data/sc/organizations/Judiciary-c539e7cc-6b38-422d-beb8-04e56cf521c3.yml
@@ -28,6 +28,7 @@ memberships:
 - id: ocd-person/9a28833a-867d-460f-b165-be02daf32093
   name: Peter M. McCoy, Jr.
   role: chairman
+  end_date: '2020-03-30'
 - id: ocd-person/16a57c6b-02c8-4a59-99bf-4f4cdcef1c0e
   name: Laurie Slade Funderburk
 - id: ocd-person/26a0f7b8-63a4-4526-8399-669d4f7b86e8
@@ -89,5 +90,5 @@ memberships:
   name: Nancy Mace
   start_date: '2018-11-12'
 - id: ocd-person/6f3e5d6a-0e85-4af0-9711-1eaa7e3da981
-  name: Seth C. Rose
+  name: Seth Rose
   start_date: '2018-11-12'

--- a/data/sc/organizations/Labor-Commerce-and-Industry-952ea8ac-889d-4074-883f-a59328dbddf6.yml
+++ b/data/sc/organizations/Labor-Commerce-and-Industry-952ea8ac-889d-4074-883f-a59328dbddf6.yml
@@ -16,7 +16,7 @@ memberships:
 - id: ocd-person/92a0b883-789a-4291-b2f1-330ec804ba12
   name: Ronnie A. Sabb
 - id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-  name: Mike Gambrell
+  name: Michael W. Gambrell
 - id: ocd-person/946afea5-c89c-4a8f-a80e-a841bf7e899a
   name: Karl B. Allen
 - id: ocd-person/558988f4-83b4-4635-a34a-946bf9e73cbd

--- a/data/sc/organizations/Legislative-Oversight-8f0e28bd-5914-4c8a-be45-1d8087e14264.yml
+++ b/data/sc/organizations/Legislative-Oversight-8f0e28bd-5914-4c8a-be45-1d8087e14264.yml
@@ -67,5 +67,5 @@ memberships:
   name: Marvin R. Pendarvis
   start_date: '2018-11-12'
 - id: ocd-person/728e5331-d2ec-4c21-a271-be37ae8843ff
-  name: Christopher Sloan "Chris" Wooten
+  name: Chris Wooten
   start_date: '2018-11-12'

--- a/data/sc/organizations/Medical-Affairs-bdf0b108-ae05-4542-82ff-c506bcfadd3a.yml
+++ b/data/sc/organizations/Medical-Affairs-bdf0b108-ae05-4542-82ff-c506bcfadd3a.yml
@@ -23,7 +23,7 @@ memberships:
 - id: ocd-person/87089a99-47f3-42ae-a55f-cd1a356656b5
   name: Kevin L. Johnson
 - id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-  name: Mike Gambrell
+  name: Michael W. Gambrell
 - id: ocd-person/16ba6021-423d-4b0d-b899-d2fe18778c12
   name: Brad Hutto
 - id: ocd-person/7bf37b05-cbd3-4aa6-b6d7-fd01aa27a045

--- a/data/sc/organizations/Medical-Military-Public-and-Municipal-Affairs-913cab51-35db-4f26-88ab-e2ce113dbb6f.yml
+++ b/data/sc/organizations/Medical-Military-Public-and-Municipal-Affairs-913cab51-35db-4f26-88ab-e2ce113dbb6f.yml
@@ -40,7 +40,7 @@ memberships:
   name: Neal A. Collins
   end_date: '2018-11-11'
 - id: ocd-person/023895b1-aeb4-410a-84d0-0059b3f10ee3
-  name: Timothy A "Tim" McGinnis
+  name: Timothy A. "Tim" McGinnis
   end_date: '2018-11-11'
 - id: ocd-person/8a69fe7b-4ec4-4f9a-bc6e-b8acf0cd06c7
   name: Jonathon D. Hill
@@ -88,7 +88,7 @@ memberships:
   name: Leola C. Robinson
   start_date: '2018-11-12'
 - id: ocd-person/648a5fc9-ef93-4106-bc39-e45827f51306
-  name: Krystle N. Simmons
+  name: Krystle N. Matthews
   start_date: '2018-11-12'
 - id: ocd-person/041b9252-ba36-4664-a79f-4f620e5688b5
   name: Shedron D. Williams

--- a/data/sc/organizations/Regulations-and-Admin-Procedures-ecf1494f-98f2-4b97-9638-68a3b2a65d41.yml
+++ b/data/sc/organizations/Regulations-and-Admin-Procedures-ecf1494f-98f2-4b97-9638-68a3b2a65d41.yml
@@ -47,11 +47,11 @@ memberships:
   name: Steven Wayne Long
   start_date: '2018-11-12'
 - id: ocd-person/023895b1-aeb4-410a-84d0-0059b3f10ee3
-  name: Timothy A "Tim" McGinnis
+  name: Timothy A. "Tim" McGinnis
   start_date: '2018-11-12'
 - id: ocd-person/a0443577-dcd2-4bce-a6cb-70ebcd6325a5
   name: Leola C. Robinson
   start_date: '2018-11-12'
 - id: ocd-person/6f3e5d6a-0e85-4af0-9711-1eaa7e3da981
-  name: Seth C. Rose
+  name: Seth Rose
   start_date: '2018-11-12'

--- a/data/sc/organizations/Rules-82c00ab6-2804-4cc2-9aea-dd4107deff49.yml
+++ b/data/sc/organizations/Rules-82c00ab6-2804-4cc2-9aea-dd4107deff49.yml
@@ -73,3 +73,4 @@ memberships:
 - id: ocd-person/79c3a2ca-d046-4fc6-bfae-04a1fdd08546
   name: Ronald "Ronnie" Young
   start_date: '2018-11-12'
+  end_date: '2019-05-19'

--- a/data/sc/people/Adam-M-Morgan-d1f0e6e5-5d28-4e9e-a0f9-04d6164b4173.yml
+++ b/data/sc/people/Adam-M-Morgan-d1f0e6e5-5d28-4e9e-a0f9-04d6164b4173.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 314A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6795
 - address: 803 Ikes RoadTaylors 29687
   note: District Office
   voice: 864-517-7068
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1370454381
 image: http://www.scstatehouse.gov/images/members/1370454381.jpg
-given_name: Adam M.
+given_name: Adam
 family_name: Morgan

--- a/data/sc/people/Annie-E-McDaniel-86e53967-3383-4df1-b3b6-49aa2b327110.yml
+++ b/data/sc/people/Annie-E-McDaniel-86e53967-3383-4df1-b3b6-49aa2b327110.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 330A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6789
 - address: 2247 Kennedy RoadWinnsboro 29180
   note: District Office
   voice: 803-635-6894
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1221590763
 image: http://www.scstatehouse.gov/images/members/1221590763.jpg
-given_name: Annie E.
+given_name: Annie
 family_name: McDaniel

--- a/data/sc/people/Ashley-B-Trantham-14cfa78e-9970-4c17-97dc-420de50ed081.yml
+++ b/data/sc/people/Ashley-B-Trantham-14cfa78e-9970-4c17-97dc-420de50ed081.yml
@@ -7,10 +7,10 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 306D Blatt Bldg.Columbia 29201
+- address: 522A Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6966
-- address: 101 West Court St.Suite A, Greenville 29601
+- address: 305 McKittrick Rd.Pelzer 29669
   note: District Office
   voice: 864-243-5928
 links:
@@ -26,5 +26,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000286
   scheme: legacy_openstates
-given_name: Ashley B.
+given_name: Ashley
 family_name: Trantham

--- a/data/sc/people/Bart-T-Blackwell-7b3e5580-ce7c-4c48-b021-173b8cbd8a77.yml
+++ b/data/sc/people/Bart-T-Blackwell-7b3e5580-ce7c-4c48-b021-173b8cbd8a77.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0144318165.jpg
 other_identifiers:
 - identifier: SCL000253
   scheme: legacy_openstates
-given_name: Bart T.
+given_name: Bart
 family_name: Blackwell

--- a/data/sc/people/Beth-E-Bernstein-a45d8c37-372d-4d32-b9a5-cce96299ea3d.yml
+++ b/data/sc/people/Beth-E-Bernstein-a45d8c37-372d-4d32-b9a5-cce96299ea3d.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0141477256.jpg
 other_identifiers:
 - identifier: SCL000184
   scheme: legacy_openstates
-given_name: Beth E.
+given_name: Beth
 family_name: Bernstein

--- a/data/sc/people/Bobby-J-Cox-083dd694-e9e1-43fb-a857-760acfb78ef8.yml
+++ b/data/sc/people/Bobby-J-Cox-083dd694-e9e1-43fb-a857-760acfb78ef8.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 312A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6883
 - address: '419 The Parkway PMB #128Greer 29650'
   note: District Office
   voice: 864-631-5840
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0427840858
 image: http://www.scstatehouse.gov/images/members/0427840858.jpg
-given_name: Bobby J.
+given_name: Bobby
 family_name: Cox

--- a/data/sc/people/Brandon-Michael-Newton-aa158d61-1373-4c4a-9ad3-ea74bf422cc3.yml
+++ b/data/sc/people/Brandon-Michael-Newton-aa158d61-1373-4c4a-9ad3-ea74bf422cc3.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1418607785.jpg
 other_identifiers:
 - identifier: SCL000267
   scheme: legacy_openstates
-given_name: Brandon Michael
+given_name: Brandon
 family_name: Newton

--- a/data/sc/people/Bruce-M-Bryant-1b3de8c5-9e0b-488a-a49d-1c74454678df.yml
+++ b/data/sc/people/Bruce-M-Bryant-1b3de8c5-9e0b-488a-a49d-1c74454678df.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 432A Blatt Bldg.Columbia 29201
+- address: 530A Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6888
 links:
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0234090881.jpg
 other_identifiers:
 - identifier: SCL000276
   scheme: legacy_openstates
-given_name: Bruce M.
+given_name: Bruce
 family_name: Bryant

--- a/data/sc/people/Cally-R-Cal-Forrest-bbff9a4c-7b59-4538-b869-64ba0c8431ff.yml
+++ b/data/sc/people/Cally-R-Cal-Forrest-bbff9a4c-7b59-4538-b869-64ba0c8431ff.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0608238564.jpg
 other_identifiers:
 - identifier: SCL000257
   scheme: legacy_openstates
-given_name: Cally R. "Cal"
+given_name: Cally
 family_name: Forrest

--- a/data/sc/people/Cezar-E-McKnight-18b39487-6885-42a3-a150-69c114a362e6.yml
+++ b/data/sc/people/Cezar-E-McKnight-18b39487-6885-42a3-a150-69c114a362e6.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 314A Blatt Bldg.Columbia 29201
+- address: 314B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6926
 - address: P.O. Box 688Lake City 29560
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1276136211.jpg
 other_identifiers:
 - identifier: SCL000229
   scheme: legacy_openstates
-given_name: Cezar E.
+given_name: Cezar
 family_name: McKnight

--- a/data/sc/people/Chris-Murphy-1dad9d19-81d6-445c-8c7e-3c014bff257b.yml
+++ b/data/sc/people/Chris-Murphy-1dad9d19-81d6-445c-8c7e-3c014bff257b.yml
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000243
   scheme: legacy_openstates
-given_name: Christopher
+given_name: Chris
 family_name: Murphy

--- a/data/sc/people/Christopher-Sloan-Chris-Wooten-728e5331-d2ec-4c21-a271-be37ae8843ff.yml
+++ b/data/sc/people/Christopher-Sloan-Chris-Wooten-728e5331-d2ec-4c21-a271-be37ae8843ff.yml
@@ -1,5 +1,5 @@
 id: ocd-person/728e5331-d2ec-4c21-a271-be37ae8843ff
-name: Christopher Sloan "Chris" Wooten
+name: Chris Wooten
 party:
 - name: Republican
 roles:
@@ -22,5 +22,7 @@ image: http://www.scstatehouse.gov/images/members/1978408854.jpg
 other_identifiers:
 - identifier: SCL000290
   scheme: legacy_openstates
-given_name: Christopher Sloan "Chris"
+other_names:
+- name: Christopher Sloan "Chris" Wooten
+given_name: Chris
 family_name: Wooten

--- a/data/sc/people/Converse-A-Con-Chellis-IV-85b6c740-53c9-4231-aa87-161e816738a5.yml
+++ b/data/sc/people/Converse-A-Con-Chellis-IV-85b6c740-53c9-4231-aa87-161e816738a5.yml
@@ -1,5 +1,5 @@
 id: ocd-person/85b6c740-53c9-4231-aa87-161e816738a5
-name: Converse A "Con" Chellis, IV
+name: Converse A. "Con" Chellis, IV
 party:
 - name: Republican
 roles:
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 308A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6871
 - address: 216 Marion AvenueSummerville 29483
   note: District Office
   voice: 843-873-1584
@@ -17,5 +20,7 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0350568140
 image: http://www.scstatehouse.gov/images/members/0350568140.jpg
-given_name: Converse A "Con" Chellis,
-family_name: IV
+other_names:
+- name: Converse A "Con" Chellis, IV
+given_name: Converse
+family_name: Chellis

--- a/data/sc/people/Craig-A-Gagnon-52ab3f52-ec8b-4268-bfb2-16322df47839.yml
+++ b/data/sc/people/Craig-A-Gagnon-52ab3f52-ec8b-4268-bfb2-16322df47839.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0632954470.jpg
 other_identifiers:
 - identifier: SCL000189
   scheme: legacy_openstates
-given_name: Craig A.
+given_name: Craig
 family_name: Gagnon

--- a/data/sc/people/Dwight-A-Loftis-7f17bd25-fbc5-48a1-a69a-5c9be03b66f5.yml
+++ b/data/sc/people/Dwight-A-Loftis-7f17bd25-fbc5-48a1-a69a-5c9be03b66f5.yml
@@ -6,17 +6,22 @@ roles:
 - district: '19'
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
+  end_date: 2019-04-02
+- district: '6'
+  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
+  type: upper
+  start_date: 2019-04-02
 contact_details:
-- address: 522C Blatt Bldg.Columbia 29201
+- address: 501 Gressette Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-734-3101
+  voice: 803-212-6100
 - address: P.O. Box 14784Greenville 29610
   note: District Office
   voice: 864-834-5760
 links:
 - url: http://www.scstatehouse.gov/member.php?code=1111363503
 sources:
-- url: http://www.scstatehouse.gov/member.php?chamber=H
+- url: http://www.scstatehouse.gov/member.php?chamber=S
 - url: http://www.scstatehouse.gov/member.php?code=1111363503
 image: http://www.scstatehouse.gov/images/members/1111363503.jpg
 other_identifiers:

--- a/data/sc/people/F-Michael-Mike-Sottile-6f8b2c6d-52bc-4133-bacf-6b5712c5e539.yml
+++ b/data/sc/people/F-Michael-Mike-Sottile-6f8b2c6d-52bc-4133-bacf-6b5712c5e539.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 310A Blatt Bldg.Columbia 29201
+- address: 310D Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6880
 - address: 132 Sparrow Dr.Isle of Palms 29451

--- a/data/sc/people/G-Murrell-Smith-Jr-bc549137-780f-4b77-9438-61a92d3dce48.yml
+++ b/data/sc/people/G-Murrell-Smith-Jr-bc549137-780f-4b77-9438-61a92d3dce48.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 420B Blatt Bldg.Columbia 29201
+- address: 525 Blatt Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-734-3042
+  voice: 803-734-3144
 - address: P.O. Box 580Sumter 29151
   note: District Office
   voice: 803-469-4416

--- a/data/sc/people/Gary-E-Clary-26a0f7b8-63a4-4526-8399-669d4f7b86e8.yml
+++ b/data/sc/people/Gary-E-Clary-26a0f7b8-63a4-4526-8399-669d4f7b86e8.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0353551095.jpg
 other_identifiers:
 - identifier: SCL000217
   scheme: legacy_openstates
-given_name: Gary E.
+given_name: Gary
 family_name: Clary

--- a/data/sc/people/Glenn-G-Reese-cfe2d50f-0241-496c-9557-2a3d6edef4fd.yml
+++ b/data/sc/people/Glenn-G-Reese-cfe2d50f-0241-496c-9557-2a3d6edef4fd.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 502 Gressette Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6108
-- address: 507 Fagan DriveLake Bowen, Inman 29349
+- address: 507 Fagan DriveInman 29349
   note: District Office
   voice: 864-592-2984
 links:

--- a/data/sc/people/Greg-Hembree-d09cb270-bb44-44e7-86d6-a880ce40d93d.yml
+++ b/data/sc/people/Greg-Hembree-d09cb270-bb44-44e7-86d6-a880ce40d93d.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: upper
 contact_details:
-- address: 604 Gressette Bldg.Columbia 29201
+- address: 404 Gressette Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-212-6016
+  voice: 803-212-6350
 - address: P. O. Box 944N. Myrtle Beach 29597
   note: District Office
   voice: 843-222-1001

--- a/data/sc/people/Heather-Ammons-Crawford-814c55e9-568f-403e-9e8a-ee3859c07300.yml
+++ b/data/sc/people/Heather-Ammons-Crawford-814c55e9-568f-403e-9e8a-ee3859c07300.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 522A Blatt Bldg.Columbia 29201
+- address: 522B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6933
 - address: P.O. Box 31385Myrtle Beach 29588
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0428977222.jpg
 other_identifiers:
 - identifier: SCL000172
   scheme: legacy_openstates
-given_name: Heather Ammons
+given_name: Heather
 family_name: Crawford

--- a/data/sc/people/Ivory-Torrey-Thigpen-13c06705-600b-49d0-a5a0-393668a03e73.yml
+++ b/data/sc/people/Ivory-Torrey-Thigpen-13c06705-600b-49d0-a5a0-393668a03e73.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1815908873.jpg
 other_identifiers:
 - identifier: SCL000270
   scheme: legacy_openstates
-given_name: Ivory Torrey
+given_name: Ivory
 family_name: Thigpen

--- a/data/sc/people/J-Gary-Simrill-99ada22b-98f9-400c-b0cf-1a548ed72257.yml
+++ b/data/sc/people/J-Gary-Simrill-99ada22b-98f9-400c-b0cf-1a548ed72257.yml
@@ -9,7 +9,7 @@ roles:
 contact_details:
 - address: 518C Blatt Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-734-3138
+  voice: 803-734-3040
 - address: 1515 Alexander Rd.Rock Hill 29732
   note: District Office
   voice: 803-328-8089

--- a/data/sc/people/JA-Moore-6f92ad6a-95c7-4e74-aa91-05fd5448c99a.yml
+++ b/data/sc/people/JA-Moore-6f92ad6a-95c7-4e74-aa91-05fd5448c99a.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 432A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6890
 - address: P.O. Box 62103North Charleston 29419
   note: District Office
   voice: 843-640-0130

--- a/data/sc/people/James-Mikell-Mike-Burns-6ffe4e57-021a-4424-bc36-b933c8e18477.yml
+++ b/data/sc/people/James-Mikell-Mike-Burns-6ffe4e57-021a-4424-bc36-b933c8e18477.yml
@@ -10,9 +10,6 @@ contact_details:
 - address: 326B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6891
-- address: 100 Old Locust Hill Rd.Taylors 29687
-  note: District Office
-  voice: 864-895-4593
 links:
 - url: http://www.scstatehouse.gov/member.php?code=0257954515
 sources:
@@ -22,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0257954515.jpg
 other_identifiers:
 - identifier: SCL000208
   scheme: legacy_openstates
-given_name: James Mikell "Mike"
+given_name: James
 family_name: Burns

--- a/data/sc/people/Jeffrey-A-Jeff-Bradley-99dd735b-3ab4-4362-a2c5-f1b5c9257e52.yml
+++ b/data/sc/people/Jeffrey-A-Jeff-Bradley-99dd735b-3ab4-4362-a2c5-f1b5c9257e52.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 320A Blatt Bldg.Columbia 29201
+- address: 306B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6928
 - address: 304 Seabrook DriveHilton Head Island 29926
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0171590889.jpg
 other_identifiers:
 - identifier: SCL000222
   scheme: legacy_openstates
-given_name: Jeffrey A. "Jeff"
+given_name: Jeffrey
 family_name: Bradley

--- a/data/sc/people/Jeffrey-E-Jeff-Johnson-7b2dc589-67e0-4286-9a21-73a69a299ef7.yml
+++ b/data/sc/people/Jeffrey-E-Jeff-Johnson-7b2dc589-67e0-4286-9a21-73a69a299ef7.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 434B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6946
-- address: 7223 Pee Dee Hwy.Conway 29527
+- address: 1409 Second Ave.Conway 29526
   note: District Office
   voice: 843-397-0079
 links:
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0938636251.jpg
 other_identifiers:
 - identifier: SCL000219
   scheme: legacy_openstates
-given_name: Jeffrey E. "Jeff"
+given_name: Jeffrey
 family_name: Johnson

--- a/data/sc/people/John-R-McCravy-III-f946b369-cfbd-4cc5-84f2-4cc343beb03a.yml
+++ b/data/sc/people/John-R-McCravy-III-f946b369-cfbd-4cc5-84f2-4cc343beb03a.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 420A Blatt Bldg.Columbia 29201
+- address: 420B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6939
 - address: P.O. Box 50658Greenwood 29649
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1217045309.jpg
 other_identifiers:
 - identifier: SCL000266
   scheme: legacy_openstates
-given_name: John R.
+given_name: John
 family_name: McCravy

--- a/data/sc/people/John-Taliaferro-Jay-West-IV-61ad39ff-e788-4232-b68a-d9c8f128af7e.yml
+++ b/data/sc/people/John-Taliaferro-Jay-West-IV-61ad39ff-e788-4232-b68a-d9c8f128af7e.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1903408863.jpg
 other_identifiers:
 - identifier: SCL000248
   scheme: legacy_openstates
-given_name: John Taliaferro "Jay"
+given_name: John
 family_name: West

--- a/data/sc/people/Jonathon-D-Hill-8a69fe7b-4ec4-4f9a-bc6e-b8acf0cd06c7.yml
+++ b/data/sc/people/Jonathon-D-Hill-8a69fe7b-4ec4-4f9a-bc6e-b8acf0cd06c7.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 434A Blatt Bldg.Columbia 29201
+- address: 434C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6919
 links:
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0835227173.jpg
 other_identifiers:
 - identifier: SCL000230
   scheme: legacy_openstates
-given_name: Jonathon D.
+given_name: Jonathon
 family_name: Hill

--- a/data/sc/people/Joseph-S-Daning-b57afd47-89d7-4672-b6f1-59f5bf273bc6.yml
+++ b/data/sc/people/Joseph-S-Daning-b57afd47-89d7-4672-b6f1-59f5bf273bc6.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 310B Blatt Bldg.Columbia 29201
+- address: 310C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-734-2951
 - address: 118 Queensbury Cir.Goose Creek 29445

--- a/data/sc/people/Justin-T-Bamberg-88861a7f-ca46-4ed7-a053-0d463cca48e0.yml
+++ b/data/sc/people/Justin-T-Bamberg-88861a7f-ca46-4ed7-a053-0d463cca48e0.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 335D Blatt Bldg.Columbia 29201
+- address: 335C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6907
 - address: 232 Azalea AvenueBamberg 29003
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000232
   scheme: legacy_openstates
-given_name: Justin T.
+given_name: Justin
 family_name: Bamberg

--- a/data/sc/people/Kambrell-H-Garvin-904331e5-36ae-43d5-8e3e-62a845c7965e.yml
+++ b/data/sc/people/Kambrell-H-Garvin-904331e5-36ae-43d5-8e3e-62a845c7965e.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 335D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6875
 - address: P.O. Box 292434Columbia 29229
   note: District Office
   voice: 803-470-3961
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0657954467
 image: http://www.scstatehouse.gov/images/members/0657954467.jpg
-given_name: Kambrell H.
+given_name: Kambrell
 family_name: Garvin

--- a/data/sc/people/Katrina-Frye-Shealy-0a07f819-4966-4b86-8e1f-d6b66b447460.yml
+++ b/data/sc/people/Katrina-Frye-Shealy-0a07f819-4966-4b86-8e1f-d6b66b447460.yml
@@ -21,5 +21,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000206
   scheme: legacy_openstates
-given_name: Katrina Frye
+given_name: Katrina
 family_name: Shealy

--- a/data/sc/people/Krystle-N-Simmons-648a5fc9-ef93-4106-bc39-e45827f51306.yml
+++ b/data/sc/people/Krystle-N-Simmons-648a5fc9-ef93-4106-bc39-e45827f51306.yml
@@ -1,5 +1,5 @@
 id: ocd-person/648a5fc9-ef93-4106-bc39-e45827f51306
-name: Krystle N. Simmons
+name: Krystle N. Matthews
 party:
 - name: Democratic
 roles:
@@ -8,14 +8,19 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 414A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6879
 - address: P.O. Box 555Ladson 29456
   note: District Office
-  voice: 843-508-3100
+  voice: 843-310-8755
 links:
 - url: http://www.scstatehouse.gov/member.php?code=1694886161
 sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1694886161
 image: http://www.scstatehouse.gov/images/members/1694886161.jpg
-given_name: Krystle N.
-family_name: Simmons
+other_names:
+- name: Krystle N. Simmons
+given_name: Krystle
+family_name: Matthews

--- a/data/sc/people/Laurie-Slade-Funderburk-16a57c6b-02c8-4a59-99bf-4f4cdcef1c0e.yml
+++ b/data/sc/people/Laurie-Slade-Funderburk-16a57c6b-02c8-4a59-99bf-4f4cdcef1c0e.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0629545379.jpg
 other_identifiers:
 - identifier: SCL000087
   scheme: legacy_openstates
-given_name: Laurie Slade
+given_name: Laurie
 family_name: Funderburk

--- a/data/sc/people/Leola-C-Robinson-a0443577-dcd2-4bce-a6cb-70ebcd6325a5.yml
+++ b/data/sc/people/Leola-C-Robinson-a0443577-dcd2-4bce-a6cb-70ebcd6325a5.yml
@@ -8,7 +8,7 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
-- address: 330A Blatt Bldg.Columbia 29201
+- address: 330B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6941
 - address: 19 Prince Ave.Greenville 29605
@@ -20,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1567045267
 image: http://www.scstatehouse.gov/images/members/1567045267.jpg
-given_name: Leola C.
+given_name: Leola
 family_name: Robinson

--- a/data/sc/people/Leon-D-Doug-Gilliam-3a09cbd2-aa21-4fa8-9511-d1f842816e49.yml
+++ b/data/sc/people/Leon-D-Doug-Gilliam-3a09cbd2-aa21-4fa8-9511-d1f842816e49.yml
@@ -8,8 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
-- note: Capitol Office
-  voice: 864-426-0785
+- address: 420C Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6968
 - address: 3347 Buffalo-W. Springs HighwayBuffalo 29321
   note: District Office
   voice: 864-427-5711
@@ -19,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0675426055
 image: http://www.scstatehouse.gov/images/members/0675426055.jpg
-given_name: Leon D. "Doug"
+given_name: Leon
 family_name: Gilliam

--- a/data/sc/people/Leonidas-E-Leon-Stavrinakis-3faa0b04-4277-4a07-ae78-bc9cb0d20e07.yml
+++ b/data/sc/people/Leonidas-E-Leon-Stavrinakis-3faa0b04-4277-4a07-ae78-bc9cb0d20e07.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 420C Blatt Bldg.Columbia 29201
+- address: 522C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-734-3039
 - address: P.O. Box 30099Charleston 29417

--- a/data/sc/people/Linda-Lin-Bennett-4cb0dd3a-f986-46f9-ae86-59c89f93c1b9.yml
+++ b/data/sc/people/Linda-Lin-Bennett-4cb0dd3a-f986-46f9-ae86-59c89f93c1b9.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0140624984.jpg
 other_identifiers:
 - identifier: SCL000260
   scheme: legacy_openstates
-given_name: Linda "Lin"
+given_name: Linda
 family_name: Bennett

--- a/data/sc/people/Mandy-Powers-Norrell-6e2c4025-374e-4a75-92bb-341b1ddb0aa0.yml
+++ b/data/sc/people/Mandy-Powers-Norrell-6e2c4025-374e-4a75-92bb-341b1ddb0aa0.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1493181639.jpg
 other_identifiers:
 - identifier: SCL000196
   scheme: legacy_openstates
-given_name: Mandy Powers
-family_name: Norrell
+given_name: Mandy
+family_name: Powers Norrell

--- a/data/sc/people/Mandy-W-Kimmons-61cea6e1-b6ee-48b8-8338-5d83df9abe20.yml
+++ b/data/sc/people/Mandy-W-Kimmons-61cea6e1-b6ee-48b8-8338-5d83df9abe20.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 310A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6973
 - address: 108 Sullivans Landing RoadRidgeville 29472
   note: District Office
   voice: 843-697-1304
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0993749881
 image: http://www.scstatehouse.gov/images/members/0993749881.jpg
-given_name: Mandy W.
+given_name: Mandy
 family_name: Kimmons

--- a/data/sc/people/Margie-Bright-Matthews-829bd3ab-d117-43fd-b274-f9ff8177c789.yml
+++ b/data/sc/people/Margie-Bright-Matthews-829bd3ab-d117-43fd-b274-f9ff8177c789.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0194318159.jpg
 other_identifiers:
 - identifier: SCL000237
   scheme: legacy_openstates
-given_name: Margie Bright
-family_name: Matthews
+given_name: Margie
+family_name: Bright Matthews

--- a/data/sc/people/Marlon-E-Kimpson-4c562d79-9db1-48f8-8361-f2894d46e150.yml
+++ b/data/sc/people/Marlon-E-Kimpson-4c562d79-9db1-48f8-8361-f2894d46e150.yml
@@ -21,5 +21,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000211
   scheme: legacy_openstates
-given_name: Marlon E.
+given_name: Marlon
 family_name: Kimpson

--- a/data/sc/people/Marvin-R-Pendarvis-b8b48cdf-733e-4317-988f-9262b2a4ba77.yml
+++ b/data/sc/people/Marvin-R-Pendarvis-b8b48cdf-733e-4317-988f-9262b2a4ba77.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1457812326.jpg
 other_identifiers:
 - identifier: SCL000279
   scheme: legacy_openstates
-given_name: Marvin R.
+given_name: Marvin
 family_name: Pendarvis

--- a/data/sc/people/Max-T-Hyde-Jr-f17c0073-e7c8-4482-bd40-0703fc296f2b.yml
+++ b/data/sc/people/Max-T-Hyde-Jr-f17c0073-e7c8-4482-bd40-0703fc296f2b.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 402A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6790
 - address: 22 Woodburn RoadSpartanburg 29302
   note: District Office
   voice: 864-582-1742
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0914772618
 image: http://www.scstatehouse.gov/images/members/0914772618.jpg
-given_name: Max T. Hyde,
-family_name: Jr.
+given_name: Max
+family_name: Hyde

--- a/data/sc/people/Melissa-Lackey-Oremus-b3dcafed-7f7a-4b8b-8a5e-a517d768ed42.yml
+++ b/data/sc/people/Melissa-Lackey-Oremus-b3dcafed-7f7a-4b8b-8a5e-a517d768ed42.yml
@@ -1,0 +1,21 @@
+id: ocd-person/b3dcafed-7f7a-4b8b-8a5e-a517d768ed42
+name: Melissa Lackey Oremus
+party:
+- name: Republican
+roles:
+- district: '84'
+  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
+  type: lower
+  start_date: 2019-10-21
+contact_details:
+- address: 418A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6917
+links:
+- url: http://www.scstatehouse.gov/member.php?code=1432386192
+sources:
+- url: http://www.scstatehouse.gov/member.php?chamber=H
+- url: http://www.scstatehouse.gov/member.php?code=1432386192
+image: http://www.scstatehouse.gov/images/members/1432386192.jpg
+given_name: Melissa
+family_name: Oremus

--- a/data/sc/people/Mia-S-McLeod-9b4e7cb9-4e4e-484d-8ce9-4fe4a73b8c59.yml
+++ b/data/sc/people/Mia-S-McLeod-9b4e7cb9-4e4e-484d-8ce9-4fe4a73b8c59.yml
@@ -28,5 +28,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ocd-person/f5283ddc-7442-4170-80a2-248c485263cc
   scheme: openstates
-given_name: Mia S.
+given_name: Mia
 family_name: McLeod

--- a/data/sc/people/Micajah-P-Micah-Caskey-IV-32c6ccd9-4b56-4075-a99b-1882f4dd176d.yml
+++ b/data/sc/people/Micajah-P-Micah-Caskey-IV-32c6ccd9-4b56-4075-a99b-1882f4dd176d.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0329545415.jpg
 other_identifiers:
 - identifier: SCL000252
   scheme: legacy_openstates
-given_name: Micajah P. "Micah"
+given_name: Micajah
 family_name: Caskey

--- a/data/sc/people/Michael-F-Rivers-Sr-ebf046cf-233e-4c98-b78e-4cefbb07615b.yml
+++ b/data/sc/people/Michael-F-Rivers-Sr-ebf046cf-233e-4c98-b78e-4cefbb07615b.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 432D Blatt Bldg.Columbia 29201
+- address: 432C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6952
 links:
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1564346404.jpg
 other_identifiers:
 - identifier: SCL000264
   scheme: legacy_openstates
-given_name: Michael F.
+given_name: Michael
 family_name: Rivers

--- a/data/sc/people/Mike-Gambrell-52d745c3-ccb7-41db-9b4a-624c757b678a.yml
+++ b/data/sc/people/Mike-Gambrell-52d745c3-ccb7-41db-9b4a-624c757b678a.yml
@@ -1,5 +1,5 @@
 id: ocd-person/52d745c3-ccb7-41db-9b4a-624c757b678a
-name: Mike Gambrell
+name: Michael W. Gambrell
 party:
 - name: Republican
 roles:
@@ -21,5 +21,7 @@ image: http://www.scstatehouse.gov/images/members/0635227197.jpg
 other_identifiers:
 - identifier: SCL000262
   scheme: legacy_openstates
-given_name: Mike
+other_names:
+- name: Mike Gambrell
+given_name: Michael
 family_name: Gambrell

--- a/data/sc/people/Nancy-Mace-94d1c8ae-8ade-49c2-a06e-88a7deae3556.yml
+++ b/data/sc/people/Nancy-Mace-94d1c8ae-8ade-49c2-a06e-88a7deae3556.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 308A Blatt Bldg.Columbia 29201
+- address: 308B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6717
 links:

--- a/data/sc/people/Nathan-Ballentine-129fde97-b4fa-4004-bfb9-f96169a7c0a5.yml
+++ b/data/sc/people/Nathan-Ballentine-129fde97-b4fa-4004-bfb9-f96169a7c0a5.yml
@@ -10,7 +10,7 @@ contact_details:
 - address: 320B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-734-2969
-- address: 324 Sienna DrChapin 29036
+- address: 108 Tapp PointeChapin 29036
   note: District Office
   voice: 803-732-1861
 links:

--- a/data/sc/people/Neal-A-Collins-73b7f73e-705e-409a-b582-51060e573fd5.yml
+++ b/data/sc/people/Neal-A-Collins-73b7f73e-705e-409a-b582-51060e573fd5.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0388636317.jpg
 other_identifiers:
 - identifier: SCL000227
   scheme: legacy_openstates
-given_name: Neal A.
+given_name: Neal
 family_name: Collins

--- a/data/sc/people/P-Michael-Mike-Forrester-a3d1c825-e269-434e-9a3f-66e5103bd354.yml
+++ b/data/sc/people/P-Michael-Mike-Forrester-a3d1c825-e269-434e-9a3f-66e5103bd354.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 402C Blatt Bldg.Columbia 29201
+- address: 402B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6792
 - address: 287 Creekridge Dr.Spartanburg 29301

--- a/data/sc/people/Patricia-Moore-Pat-Henegan-951188b7-b57f-4705-b966-a24c806fef62.yml
+++ b/data/sc/people/Patricia-Moore-Pat-Henegan-951188b7-b57f-4705-b966-a24c806fef62.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0829545355.jpg
 other_identifiers:
 - identifier: SCL000216
   scheme: legacy_openstates
-given_name: Patricia Moore "Pat"
+given_name: Patricia
 family_name: Henegan

--- a/data/sc/people/Patrick-B-Haddon-08f0816c-5d19-47df-90fb-1249e3f50fae.yml
+++ b/data/sc/people/Patrick-B-Haddon-08f0816c-5d19-47df-90fb-1249e3f50fae.yml
@@ -1,0 +1,24 @@
+id: ocd-person/08f0816c-5d19-47df-90fb-1249e3f50fae
+name: Patrick B. Haddon
+party:
+- name: Republican
+roles:
+- district: '19'
+  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
+  type: lower
+  start_date: 2019-09-05
+contact_details:
+- address: 320A Blatt Bldg.Columbia, 29201
+  note: Capitol Office
+  voice: 803-212-6962
+- address: PO Box 14884Greenville, 29610
+  note: District Office
+  voice: 864-320-1946
+links:
+- url: http://www.scstatehouse.gov/member.php?code=0733806731
+sources:
+- url: http://www.scstatehouse.gov/member.php?chamber=H
+- url: http://www.scstatehouse.gov/member.php?code=0733806731
+image: http://www.scstatehouse.gov/images/members/0733806731.jpg
+given_name: Patrick
+family_name: Haddon

--- a/data/sc/people/Paula-Rawl-Calhoon-ee278d2b-ce89-40bf-af2c-42ede04e3afd.yml
+++ b/data/sc/people/Paula-Rawl-Calhoon-ee278d2b-ce89-40bf-af2c-42ede04e3afd.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 320D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6924
 - address: P.O. Box 1913Lexington 29071
   note: District Office
   voice: 803-359-4550
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0293181783
 image: http://www.scstatehouse.gov/images/members/0293181783.jpg
-given_name: Paula Rawl
+given_name: Paula
 family_name: Calhoon

--- a/data/sc/people/R-Raye-Felder-dafa79f2-1f22-4fb4-9620-09d86ecddcb7.yml
+++ b/data/sc/people/R-Raye-Felder-dafa79f2-1f22-4fb4-9620-09d86ecddcb7.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 402A Blatt Bldg.Columbia 29201
+- address: 402C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6892
 - address: 116 Mary Mack LaneFort Mill 29715

--- a/data/sc/people/Rex-F-Rice-bfea6436-5d17-4d26-bc37-15f1a975575e.yml
+++ b/data/sc/people/Rex-F-Rice-bfea6436-5d17-4d26-bc37-15f1a975575e.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: upper
 contact_details:
-- address: 501 Gressette Bldg.Columbia 29201
+- address: 601 Gressette Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-212-6100
+  voice: 803-212-6116
 links:
 - url: http://www.scstatehouse.gov/member.php?code=1547727087
 sources:
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1547727087.jpg
 other_identifiers:
 - identifier: SCL000259
   scheme: legacy_openstates
-given_name: Rex F.
+given_name: Rex
 family_name: Rice

--- a/data/sc/people/Richard-A-Dick-Harpootlian-26d51af3-b5c2-4869-be73-0ea9c2fa2a22.yml
+++ b/data/sc/people/Richard-A-Dick-Harpootlian-26d51af3-b5c2-4869-be73-0ea9c2fa2a22.yml
@@ -7,12 +7,15 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: upper
   start_date: '2018-11-12'
-contact_details: []
+contact_details:
+- address: 602 Gressette Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6008
 links:
 - url: http://www.scstatehouse.gov/member.php?code=0747159001
 sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=S
 - url: http://www.scstatehouse.gov/member.php?code=0747159001
 image: http://www.scstatehouse.gov/images/members/0747159001.jpg
-given_name: Richard A. "Dick"
+given_name: Richard
 family_name: Harpootlian

--- a/data/sc/people/Richard-J-Cash-69162972-6151-4fe2-b5fe-dee599d86ad3.yml
+++ b/data/sc/people/Richard-J-Cash-69162972-6151-4fe2-b5fe-dee599d86ad3.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/0328409052.jpg
 other_identifiers:
 - identifier: SCL000275
   scheme: legacy_openstates
-given_name: Richard J.
+given_name: Richard
 family_name: Cash

--- a/data/sc/people/Richard-L-Richie-Yow-ebfb814e-0b47-4d8f-be94-63718f71a96c.yml
+++ b/data/sc/people/Richard-L-Richie-Yow-ebfb814e-0b47-4d8f-be94-63718f71a96c.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1998863577.jpg
 other_identifiers:
 - identifier: SCL000218
   scheme: legacy_openstates
-given_name: Richard L. "Richie"
+given_name: Richard
 family_name: Yow

--- a/data/sc/people/Richard-Rick-Martin-a3126675-bbb8-4a20-8b44-2b201fd955fa.yml
+++ b/data/sc/people/Richard-Rick-Martin-a3126675-bbb8-4a20-8b44-2b201fd955fa.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1178408950.jpg
 other_identifiers:
 - identifier: SCL000256
   scheme: legacy_openstates
-given_name: Richard "Rick"
+given_name: Richard
 family_name: Martin

--- a/data/sc/people/Robert-L-Ridgeway-III-e43e2a26-4229-4672-abc7-971200f29848.yml
+++ b/data/sc/people/Robert-L-Ridgeway-III-e43e2a26-4229-4672-abc7-971200f29848.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1553408905.jpg
 other_identifiers:
 - identifier: SCL000197
   scheme: legacy_openstates
-given_name: Robert L.
+given_name: Robert
 family_name: Ridgeway

--- a/data/sc/people/Roger-K-Kirby-9aa18702-15a2-4281-926b-4e980f2e8aa0.yml
+++ b/data/sc/people/Roger-K-Kirby-9aa18702-15a2-4281-926b-4e980f2e8aa0.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1006818061.jpg
 other_identifiers:
 - identifier: SCL000221
   scheme: legacy_openstates
-given_name: Roger K.
+given_name: Roger
 family_name: Kirby

--- a/data/sc/people/Rosalyn-D-Henderson-Myers-6a6c75f2-f3be-4764-9b7d-04b13c28b4aa.yml
+++ b/data/sc/people/Rosalyn-D-Henderson-Myers-6a6c75f2-f3be-4764-9b7d-04b13c28b4aa.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 414A Blatt Bldg.Columbia 29201
+- address: 530C Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6965
 - address: P.O. Box 1311Spartanburg SC 29304
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000281
   scheme: legacy_openstates
-given_name: Rosalyn D.
+given_name: Rosalyn
 family_name: Henderson-Myers

--- a/data/sc/people/Russell-L-Ott-458d191f-6584-4548-b464-a3a24cda3cf3.yml
+++ b/data/sc/people/Russell-L-Ott-458d191f-6584-4548-b464-a3a24cda3cf3.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1433096420.jpg
 other_identifiers:
 - identifier: SCL000212
   scheme: legacy_openstates
-given_name: Russell L.
+given_name: Russell
 family_name: Ott

--- a/data/sc/people/Russell-W-Fry-2426fbdd-e5db-4c4b-8ccf-ad4d72466b35.yml
+++ b/data/sc/people/Russell-W-Fry-2426fbdd-e5db-4c4b-8ccf-ad4d72466b35.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 522D Blatt Office Bldg.Columbia 29201
+- address: 522D Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6781
 - address: P.O. Box 14444Surfside Beach 29587
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0623863562.jpg
 other_identifiers:
 - identifier: SCL000235
   scheme: legacy_openstates
-given_name: Russell W.
+given_name: Russell
 family_name: Fry

--- a/data/sc/people/Sean-M-Bennett-3265c6c1-e300-4fd3-9d61-1cef57279d67.yml
+++ b/data/sc/people/Sean-M-Bennett-3265c6c1-e300-4fd3-9d61-1cef57279d67.yml
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000272
   scheme: legacy_openstates
-given_name: Sean M.
+given_name: Sean
 family_name: Bennett

--- a/data/sc/people/Seth-C-Rose-6f3e5d6a-0e85-4af0-9711-1eaa7e3da981.yml
+++ b/data/sc/people/Seth-C-Rose-6f3e5d6a-0e85-4af0-9711-1eaa7e3da981.yml
@@ -1,5 +1,5 @@
 id: ocd-person/6f3e5d6a-0e85-4af0-9711-1eaa7e3da981
-name: Seth C. Rose
+name: Seth Rose
 party:
 - name: Democratic
 roles:
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 532D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6971
 - address: 1528 Blanding StreetColumbia 29201
   note: District Office
   voice: 803-361-2360
@@ -17,5 +20,7 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1584090719
 image: http://www.scstatehouse.gov/images/members/1584090719.jpg
-given_name: Seth C.
+other_names:
+- name: Seth C. Rose
+given_name: Seth
 family_name: Rose

--- a/data/sc/people/Shedron-D-Williams-041b9252-ba36-4664-a79f-4f620e5688b5.yml
+++ b/data/sc/people/Shedron-D-Williams-041b9252-ba36-4664-a79f-4f620e5688b5.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 432D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6974
 - address: 608 Barry AvenueHampton 29924
   note: District Office
   voice: 803-914-0612
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1942187268
 image: http://www.scstatehouse.gov/images/members/1942187268.jpg
-given_name: Shedron D.
+given_name: Shedron
 family_name: Williams

--- a/data/sc/people/Stephen-L-Goldfinch-9837e1c5-5014-4306-9f78-1550b1a9a2c2.yml
+++ b/data/sc/people/Stephen-L-Goldfinch-9837e1c5-5014-4306-9f78-1550b1a9a2c2.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0682386282.jpg
 other_identifiers:
 - identifier: SCL000261
   scheme: legacy_openstates
-given_name: Stephen L.
+given_name: Stephen
 family_name: Goldfinch

--- a/data/sc/people/Steven-Wayne-Long-72f330b5-9ae0-40e6-b1d2-0ab6725cccf2.yml
+++ b/data/sc/people/Steven-Wayne-Long-72f330b5-9ae0-40e6-b1d2-0ab6725cccf2.yml
@@ -19,5 +19,5 @@ image: http://www.scstatehouse.gov/images/members/1120454411.jpg
 other_identifiers:
 - identifier: SCL000268
   scheme: legacy_openstates
-given_name: Steven Wayne
+given_name: Steven
 family_name: Long

--- a/data/sc/people/Stewart-Jones-d62a848e-7a5b-48ae-8546-2e4003b95bdd.yml
+++ b/data/sc/people/Stewart-Jones-d62a848e-7a5b-48ae-8546-2e4003b95bdd.yml
@@ -1,17 +1,14 @@
 id: ocd-person/d62a848e-7a5b-48ae-8546-2e4003b95bdd
-name: Stewart Jones
+name: Stewart O. Jones
 given_name: Stewart
 family_name: Jones
 image: https://www.scstatehouse.gov/images/members/0952272613.jpg
 party:
 - name: Republican
 contact_details:
-- address: 420A Blatt Bldg.;Columbia, SC 29201
+- address: 420A Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6713
-- address: P.O. Box 982;Laurens, SC 29360
-  note: District Office
-  voice: 864-993-4336
 roles:
 - district: '14'
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
@@ -20,4 +17,7 @@ roles:
 links:
 - url: https://www.scstatehouse.gov/member.php?code=0952272613
 sources:
+- url: https://www.scstatehouse.gov/member.php?chamber=H
 - url: https://www.scstatehouse.gov/member.php?code=0952272613
+other_names:
+- name: Stewart Jones

--- a/data/sc/people/Sylleste-H-Davis-36dea3e2-2ea8-47e8-84df-cfc4a28073e7.yml
+++ b/data/sc/people/Sylleste-H-Davis-36dea3e2-2ea8-47e8-84df-cfc4a28073e7.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0456249946.jpg
 other_identifiers:
 - identifier: SCL000242
   scheme: legacy_openstates
-given_name: Sylleste H.
+given_name: Sylleste
 family_name: Davis

--- a/data/sc/people/Thomas-R-Randy-Ligon-e4ab57f5-cf10-42ea-9c31-a6a4cc1a8c29.yml
+++ b/data/sc/people/Thomas-R-Randy-Ligon-e4ab57f5-cf10-42ea-9c31-a6a4cc1a8c29.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 306D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6972
 - address: P.O. Box 4815Rock Hill 29732
   note: District Office
   voice: 803-377-1284
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=1087499870
 image: http://www.scstatehouse.gov/images/members/1087499870.jpg
-given_name: Thomas R. "Randy"
+given_name: Thomas
 family_name: Ligon

--- a/data/sc/people/Timothy-A-Tim-McGinnis-023895b1-aeb4-410a-84d0-0059b3f10ee3.yml
+++ b/data/sc/people/Timothy-A-Tim-McGinnis-023895b1-aeb4-410a-84d0-0059b3f10ee3.yml
@@ -1,5 +1,5 @@
 id: ocd-person/023895b1-aeb4-410a-84d0-0059b3f10ee3
-name: Timothy A "Tim" McGinnis
+name: Timothy A. "Tim" McGinnis
 party:
 - name: Republican
 roles:
@@ -23,5 +23,7 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000287
   scheme: legacy_openstates
-given_name: Timothy A "Tim"
+other_names:
+- name: Timothy A "Tim" McGinnis
+given_name: Timothy
 family_name: McGinnis

--- a/data/sc/people/Tom-Davis-33fe6bed-f8b0-4002-90fa-870813b72caf.yml
+++ b/data/sc/people/Tom-Davis-33fe6bed-f8b0-4002-90fa-870813b72caf.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: upper
 contact_details:
-- address: 404 Gressette Bldg.Columbia 29201
+- address: 604 Gressette Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-212-6350
+  voice: 803-212-6016
 - address: P.O. Drawer 1107Beaufort 29901-1107
   note: District Office
   voice: 843-252-8583

--- a/data/sc/people/Tom-Young-Jr-b01d47f8-2131-4fe5-a611-d1b571696346.yml
+++ b/data/sc/people/Tom-Young-Jr-b01d47f8-2131-4fe5-a611-d1b571696346.yml
@@ -26,5 +26,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000205
   scheme: legacy_openstates
-given_name: Thomas
+given_name: Tom
 family_name: Young

--- a/data/sc/people/W-Brian-White-b70ac543-457e-4de4-95ec-cd60c500b1a6.yml
+++ b/data/sc/people/W-Brian-White-b70ac543-457e-4de4-95ec-cd60c500b1a6.yml
@@ -7,9 +7,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 525 Blatt Bldg.Columbia 29201
+- address: 436D Blatt Bldg.Columbia 29201
   note: Capitol Office
-  voice: 803-734-3144
+  voice: 803-734-3066
 - address: P.O. Box 970Anderson 29622
   note: District Office
   voice: 864-260-4025

--- a/data/sc/people/Wallace-H-Jay-Jordan-Jr-00d450b3-f427-4e64-b0bd-45609b0a433b.yml
+++ b/data/sc/people/Wallace-H-Jay-Jordan-Jr-00d450b3-f427-4e64-b0bd-45609b0a433b.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0957954431.jpg
 other_identifiers:
 - identifier: SCL000234
   scheme: legacy_openstates
-given_name: Wallace H. "Jay"
+given_name: Wallace
 family_name: Jordan

--- a/data/sc/people/Wendy-C-Brawley-b7a3b3ce-c5ee-48c4-91d9-dfc1fcf6417f.yml
+++ b/data/sc/people/Wendy-C-Brawley-b7a3b3ce-c5ee-48c4-91d9-dfc1fcf6417f.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0187499978.jpg
 other_identifiers:
 - identifier: SCL000277
   scheme: legacy_openstates
-given_name: Wendy C.
+given_name: Wendy
 family_name: Brawley

--- a/data/sc/people/Westley-P-West-Cox-5e292642-1083-42a7-b679-143ff5e537a0.yml
+++ b/data/sc/people/Westley-P-West-Cox-5e292642-1083-42a7-b679-143ff5e537a0.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 434A Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6931
 - address: P.O. Box 315Williamston 29697
   note: District Office
   voice: 864-625-0463
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0428693131
 image: http://www.scstatehouse.gov/images/members/0428693131.jpg
-given_name: Westley P. "West"
+given_name: Westley
 family_name: Cox

--- a/data/sc/people/William-H-Bailey-40032da4-e72a-445f-b2df-7975724e64bb.yml
+++ b/data/sc/people/William-H-Bailey-40032da4-e72a-445f-b2df-7975724e64bb.yml
@@ -8,6 +8,9 @@ roles:
   type: lower
   start_date: '2018-11-12'
 contact_details:
+- address: 420D Blatt Bldg.Columbia 29201
+  note: Capitol Office
+  voice: 803-212-6918
 - address: 4487 Lake CircleLittle River 29566
   note: District Office
   voice: 843-458-0844
@@ -17,5 +20,5 @@ sources:
 - url: http://www.scstatehouse.gov/member.php?chamber=H
 - url: http://www.scstatehouse.gov/member.php?code=0088636353
 image: http://www.scstatehouse.gov/images/members/0088636353.jpg
-given_name: William H.
+given_name: William
 family_name: Bailey

--- a/data/sc/people/William-Scott-Cogswell-Jr-dfd3d968-b6d2-42de-a237-98337ed8343c.yml
+++ b/data/sc/people/William-Scott-Cogswell-Jr-dfd3d968-b6d2-42de-a237-98337ed8343c.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
 contact_details:
-- address: 530A Blatt Bldg.Columbia 29201
+- address: 310B Blatt Bldg.Columbia 29201
   note: Capitol Office
   voice: 803-212-6950
 - address: 701 East Bay St.Suite 310, Charleston 29403
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/0374999955.jpg
 other_identifiers:
 - identifier: SCL000265
   scheme: legacy_openstates
-given_name: William Scott
+given_name: William
 family_name: Cogswell

--- a/data/sc/people/William-W-Will-Wheeler-III-911b30fa-34dd-48ff-b35a-b3202031b031.yml
+++ b/data/sc/people/William-W-Will-Wheeler-III-911b30fa-34dd-48ff-b35a-b3202031b031.yml
@@ -22,5 +22,5 @@ image: http://www.scstatehouse.gov/images/members/1907386135.jpg
 other_identifiers:
 - identifier: SCL000263
   scheme: legacy_openstates
-given_name: William W. "Will"
+given_name: William
 family_name: Wheeler

--- a/data/sc/people/Wm-Weston-J-Newton-eba4b1a4-14ca-44dd-93ab-25cdd3cbd5fd.yml
+++ b/data/sc/people/Wm-Weston-J-Newton-eba4b1a4-14ca-44dd-93ab-25cdd3cbd5fd.yml
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: SCL000204
   scheme: legacy_openstates
-given_name: Wm. Weston J.
+given_name: Weston
 family_name: Newton

--- a/data/sc/retired/Peter-M-McCoy-Jr-9a28833a-867d-460f-b165-be02daf32093.yml
+++ b/data/sc/retired/Peter-M-McCoy-Jr-9a28833a-867d-460f-b165-be02daf32093.yml
@@ -6,6 +6,7 @@ roles:
 - district: '115'
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
+  end_date: '2020-03-30'
 contact_details:
 - address: 420D Blatt Bldg.Columbia 29201
   note: Capitol Office

--- a/data/sc/retired/Ronald-Ronnie-Young-79c3a2ca-d046-4fc6-bfae-04a1fdd08546.yml
+++ b/data/sc/retired/Ronald-Ronnie-Young-79c3a2ca-d046-4fc6-bfae-04a1fdd08546.yml
@@ -6,6 +6,8 @@ roles:
 - district: '84'
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: lower
+  end_date: '2019-05-19'
+  end_reason: Deceased
 contact_details:
 - address: 418A Blatt Bldg.Columbia 29201
   note: Capitol Office
@@ -24,3 +26,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Ronald "Ronnie"
 family_name: Young
+death_date: '2019-05-19'

--- a/data/sc/retired/William-Timmons-f80f5cbc-aebf-462e-ae16-7e5d32e002a5.yml
+++ b/data/sc/retired/William-Timmons-f80f5cbc-aebf-462e-ae16-7e5d32e002a5.yml
@@ -6,6 +6,7 @@ roles:
 - district: '6'
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   type: upper
+  end_date: '2018-11-09'
 contact_details:
 - address: 602 Gressette Bldg.Columbia 29201
   note: Capitol Office

--- a/settings.yml
+++ b/settings.yml
@@ -31,6 +31,11 @@ mo:
     - chamber: lower
       district: 34
       vacant_until: 2021-01-01
+sc:
+  vacancies:
+    - chamber: lower
+      district: 115
+      vacant_until: 2020-09-01
 
 parties:
  - Democratic


### PR DESCRIPTION
Add two new legislators as a result of two resignations and one death, along with one representative moving to the senate. One seat remains open with a special election scheduled for August. This also updates some given/family names and contact information.