### PR TITLE
Update Minnesota legislators

### DIFF
--- a/data/mn/organizations/Civil-Law-and-Data-Practices-Policy-ad171c0d-94bf-4dea-a5b1-d0b001f80ace.yml
+++ b/data/mn/organizations/Civil-Law-and-Data-Practices-Policy-ad171c0d-94bf-4dea-a5b1-d0b001f80ace.yml
@@ -40,7 +40,7 @@ memberships:
   name: Abigail Whelan
   end_date: '2019-01-07'
 - id: ocd-person/971dbd16-363f-4151-a75c-306746aec18e
-  name: Jeff Howe
+  name: Jeff R. Howe
 - id: ocd-person/09019187-1e4f-445e-9e21-313ef58cc566
   name: Bob Loonan
   end_date: '2019-01-07'

--- a/data/mn/organizations/Health-and-Human-Services-Finance-417b0f2f-3a20-47c8-8ce1-b3a3d7828e0f.yml
+++ b/data/mn/organizations/Health-and-Human-Services-Finance-417b0f2f-3a20-47c8-8ce1-b3a3d7828e0f.yml
@@ -21,9 +21,11 @@ memberships:
   name: Mary Franson
 - id: ocd-person/d9973ac3-6811-4f24-97f3-f300968d9f5e
   name: Diane Loeffler
+  end_date: '2019-11-16'
 - name: John
 - id: ocd-person/ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50
   name: Nick Zerwas
+  end_date: '2019-12-06'
 - id: ocd-person/81828030-d1b8-4641-8692-8148fca58b28
   name: Erin Murphy
   role: DFL Lead

--- a/data/mn/organizations/Higher-Education-and-Career-Readiness-Policy-and-Finance-38307c0a-3c2d-4763-b2b3-fa6746d20be6.yml
+++ b/data/mn/organizations/Higher-Education-and-Career-Readiness-Policy-and-Finance-38307c0a-3c2d-4763-b2b3-fa6746d20be6.yml
@@ -20,6 +20,7 @@ memberships:
   end_date: '2019-01-07'
 - id: ocd-person/ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50
   name: Nick Zerwas
+  end_date: '2019-12-06'
 - id: ocd-person/18549c8f-0d80-4c2f-bdcc-f3762c3acb19
   name: Josh Heintzeman
 - id: ocd-person/50929c69-6211-4f9c-ae99-615d89c16fec

--- a/data/mn/organizations/Job-Growth-and-Energy-Affordability-Policy-and-Finance-61b44458-7e51-4d03-82b5-dcc3b6014643.yml
+++ b/data/mn/organizations/Job-Growth-and-Energy-Affordability-Policy-and-Finance-61b44458-7e51-4d03-82b5-dcc3b6014643.yml
@@ -47,7 +47,7 @@ memberships:
   role: Vice Chair
   end_date: '2019-01-07'
 - id: ocd-person/971dbd16-363f-4151-a75c-306746aec18e
-  name: Jeff Howe
+  name: Jeff R. Howe
 - id: ocd-person/ab35dde5-226a-4427-9344-c74d8291a75f
   name: Paul Anderson
 - id: ocd-person/0682bc6b-e4f2-427a-917b-96fbc49bb741

--- a/data/mn/organizations/Public-Safety-and-Security-Policy-and-Finance-cf1cd01a-8759-468f-ae10-299c79537223.yml
+++ b/data/mn/organizations/Public-Safety-and-Security-Policy-and-Finance-cf1cd01a-8759-468f-ae10-299c79537223.yml
@@ -14,6 +14,7 @@ memberships:
   name: Jamie Becker-Finn
 - id: ocd-person/ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50
   name: Nick Zerwas
+  end_date: '2019-12-06'
 - id: ocd-person/da4c1675-372e-4c9d-9599-ce45502c93fc
   name: Brian Johnson
   role: Committee Chair
@@ -32,7 +33,7 @@ memberships:
 - id: ocd-person/7e27b2f0-5cd3-405c-87aa-94df3c70db17
   name: Raymond Dehn
 - id: ocd-person/971dbd16-363f-4151-a75c-306746aec18e
-  name: Jeff Howe
+  name: Jeff R. Howe
 - id: ocd-person/7743a604-e5dd-4946-a5f9-5fce8cb4136e
   name: Jim Newberger
   end_date: '2019-01-07'

--- a/data/mn/organizations/Taxes-40305249-eb60-4ae4-9ffe-3773546ed3c6.yml
+++ b/data/mn/organizations/Taxes-40305249-eb60-4ae4-9ffe-3773546ed3c6.yml
@@ -19,6 +19,7 @@ memberships:
   end_date: '2019-01-07'
 - id: ocd-person/d9973ac3-6811-4f24-97f3-f300968d9f5e
   name: Diane Loeffler
+  end_date: '2019-11-16'
 - id: ocd-person/7a52595e-fa21-4e21-88d6-b03e4d9f1f77
   name: Glenn Gruenhagen
 - id: ocd-person/f754beae-8d82-40e6-aa9e-f15042dcbf74

--- a/data/mn/organizations/Transportation-Finance-d0842673-420c-41a1-b12c-e28f738227ca.yml
+++ b/data/mn/organizations/Transportation-Finance-d0842673-420c-41a1-b12c-e28f738227ca.yml
@@ -58,4 +58,4 @@ memberships:
 - id: ocd-person/8e0e166d-ee1f-4f5e-a5e8-bf94023173e5
   name: Mike Sundin
 - id: ocd-person/971dbd16-363f-4151-a75c-306746aec18e
-  name: Jeff Howe
+  name: Jeff R. Howe

--- a/data/mn/people/Andrew-Mathews-aabdca28-85ec-41e4-be90-726acaaa0cff.yml
+++ b/data/mn/people/Andrew-Mathews-aabdca28-85ec-41e4-be90-726acaaa0cff.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-8075
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1222
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1222
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/15Mathews.jpg
+image: http://www.senate.mn/img/member_thumbnails/15Mathews.jpg
 other_identifiers:
 - identifier: MNL000745
   scheme: legacy_openstates

--- a/data/mn/people/Andrew-R-Lang-3e1cd4f3-2c37-4531-b2cb-ca875c82d773.yml
+++ b/data/mn/people/Andrew-R-Lang-3e1cd4f3-2c37-4531-b2cb-ca875c82d773.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4918
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1223
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1223
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/17Lang.jpg
+image: http://www.senate.mn/img/member_thumbnails/17Lang.jpg
 other_identifiers:
 - identifier: MNL000749
   scheme: legacy_openstates

--- a/data/mn/people/Ann-H-Rest-ec588921-873b-4335-8fa1-2e3485008d3e.yml
+++ b/data/mn/people/Ann-H-Rest-ec588921-873b-4335-8fa1-2e3485008d3e.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-2889
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1051
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1051
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/45Rest.jpg
+image: http://www.senate.mn/img/member_thumbnails/45Rest.jpg
 other_identifiers:
 - identifier: MNL000049
   scheme: legacy_openstates

--- a/data/mn/people/Bill-Ingebrigtsen-039e7d1f-be0b-414f-bb13-969d17573329.yml
+++ b/data/mn/people/Bill-Ingebrigtsen-039e7d1f-be0b-414f-bb13-969d17573329.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-297-8063
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1120
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1120
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/08Ingebrigtsen.jpg
+image: http://www.senate.mn/img/member_thumbnails/08Ingebrigtsen.jpg
 other_identifiers:
 - identifier: MNL000023
   scheme: legacy_openstates

--- a/data/mn/people/Bill-Weber-f839da78-1e9c-4e4b-b1d7-d203970ec6b2.yml
+++ b/data/mn/people/Bill-Weber-f839da78-1e9c-4e4b-b1d7-d203970ec6b2.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5650
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1199
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1199
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/22Weber.jpg
+image: http://www.senate.mn/img/member_thumbnails/22Weber.jpg
 other_identifiers:
 - identifier: MNL000555
   scheme: legacy_openstates

--- a/data/mn/people/Bobby-Joe-Champion-c7436be4-472a-4d5e-82f5-f46359395d3a.yml
+++ b/data/mn/people/Bobby-Joe-Champion-c7436be4-472a-4d5e-82f5-f46359395d3a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-9246
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1212
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1212
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/59Champion.jpg
+image: http://www.senate.mn/img/member_thumbnails/59Champion.jpg
 other_identifiers:
 - identifier: MNL000183
   scheme: legacy_openstates

--- a/data/mn/people/Bruce-D-Anderson-63ed97bf-edfa-44d2-9259-9ac1799dfea6.yml
+++ b/data/mn/people/Bruce-D-Anderson-63ed97bf-edfa-44d2-9259-9ac1799dfea6.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5981
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1201
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1201
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/29Anderson.jpg
+image: http://www.senate.mn/img/member_thumbnails/29Anderson.jpg
 other_identifiers:
 - identifier: MNL000104
   scheme: legacy_openstates

--- a/data/mn/people/Carla-J-Nelson-69ac712d-4de2-448a-8b84-ef07b4c4e423.yml
+++ b/data/mn/people/Carla-J-Nelson-69ac712d-4de2-448a-8b84-ef07b4c4e423.yml
@@ -8,15 +8,15 @@ roles:
   type: upper
 contact_details:
 - address: 3235 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
-  email: sd26iq@mnsenate.lmhostediq.com
+  email: Sen.Carla.Nelson@senate.mn
   note: Capitol Office
   voice: 651-296-4848
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1178
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1178
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/26Nelson.jpg
+image: http://www.senate.mn/img/member_thumbnails/26Nelson.jpg
 other_identifiers:
 - identifier: MNL000219
   scheme: legacy_openstates

--- a/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
+++ b/data/mn/people/Carolyn-Laine-881a4eb7-f298-4b96-851b-77a6e6c1aae9.yml
@@ -22,11 +22,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4334
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1230
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1230
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/41Laine.jpg
+image: http://www.senate.mn/img/member_thumbnails/41Laine.jpg
 other_identifiers:
 - identifier: MNL000735
   scheme: legacy_openstates

--- a/data/mn/people/Carrie-Ruud-ae46fe13-949c-444e-8dee-af9f9039c1d5.yml
+++ b/data/mn/people/Carrie-Ruud-ae46fe13-949c-444e-8dee-af9f9039c1d5.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4913
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1196
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1196
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/10Ruud.jpg
+image: http://www.senate.mn/img/member_thumbnails/10Ruud.jpg
 other_identifiers:
 - identifier: MNL000542
   scheme: legacy_openstates

--- a/data/mn/people/Charles-W-Wiger-80e8a46d-d383-4740-83b9-c876b2a9eca9.yml
+++ b/data/mn/people/Charles-W-Wiger-80e8a46d-d383-4740-83b9-c876b2a9eca9.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-6820
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1067
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1067
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/43Wiger.jpg
+image: http://www.senate.mn/img/member_thumbnails/43Wiger.jpg
 other_identifiers:
 - identifier: MNL000067
   scheme: legacy_openstates

--- a/data/mn/people/Chris-A-Eaton-a2e40b88-c0e3-4435-a1df-1ccc7d218a8a.yml
+++ b/data/mn/people/Chris-A-Eaton-a2e40b88-c0e3-4435-a1df-1ccc7d218a8a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-8869
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1192
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1192
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/40Eaton.jpg
+image: http://www.senate.mn/img/member_thumbnails/40Eaton.jpg
 other_identifiers:
 - identifier: MNL000365
   scheme: legacy_openstates

--- a/data/mn/people/D-Scott-Dibble-4dc8ff31-159a-457a-9551-a897d222f87e.yml
+++ b/data/mn/people/D-Scott-Dibble-4dc8ff31-159a-457a-9551-a897d222f87e.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4191
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1010
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1010
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/61Dibble.jpg
+image: http://www.senate.mn/img/member_thumbnails/61Dibble.jpg
 other_identifiers:
 - identifier: MNL000011
   scheme: legacy_openstates

--- a/data/mn/people/Dan-D-Hall-4e9b1387-c076-4e00-8719-e0866869ed38.yml
+++ b/data/mn/people/Dan-D-Hall-4e9b1387-c076-4e00-8719-e0866869ed38.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5975
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1182
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1182
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/56Hall.jpg
+image: http://www.senate.mn/img/member_thumbnails/56Hall.jpg
 other_identifiers:
 - identifier: MNL000211
   scheme: legacy_openstates

--- a/data/mn/people/Dan-Sparks-29746547-62c4-4ca1-8fb8-1fd1daa6970b.yml
+++ b/data/mn/people/Dan-Sparks-29746547-62c4-4ca1-8fb8-1fd1daa6970b.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-9248
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1062
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1062
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/27Sparks.jpg
+image: http://www.senate.mn/img/member_thumbnails/27Sparks.jpg
 other_identifiers:
 - identifier: MNL000061
   scheme: legacy_openstates

--- a/data/mn/people/Dave-Baker-c0275aeb-e2ff-44c7-b4ab-cae4bf495d84.yml
+++ b/data/mn/people/Dave-Baker-c0275aeb-e2ff-44c7-b4ab-cae4bf495d84.yml
@@ -7,7 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: lower
 contact_details:
-- address: 393 State Office Building;St. Paul, MN 55155
+- address: 387 State Office Building;St. Paul, MN 55155
   email: rep.dave.baker@house.mn
   note: Capitol Office
   voice: 651-296-6206

--- a/data/mn/people/David-H-Senjem-80c0e33c-6aec-46c7-b809-20ef8d785e0a.yml
+++ b/data/mn/people/David-H-Senjem-80c0e33c-6aec-46c7-b809-20ef8d785e0a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-3903
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1058
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1058
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/25Senjem.jpg
+image: http://www.senate.mn/img/member_thumbnails/25Senjem.jpg
 other_identifiers:
 - identifier: MNL000056
   scheme: legacy_openstates

--- a/data/mn/people/David-J-Osmek-15e240a5-2936-46cd-9de7-105d1a910e8b.yml
+++ b/data/mn/people/David-J-Osmek-15e240a5-2936-46cd-9de7-105d1a910e8b.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-1282
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1203
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1203
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/33Osmek.jpg
+image: http://www.senate.mn/img/member_thumbnails/33Osmek.jpg
 other_identifiers:
 - identifier: MNL000534
   scheme: legacy_openstates

--- a/data/mn/people/David-J-Tomassoni-3a12495e-e31e-4d09-abdf-4ee59d38322a.yml
+++ b/data/mn/people/David-J-Tomassoni-3a12495e-e31e-4d09-abdf-4ee59d38322a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-8017
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1064
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1064
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/06Tomassoni.jpg
+image: http://www.senate.mn/img/member_thumbnails/06Tomassoni.jpg
 other_identifiers:
 - identifier: MNL000063
   scheme: legacy_openstates

--- a/data/mn/people/Eric-R-Pratt-f520232e-1086-4353-b904-9ff7a89ba5e8.yml
+++ b/data/mn/people/Eric-R-Pratt-f520232e-1086-4353-b904-9ff7a89ba5e8.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4123
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1210
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1210
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/55Pratt.jpg
+image: http://www.senate.mn/img/member_thumbnails/55Pratt.jpg
 other_identifiers:
 - identifier: MNL000538
   scheme: legacy_openstates

--- a/data/mn/people/Erik-Simonson-2f94f2ac-3097-4ed6-89bf-66bfe2c36f42.yml
+++ b/data/mn/people/Erik-Simonson-2f94f2ac-3097-4ed6-89bf-66bfe2c36f42.yml
@@ -17,11 +17,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4188
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1220
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1220
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/07Simonson.jpg
+image: http://www.senate.mn/img/member_thumbnails/07Simonson.jpg
 other_identifiers:
 - identifier: MNL000750
   scheme: legacy_openstates

--- a/data/mn/people/Foung-Hawj-5644f3f8-6394-4ab6-9619-7ab6702b37ea.yml
+++ b/data/mn/people/Foung-Hawj-5644f3f8-6394-4ab6-9619-7ab6702b37ea.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5285
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1213
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1213
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/67Hawj.jpg
+image: http://www.senate.mn/img/member_thumbnails/67Hawj.jpg
 other_identifiers:
 - identifier: MNL000514
   scheme: legacy_openstates

--- a/data/mn/people/Gary-H-Dahms-d1b377a1-8caa-4e37-999b-83ef8a1bf92c.yml
+++ b/data/mn/people/Gary-H-Dahms-d1b377a1-8caa-4e37-999b-83ef8a1bf92c.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-8138
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1174
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1174
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/16Dahms.jpg
+image: http://www.senate.mn/img/member_thumbnails/16Dahms.jpg
 other_identifiers:
 - identifier: MNL000206
   scheme: legacy_openstates

--- a/data/mn/people/Gregory-D-Clausen-e1c3b10e-a051-4df2-b8d4-dc1a6a01623b.yml
+++ b/data/mn/people/Gregory-D-Clausen-e1c3b10e-a051-4df2-b8d4-dc1a6a01623b.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4120
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1211
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1211
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/57Clausen.jpg
+image: http://www.senate.mn/img/member_thumbnails/57Clausen.jpg
 other_identifiers:
 - identifier: MNL000500
   scheme: legacy_openstates

--- a/data/mn/people/Jason-Isaacson-d32312d3-1b72-470d-bc1a-cd0c3359b224.yml
+++ b/data/mn/people/Jason-Isaacson-d32312d3-1b72-470d-bc1a-cd0c3359b224.yml
@@ -17,11 +17,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5537
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1231
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1231
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/42Isaacson.jpg
+image: http://www.senate.mn/img/member_thumbnails/42Isaacson.jpg
 other_identifiers:
 - identifier: MNL000768
   scheme: legacy_openstates

--- a/data/mn/people/Jason-Rarick-f15c0d42-4380-4f9b-b66d-14ffe61e1a40.yml
+++ b/data/mn/people/Jason-Rarick-f15c0d42-4380-4f9b-b66d-14ffe61e1a40.yml
@@ -12,16 +12,16 @@ roles:
   type: upper
   start_date: '2019-02-13'
 contact_details:
-- address: 13954 Beroun Crossing Road;Brook Park, MN 55007
+- address: 3411 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
   email: sen.jason.rarick@senate.mn
   note: Capitol Office
   voice: 651-296-1508
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1240
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1240
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/11Rarick.jpg
+image: http://www.senate.mn/img/member_thumbnails/11Rarick.jpg
 other_identifiers:
 - identifier: MNL000582
   scheme: legacy_openstates

--- a/data/mn/people/Jeff-Hayden-1f7e501e-ec11-43f2-98b4-f31020f1977a.yml
+++ b/data/mn/people/Jeff-Hayden-1f7e501e-ec11-43f2-98b4-f31020f1977a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4261
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1191
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1191
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/62Hayden.jpg
+image: http://www.senate.mn/img/member_thumbnails/62Hayden.jpg
 other_identifiers:
 - identifier: MNL000189
   scheme: legacy_openstates

--- a/data/mn/people/Jeff-Howe-971dbd16-363f-4151-a75c-306746aec18e.yml
+++ b/data/mn/people/Jeff-Howe-971dbd16-363f-4151-a75c-306746aec18e.yml
@@ -1,5 +1,5 @@
 id: ocd-person/971dbd16-363f-4151-a75c-306746aec18e
-name: Jeff Howe
+name: Jeff R. Howe
 party:
 - name: Republican
 roles:
@@ -17,11 +17,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-2084
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1239
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1239
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/13Howe.jpg
+image: http://www.senate.mn/img/member_thumbnails/13Howe.jpg
 other_identifiers:
 - identifier: MNL000422
   scheme: legacy_openstates
@@ -29,3 +29,5 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Jeff
 family_name: Howe
+other_names:
+- name: Jeff Howe

--- a/data/mn/people/Jeremy-R-Miller-f0824aef-4692-46c8-bafa-f19a01a9d716.yml
+++ b/data/mn/people/Jeremy-R-Miller-f0824aef-4692-46c8-bafa-f19a01a9d716.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5649
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1179
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1179
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/28Miller.jpg
+image: http://www.senate.mn/img/member_thumbnails/28Miller.jpg
 other_identifiers:
 - identifier: MNL000218
   scheme: legacy_openstates

--- a/data/mn/people/Jerry-Newton-9ec4bda3-571f-4d6d-85f1-39a2d54d106a.yml
+++ b/data/mn/people/Jerry-Newton-9ec4bda3-571f-4d6d-85f1-39a2d54d106a.yml
@@ -22,11 +22,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-2556
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1229
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1229
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/37Newton.jpg
+image: http://www.senate.mn/img/member_thumbnails/37Newton.jpg
 other_identifiers:
 - identifier: MNL000748
   scheme: legacy_openstates

--- a/data/mn/people/Jerry-Relph-976d046e-bad5-4feb-8634-8af24c4229e3.yml
+++ b/data/mn/people/Jerry-Relph-976d046e-bad5-4feb-8634-8af24c4229e3.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-6455
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1221
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1221
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/14Relph.jpg
+image: http://www.senate.mn/img/member_thumbnails/14Relph.jpg
 other_identifiers:
 - identifier: MNL000742
   scheme: legacy_openstates

--- a/data/mn/people/Jim-Abeler-fc189dd9-b597-4744-86d3-ac315b93a3f3.yml
+++ b/data/mn/people/Jim-Abeler-fc189dd9-b597-4744-86d3-ac315b93a3f3.yml
@@ -22,11 +22,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-3733
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1216
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1216
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/35Abeler.jpg
+image: http://www.senate.mn/img/member_thumbnails/35Abeler.jpg
 other_identifiers:
 - identifier: MNL000729
   scheme: legacy_openstates

--- a/data/mn/people/Jim-Carlson-ac087885-bab6-4fbf-b88a-daf71262c8b6.yml
+++ b/data/mn/people/Jim-Carlson-ac087885-bab6-4fbf-b88a-daf71262c8b6.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-297-8073
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1140
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1140
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/51Carlson.jpg
+image: http://www.senate.mn/img/member_thumbnails/51Carlson.jpg
 other_identifiers:
 - identifier: MNL000006
   scheme: legacy_openstates

--- a/data/mn/people/John-A-Hoffman-b31cb55a-94ea-4f44-a4b9-8003b32c749a.yml
+++ b/data/mn/people/John-A-Hoffman-b31cb55a-94ea-4f44-a4b9-8003b32c749a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4154
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1205
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1205
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/36Hoffman.jpg
+image: http://www.senate.mn/img/member_thumbnails/36Hoffman.jpg
 other_identifiers:
 - identifier: MNL000516
   scheme: legacy_openstates

--- a/data/mn/people/John-Marty-4acf27d9-edd4-4f04-97c7-164390a5664b.yml
+++ b/data/mn/people/John-Marty-4acf27d9-edd4-4f04-97c7-164390a5664b.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5645
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1035
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1035
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/66Marty.jpg
+image: http://www.senate.mn/img/member_thumbnails/66Marty.jpg
 other_identifiers:
 - identifier: MNL000035
   scheme: legacy_openstates

--- a/data/mn/people/John-R-Jasinski-f6b649e0-5359-4d22-8ff0-6ca017bc5e23.yml
+++ b/data/mn/people/John-R-Jasinski-f6b649e0-5359-4d22-8ff0-6ca017bc5e23.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-0284
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1227
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1227
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/24Jasinski.jpg
+image: http://www.senate.mn/img/member_thumbnails/24Jasinski.jpg
 other_identifiers:
 - identifier: MNL000744
   scheme: legacy_openstates

--- a/data/mn/people/Julie-A-Rosen-f640663f-cc51-4887-92fa-624ff066d919.yml
+++ b/data/mn/people/Julie-A-Rosen-f640663f-cc51-4887-92fa-624ff066d919.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5713
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1053
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1053
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/23Rosen.jpg
+image: http://www.senate.mn/img/member_thumbnails/23Rosen.jpg
 other_identifiers:
 - identifier: MNL000051
   scheme: legacy_openstates

--- a/data/mn/people/Justin-D-Eichorn-022f293c-ec0c-45c9-a304-c4efad5908b0.yml
+++ b/data/mn/people/Justin-D-Eichorn-022f293c-ec0c-45c9-a304-c4efad5908b0.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-7079
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1219
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1219
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/05Eichorn.jpg
+image: http://www.senate.mn/img/member_thumbnails/05Eichorn.jpg
 other_identifiers:
 - identifier: MNL000762
   scheme: legacy_openstates

--- a/data/mn/people/Kari-Dziedzic-20d236e4-9e82-4b9b-a68f-6aa4ff2cf474.yml
+++ b/data/mn/people/Kari-Dziedzic-20d236e4-9e82-4b9b-a68f-6aa4ff2cf474.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-7809
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1193
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1193
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/60Dziedzic.jpg
+image: http://www.senate.mn/img/member_thumbnails/60Dziedzic.jpg
 other_identifiers:
 - identifier: MNL000368
   scheme: legacy_openstates

--- a/data/mn/people/Karin-Housley-dde8cf7d-52c2-48e5-bf65-f0fe2477713c.yml
+++ b/data/mn/people/Karin-Housley-dde8cf7d-52c2-48e5-bf65-f0fe2477713c.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4351
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1214
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1214
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/39Housley.jpg
+image: http://www.senate.mn/img/member_thumbnails/39Housley.jpg
 other_identifiers:
 - identifier: MNL000517
   scheme: legacy_openstates

--- a/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
+++ b/data/mn/people/Karla-Bigham-8ef7f23a-5dde-476e-bde5-c5d64e5ddaff.yml
@@ -13,15 +13,15 @@ roles:
   type: upper
 contact_details:
 - address: 2327 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
-  email: sd54iq@mnsenate.lmhostediq.com
+  email: Sen.Karla.Bigham@senate.mn
   note: Capitol Office
   voice: 651-297-8060
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1238
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1238
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/54Bigham.jpg
+image: http://www.senate.mn/img/member_thumbnails/54Bigham.jpg
 other_identifiers:
 - identifier: MNL000786
   scheme: legacy_openstates

--- a/data/mn/people/Kent-Eken-1f6f9528-c2e2-40e0-a7c3-d39f2e048a0d.yml
+++ b/data/mn/people/Kent-Eken-1f6f9528-c2e2-40e0-a7c3-d39f2e048a0d.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-3205
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1195
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1195
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/04Eken.jpg
+image: http://www.senate.mn/img/member_thumbnails/04Eken.jpg
 other_identifiers:
 - identifier: MNL000070
   scheme: legacy_openstates

--- a/data/mn/people/Mark-Johnson-de9b28f6-a2a8-4edd-98cb-2b3ff2e6382c.yml
+++ b/data/mn/people/Mark-Johnson-de9b28f6-a2a8-4edd-98cb-2b3ff2e6382c.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5782
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1217
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1217
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/01Johnson.jpg
+image: http://www.senate.mn/img/member_thumbnails/01Johnson.jpg
 other_identifiers:
 - identifier: MNL000767
   scheme: legacy_openstates

--- a/data/mn/people/Mark-W-Koran-f20a4255-6c65-4091-a0f5-aea70f133cdb.yml
+++ b/data/mn/people/Mark-W-Koran-f20a4255-6c65-4091-a0f5-aea70f133cdb.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5419
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1228
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1228
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/32Koran.jpg
+image: http://www.senate.mn/img/member_thumbnails/32Koran.jpg
 other_identifiers:
 - identifier: MNL000753
   scheme: legacy_openstates

--- a/data/mn/people/Mary-Kiffmeyer-f307f4be-b411-4c7a-a466-cd12595b255f.yml
+++ b/data/mn/people/Mary-Kiffmeyer-f307f4be-b411-4c7a-a466-cd12595b255f.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5655
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1202
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1202
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/30Kiffmeyer.jpg
+image: http://www.senate.mn/img/member_thumbnails/30Kiffmeyer.jpg
 other_identifiers:
 - identifier: MNL000099
   scheme: legacy_openstates

--- a/data/mn/people/Matt-D-Klein-a4b21c2d-d3fe-41dc-9614-0ff80878850c.yml
+++ b/data/mn/people/Matt-D-Klein-a4b21c2d-d3fe-41dc-9614-0ff80878850c.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4370
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1235
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1235
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/52Klein.jpg
+image: http://www.senate.mn/img/member_thumbnails/52Klein.jpg
 other_identifiers:
 - identifier: MNL000763
   scheme: legacy_openstates

--- a/data/mn/people/Matt-Little-68ad9588-0e5a-4a4b-bb28-29d2a170b9c3.yml
+++ b/data/mn/people/Matt-Little-68ad9588-0e5a-4a4b-bb28-29d2a170b9c3.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5252
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1237
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1237
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/58Little.jpg
+image: http://www.senate.mn/img/member_thumbnails/58Little.jpg
 other_identifiers:
 - identifier: MNL000730
   scheme: legacy_openstates

--- a/data/mn/people/Melisa-Franzen-f71bc7cb-3e34-4f65-9b08-dfa1d5b136e5.yml
+++ b/data/mn/people/Melisa-Franzen-f71bc7cb-3e34-4f65-9b08-dfa1d5b136e5.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-6238
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1208
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1208
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/49Franzen.jpg
+image: http://www.senate.mn/img/member_thumbnails/49Franzen.jpg
 other_identifiers:
 - identifier: MNL000509
   scheme: legacy_openstates

--- a/data/mn/people/Melissa-H-Wiklund-d2fb6801-379e-481c-9313-2ac099d3a775.yml
+++ b/data/mn/people/Melissa-H-Wiklund-d2fb6801-379e-481c-9313-2ac099d3a775.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-297-8061
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1209
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1209
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/50Wiklund.jpg
+image: http://www.senate.mn/img/member_thumbnails/50Wiklund.jpg
 other_identifiers:
 - identifier: MNL000558
   scheme: legacy_openstates

--- a/data/mn/people/Michael-P-Goggin-513fe47f-a5d6-4443-a23e-494415fadbf0.yml
+++ b/data/mn/people/Michael-P-Goggin-513fe47f-a5d6-4443-a23e-494415fadbf0.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5612
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1226
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1226
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/21Goggin.jpg
+image: http://www.senate.mn/img/member_thumbnails/21Goggin.jpg
 other_identifiers:
 - identifier: MNL000761
   scheme: legacy_openstates

--- a/data/mn/people/Michelle-R-Benson-dcb214ab-2a6b-4904-b8e1-d6704caff723.yml
+++ b/data/mn/people/Michelle-R-Benson-dcb214ab-2a6b-4904-b8e1-d6704caff723.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-3219
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1184
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1184
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/31Benson.jpg
+image: http://www.senate.mn/img/member_thumbnails/31Benson.jpg
 other_identifiers:
 - identifier: MNL000202
   scheme: legacy_openstates

--- a/data/mn/people/Nathan-Nelson-172cb289-beec-4bc1-8627-f027f2cd3769.yml
+++ b/data/mn/people/Nathan-Nelson-172cb289-beec-4bc1-8627-f027f2cd3769.yml
@@ -18,4 +18,4 @@ contact_details:
 links:
 - url: https://www.house.leg.state.mn.us/members/profile/15534
 sources:
-- url: https://www.house.leg.state.mn.us/members/profile/15534
+- url: https://www.house.leg.state.mn.us/members/hmem.asp

--- a/data/mn/people/Nick-A-Frentz-55a02119-b43d-4b39-a19b-07411c5ec7c9.yml
+++ b/data/mn/people/Nick-A-Frentz-55a02119-b43d-4b39-a19b-07411c5ec7c9.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-6153
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1224
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1224
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/19Frentz.jpg
+image: http://www.senate.mn/img/member_thumbnails/19Frentz.jpg
 other_identifiers:
 - identifier: MNL000765
   scheme: legacy_openstates

--- a/data/mn/people/Patricia-Torres-Ray-9d93d9f1-9bd5-4d28-a18b-1333c9a210cb.yml
+++ b/data/mn/people/Patricia-Torres-Ray-9d93d9f1-9bd5-4d28-a18b-1333c9a210cb.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4274
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1151
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1151
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/63TorresRay.jpg
+image: http://www.senate.mn/img/member_thumbnails/63TorresRay.jpg
 other_identifiers:
 - identifier: MNL000064
   scheme: legacy_openstates

--- a/data/mn/people/Paul-E-Gazelka-0a0641bd-4b3a-4eb3-8044-b1ff468b8193.yml
+++ b/data/mn/people/Paul-E-Gazelka-0a0641bd-4b3a-4eb3-8044-b1ff468b8193.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4875
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1169
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1169
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/09Gazelka.jpg
+image: http://www.senate.mn/img/member_thumbnails/09Gazelka.jpg
 other_identifiers:
 - identifier: MNL000209
   scheme: legacy_openstates

--- a/data/mn/people/Paul-J-Utke-fde08265-b73e-4a4b-ba87-d90d71319640.yml
+++ b/data/mn/people/Paul-J-Utke-fde08265-b73e-4a4b-ba87-d90d71319640.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-9651
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1218
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1218
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/02Utke.jpg
+image: http://www.senate.mn/img/member_thumbnails/02Utke.jpg
 other_identifiers:
 - identifier: MNL000741
   scheme: legacy_openstates

--- a/data/mn/people/Paul-Novotny-3e0eb8aa-b66c-4b30-9a0e-f1326c6f0589.yml
+++ b/data/mn/people/Paul-Novotny-3e0eb8aa-b66c-4b30-9a0e-f1326c6f0589.yml
@@ -1,25 +1,21 @@
-id: ocd-person/ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50
-name: Nick Zerwas
+id: ocd-person/3e0eb8aa-b66c-4b30-9a0e-f1326c6f0589
+name: Paul Novotny
 party:
 - name: Republican
 roles:
 - district: 30A
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: lower
+  start_date: 2020-02-11
 contact_details:
 - address: 301 State Office Building;St. Paul, MN 55155
-  email: rep.nick.zerwas@house.mn
+  email: rep.paul.novotny@house.mn
   note: Capitol Office
   voice: 651-296-4237
 links:
-- url: http://www.house.leg.state.mn.us/members/profile/15422
+- url: http://www.house.leg.state.mn.us/members/profile/15536
 sources:
 - url: http://www.house.leg.state.mn.us/members/hmem.asp
 image: https://www.house.leg.state.mn.us/hinfo/memberimgls91/30A.gif
-other_identifiers:
-- identifier: MNL000491
-  scheme: legacy_openstates
-- identifier: MNL000601
-  scheme: legacy_openstates
-given_name: Nick
-family_name: Zerwas
+given_name: Paul
+family_name: Novotny

--- a/data/mn/people/Paul-T-Anderson-86e4040d-cfb6-4345-b1e6-9816f33da8f2.yml
+++ b/data/mn/people/Paul-T-Anderson-86e4040d-cfb6-4345-b1e6-9816f33da8f2.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-9261
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1232
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1232
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/44Anderson.jpg
+image: http://www.senate.mn/img/member_thumbnails/44Anderson.jpg
 other_identifiers:
 - identifier: MNL000752
   scheme: legacy_openstates

--- a/data/mn/people/Rich-Draheim-f9fb7c65-e0ab-484c-8517-b20267cc3f07.yml
+++ b/data/mn/people/Rich-Draheim-f9fb7c65-e0ab-484c-8517-b20267cc3f07.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-5558
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1225
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1225
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/20Draheim.jpg
+image: http://www.senate.mn/img/member_thumbnails/20Draheim.jpg
 other_identifiers:
 - identifier: MNL000739
   scheme: legacy_openstates

--- a/data/mn/people/Richard-Cohen-be544f3b-ce7b-4ac1-bc75-97b9c1417f1c.yml
+++ b/data/mn/people/Richard-Cohen-be544f3b-ce7b-4ac1-bc75-97b9c1417f1c.yml
@@ -8,15 +8,15 @@ roles:
   type: upper
 contact_details:
 - address: 2301 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
-  email: sd64iq@mnsenate.lmhostediq.com
+  email: sen.richard.cohen@senate.mn
   note: Capitol Office
   voice: 651-296-5931
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1008
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1008
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/64Cohen.jpg
+image: http://www.senate.mn/img/member_thumbnails/64Cohen.jpg
 other_identifiers:
 - identifier: MNL000009
   scheme: legacy_openstates

--- a/data/mn/people/Roger-C-Chamberlain-1e9cddda-6d64-4081-bc55-fe8a1948f7d8.yml
+++ b/data/mn/people/Roger-C-Chamberlain-1e9cddda-6d64-4081-bc55-fe8a1948f7d8.yml
@@ -8,15 +8,15 @@ roles:
   type: upper
 contact_details:
 - address: 3225 Minnesota Senate Bldg.;95 University Avenue W.;St. Paul, MN 55155
-  email: sd38iq@mnsenate.lmhostediq.com
+  email: sen.roger.chamberlain@senate.mn
   note: Capitol Office
   voice: 651-296-1253
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1187
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1187
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/38Chamberlain.jpg
+image: http://www.senate.mn/img/member_thumbnails/38Chamberlain.jpg
 other_identifiers:
 - identifier: MNL000205
   scheme: legacy_openstates

--- a/data/mn/people/Ron-Latz-834a2c10-beb0-454e-8e08-619309d8a08a.yml
+++ b/data/mn/people/Ron-Latz-834a2c10-beb0-454e-8e08-619309d8a08a.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-297-8065
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1102
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1102
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/46Latz.jpg
+image: http://www.senate.mn/img/member_thumbnails/46Latz.jpg
 other_identifiers:
 - identifier: MNL000031
   scheme: legacy_openstates

--- a/data/mn/people/Sandra-L-Pappas-0b83a916-567b-4d36-843f-17d8f5e13b8d.yml
+++ b/data/mn/people/Sandra-L-Pappas-0b83a916-567b-4d36-843f-17d8f5e13b8d.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-1802
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1046
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1046
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/65Pappas.jpg
+image: http://www.senate.mn/img/member_thumbnails/65Pappas.jpg
 other_identifiers:
 - identifier: MNL000044
   scheme: legacy_openstates

--- a/data/mn/people/Scott-J-Newman-2ee8ad41-fcd3-4b9c-99e8-f20acf45efb3.yml
+++ b/data/mn/people/Scott-J-Newman-2ee8ad41-fcd3-4b9c-99e8-f20acf45efb3.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4131
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1173
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1173
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/18Newman.jpg
+image: http://www.senate.mn/img/member_thumbnails/18Newman.jpg
 other_identifiers:
 - identifier: MNL000220
   scheme: legacy_openstates

--- a/data/mn/people/Scott-M-Jensen-4e9e8675-1fa2-43dd-86f3-41201abfdb7c.yml
+++ b/data/mn/people/Scott-M-Jensen-4e9e8675-1fa2-43dd-86f3-41201abfdb7c.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4837
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1233
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1233
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/47Jensen.jpg
+image: http://www.senate.mn/img/member_thumbnails/47Jensen.jpg
 other_identifiers:
 - identifier: MNL000746
   scheme: legacy_openstates

--- a/data/mn/people/Steve-A-Cwodzinski-e67843ce-752d-4cc0-abb9-4a45b8b8fdca.yml
+++ b/data/mn/people/Steve-A-Cwodzinski-e67843ce-752d-4cc0-abb9-4a45b8b8fdca.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-1314
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1234
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1234
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/48Cwodzinski.jpg
+image: http://www.senate.mn/img/member_thumbnails/48Cwodzinski.jpg
 other_identifiers:
 - identifier: MNL000759
   scheme: legacy_openstates

--- a/data/mn/people/Susan-Kent-232c625b-79bc-48d3-addb-cfffa0f15108.yml
+++ b/data/mn/people/Susan-Kent-232c625b-79bc-48d3-addb-cfffa0f15108.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-4166
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1215
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1215
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/53Kent.jpg
+image: http://www.senate.mn/img/member_thumbnails/53Kent.jpg
 other_identifiers:
 - identifier: MNL000521
   scheme: legacy_openstates

--- a/data/mn/people/Sydney-Jordan-e60bb3ff-5164-4d6d-9029-d2e3d2ac69a0.yml
+++ b/data/mn/people/Sydney-Jordan-e60bb3ff-5164-4d6d-9029-d2e3d2ac69a0.yml
@@ -1,0 +1,21 @@
+id: ocd-person/e60bb3ff-5164-4d6d-9029-d2e3d2ac69a0
+name: Sydney Jordan
+party:
+- name: Democratic-Farmer-Labor
+roles:
+- district: 60A
+  jurisdiction: ocd-jurisdiction/country:us/state:mn/government
+  type: lower
+  start_date: 2020-02-11
+contact_details:
+- address: 553 State Office Building;St. Paul, MN 55155
+  email: rep.sydney.jordan@house.mn
+  note: Capitol Office
+  voice: 651-296-4219
+links:
+- url: http://www.house.leg.state.mn.us/members/profile/15535
+sources:
+- url: http://www.house.leg.state.mn.us/members/hmem.asp
+image: https://www.house.leg.state.mn.us/hinfo/memberimgls91/60A.gif
+given_name: Sydney
+family_name: Jordan

--- a/data/mn/people/Thomas-M-Bakk-3e5f28a5-aab0-4679-b17a-2e7ec4195ef9.yml
+++ b/data/mn/people/Thomas-M-Bakk-3e5f28a5-aab0-4679-b17a-2e7ec4195ef9.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-8881
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1003
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1003
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/03Bakk.jpg
+image: http://www.senate.mn/img/member_thumbnails/03Bakk.jpg
 other_identifiers:
 - identifier: MNL000002
   scheme: legacy_openstates

--- a/data/mn/people/Torrey-N-Westrom-1c19414e-994b-46d4-8971-432ed482ca39.yml
+++ b/data/mn/people/Torrey-N-Westrom-1c19414e-994b-46d4-8971-432ed482ca39.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-3826
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1197
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1197
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/12Westrom.jpg
+image: http://www.senate.mn/img/member_thumbnails/12Westrom.jpg
 other_identifiers:
 - identifier: MNL000556
   scheme: legacy_openstates

--- a/data/mn/people/Warren-Limmer-dc676c57-0779-4d0e-9ba4-a07d7034dfa1.yml
+++ b/data/mn/people/Warren-Limmer-dc676c57-0779-4d0e-9ba4-a07d7034dfa1.yml
@@ -12,11 +12,11 @@ contact_details:
   note: Capitol Office
   voice: 651-296-2159
 links:
-- url: http://www.senate.mn/members/member_bio.php?member_id=1032
+- url: https://www.senate.mn/members/member_bio.html?mem_id=1032
 sources:
 - url: http://www.senate.mn/members/member_list_ascii.php?ls=
 - url: http://www.senate.mn/members/index.php
-image: http://www.senate.mn/graphics/member_thumbnails/34Limmer.jpg
+image: http://www.senate.mn/img/member_thumbnails/34Limmer.jpg
 other_identifiers:
 - identifier: MNL000032
   scheme: legacy_openstates

--- a/data/mn/retired/Diane-Loeffler-d9973ac3-6811-4f24-97f3-f300968d9f5e.yml
+++ b/data/mn/retired/Diane-Loeffler-d9973ac3-6811-4f24-97f3-f300968d9f5e.yml
@@ -6,6 +6,8 @@ roles:
 - district: 60A
   jurisdiction: ocd-jurisdiction/country:us/state:mn/government
   type: lower
+  end_date: '2019-11-16'
+  end_reason: Deceased
 contact_details:
 - address: 553 State Office Building;St. Paul, MN 55155
   email: rep.diane.loeffler@house.mn
@@ -27,3 +29,4 @@ other_identifiers:
   scheme: legacy_openstates
 given_name: Diane
 family_name: Loeffler
+death_date: '2019-11-16'

--- a/data/mn/retired/Nick-Zerwas-ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50.yml
+++ b/data/mn/retired/Nick-Zerwas-ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50.yml
@@ -1,0 +1,26 @@
+id: ocd-person/ad5e8216-1c99-4957-b8f8-dcd1f7dd9d50
+name: Nick Zerwas
+party:
+- name: Republican
+roles:
+- district: 30A
+  jurisdiction: ocd-jurisdiction/country:us/state:mn/government
+  type: lower
+  end_date: '2019-12-06'
+contact_details:
+- address: 301 State Office Building;St. Paul, MN 55155
+  email: rep.nick.zerwas@house.mn
+  note: Capitol Office
+  voice: 651-296-4237
+links:
+- url: http://www.house.leg.state.mn.us/members/profile/15422
+sources:
+- url: http://www.house.leg.state.mn.us/members/hmem.asp
+image: https://www.house.leg.state.mn.us/hinfo/memberimgls91/30A.gif
+other_identifiers:
+- identifier: MNL000491
+  scheme: legacy_openstates
+- identifier: MNL000601
+  scheme: legacy_openstates
+given_name: Nick
+family_name: Zerwas


### PR DESCRIPTION
Add two new legislators as a result of one resignation and one death. Also update some URLs and contact information. Fixes https://github.com/openstates/issues/issues/81.