### PR TITLE
Update Nevada legislators

### DIFF
--- a/data/nv/organizations/Corrections-Parole-and-Probation-676e7e07-3cd4-4c16-a089-c268c7812f4a.yml
+++ b/data/nv/organizations/Corrections-Parole-and-Probation-676e7e07-3cd4-4c16-a089-c268c7812f4a.yml
@@ -30,6 +30,7 @@ memberships:
   name: Lesley E. Cohen
 - id: ocd-person/a0928af9-6eb8-419a-986c-f8e1f9d9abf1
   name: Tyrone Thompson
+  end_date: '2019-05-04'
 - id: ocd-person/287d0078-78f3-4717-8493-9f77d0eb57d6
   name: Brittney Miller
 - id: ocd-person/75d6c9b4-d0ee-49bb-aa17-ec20bb33e9eb

--- a/data/nv/organizations/Education-d13ba0a5-e73f-4f9b-a419-09c27be78ccc.yml
+++ b/data/nv/organizations/Education-d13ba0a5-e73f-4f9b-a419-09c27be78ccc.yml
@@ -23,6 +23,7 @@ memberships:
 - id: ocd-person/a0928af9-6eb8-419a-986c-f8e1f9d9abf1
   name: Tyrone Thompson
   role: Chair
+  end_date: '2019-05-04'
 - id: ocd-person/b82b9b71-1d83-4f91-9a7f-8adec73b023f
   name: Lisa Krasner
 - id: ocd-person/287d0078-78f3-4717-8493-9f77d0eb57d6

--- a/data/nv/organizations/Health-and-Human-Services-8f131e55-094c-4184-b331-a21cf94ff685.yml
+++ b/data/nv/organizations/Health-and-Human-Services-8f131e55-094c-4184-b331-a21cf94ff685.yml
@@ -18,6 +18,7 @@ memberships:
   role: Vice Chair
 - id: ocd-person/a0928af9-6eb8-419a-986c-f8e1f9d9abf1
   name: Tyrone Thompson
+  end_date: '2019-05-04'
 - id: ocd-person/6aa57859-c195-4a44-9404-b6e2bbe4ac04
   name: Robin L. Titus
 - id: ocd-person/b04e69b4-7ce6-4d42-944b-dcb3d1a47415

--- a/data/nv/organizations/Judiciary-00a7b344-d98d-4c17-9f61-4e46aa561f70.yml
+++ b/data/nv/organizations/Judiciary-00a7b344-d98d-4c17-9f61-4e46aa561f70.yml
@@ -27,6 +27,7 @@ memberships:
   name: Ira Hansen
 - id: ocd-person/a0928af9-6eb8-419a-986c-f8e1f9d9abf1
   name: Tyrone Thompson
+  end_date: '2019-05-04'
 - id: ocd-person/fb571e08-9ef7-4da6-9b0b-0abdf87a2b5a
   name: Jill Tolles
 - id: ocd-person/3f15afd1-b733-4b19-982f-7be9bdb62915

--- a/data/nv/people/Al-Kramer-dc645a5d-c2b0-4686-a727-920c027470ef.yml
+++ b/data/nv/people/Al-Kramer-dc645a5d-c2b0-4686-a727-920c027470ef.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=342
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=342
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Kramer.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Kramer.Al.342.jpg
 other_identifiers:
 - identifier: NVL000361
   scheme: legacy_openstates

--- a/data/nv/people/Alex-Assefa-90f7747d-832e-48a9-9654-d49d8652f91e.yml
+++ b/data/nv/people/Alex-Assefa-90f7747d-832e-48a9-9654-d49d8652f91e.yml
@@ -1,5 +1,5 @@
 id: ocd-person/90f7747d-832e-48a9-9654-d49d8652f91e
-name: Alex Assefa
+name: Alexander Assefa
 party:
 - name: Democratic
 roles:
@@ -9,9 +9,14 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 4001 South Decatur Boulevard, No. 37-497;Las Vegas, NV 89103-5860
+  email: Alex.Assefa@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=357
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=357
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Assefa.Alexander.357.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Assefa.Alex.357.jpg
+other_names:
+- name: Alex Assefa
+given_name: Alexander
+family_name: Assefa

--- a/data/nv/people/Alexis-Hansen-6fee4c5a-f125-46bc-b11a-d254e40428e4.yml
+++ b/data/nv/people/Alexis-Hansen-6fee4c5a-f125-46bc-b11a-d254e40428e4.yml
@@ -17,3 +17,5 @@ links:
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=366
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Hansen.Alexis.366.jpg
+given_name: Alexis
+family_name: Hansen

--- a/data/nv/people/Bea-Duran-ba795c1a-235c-49d1-af4d-9d23a2395ccb.yml
+++ b/data/nv/people/Bea-Duran-ba795c1a-235c-49d1-af4d-9d23a2395ccb.yml
@@ -8,10 +8,13 @@ roles:
   type: lower
   start_date: '2019-02-04'
 contact_details:
-- address: 241 North 18th Street, Unit B;Las Vegas, NV 89101-4492
+- address: P.O. Box 999;Las Vegas, NV 89125-0999
+  email: beatrice.duran@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=373
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=373
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Duran.Bea.373.jpg
+given_name: Bea
+family_name: Duran

--- a/data/nv/people/Ben-Kieckhefer-b59d17af-7d1c-453a-817b-a761bdc90944.yml
+++ b/data/nv/people/Ben-Kieckhefer-b59d17af-7d1c-453a-817b-a761bdc90944.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=115
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=115
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Kieckhefer.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Kieckhefer.Ben.115.jpg
 other_identifiers:
 - identifier: NVL000110
   scheme: legacy_openstates

--- a/data/nv/people/Brittney-Miller-287d0078-78f3-4717-8493-9f77d0eb57d6.yml
+++ b/data/nv/people/Brittney-Miller-287d0078-78f3-4717-8493-9f77d0eb57d6.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=304
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=304
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Miller.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Miller.Brittney.304.jpg
 other_identifiers:
 - identifier: NVL000365
   scheme: legacy_openstates

--- a/data/nv/people/Chris-Edwards-55e70444-f884-463e-a8af-240aa916de57.yml
+++ b/data/nv/people/Chris-Edwards-55e70444-f884-463e-a8af-240aa916de57.yml
@@ -7,15 +7,14 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:nv/government
   type: lower
 contact_details:
-- address: 6088 Riflecrest Avenue;Las Vegas, NV 89156-4778
+- address: 139 La Mirada Drive;Henderson, NV 89015-2761
   email: Chris.Edwards@asm.state.nv.us
   note: District Office
-  voice: 702-715-4308
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=279
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=279
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Edwards.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Edwards.Chris.279.jpg
 other_identifiers:
 - identifier: NVL000287
   scheme: legacy_openstates

--- a/data/nv/people/Connie-Munk-6036daa0-6fa7-47e1-8e6a-0cd6a0d5cd1e.yml
+++ b/data/nv/people/Connie-Munk-6036daa0-6fa7-47e1-8e6a-0cd6a0d5cd1e.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 10040 West Cheyenne Avenue, No. 170-184;Las Vegas, NV 89129-7719
+  email: Connie.Munk@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=360
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=360
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Munk.Connie.360.jpg
+given_name: Connie
+family_name: Munk

--- a/data/nv/people/Dallas-Harris-ab30aa3f-5248-44f6-9e23-00f85f8e4d2e.yml
+++ b/data/nv/people/Dallas-Harris-ab30aa3f-5248-44f6-9e23-00f85f8e4d2e.yml
@@ -1,17 +1,20 @@
 id: ocd-person/ab30aa3f-5248-44f6-9e23-00f85f8e4d2e
 name: Dallas Harris
 party:
-  - name: Democratic
+- name: Democratic
 roles:
-  - district: "11"
-    jurisdiction: ocd-jurisdiction/country:us/state:nv/government
-    type: upper
-    start_date: "2019-02-04"
+- district: '11'
+  jurisdiction: ocd-jurisdiction/country:us/state:nv/government
+  type: upper
+  start_date: '2019-02-04'
 contact_details:
-  - address: "8020 South Rainbow Blvd., Suite 100, #271;Las Vegas, NV 89139"
-    note: District Office
+- address: '8020 South Rainbow Boulevard, Suite 100, #271;Las Vegas, NV 89139'
+  email: Dallas.Harris@sen.state.nv.us
+  note: District Office
 links:
-  - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=370
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=370
 sources:
-  - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=370
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=370
 image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Harris.Dallas.370.jpg
+given_name: Dallas
+family_name: Harris

--- a/data/nv/people/Daniele-Monroe-Moreno-b266a1bc-d8f5-472c-ba8d-e98e0d904ee3.yml
+++ b/data/nv/people/Daniele-Monroe-Moreno-b266a1bc-d8f5-472c-ba8d-e98e0d904ee3.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=307
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=307
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Monroe-Moreno.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/MonroeMoreno.Daniele.307.jpg
 other_identifiers:
 - identifier: NVL000375
   scheme: legacy_openstates

--- a/data/nv/people/David-R-Parks-891afaa6-0579-43c9-87af-ac69d54c0817.yml
+++ b/data/nv/people/David-R-Parks-891afaa6-0579-43c9-87af-ac69d54c0817.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=34
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=34
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Parks.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Parks.David.34.jpg
 other_identifiers:
 - identifier: NVL000014
   scheme: legacy_openstates
@@ -25,5 +25,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NVL000295
   scheme: legacy_openstates
-given_name: David R.
+given_name: David
 family_name: Parks

--- a/data/nv/people/Dina-Neal-6da4be55-c493-4b72-b436-5257259247d2.yml
+++ b/data/nv/people/Dina-Neal-6da4be55-c493-4b72-b436-5257259247d2.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=129
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=129
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Neal.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Neal.Dina.129.jpg
 other_identifiers:
 - identifier: NVL000134
   scheme: legacy_openstates

--- a/data/nv/people/Edgar-Flores-e5b06346-f5ee-4e1d-baed-342cc4a8ff36.yml
+++ b/data/nv/people/Edgar-Flores-e5b06346-f5ee-4e1d-baed-342cc4a8ff36.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=273
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=273
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Flores.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Flores.Edgar.273.jpg
 other_identifiers:
 - identifier: NVL000283
   scheme: legacy_openstates

--- a/data/nv/people/Ellen-B-Spiegel-de3a576a-63ed-4a42-a780-f633d5ca3cf0.yml
+++ b/data/nv/people/Ellen-B-Spiegel-de3a576a-63ed-4a42-a780-f633d5ca3cf0.yml
@@ -15,11 +15,11 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=93
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=93
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Spiegel,E.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Spiegel.Ellen.93.jpg
 other_identifiers:
 - identifier: NVL000285
   scheme: legacy_openstates
 - identifier: NVL000332
   scheme: legacy_openstates
-given_name: Ellen B.
+given_name: Ellen
 family_name: Spiegel

--- a/data/nv/people/Glen-Leavitt-cbdc4379-45a2-41b9-9f92-51f3c4811744.yml
+++ b/data/nv/people/Glen-Leavitt-cbdc4379-45a2-41b9-9f92-51f3c4811744.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 1000 Nevada Way, Suite 105;Boulder City, NV 89005-1828
+  email: Glen.Leavitt@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=365
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=365
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Leavitt.Glen.365.jpg
+given_name: Glen
+family_name: Leavitt

--- a/data/nv/people/Greg-Smith-0b945a19-1c48-4c8c-ae4f-304b522a5690.yml
+++ b/data/nv/people/Greg-Smith-0b945a19-1c48-4c8c-ae4f-304b522a5690.yml
@@ -11,6 +11,10 @@ roles:
   start_date: '2019-03-26'
   type: lower
 links:
-- url: https://www.leg.state.nv.us/App/Legislator/A/Assembly/Current/30
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=374
 sources:
-- url: https://www.leg.state.nv.us/App/Legislator/A/Assembly/Current/30
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=374
+contact_details:
+- address: 5455 Wedekind Road;Sparks, NV 89431-1145
+  email: Greg.Smith@asm.state.nv.us
+  note: District Office

--- a/data/nv/people/Gregory-T-Hafen-II-33330e1e-b22d-49d7-bce8-6964b289683a.yml
+++ b/data/nv/people/Gregory-T-Hafen-II-33330e1e-b22d-49d7-bce8-6964b289683a.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 5250 Hafen Ranch Road;Pahrump, NV 89061-7502
+  email: Gregory.Hafen@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=371
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=371
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/HafenII.Gregory.371.jpg
+given_name: Gregory
+family_name: Hafen

--- a/data/nv/people/Heidi-Seevers-Gansert-a9c5b02b-6b3c-42ab-9085-104a6f673f00.yml
+++ b/data/nv/people/Heidi-Seevers-Gansert-a9c5b02b-6b3c-42ab-9085-104a6f673f00.yml
@@ -8,10 +8,13 @@ roles:
   type: upper
   start_date: '2019-02-04'
 contact_details:
-- address: '316 California Ave., #519;Reno, NV 89509'
+- address: '316 California Avenue, #519;Reno, NV 89509'
+  email: Heidi.Gansert@sen.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=12
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=12
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Gansert.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/SeeversGansert.Heidi.12.jpg
+given_name: Heidi
+family_name: Seevers Gansert

--- a/data/nv/people/Heidi-Swank-130c1568-7542-4441-82d9-88152b5b8ce4.yml
+++ b/data/nv/people/Heidi-Swank-130c1568-7542-4441-82d9-88152b5b8ce4.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=235
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=235
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Swank,H.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Swank.Heidi.235.jpg
 other_identifiers:
 - identifier: NVL000254
   scheme: legacy_openstates

--- a/data/nv/people/Howard-Watts-b88fd854-c97b-4908-a554-583b93bca5c4.yml
+++ b/data/nv/people/Howard-Watts-b88fd854-c97b-4908-a554-583b93bca5c4.yml
@@ -8,10 +8,13 @@ roles:
   type: lower
   start_date: '2019-02-04'
 contact_details:
-- address: 1701 South 14th Street;Las Vegas, NV 89104-3119
+- address: P.O. Box 43413;Las Vegas, NV 89116-1413
+  email: Howard.Watts@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=363
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=363
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/WattsIII.Howard.363.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Watts.Howard.363.jpg
+given_name: Howard
+family_name: Watts

--- a/data/nv/people/James-A-Settelmeyer-fd88d6ca-9461-4666-b3c4-bbbf2fa3e9e6.yml
+++ b/data/nv/people/James-A-Settelmeyer-fd88d6ca-9461-4666-b3c4-bbbf2fa3e9e6.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=74
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=74
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Settelmeyer.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Settelmeyer.James.74.jpg
 other_identifiers:
 - identifier: NVL000101
   scheme: legacy_openstates

--- a/data/nv/people/Jason-Frierson-9124c41d-12ad-4803-aef6-3d8dd9c208f9.yml
+++ b/data/nv/people/Jason-Frierson-9124c41d-12ad-4803-aef6-3d8dd9c208f9.yml
@@ -11,12 +11,11 @@ contact_details:
 - address: 7925 West Russell Road, No. 400187;Las Vegas, NV 89140-8009
   email: Jason.Frierson@asm.state.nv.us
   note: District Office
-  voice: 702-280-2981
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=132
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=132
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Frierson.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Frierson.Jason.132.jpg
 other_identifiers:
 - identifier: NVL000362
   scheme: legacy_openstates

--- a/data/nv/people/Jill-Tolles-fb571e08-9ef7-4da6-9b0b-0abdf87a2b5a.yml
+++ b/data/nv/people/Jill-Tolles-fb571e08-9ef7-4da6-9b0b-0abdf87a2b5a.yml
@@ -10,12 +10,11 @@ contact_details:
 - address: 4790 Caughlin Parkway, No. 180;Reno, NV 89519-0907
   email: Jill.Tolles@asm.state.nv.us
   note: District Office
-  voice: 775-815-4237
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=326
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=326
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Tolles.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Tolles.Jill.326.jpg
 other_identifiers:
 - identifier: NVL000367
   scheme: legacy_openstates

--- a/data/nv/people/Jim-Wheeler-e51db438-c32b-4022-aa8b-0c68cb7a7134.yml
+++ b/data/nv/people/Jim-Wheeler-e51db438-c32b-4022-aa8b-0c68cb7a7134.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=260
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=260
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Wheeler,J.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Wheeler.Jim.260.jpg
 other_identifiers:
 - identifier: NVL000261
   scheme: legacy_openstates

--- a/data/nv/people/John-C-Ellison-87e878e2-fd19-4b55-a7b5-b76adf520e84.yml
+++ b/data/nv/people/John-C-Ellison-87e878e2-fd19-4b55-a7b5-b76adf520e84.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=159
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=159
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Ellison.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Ellison.John.159.jpg
 other_identifiers:
 - identifier: NVL000124
   scheme: legacy_openstates
@@ -27,5 +27,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: NVL000342
   scheme: legacy_openstates
-given_name: John C.
+given_name: John
 family_name: Ellison

--- a/data/nv/people/John-Hambrick-96972dfa-2b9a-44ea-9aaf-c428e2c1553e.yml
+++ b/data/nv/people/John-Hambrick-96972dfa-2b9a-44ea-9aaf-c428e2c1553e.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=90
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=90
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Hambrick,S.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Hambrick.John.90.jpg
 other_identifiers:
 - identifier: NVL000082
   scheme: legacy_openstates

--- a/data/nv/people/Joseph-Joe-P-Hardy-c88ba71c-5e41-4bf8-92d9-9e00683edfdf.yml
+++ b/data/nv/people/Joseph-Joe-P-Hardy-c88ba71c-5e41-4bf8-92d9-9e00683edfdf.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=17
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=17
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Hardy.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Hardy.Joseph.17.jpg
 other_identifiers:
 - identifier: NVL000041
   scheme: legacy_openstates

--- a/data/nv/people/Joyce-Woodhouse-227944e4-3deb-46e9-a036-260a5739cb8f.yml
+++ b/data/nv/people/Joyce-Woodhouse-227944e4-3deb-46e9-a036-260a5739cb8f.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=64
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=64
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Woodhouse,J.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Woodhouse.Joyce.64.jpg
 other_identifiers:
 - identifier: NVL000021
   scheme: legacy_openstates

--- a/data/nv/people/Julia-Ratti-4ae486e9-52d6-49c5-9d6d-efe743825c92.yml
+++ b/data/nv/people/Julia-Ratti-4ae486e9-52d6-49c5-9d6d-efe743825c92.yml
@@ -10,12 +10,11 @@ contact_details:
 - address: P.O. Box 4228;Sparks, NV 89432
   email: Julia.Ratti@sen.state.nv.us
   note: District Office
-  voice: 775-525-0359
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=294
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=294
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Ratti.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Ratti.Julia.294.jpg
 other_identifiers:
 - identifier: NVL000373
   scheme: legacy_openstates

--- a/data/nv/people/Keith-F-Pickard-08269c01-28ee-4862-ab45-9ea9bbd4f0a4.yml
+++ b/data/nv/people/Keith-F-Pickard-08269c01-28ee-4862-ab45-9ea9bbd4f0a4.yml
@@ -8,10 +8,13 @@ roles:
   type: upper
   start_date: '2019-02-04'
 contact_details:
-- address: 10120 S. Eastern Av, Suite 140;Henderson, NV 89052
+- address: 10120 S. Eastern Avenue, Suite 140;Henderson, NV 89052
+  email: Keith.Pickard@sen.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=322
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=322
 image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Pickard.Keith.322.jpg
+given_name: Keith
+family_name: Pickard

--- a/data/nv/people/Lesley-E-Cohen-0f7983ab-0a1f-435a-b8ae-f5f4a73e26c5.yml
+++ b/data/nv/people/Lesley-E-Cohen-0f7983ab-0a1f-435a-b8ae-f5f4a73e26c5.yml
@@ -16,7 +16,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=268
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=268
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Cohen.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Cohen.Lesley.268.jpg
 other_identifiers:
 - identifier: NVL000379
   scheme: legacy_openstates
@@ -24,5 +24,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ocd-person/68c9893e-bba9-48f7-90f3-1931b8d1169e
   scheme: openstates
-given_name: Lesley E.
+given_name: Lesley
 family_name: Cohen

--- a/data/nv/people/Lisa-Krasner-b82b9b71-1d83-4f91-9a7f-8adec73b023f.yml
+++ b/data/nv/people/Lisa-Krasner-b82b9b71-1d83-4f91-9a7f-8adec73b023f.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=327
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=327
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Krasner.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Krasner.Lisa.327.jpg
 other_identifiers:
 - identifier: NVL000380
   scheme: legacy_openstates

--- a/data/nv/people/Maggie-Carlton-5d73add2-5880-44d9-a6d6-9102d8d95265.yml
+++ b/data/nv/people/Maggie-Carlton-5d73add2-5880-44d9-a6d6-9102d8d95265.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=46
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=46
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Carlton.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Carlton.Maggie.46.jpg
 other_identifiers:
 - identifier: NVL000004
   scheme: legacy_openstates

--- a/data/nv/people/Marcia-Washington-094c4b6f-1fdb-42c3-bf96-72a23b6c848a.yml
+++ b/data/nv/people/Marcia-Washington-094c4b6f-1fdb-42c3-bf96-72a23b6c848a.yml
@@ -1,8 +1,8 @@
 id: ocd-person/094c4b6f-1fdb-42c3-bf96-72a23b6c848a
-name: Marcia Washington
+name: Marcia L. Washington
 given_name: Marcia
 family_name: Washington
-image: https://www.leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Washington.Marcia.369.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Washington.Marcia.369.jpg
 party:
 - name: Democratic
 roles:
@@ -11,6 +11,12 @@ roles:
   start_date: '2019-05-15'
   type: upper
 links:
-- url: https://www.leg.state.nv.us/App/Legislator/A/Senate/Current/4
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=369
 sources:
-- url: https://www.leg.state.nv.us/App/Legislator/A/Senate/Current/4
+- url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=369
+contact_details:
+- address: 401 South Carson Street, Room 2145;Carson City, NV 89701-4747
+  email: Marcia.Washington@sen.state.nv.us
+  note: District Office
+other_names:
+- name: Marcia Washington

--- a/data/nv/people/Marilyn-Dondero-Loop-0435a1f4-d8e4-43d9-9ac1-788a0aed92e4.yml
+++ b/data/nv/people/Marilyn-Dondero-Loop-0435a1f4-d8e4-43d9-9ac1-788a0aed92e4.yml
@@ -13,7 +13,8 @@ roles:
   type: upper
   start_date: '2019-02-04'
 contact_details:
-- address: 9811 W. Charleston Blvd., Suite 2-420;Las Vegas, NV 89117-7528
+- address: 9811 W. Charleston Boulevard, Suite 2-420;Las Vegas, NV 89117-7528
+  email: Marilyn.DonderoLoop@sen.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=92
@@ -31,3 +32,5 @@ other_identifiers:
   scheme: legacy_openstates
 - identifier: ocd-person/a8534d64-df56-4c14-8ab7-7ba720aea74a
   scheme: openstates
+given_name: Marilyn
+family_name: Dondero Loop

--- a/data/nv/people/Melanie-Scheible-860029b3-070b-4c23-a826-51948c5d995c.yml
+++ b/data/nv/people/Melanie-Scheible-860029b3-070b-4c23-a826-51948c5d995c.yml
@@ -8,10 +8,13 @@ roles:
   type: upper
   start_date: '2019-02-04'
 contact_details:
-- address: '4030 South Jones Blvd., #30125;Las Vegas, NV 89173-8806'
+- address: '4030 South Jones Boulevard, #30125;Las Vegas, NV 89173-8806'
+  email: Melanie.Scheible@sen.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=358
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=358
 image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Scheible.Melanie.358.jpg
+given_name: Melanie
+family_name: Scheible

--- a/data/nv/people/Melissa-Hardy-5cafbfaf-3066-4080-9754-b53f337ba4ba.yml
+++ b/data/nv/people/Melissa-Hardy-5cafbfaf-3066-4080-9754-b53f337ba4ba.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 1405 West Sunset Road, No. 101;Henderson, NV 89014-6673
+  email: Melissa.Hardy@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=364
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=364
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Hardy.Melissa.364.jpg
+given_name: Melissa
+family_name: Hardy

--- a/data/nv/people/Michelle-Gorelow-3435f7f4-4515-40da-a6e8-d03f1e01e9d3.yml
+++ b/data/nv/people/Michelle-Gorelow-3435f7f4-4515-40da-a6e8-d03f1e01e9d3.yml
@@ -8,10 +8,13 @@ roles:
   type: lower
   start_date: '2019-02-04'
 contact_details:
-- address: 8545 West Warm Springs Road, Suite A-4;Las Vegas, NV 89113-3677
+- address: 8545 West Warm Springs Road, Suite A-4, Box 107;Las Vegas, NV 89113-3677
+  email: Michelle.Gorelow@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=367
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=367
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Gorelow.Michelle.367.jpg
+given_name: Michelle
+family_name: Gorelow

--- a/data/nv/people/Moises-Mo-Denis-6c677ee8-4d29-4fef-927f-675d809f258b.yml
+++ b/data/nv/people/Moises-Mo-Denis-6c677ee8-4d29-4fef-927f-675d809f258b.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=11
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=11
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Denis.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Denis.Moises.11.jpg
 other_identifiers:
 - identifier: NVL000075
   scheme: legacy_openstates

--- a/data/nv/people/Nicole-J-Cannizzaro-d2ca0a59-3bf1-4e1c-b4d7-9da33a4c5152.yml
+++ b/data/nv/people/Nicole-J-Cannizzaro-d2ca0a59-3bf1-4e1c-b4d7-9da33a4c5152.yml
@@ -15,9 +15,9 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=347
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=347
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Cannizzaro.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Cannizzaro.Nicole.347.jpg
 other_identifiers:
 - identifier: NVL000377
   scheme: legacy_openstates
-given_name: Nicole J.
+given_name: Nicole
 family_name: Cannizzaro

--- a/data/nv/people/Ozzie-Fumo-e3c61d50-d2cf-44a4-8a31-77d368260215.yml
+++ b/data/nv/people/Ozzie-Fumo-e3c61d50-d2cf-44a4-8a31-77d368260215.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=320
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=320
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Fumo.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Fumo.Ozzie.320.jpg
 other_identifiers:
 - identifier: NVL000378
   scheme: legacy_openstates

--- a/data/nv/people/Pat-Spearman-313e26dd-bd3c-42fb-8694-b004661b068c.yml
+++ b/data/nv/people/Pat-Spearman-313e26dd-bd3c-42fb-8694-b004661b068c.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=204
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=204
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Spearman,P.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Spearman.Pat.204.jpg
 other_identifiers:
 - identifier: NVL000217
   scheme: legacy_openstates

--- a/data/nv/people/Pete-Goicoechea-10a65aab-d47e-46c5-84d6-b35bafce0d35.yml
+++ b/data/nv/people/Pete-Goicoechea-10a65aab-d47e-46c5-84d6-b35bafce0d35.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=15
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=15
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Goicoechea.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Goicoechea.Pete.15.jpg
 other_identifiers:
 - identifier: NVL000079
   scheme: legacy_openstates

--- a/data/nv/people/Richard-Carrillo-4b09e6bc-114c-4dac-95b5-dfaa70f88325.yml
+++ b/data/nv/people/Richard-Carrillo-4b09e6bc-114c-4dac-95b5-dfaa70f88325.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=116
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=116
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Carrillo.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Carrillo.Richard.116.jpg
 other_identifiers:
 - identifier: NVL000121
   scheme: legacy_openstates

--- a/data/nv/people/Robin-L-Titus-6aa57859-c195-4a44-9404-b6e2bbe4ac04.yml
+++ b/data/nv/people/Robin-L-Titus-6aa57859-c195-4a44-9404-b6e2bbe4ac04.yml
@@ -10,16 +10,16 @@ contact_details:
 - address: P.O. Box 377;Wellington, NV 89444-0377
   email: Robin.Titus@asm.state.nv.us
   note: District Office
-  voice: 775-465-2587
+  voice: 775-901-3844
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=281
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=281
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Titus.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Titus.Robin.281.jpg
 other_identifiers:
 - identifier: NVL000278
   scheme: legacy_openstates
 - identifier: NVL000335
   scheme: legacy_openstates
-given_name: Robin L.
+given_name: Robin
 family_name: Titus

--- a/data/nv/people/Rochelle-T-Nguyen-d84ad99c-617a-4d33-a351-8bde19868746.yml
+++ b/data/nv/people/Rochelle-T-Nguyen-d84ad99c-617a-4d33-a351-8bde19868746.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: P. O. Box 26025;Las Vegas, NV 89126-0025
+  email: rochelle.nguyen@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=372
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=372
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Nguyen.Rochelle.372.jpg
+given_name: Rochelle
+family_name: Nguyen

--- a/data/nv/people/Sandra-Jauregui-25e09131-39e3-4c58-96b0-6c1ac9e74b19.yml
+++ b/data/nv/people/Sandra-Jauregui-25e09131-39e3-4c58-96b0-6c1ac9e74b19.yml
@@ -8,12 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: 7582 Las Vegas Boulevard South, No. 118;Las Vegas, NV 89123-1009
+  email: Sandra.Jauregui@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=344
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=344
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Jauregui.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Jauregui.Sandra.344.jpg
 other_identifiers:
 - identifier: NVL000368
   scheme: legacy_openstates

--- a/data/nv/people/Sarah-Peters-be47c5c9-c307-4324-9e83-c46e594b5f06.yml
+++ b/data/nv/people/Sarah-Peters-be47c5c9-c307-4324-9e83-c46e594b5f06.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 2258 Sunrise Drive;Reno, NV 89509-3750
+  email: Sarah.Peters@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=356
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=356
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Peters.Sarah.356.jpg
+given_name: Sarah
+family_name: Peters

--- a/data/nv/people/Scott-Hammond-0150fa14-5f3f-454c-bd97-913af2471e07.yml
+++ b/data/nv/people/Scott-Hammond-0150fa14-5f3f-454c-bd97-913af2471e07.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=143
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=143
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Hammond.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Hammond.Scott.143.jpg
 other_identifiers:
 - identifier: NVL000127
   scheme: legacy_openstates

--- a/data/nv/people/Selena-Torres-59a3b5f2-a135-48e5-9baa-98585f8ff35e.yml
+++ b/data/nv/people/Selena-Torres-59a3b5f2-a135-48e5-9baa-98585f8ff35e.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 1027 South Rainbow Boulevard, No. 122;Las Vegas, NV 89145-6232
+  email: Selena.Torres@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=359
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=359
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Torres.Selena.359.jpg
+given_name: Selena
+family_name: Torres

--- a/data/nv/people/Shannon-Bilbray-Axelrod-c9d78312-791c-488f-9a62-6aca63db21f0.yml
+++ b/data/nv/people/Shannon-Bilbray-Axelrod-c9d78312-791c-488f-9a62-6aca63db21f0.yml
@@ -8,12 +8,13 @@ roles:
   type: lower
 contact_details:
 - address: 7500 West Lake Mead Boulevard, Suite 9-486;Las Vegas, NV 89128-0298
+  email: Shannon.BilbrayAxelrod@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=332
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=332
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Bilbray-Axelrod.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/BilbrayAxelrod.Shannon.332.jpg
 other_identifiers:
 - identifier: NVL000376
   scheme: legacy_openstates

--- a/data/nv/people/Shea-Backus-9c694eea-ad2d-4678-99c4-1ebba457a857.yml
+++ b/data/nv/people/Shea-Backus-9c694eea-ad2d-4678-99c4-1ebba457a857.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 2251 North Rampart Boulevard, No. 587;Las Vegas, NV 89128-7640
+  email: Shea.Backus@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=368
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=368
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Backus.Shea.368.jpg
+given_name: Shea
+family_name: Backus

--- a/data/nv/people/Skip-Daly-3c8ae405-5bc3-4bf5-bb90-eca7fcd67ffd.yml
+++ b/data/nv/people/Skip-Daly-3c8ae405-5bc3-4bf5-bb90-eca7fcd67ffd.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=155
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=155
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Daly.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Daly.Skip.155.jpg
 other_identifiers:
 - identifier: NVL000371
   scheme: legacy_openstates

--- a/data/nv/people/Steve-Yeager-4caae060-1c91-4d9d-a8f9-83d74c7d0f58.yml
+++ b/data/nv/people/Steve-Yeager-4caae060-1c91-4d9d-a8f9-83d74c7d0f58.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=310
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=310
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Yeager.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Yeager.Steve.310.jpg
 other_identifiers:
 - identifier: NVL000381
   scheme: legacy_openstates

--- a/data/nv/people/Susie-Martinez-09f9fbba-7965-44b5-9d31-dfdd48ff4b17.yml
+++ b/data/nv/people/Susie-Martinez-09f9fbba-7965-44b5-9d31-dfdd48ff4b17.yml
@@ -8,10 +8,13 @@ roles:
   type: lower
   start_date: '2019-02-04'
 contact_details:
-- address: 6081 Sunkiss Drive;Las Vegas, NV 89110-1820
+- address: 8545 West Warm Springs Road, Suite A-4, Box 107;Las Vegas, NV 89113-3677
+  email: Susan.Martinez@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=361
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=361
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Martinez.Susan.361.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Martinez.Susie.361.jpg
+given_name: Susie
+family_name: Martinez

--- a/data/nv/people/Teresa-Benitez-Thompson-b04e69b4-7ce6-4d42-944b-dcb3d1a47415.yml
+++ b/data/nv/people/Teresa-Benitez-Thompson-b04e69b4-7ce6-4d42-944b-dcb3d1a47415.yml
@@ -15,7 +15,7 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=149
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=149
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Benitez-Thompson.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/BenitezThompson.Teresa.149.jpg
 other_identifiers:
 - identifier: NVL000117
   scheme: legacy_openstates

--- a/data/nv/people/Tom-Roberts-34ae59d1-f877-4e9d-baae-8a66fbbbda67.yml
+++ b/data/nv/people/Tom-Roberts-34ae59d1-f877-4e9d-baae-8a66fbbbda67.yml
@@ -9,9 +9,12 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 7260 West Azure Drive, Suite 140-157;Las Vegas, NV 89130-7999
+  email: Tom.Roberts@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=362
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=362
 image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/Roberts.Tom.362.jpg
+given_name: Tom
+family_name: Roberts

--- a/data/nv/people/William-McCurdy-18b7087a-a521-445e-a475-5695e9db53b8.yml
+++ b/data/nv/people/William-McCurdy-18b7087a-a521-445e-a475-5695e9db53b8.yml
@@ -1,5 +1,5 @@
 id: ocd-person/18b7087a-a521-445e-a475-5695e9db53b8
-name: William McCurdy
+name: William McCurdy II
 party:
 - name: Democratic
 roles:
@@ -9,9 +9,14 @@ roles:
   start_date: '2019-02-04'
 contact_details:
 - address: 1117 Hart Avenue;Las Vegas, NV 89106-2401
+  email: William.McCurdy@asm.state.nv.us
   note: District Office
 links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=306
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=306
-image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/McCurdy.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Assembly/Images/McCurdy.William.306.jpg
+other_names:
+- name: William McCurdy
+given_name: William
+family_name: McCurdy

--- a/data/nv/people/Yvanna-D-Cancela-beb2d23e-d01e-431f-a4b7-61401b9745fd.yml
+++ b/data/nv/people/Yvanna-D-Cancela-beb2d23e-d01e-431f-a4b7-61401b9745fd.yml
@@ -15,9 +15,9 @@ links:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=349
 sources:
 - url: https://www.leg.state.nv.us/App/Legislator/A/api/80th2019/Legislator?id=349
-image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Cancela.jpg
+image: https://leg.state.nv.us/Session/80th2019/legislators/Senators/Images/Cancela.Yvanna.349.jpg
 other_identifiers:
 - identifier: NVL000363
   scheme: legacy_openstates
-given_name: Yvanna D.
+given_name: Yvanna
 family_name: Cancela

--- a/data/nv/retired/Tyrone-Thompson-a0928af9-6eb8-419a-986c-f8e1f9d9abf1.yml
+++ b/data/nv/retired/Tyrone-Thompson-a0928af9-6eb8-419a-986c-f8e1f9d9abf1.yml
@@ -6,6 +6,8 @@ roles:
 - district: '17'
   jurisdiction: ocd-jurisdiction/country:us/state:nv/government
   type: lower
+  end_date: '2019-05-04'
+  end_reason: Deceased
 contact_details:
 - address: 117 Fox Crossing Avenue;North Las Vegas, NV 89084-5207
   email: Tyrone.Thompson@asm.state.nv.us
@@ -23,3 +25,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Tyrone
 family_name: Thompson
+death_date: '2019-05-04'

--- a/settings.yml
+++ b/settings.yml
@@ -31,6 +31,11 @@ mo:
     - chamber: lower
       district: 34
       vacant_until: 2021-01-01
+nv:
+  vacancies:
+    - chamber: lower
+      district: 17
+      vacant_until: 2021-01-01
 sc:
   vacancies:
     - chamber: lower


### PR DESCRIPTION
One legislator's death leaves one unfilled vacancy. This adds in a bunch of emails and updates other contact information/names.