### PR TITLE
PA: Update legislator links

### DIFF
--- a/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
+++ b/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
@@ -14,7 +14,7 @@ given_name: Aaron
 id: ocd-person/844f3ed7-03df-420f-81bd-3f547c12e61e
 image: https://www.legis.state.pa.us/images/members/200/1742.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1742
 name: Aaron Bernstine
 other_identifiers:
 - identifier: PAL000540

--- a/data/pa/legislature/Aaron-D-Kaufer-2cab8939-be5a-492d-8933-ad9f55f12145.yml
+++ b/data/pa/legislature/Aaron-D-Kaufer-2cab8939-be5a-492d-8933-ad9f55f12145.yml
@@ -15,7 +15,7 @@ given_name: Aaron
 id: ocd-person/2cab8939-be5a-492d-8933-ad9f55f12145
 image: https://www.legis.state.pa.us/images/members/200/1693.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1693
 name: Aaron D. Kaufer
 other_identifiers:
 - identifier: PAL000484

--- a/data/pa/legislature/Adam-Ravenstahl-6adc27d5-db4d-40ce-a72e-f125e3f0929d.yml
+++ b/data/pa/legislature/Adam-Ravenstahl-6adc27d5-db4d-40ce-a72e-f125e3f0929d.yml
@@ -15,7 +15,7 @@ given_name: Adam
 id: ocd-person/6adc27d5-db4d-40ce-a72e-f125e3f0929d
 image: https://www.legis.state.pa.us/images/members/200/1194.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1194
 name: Adam Ravenstahl
 other_identifiers:
 - identifier: PAL000203

--- a/data/pa/legislature/Andrew-E-Dinniman-a0131e97-8171-4c05-ae8d-2c37c1cb3b90.yml
+++ b/data/pa/legislature/Andrew-E-Dinniman-a0131e97-8171-4c05-ae8d-2c37c1cb3b90.yml
@@ -14,7 +14,7 @@ given_name: Andrew
 id: ocd-person/a0131e97-8171-4c05-ae8d-2c37c1cb3b90
 image: https://www.legis.state.pa.us/images/members/200/1049.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1049
 name: Andrew E. Dinniman
 other_identifiers:
 - identifier: PAL000009

--- a/data/pa/legislature/Andrew-Lewis-460753b9-d8a2-4397-a1a4-bdf742883c5f.yml
+++ b/data/pa/legislature/Andrew-Lewis-460753b9-d8a2-4397-a1a4-bdf742883c5f.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-2014
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1843
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1843

--- a/data/pa/legislature/Angel-Cruz-9f5499c4-8f8a-47f2-9226-14e1ebc6f4ab.yml
+++ b/data/pa/legislature/Angel-Cruz-9f5499c4-8f8a-47f2-9226-14e1ebc6f4ab.yml
@@ -14,7 +14,7 @@ given_name: Angel
 id: ocd-person/9f5499c4-8f8a-47f2-9226-14e1ebc6f4ab
 image: https://www.legis.state.pa.us/images/members/200/304.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=304
 name: Angel Cruz
 other_identifiers:
 - identifier: PAL000082

--- a/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
+++ b/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
@@ -12,7 +12,7 @@ given_name: Anita
 id: ocd-person/999d1ffd-b893-4aac-9fbb-ae43b3039038
 image: https://www.legis.state.pa.us/images/members/200/1744.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1744
 name: Anita Astorino Kulik
 other_identifiers:
 - identifier: PAL000538

--- a/data/pa/legislature/Anthony-H-Williams-fe79a0f0-7dfd-442a-8b79-f8792613a4de.yml
+++ b/data/pa/legislature/Anthony-H-Williams-fe79a0f0-7dfd-442a-8b79-f8792613a4de.yml
@@ -18,7 +18,7 @@ given_name: Anthony
 id: ocd-person/fe79a0f0-7dfd-442a-8b79-f8792613a4de
 image: https://www.legis.state.pa.us/images/members/200/153.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=153
 name: Anthony H. Williams
 other_identifiers:
 - identifier: PAL000048

--- a/data/pa/legislature/Anthony-M-DeLuca-e39c2d98-ef30-4642-be90-6fed8cc006f9.yml
+++ b/data/pa/legislature/Anthony-M-DeLuca-e39c2d98-ef30-4642-be90-6fed8cc006f9.yml
@@ -15,7 +15,7 @@ given_name: Anthony
 id: ocd-person/e39c2d98-ef30-4642-be90-6fed8cc006f9
 image: https://www.legis.state.pa.us/images/members/200/47.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=47
 name: Anthony M. DeLuca
 other_identifiers:
 - identifier: PAL000087

--- a/data/pa/legislature/Art-Haywood-ea712eba-1da5-45e2-8d9f-022e8307a614.yml
+++ b/data/pa/legislature/Art-Haywood-ea712eba-1da5-45e2-8d9f-022e8307a614.yml
@@ -17,7 +17,7 @@ given_name: Art
 id: ocd-person/ea712eba-1da5-45e2-8d9f-022e8307a614
 image: https://www.legis.state.pa.us/images/members/200/1689.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1689
 name: Art Haywood
 other_identifiers:
 - identifier: PAL000496

--- a/data/pa/legislature/Austin-A-Davis-e5de67f9-3e82-4e65-89ce-47aa0772d1f8.yml
+++ b/data/pa/legislature/Austin-A-Davis-e5de67f9-3e82-4e65-89ce-47aa0772d1f8.yml
@@ -12,7 +12,7 @@ given_name: Austin
 id: ocd-person/e5de67f9-3e82-4e65-89ce-47aa0772d1f8
 image: https://www.legis.state.pa.us/images/members/200/1794.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1794
 name: Austin A. Davis
 other_identifiers:
 - identifier: PAL000570

--- a/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
+++ b/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-2280
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1864
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1864

--- a/data/pa/legislature/Barry-J-Jozwiak-1ebacf77-8895-4b52-af40-ccfdf6448ac6.yml
+++ b/data/pa/legislature/Barry-J-Jozwiak-1ebacf77-8895-4b52-af40-ccfdf6448ac6.yml
@@ -16,7 +16,7 @@ given_name: Barry
 id: ocd-person/1ebacf77-8895-4b52-af40-ccfdf6448ac6
 image: https://www.legis.state.pa.us/images/members/200/1692.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1692
 name: Barry J. Jozwiak
 other_identifiers:
 - identifier: PAL000516

--- a/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
+++ b/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-7619
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1849
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1849

--- a/data/pa/legislature/Bob-Brooks-30af0f56-856f-4da4-afd3-e420ee286ff8.yml
+++ b/data/pa/legislature/Bob-Brooks-30af0f56-856f-4da4-afd3-e420ee286ff8.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-260-6129
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1833
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1833

--- a/data/pa/legislature/Bob-Mensch-289e519a-c683-48b0-8b12-e74ffe3c21b5.yml
+++ b/data/pa/legislature/Bob-Mensch-289e519a-c683-48b0-8b12-e74ffe3c21b5.yml
@@ -16,7 +16,7 @@ given_name: Bob
 id: ocd-person/289e519a-c683-48b0-8b12-e74ffe3c21b5
 image: https://www.legis.state.pa.us/images/members/200/1121.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1121
 name: Bob Mensch
 other_identifiers:
 - identifier: PAL000026

--- a/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
+++ b/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
@@ -15,7 +15,7 @@ given_name: Brad
 id: ocd-person/979ea568-4c43-41bd-ba1e-4c2da172bb82
 image: https://www.legis.state.pa.us/images/members/200/1083.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1083
 name: Brad Roae
 other_identifiers:
 - identifier: PAL000208

--- a/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
+++ b/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-4511
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1825
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1825

--- a/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
+++ b/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
@@ -15,7 +15,7 @@ given_name: Brett
 id: ocd-person/1a6e36d3-ff44-4e21-bb9d-397a56482b34
 image: https://www.legis.state.pa.us/images/members/200/1699.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1699
 name: Brett R. Miller
 other_identifiers:
 - identifier: PAL000517

--- a/data/pa/legislature/Brian-Kirkland-8379190d-5e7a-4507-8531-fa2489bc9ae3.yml
+++ b/data/pa/legislature/Brian-Kirkland-8379190d-5e7a-4507-8531-fa2489bc9ae3.yml
@@ -12,7 +12,7 @@ given_name: Brian
 id: ocd-person/8379190d-5e7a-4507-8531-fa2489bc9ae3
 image: https://www.legis.state.pa.us/images/members/200/1756.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1756
 name: Brian Kirkland
 other_identifiers:
 - identifier: PAL000553

--- a/data/pa/legislature/Brian-Sims-9a086031-ed33-419d-800a-eb8792613418.yml
+++ b/data/pa/legislature/Brian-Sims-9a086031-ed33-419d-800a-eb8792613418.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4072
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1650
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1650

--- a/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
+++ b/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4874
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1866
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1866

--- a/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
+++ b/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
@@ -16,7 +16,7 @@ given_name: Bryan
 id: ocd-person/fd5d0580-766c-482c-a12f-e4689e0bcf30
 image: https://www.legis.state.pa.us/images/members/200/1105.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1105
 name: Bryan Cutler
 other_identifiers:
 - identifier: PAL000084

--- a/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
+++ b/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
@@ -14,7 +14,7 @@ given_name: Bud
 id: ocd-person/9b9857aa-5fad-4678-a4f9-7e40bc642f64
 image: https://www.legis.state.pa.us/images/members/200/1745.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1745
 name: Bud Cook
 other_identifiers:
 - identifier: PAL000543

--- a/data/pa/legislature/Camera-Bartolotta-66b8c0a7-f8be-4acd-aafb-29ca02fcde65.yml
+++ b/data/pa/legislature/Camera-Bartolotta-66b8c0a7-f8be-4acd-aafb-29ca02fcde65.yml
@@ -17,7 +17,7 @@ given_name: Camera
 id: ocd-person/66b8c0a7-f8be-4acd-aafb-29ca02fcde65
 image: https://www.legis.state.pa.us/images/members/200/1698.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1698
 name: Camera Bartolotta
 other_identifiers:
 - identifier: PAL000502

--- a/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
+++ b/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
@@ -14,7 +14,7 @@ given_name: Carl Walker
 id: ocd-person/462fc474-e481-436e-b47a-7bbde2de3e3a
 image: https://www.legis.state.pa.us/images/members/200/1174.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1174
 name: Carl Walker Metzgar
 other_identifiers:
 - identifier: PAL000168

--- a/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
+++ b/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
@@ -15,7 +15,7 @@ given_name: Carol
 id: ocd-person/cafbffed-be4d-4e5b-9d99-9aec024675e2
 image: https://www.legis.state.pa.us/images/members/200/1749.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1749
 name: Carol Hill-Evans
 other_identifiers:
 - identifier: PAL000554

--- a/data/pa/legislature/Carolyn-T-Comitta-da10be68-90ad-4fec-842b-12f967cc1be4.yml
+++ b/data/pa/legislature/Carolyn-T-Comitta-da10be68-90ad-4fec-842b-12f967cc1be4.yml
@@ -12,7 +12,7 @@ given_name: Carolyn
 id: ocd-person/da10be68-90ad-4fec-842b-12f967cc1be4
 image: https://www.legis.state.pa.us/images/members/200/1790.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1790
 name: Carolyn T. Comitta
 other_identifiers:
 - identifier: PAL000565

--- a/data/pa/legislature/Chris-Sainato-613ee6c0-e7f1-441c-9fcd-c89fe207e54c.yml
+++ b/data/pa/legislature/Chris-Sainato-613ee6c0-e7f1-441c-9fcd-c89fe207e54c.yml
@@ -14,7 +14,7 @@ given_name: Chris
 id: ocd-person/613ee6c0-e7f1-441c-9fcd-c89fe207e54c
 image: https://www.legis.state.pa.us/images/members/200/90.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=90
 name: Chris Sainato
 other_identifiers:
 - identifier: PAL000214

--- a/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
+++ b/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-9973
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1852
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1852

--- a/data/pa/legislature/Christine-M-Tartaglione-f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd.yml
+++ b/data/pa/legislature/Christine-M-Tartaglione-f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd.yml
@@ -14,7 +14,7 @@ given_name: Christine
 id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
 image: https://www.legis.state.pa.us/images/members/200/277.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=277
 name: Christine M. Tartaglione
 other_identifiers:
 - identifier: PAL000039

--- a/data/pa/legislature/Christopher-B-Quinn-d6358ed3-bd9b-4299-ba0a-e5449b38ecd4.yml
+++ b/data/pa/legislature/Christopher-B-Quinn-d6358ed3-bd9b-4299-ba0a-e5449b38ecd4.yml
@@ -15,7 +15,7 @@ given_name: Christopher
 id: ocd-person/d6358ed3-bd9b-4299-ba0a-e5449b38ecd4
 image: https://www.legis.state.pa.us/images/members/200/1741.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1741
 name: Christopher B. Quinn
 other_identifiers:
 - identifier: PAL000537

--- a/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
+++ b/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
@@ -12,7 +12,7 @@ given_name: Christopher
 id: ocd-person/e6a8e555-0d65-4a1f-9673-56ad1e3c7855
 image: https://www.legis.state.pa.us/images/members/200/1760.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1760
 name: Christopher M. Rabb
 other_identifiers:
 - identifier: PAL000551

--- a/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
+++ b/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
@@ -12,7 +12,7 @@ given_name: Clint
 id: ocd-person/626de4be-b2f3-4a37-bbbc-ede598381d6b
 image: https://www.legis.state.pa.us/images/members/200/1796.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1796
 name: Clint Owlett
 other_identifiers:
 - identifier: PAL000571

--- a/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
+++ b/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
@@ -15,7 +15,7 @@ given_name: Craig
 id: ocd-person/bb324f66-3a5c-4e90-9c75-d142cce81c92
 image: https://www.legis.state.pa.us/images/members/200/1707.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1707
 name: Craig T. Staats
 other_identifiers:
 - identifier: PAL000506

--- a/data/pa/legislature/Cris-Dush-020bc334-a50b-4970-8e94-5546eb699228.yml
+++ b/data/pa/legislature/Cris-Dush-020bc334-a50b-4970-8e94-5546eb699228.yml
@@ -15,7 +15,7 @@ given_name: Cris
 id: ocd-person/020bc334-a50b-4970-8e94-5546eb699228
 image: https://www.legis.state.pa.us/images/members/200/1687.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1687
 name: Cris Dush
 other_identifiers:
 - identifier: PAL000513

--- a/data/pa/legislature/Curtis-G-Sonney-a433eeec-e792-464d-b0a1-774974da6e39.yml
+++ b/data/pa/legislature/Curtis-G-Sonney-a433eeec-e792-464d-b0a1-774974da6e39.yml
@@ -15,7 +15,7 @@ given_name: Curtis
 id: ocd-person/a433eeec-e792-464d-b0a1-774974da6e39
 image: https://www.legis.state.pa.us/images/members/200/1046.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1046
 name: Curtis G. Sonney
 other_identifiers:
 - identifier: PAL000228

--- a/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
+++ b/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
@@ -16,7 +16,7 @@ given_name: Dan
 id: ocd-person/96667f6d-d967-4f6a-9cd9-23bf480a98c1
 image: https://www.legis.state.pa.us/images/members/200/84.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=84
 name: Dan Frankel
 other_identifiers:
 - identifier: PAL000106

--- a/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
+++ b/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4103
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1837
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1837

--- a/data/pa/legislature/Dan-L-Miller-cf94e0e7-498b-419b-9d3a-36c31d1eaf46.yml
+++ b/data/pa/legislature/Dan-L-Miller-cf94e0e7-498b-419b-9d3a-36c31d1eaf46.yml
@@ -14,7 +14,7 @@ given_name: Dan
 id: ocd-person/cf94e0e7-498b-419b-9d3a-36c31d1eaf46
 image: https://www.legis.state.pa.us/images/members/200/1679.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1679
 name: Dan L. Miller
 other_identifiers:
 - identifier: PAL000515

--- a/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
+++ b/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
@@ -14,7 +14,7 @@ given_name: Dan
 id: ocd-person/f4071288-fa18-48bb-99f1-41abd60d215e
 image: https://www.legis.state.pa.us/images/members/200/1101.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1101
 name: Dan Moul
 other_identifiers:
 - identifier: PAL000175

--- a/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
+++ b/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
@@ -12,7 +12,7 @@ given_name: Daniel
 id: ocd-person/2608882d-9ae2-4522-b8b2-83d905913d3f
 image: https://www.legis.state.pa.us/images/members/200/1166.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1166
 name: Daniel J. Deasy
 other_identifiers:
 - identifier: PAL000090

--- a/data/pa/legislature/Daniel-Laughlin-431a823e-0268-4921-a62d-5f698211e706.yml
+++ b/data/pa/legislature/Daniel-Laughlin-431a823e-0268-4921-a62d-5f698211e706.yml
@@ -15,7 +15,7 @@ given_name: Daniel
 id: ocd-person/431a823e-0268-4921-a62d-5f698211e706
 image: https://www.legis.state.pa.us/images/members/200/1766.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1766
 name: Daniel Laughlin
 other_identifiers:
 - identifier: PAL000539

--- a/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
+++ b/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-5009
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1850
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1850

--- a/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
+++ b/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-2004
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1863
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1863

--- a/data/pa/legislature/Daryl-D-Metcalfe-e72daf8d-195e-442a-a778-78d530eb6edf.yml
+++ b/data/pa/legislature/Daryl-D-Metcalfe-e72daf8d-195e-442a-a778-78d530eb6edf.yml
@@ -15,7 +15,7 @@ given_name: Daryl
 id: ocd-person/e72daf8d-195e-442a-a778-78d530eb6edf
 image: https://www.legis.state.pa.us/images/members/200/13.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=13
 name: Daryl D. Metcalfe
 other_identifiers:
 - identifier: PAL000167

--- a/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
+++ b/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-6437
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1853
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1853

--- a/data/pa/legislature/David-G-Argall-2a2df3c1-9ede-46b7-8d73-896b1e317aff.yml
+++ b/data/pa/legislature/David-G-Argall-2a2df3c1-9ede-46b7-8d73-896b1e317aff.yml
@@ -17,7 +17,7 @@ given_name: David
 id: ocd-person/2a2df3c1-9ede-46b7-8d73-896b1e317aff
 image: https://www.legis.state.pa.us/images/members/200/69.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=69
 name: David G. Argall
 other_identifiers:
 - identifier: PAL000002

--- a/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
+++ b/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
@@ -15,7 +15,7 @@ given_name: David
 id: ocd-person/2fbada46-9c48-4be5-a49f-e1ca0af132ed
 image: https://www.legis.state.pa.us/images/members/200/1711.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1711
 name: David H. Zimmerman
 other_identifiers:
 - identifier: PAL000514

--- a/data/pa/legislature/David-J-Arnold-b3d9d12e-fd76-49d8-ac76-e1e129fc6186.yml
+++ b/data/pa/legislature/David-J-Arnold-b3d9d12e-fd76-49d8-ac76-e1e129fc6186.yml
@@ -15,7 +15,7 @@ contact_details:
   note: District Office
   voice: 717-274-6735
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1873
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1873

--- a/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
+++ b/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
@@ -15,7 +15,7 @@ given_name: David
 id: ocd-person/fb4a0115-dd63-4e25-8d36-0ea6afc55faf
 image: https://www.legis.state.pa.us/images/members/200/1226.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1226
 name: David M. Maloney
 other_identifiers:
 - identifier: PAL000290

--- a/data/pa/legislature/David-R-Millard-1ef8fc41-4dde-431a-b771-98dd465f5683.yml
+++ b/data/pa/legislature/David-R-Millard-1ef8fc41-4dde-431a-b771-98dd465f5683.yml
@@ -15,7 +15,7 @@ given_name: David
 id: ocd-person/1ef8fc41-4dde-431a-b771-98dd465f5683
 image: https://www.legis.state.pa.us/images/members/200/1033.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1033
 name: David R. Millard
 other_identifiers:
 - identifier: PAL000171

--- a/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
+++ b/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
@@ -11,7 +11,7 @@ roles:
   start_date: '2019-09-17'
   type: lower
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1871
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1871

--- a/data/pa/legislature/David-S-Hickernell-2cf3b740-312f-492b-b9a3-06c938ea4938.yml
+++ b/data/pa/legislature/David-S-Hickernell-2cf3b740-312f-492b-b9a3-06c938ea4938.yml
@@ -12,7 +12,7 @@ given_name: David
 id: ocd-person/2cf3b740-312f-492b-b9a3-06c938ea4938
 image: https://www.legis.state.pa.us/images/members/200/1013.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1013
 name: David S. Hickernell
 other_identifiers:
 - identifier: PAL000134

--- a/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
+++ b/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
@@ -14,7 +14,7 @@ given_name: Dawn
 id: ocd-person/2a13f9df-b7e6-4281-82e4-f7263b6fa12e
 image: https://www.legis.state.pa.us/images/members/200/1748.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1748
 name: Dawn W. Keefer
 other_identifiers:
 - identifier: PAL000560

--- a/data/pa/legislature/Daylin-Leach-f9224d64-8b69-47bb-9d05-252e82f581cf.yml
+++ b/data/pa/legislature/Daylin-Leach-f9224d64-8b69-47bb-9d05-252e82f581cf.yml
@@ -17,7 +17,7 @@ given_name: Daylin
 id: ocd-person/f9224d64-8b69-47bb-9d05-252e82f581cf
 image: https://www.legis.state.pa.us/images/members/200/991.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=991
 name: Daylin Leach
 other_identifiers:
 - identifier: PAL000022

--- a/data/pa/legislature/Donna-Bullock-c7ba89f6-7317-43c8-8bc3-0270843583f6.yml
+++ b/data/pa/legislature/Donna-Bullock-c7ba89f6-7317-43c8-8bc3-0270843583f6.yml
@@ -12,7 +12,7 @@ given_name: Donna
 id: ocd-person/c7ba89f6-7317-43c8-8bc3-0270843583f6
 image: https://www.legis.state.pa.us/images/members/200/1736.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1736
 name: Donna Bullock
 other_identifiers:
 - identifier: PAL000525

--- a/data/pa/legislature/Donna-Oberlander-2c39f854-9f84-4115-81a3-10b070d73794.yml
+++ b/data/pa/legislature/Donna-Oberlander-2c39f854-9f84-4115-81a3-10b070d73794.yml
@@ -15,7 +15,7 @@ given_name: Donna
 id: ocd-person/2c39f854-9f84-4115-81a3-10b070d73794
 image: https://www.legis.state.pa.us/images/members/200/1177.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1177
 name: Donna Oberlander
 other_identifiers:
 - identifier: PAL000184

--- a/data/pa/legislature/Doug-Mastriano-cda65f80-13e8-463c-88fa-6f5569a599bf.yml
+++ b/data/pa/legislature/Doug-Mastriano-cda65f80-13e8-463c-88fa-6f5569a599bf.yml
@@ -11,7 +11,7 @@ roles:
   start_date: '2019-06-10'
   type: upper
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1869
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1869

--- a/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
+++ b/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
@@ -15,7 +15,7 @@ given_name: Doyle
 id: ocd-person/885e9a2a-c18b-4f68-b5d0-0b867ec3268d
 image: https://www.legis.state.pa.us/images/members/200/1211.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1211
 name: Doyle Heffley
 other_identifiers:
 - identifier: PAL000284

--- a/data/pa/legislature/Ed-Gainey-d147b92c-aee6-47c7-8f6c-c70c40c749d3.yml
+++ b/data/pa/legislature/Ed-Gainey-d147b92c-aee6-47c7-8f6c-c70c40c749d3.yml
@@ -16,7 +16,7 @@ given_name: Ed
 id: ocd-person/d147b92c-aee6-47c7-8f6c-c70c40c749d3
 image: https://www.legis.state.pa.us/images/members/200/1627.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1627
 name: Ed Gainey
 other_identifiers:
 - identifier: PAL000449

--- a/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
+++ b/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
@@ -16,7 +16,7 @@ given_name: Ed
 id: ocd-person/3d3d4070-dadd-4382-9d40-be2892745773
 image: https://www.legis.state.pa.us/images/members/200/1615.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1615
 name: Ed Neilson
 other_identifiers:
 - identifier: PAL000528

--- a/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
+++ b/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
@@ -16,7 +16,7 @@ given_name: Eddie
 id: ocd-person/c1cb6f95-37c8-4e25-802e-80387e70ad74
 image: https://www.legis.state.pa.us/images/members/200/1112.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1112
 name: Eddie Day Pashinski
 other_identifiers:
 - identifier: PAL000188

--- a/data/pa/legislature/Elder-A-Vogel-8a2a9b56-cdfa-45e0-a26e-b45b547a2eae.yml
+++ b/data/pa/legislature/Elder-A-Vogel-8a2a9b56-cdfa-45e0-a26e-b45b547a2eae.yml
@@ -15,7 +15,7 @@ given_name: Elder
 id: ocd-person/8a2a9b56-cdfa-45e0-a26e-b45b547a2eae
 image: https://www.legis.state.pa.us/images/members/200/1189.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1189
 name: Elder A. Vogel
 other_identifiers:
 - identifier: PAL000042

--- a/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
+++ b/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-5774
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1861
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1861

--- a/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
+++ b/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
@@ -18,7 +18,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-3825
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1875
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1875

--- a/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
+++ b/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
@@ -12,7 +12,7 @@ given_name: Eric
 id: ocd-person/0910d394-3c42-48ee-aea7-6d4c0c144130
 image: https://www.legis.state.pa.us/images/members/200/1738.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1738
 name: Eric R. Nelson
 other_identifiers:
 - identifier: PAL000533

--- a/data/pa/legislature/F-Todd-Polinchock-1ed8a4ce-abac-4d5e-98ca-ba60c11ef19f.yml
+++ b/data/pa/legislature/F-Todd-Polinchock-1ed8a4ce-abac-4d5e-98ca-ba60c11ef19f.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-5452
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1846
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1846

--- a/data/pa/legislature/Francis-X-Ryan-48423594-38db-4517-b14e-80db6b81be68.yml
+++ b/data/pa/legislature/Francis-X-Ryan-48423594-38db-4517-b14e-80db6b81be68.yml
@@ -14,7 +14,7 @@ given_name: Francis
 id: ocd-person/48423594-38db-4517-b14e-80db6b81be68
 image: https://www.legis.state.pa.us/images/members/200/1750.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1750
 name: Francis X. Ryan
 other_identifiers:
 - identifier: PAL000563

--- a/data/pa/legislature/Frank-A-Farry-611d3c65-f30f-4dde-8f80-7db4ec405a36.yml
+++ b/data/pa/legislature/Frank-A-Farry-611d3c65-f30f-4dde-8f80-7db4ec405a36.yml
@@ -14,7 +14,7 @@ given_name: Frank
 id: ocd-person/611d3c65-f30f-4dde-8f80-7db4ec405a36
 image: https://www.legis.state.pa.us/images/members/200/1169.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1169
 name: Frank A. Farry
 other_identifiers:
 - identifier: PAL000104

--- a/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
+++ b/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
@@ -16,7 +16,7 @@ given_name: Frank
 id: ocd-person/a60da669-bae3-4e1d-a241-370a7ad2c769
 image: https://www.legis.state.pa.us/images/members/200/1163.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1163
 name: Frank Burns
 other_identifiers:
 - identifier: PAL000068

--- a/data/pa/legislature/Frank-Dermody-05fddd3f-c560-4bdd-b8ff-a271f2a972fa.yml
+++ b/data/pa/legislature/Frank-Dermody-05fddd3f-c560-4bdd-b8ff-a271f2a972fa.yml
@@ -16,7 +16,7 @@ given_name: Frank
 id: ocd-person/05fddd3f-c560-4bdd-b8ff-a271f2a972fa
 image: https://www.legis.state.pa.us/images/members/200/143.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=143
 name: Frank Dermody
 other_identifiers:
 - identifier: PAL000093

--- a/data/pa/legislature/G-Roni-Green-895e8c64-08d3-4ae1-969a-351145256676.yml
+++ b/data/pa/legislature/G-Roni-Green-895e8c64-08d3-4ae1-969a-351145256676.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-3822
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1874
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1874

--- a/data/pa/legislature/Garth-D-Everett-7b314dde-58cd-47af-907f-8a8a4f273b1f.yml
+++ b/data/pa/legislature/Garth-D-Everett-7b314dde-58cd-47af-907f-8a8a4f273b1f.yml
@@ -15,7 +15,7 @@ given_name: Garth
 id: ocd-person/7b314dde-58cd-47af-907f-8a8a4f273b1f
 image: https://www.legis.state.pa.us/images/members/200/1098.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1098
 name: Garth D. Everett
 other_identifiers:
 - identifier: PAL000101

--- a/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
+++ b/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
@@ -15,7 +15,7 @@ given_name: Gary
 id: ocd-person/3088ff8e-d2d9-46b9-8ea3-bd35af9438c2
 image: https://www.legis.state.pa.us/images/members/200/1190.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1190
 name: Gary Day
 other_identifiers:
 - identifier: PAL000086

--- a/data/pa/legislature/Gene-Yaw-18127660-d04e-43c2-b931-084f0c87142c.yml
+++ b/data/pa/legislature/Gene-Yaw-18127660-d04e-43c2-b931-084f0c87142c.yml
@@ -17,7 +17,7 @@ given_name: Gene
 id: ocd-person/18127660-d04e-43c2-b931-084f0c87142c
 image: https://www.legis.state.pa.us/images/members/200/1186.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1186
 name: Gene Yaw
 other_identifiers:
 - identifier: PAL000050

--- a/data/pa/legislature/George-Dunbar-6a971ef6-eb92-434b-a390-c658cfbf2d00.yml
+++ b/data/pa/legislature/George-Dunbar-6a971ef6-eb92-434b-a390-c658cfbf2d00.yml
@@ -15,7 +15,7 @@ given_name: George
 id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00
 image: https://www.legis.state.pa.us/images/members/200/1206.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1206
 name: George Dunbar
 other_identifiers:
 - identifier: PAL000278

--- a/data/pa/legislature/Gerald-J-Mullery-4d2dae11-b2e5-4f69-8b7d-7ab1e0a4efad.yml
+++ b/data/pa/legislature/Gerald-J-Mullery-4d2dae11-b2e5-4f69-8b7d-7ab1e0a4efad.yml
@@ -16,7 +16,7 @@ given_name: Gerald
 id: ocd-person/4d2dae11-b2e5-4f69-8b7d-7ab1e0a4efad
 image: https://www.legis.state.pa.us/images/members/200/1217.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1217
 name: Gerald J. Mullery
 other_identifiers:
 - identifier: PAL000293

--- a/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
+++ b/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
@@ -15,7 +15,7 @@ given_name: Greg
 id: ocd-person/3e99b4f3-2efa-4330-b0b9-fb273b1322ea
 image: https://www.legis.state.pa.us/images/members/200/1733.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1733
 name: Greg Rothman
 other_identifiers:
 - identifier: PAL000529

--- a/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
+++ b/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
@@ -16,7 +16,7 @@ given_name: Greg
 id: ocd-person/7a1f510f-12e0-4018-b6da-556b404399be
 image: https://www.legis.state.pa.us/images/members/200/210.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=210
 name: Greg Vitali
 other_identifiers:
 - identifier: PAL000242

--- a/data/pa/legislature/Harry-Readshaw-b0786ef8-ee84-435c-a1b2-7dc7bd28ca8e.yml
+++ b/data/pa/legislature/Harry-Readshaw-b0786ef8-ee84-435c-a1b2-7dc7bd28ca8e.yml
@@ -14,7 +14,7 @@ given_name: Harry
 id: ocd-person/b0786ef8-ee84-435c-a1b2-7dc7bd28ca8e
 image: https://www.legis.state.pa.us/images/members/200/51.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=51
 name: Harry Readshaw
 other_identifiers:
 - identifier: PAL000204

--- a/data/pa/legislature/Isabella-V-Fitzgerald-33652833-8544-4886-a1ca-f87997ff7a4e.yml
+++ b/data/pa/legislature/Isabella-V-Fitzgerald-33652833-8544-4886-a1ca-f87997ff7a4e.yml
@@ -12,7 +12,7 @@ given_name: Isabella
 id: ocd-person/33652833-8544-4886-a1ca-f87997ff7a4e
 image: https://www.legis.state.pa.us/images/members/200/1762.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1762
 name: Isabella V. Fitzgerald
 other_identifiers:
 - identifier: PAL000541

--- a/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
+++ b/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
@@ -14,7 +14,7 @@ given_name: Jack
 id: ocd-person/abca93cc-5058-473c-93bc-c8e099c7fa20
 image: https://www.legis.state.pa.us/images/members/200/1703.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1703
 name: Jack Rader
 other_identifiers:
 - identifier: PAL000488

--- a/data/pa/legislature/Jake-Corman-f5418e42-be5b-4249-a920-bbee0456494e.yml
+++ b/data/pa/legislature/Jake-Corman-f5418e42-be5b-4249-a920-bbee0456494e.yml
@@ -15,7 +15,7 @@ given_name: Jake
 id: ocd-person/f5418e42-be5b-4249-a920-bbee0456494e
 image: https://www.legis.state.pa.us/images/members/200/251.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=251
 name: Jake Corman
 other_identifiers:
 - identifier: PAL000007

--- a/data/pa/legislature/Jake-Wheatley-736d5020-17c4-4d6d-877e-7e292a2c3855.yml
+++ b/data/pa/legislature/Jake-Wheatley-736d5020-17c4-4d6d-877e-7e292a2c3855.yml
@@ -16,7 +16,7 @@ given_name: Jake
 id: ocd-person/736d5020-17c4-4d6d-877e-7e292a2c3855
 image: https://www.legis.state.pa.us/images/members/200/1026.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1026
 name: Jake Wheatley
 other_identifiers:
 - identifier: PAL000248

--- a/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
+++ b/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-705-7173
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1835
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1835

--- a/data/pa/legislature/James-R-Brewster-cac6095b-9793-4edb-835a-70bc551dfd84.yml
+++ b/data/pa/legislature/James-R-Brewster-cac6095b-9793-4edb-835a-70bc551dfd84.yml
@@ -14,7 +14,7 @@ given_name: James
 id: ocd-person/cac6095b-9793-4edb-835a-70bc551dfd84
 image: https://www.legis.state.pa.us/images/members/200/1197.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1197
 name: James R. Brewster
 other_identifiers:
 - identifier: PAL000266

--- a/data/pa/legislature/James-R-Roebuck-1a51c5a2-de16-4552-87ab-e1356c128691.yml
+++ b/data/pa/legislature/James-R-Roebuck-1a51c5a2-de16-4552-87ab-e1356c128691.yml
@@ -15,7 +15,7 @@ given_name: James
 id: ocd-person/1a51c5a2-de16-4552-87ab-e1356c128691
 image: https://www.legis.state.pa.us/images/members/200/139.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=139
 name: James R. Roebuck
 other_identifiers:
 - identifier: PAL000210

--- a/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
+++ b/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
@@ -12,7 +12,7 @@ given_name: Jared
 id: ocd-person/6b6602c0-8b45-4e1e-89ba-1782da5d67c6
 image: https://www.legis.state.pa.us/images/members/200/1761.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1761
 name: Jared G. Solomon
 other_identifiers:
 - identifier: PAL000558

--- a/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
+++ b/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
@@ -12,7 +12,7 @@ given_name: Jason
 id: ocd-person/4a2176cc-292b-4d19-aff6-8b4c4b460ba0
 image: https://www.legis.state.pa.us/images/members/200/1685.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1685
 name: Jason Dawkins
 other_identifiers:
 - identifier: PAL000511

--- a/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
+++ b/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
@@ -15,7 +15,7 @@ given_name: Jason
 id: ocd-person/1871b5c7-35c4-4d32-9e09-9febf8ba3f66
 image: https://www.legis.state.pa.us/images/members/200/1701.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1701
 name: Jason Ortitay
 other_identifiers:
 - identifier: PAL000492

--- a/data/pa/legislature/Jay-Costa-ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0.yml
+++ b/data/pa/legislature/Jay-Costa-ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0.yml
@@ -18,7 +18,7 @@ given_name: Jay
 id: ocd-person/ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0
 image: https://www.legis.state.pa.us/images/members/200/254.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=254
 name: Jay Costa
 other_identifiers:
 - identifier: PAL000008

--- a/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
+++ b/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
@@ -15,7 +15,7 @@ given_name: Jeanne
 id: ocd-person/ddd14a2f-ebef-4918-bf91-578b71c085e4
 image: https://www.legis.state.pa.us/images/members/200/1793.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1793
 name: Jeanne McNeill
 other_identifiers:
 - identifier: PAL000569

--- a/data/pa/legislature/Jeff-C-Wheeland-2d7346eb-5e58-48cc-a098-052c6d375ba9.yml
+++ b/data/pa/legislature/Jeff-C-Wheeland-2d7346eb-5e58-48cc-a098-052c6d375ba9.yml
@@ -15,7 +15,7 @@ given_name: Jeff
 id: ocd-person/2d7346eb-5e58-48cc-a098-052c6d375ba9
 image: https://www.legis.state.pa.us/images/members/200/1710.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1710
 name: Jeff C. Wheeland
 other_identifiers:
 - identifier: PAL000512

--- a/data/pa/legislature/Jeffrey-P-Pyle-a59e4302-6e19-4748-8d80-7946305a64c3.yml
+++ b/data/pa/legislature/Jeffrey-P-Pyle-a59e4302-6e19-4748-8d80-7946305a64c3.yml
@@ -16,7 +16,7 @@ given_name: Jeffrey
 id: ocd-person/a59e4302-6e19-4748-8d80-7946305a64c3
 image: https://www.legis.state.pa.us/images/members/200/1019.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1019
 name: Jeffrey P. Pyle
 other_identifiers:
 - identifier: PAL000199

--- a/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
+++ b/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4090
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1855
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1855

--- a/data/pa/legislature/Jerry-Knowles-bb748ea8-5679-4317-8d91-f302424c34ab.yml
+++ b/data/pa/legislature/Jerry-Knowles-bb748ea8-5679-4317-8d91-f302424c34ab.yml
@@ -15,7 +15,7 @@ given_name: Jerry
 id: ocd-person/bb748ea8-5679-4317-8d91-f302424c34ab
 image: https://www.legis.state.pa.us/images/members/200/1193.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1193
 name: Jerry Knowles
 other_identifiers:
 - identifier: PAL000146

--- a/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
+++ b/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
@@ -12,7 +12,7 @@ given_name: Jesse
 id: ocd-person/865dbfc4-e6ec-400e-bd5c-257f9a947519
 image: https://www.legis.state.pa.us/images/members/200/1681.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1681
 name: Jesse Topper
 other_identifiers:
 - identifier: PAL000478

--- a/data/pa/legislature/Jim-Cox-323110dc-aca0-4f58-b4ee-6c6e3c1e047d.yml
+++ b/data/pa/legislature/Jim-Cox-323110dc-aca0-4f58-b4ee-6c6e3c1e047d.yml
@@ -15,7 +15,7 @@ given_name: Jim
 id: ocd-person/323110dc-aca0-4f58-b4ee-6c6e3c1e047d
 image: https://www.legis.state.pa.us/images/members/200/1114.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1114
 name: Jim Cox
 other_identifiers:
 - identifier: PAL000080

--- a/data/pa/legislature/Jim-Gregory-dd479171-721b-4f39-9b67-56061f9f98a6.yml
+++ b/data/pa/legislature/Jim-Gregory-dd479171-721b-4f39-9b67-56061f9f98a6.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-9020
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1840
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1840

--- a/data/pa/legislature/Jim-Marshall-5956a1da-5202-4043-8219-12250bba8c52.yml
+++ b/data/pa/legislature/Jim-Marshall-5956a1da-5202-4043-8219-12250bba8c52.yml
@@ -16,7 +16,7 @@ given_name: Jim
 id: ocd-person/5956a1da-5202-4043-8219-12250bba8c52
 image: https://www.legis.state.pa.us/images/members/200/1086.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1086
 name: Jim Marshall
 other_identifiers:
 - identifier: PAL000160

--- a/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
+++ b/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-9924
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1836
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1836

--- a/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
+++ b/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
@@ -12,7 +12,7 @@ given_name: Joanna
 id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5
 image: https://www.legis.state.pa.us/images/members/200/1734.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1734
 name: Joanna E. McClinton
 other_identifiers:
 - identifier: PAL000526

--- a/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
+++ b/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4086
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1847
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1847

--- a/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
+++ b/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
@@ -15,7 +15,7 @@ given_name: Joe
 id: ocd-person/0e873ea0-c8a2-4fbb-a408-de0c5bd36de9
 image: https://www.legis.state.pa.us/images/members/200/1207.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1207
 name: Joe Emrick
 other_identifiers:
 - identifier: PAL000279

--- a/data/pa/legislature/Joe-Pittman-722f324f-db47-4ce2-9cbc-93f29ae38158.yml
+++ b/data/pa/legislature/Joe-Pittman-722f324f-db47-4ce2-9cbc-93f29ae38158.yml
@@ -11,7 +11,7 @@ roles:
   start_date: '2019-06-10'
   type: upper
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1870
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1870

--- a/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
+++ b/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-0419
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1848
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1848

--- a/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
+++ b/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
@@ -15,7 +15,7 @@ given_name: John
 id: ocd-person/8c1966e4-80f4-4a98-bf55-b1de0b9705b3
 image: https://www.legis.state.pa.us/images/members/200/1215.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1215
 name: John A. Lawrence
 other_identifiers:
 - identifier: PAL000289

--- a/data/pa/legislature/John-DiSanto-01ce8a7c-29e4-4439-be3a-b919797dc912.yml
+++ b/data/pa/legislature/John-DiSanto-01ce8a7c-29e4-4439-be3a-b919797dc912.yml
@@ -15,7 +15,7 @@ given_name: John
 id: ocd-person/01ce8a7c-29e4-4439-be3a-b919797dc912
 image: https://www.legis.state.pa.us/images/members/200/1765.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1765
 name: John DiSanto
 other_identifiers:
 - identifier: PAL000549

--- a/data/pa/legislature/John-P-Blake-796b7ab7-bd7b-42ca-a9dc-c9561097d065.yml
+++ b/data/pa/legislature/John-P-Blake-796b7ab7-bd7b-42ca-a9dc-c9561097d065.yml
@@ -14,7 +14,7 @@ given_name: John
 id: ocd-person/796b7ab7-bd7b-42ca-a9dc-c9561097d065
 image: https://www.legis.state.pa.us/images/members/200/1227.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1227
 name: John P. Blake
 other_identifiers:
 - identifier: PAL000265

--- a/data/pa/legislature/John-P-Sabatina-461dce72-29da-48a1-af75-06de3022bd19.yml
+++ b/data/pa/legislature/John-P-Sabatina-461dce72-29da-48a1-af75-06de3022bd19.yml
@@ -15,7 +15,7 @@ given_name: John
 id: ocd-person/461dce72-29da-48a1-af75-06de3022bd19
 image: https://www.legis.state.pa.us/images/members/200/1044.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1044
 name: John P. Sabatina
 other_identifiers:
 - identifier: PAL000213

--- a/data/pa/legislature/John-R-Gordner-e1ca7747-f758-4327-b321-392a53d0a715.yml
+++ b/data/pa/legislature/John-R-Gordner-e1ca7747-f758-4327-b321-392a53d0a715.yml
@@ -12,7 +12,7 @@ given_name: John
 id: ocd-person/e1ca7747-f758-4327-b321-392a53d0a715
 image: https://www.legis.state.pa.us/images/members/200/96.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=96
 name: John R. Gordner
 other_identifiers:
 - identifier: PAL000017

--- a/data/pa/legislature/John-T-Galloway-bd6e291c-ffed-44d7-a378-47693778988d.yml
+++ b/data/pa/legislature/John-T-Galloway-bd6e291c-ffed-44d7-a378-47693778988d.yml
@@ -16,7 +16,7 @@ given_name: John
 id: ocd-person/bd6e291c-ffed-44d7-a378-47693778988d
 image: https://www.legis.state.pa.us/images/members/200/1118.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1118
 name: John T. Galloway
 other_identifiers:
 - identifier: PAL000110

--- a/data/pa/legislature/John-T-Yudichak-ce75fa6b-edbf-41b9-b9b8-ca503aa33596.yml
+++ b/data/pa/legislature/John-T-Yudichak-ce75fa6b-edbf-41b9-b9b8-ca503aa33596.yml
@@ -17,7 +17,7 @@ given_name: John
 id: ocd-person/ce75fa6b-edbf-41b9-b9b8-ca503aa33596
 image: https://www.legis.state.pa.us/images/members/200/64.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=64
 name: John T. Yudichak
 other_identifiers:
 - identifier: PAL000252

--- a/data/pa/legislature/Johnathan-D-Hershey-c498c73d-cebf-4208-8122-cfdb62058505.yml
+++ b/data/pa/legislature/Johnathan-D-Hershey-c498c73d-cebf-4208-8122-cfdb62058505.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-7830
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1841
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1841

--- a/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
+++ b/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
@@ -14,7 +14,7 @@ given_name: Jonathan
 id: ocd-person/23a2b079-dc91-49b0-b08e-f3ae80fba11f
 image: https://www.legis.state.pa.us/images/members/200/1752.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1752
 name: Jonathan Fritz
 other_identifiers:
 - identifier: PAL000562

--- a/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
+++ b/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
@@ -16,7 +16,7 @@ given_name: Jordan
 id: ocd-person/2313ce98-7ac4-44b9-a61d-5b128338a405
 image: https://www.legis.state.pa.us/images/members/200/1633.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1633
 name: Jordan A. Harris
 other_identifiers:
 - identifier: PAL000452

--- a/data/pa/legislature/Joseph-A-Petrarca-a7aefe9f-3f1a-4a74-8071-7243caab0f94.yml
+++ b/data/pa/legislature/Joseph-A-Petrarca-a7aefe9f-3f1a-4a74-8071-7243caab0f94.yml
@@ -14,7 +14,7 @@ given_name: Joseph
 id: ocd-person/a7aefe9f-3f1a-4a74-8071-7243caab0f94
 image: https://www.legis.state.pa.us/images/members/200/1618.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1618
 name: Joseph A. Petrarca
 other_identifiers:
 - identifier: PAL000194

--- a/data/pa/legislature/Joseph-B-Scarnati-797bd08a-d1ae-426f-9a15-9be5354cc692.yml
+++ b/data/pa/legislature/Joseph-B-Scarnati-797bd08a-d1ae-426f-9a15-9be5354cc692.yml
@@ -17,7 +17,7 @@ given_name: Joseph
 id: ocd-person/797bd08a-d1ae-426f-9a15-9be5354cc692
 image: https://www.legis.state.pa.us/images/members/200/283.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=283
 name: Joseph B. Scarnati
 other_identifiers:
 - identifier: PAL000035

--- a/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
+++ b/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4087
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1858
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1858

--- a/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
+++ b/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-260-6144
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1823
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1823

--- a/data/pa/legislature/Judith-L-Schwank-35362d6e-d00a-4cf1-806d-b4f2f2a55f72.yml
+++ b/data/pa/legislature/Judith-L-Schwank-35362d6e-d00a-4cf1-806d-b4f2f2a55f72.yml
@@ -17,7 +17,7 @@ given_name: Judith
 id: ocd-person/35362d6e-d00a-4cf1-806d-b4f2f2a55f72
 image: https://www.legis.state.pa.us/images/members/200/1234.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1234
 name: Judith L. Schwank
 other_identifiers:
 - identifier: PAL000301

--- a/data/pa/legislature/Judy-Ward-b6ed7151-9ea4-4828-b639-785f9e358eb1.yml
+++ b/data/pa/legislature/Judy-Ward-b6ed7151-9ea4-4828-b639-785f9e358eb1.yml
@@ -23,7 +23,7 @@ contact_details:
   note: District Office
   voice: 717-485-4126
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1683
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1683

--- a/data/pa/legislature/Justin-J-Simmons-0f47b83e-ab14-4a50-a12c-1d71bc04de21.yml
+++ b/data/pa/legislature/Justin-J-Simmons-0f47b83e-ab14-4a50-a12c-1d71bc04de21.yml
@@ -16,7 +16,7 @@ given_name: Justin
 id: ocd-person/0f47b83e-ab14-4a50-a12c-1d71bc04de21
 image: https://www.legis.state.pa.us/images/members/200/1220.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1220
 name: Justin J. Simmons
 other_identifiers:
 - identifier: PAL000296

--- a/data/pa/legislature/Karen-Boback-ec78f2c6-3166-4b6f-9a0f-0d8a0a1e6c67.yml
+++ b/data/pa/legislature/Karen-Boback-ec78f2c6-3166-4b6f-9a0f-0d8a0a1e6c67.yml
@@ -15,7 +15,7 @@ given_name: Karen
 id: ocd-person/ec78f2c6-3166-4b6f-9a0f-0d8a0a1e6c67
 image: https://www.legis.state.pa.us/images/members/200/1110.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1110
 name: Karen Boback
 other_identifiers:
 - identifier: PAL000060

--- a/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
+++ b/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
@@ -15,7 +15,7 @@ given_name: Kate
 id: ocd-person/08283fbe-18bc-4daf-972c-617d1e35d746
 image: https://www.legis.state.pa.us/images/members/200/1694.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1694
 name: Kate A. Klunk
 other_identifiers:
 - identifier: PAL000483

--- a/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
+++ b/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
@@ -13,7 +13,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-7319
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1876
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1876

--- a/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
+++ b/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
@@ -14,7 +14,7 @@ given_name: Kathy
 id: ocd-person/36348b5e-47fe-404a-b6c3-99359115846c
 image: https://www.legis.state.pa.us/images/members/200/1028.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1028
 name: Kathy L. Rapp
 other_identifiers:
 - identifier: PAL000202

--- a/data/pa/legislature/Katie-J-Muth-ade3ef98-a98c-4448-a974-ec4e0eede98f.yml
+++ b/data/pa/legislature/Katie-J-Muth-ade3ef98-a98c-4448-a974-ec4e0eede98f.yml
@@ -17,7 +17,7 @@ contact_details:
   note: District Office
   voice: 610-792-2137
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1802
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1802

--- a/data/pa/legislature/Keith-Gillespie-84bf36f7-5f78-4f5c-9d86-8fc6ca547dcd.yml
+++ b/data/pa/legislature/Keith-Gillespie-84bf36f7-5f78-4f5c-9d86-8fc6ca547dcd.yml
@@ -15,7 +15,7 @@ given_name: Keith
 id: ocd-person/84bf36f7-5f78-4f5c-9d86-8fc6ca547dcd
 image: https://www.legis.state.pa.us/images/members/200/1006.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1006
 name: Keith Gillespie
 other_identifiers:
 - identifier: PAL000116

--- a/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
+++ b/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
@@ -15,7 +15,7 @@ given_name: Keith
 id: ocd-person/dcd0037e-7833-416d-9523-5f25802bd43a
 image: https://www.legis.state.pa.us/images/members/200/1632.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1632
 name: Keith J. Greiner
 other_identifiers:
 - identifier: PAL000450

--- a/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
+++ b/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
@@ -15,7 +15,7 @@ given_name: Kerry
 id: ocd-person/5a5a7a42-bc5e-4a07-aee1-d1a01e810385
 image: https://www.legis.state.pa.us/images/members/200/215.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=215
 name: Kerry A. Benninghoff
 other_identifiers:
 - identifier: PAL000057

--- a/data/pa/legislature/Kevin-J-Boyle-1acc497e-f643-4138-9bf5-58983cf03270.yml
+++ b/data/pa/legislature/Kevin-J-Boyle-1acc497e-f643-4138-9bf5-58983cf03270.yml
@@ -15,7 +15,7 @@ given_name: Kevin
 id: ocd-person/1acc497e-f643-4138-9bf5-58983cf03270
 image: https://www.legis.state.pa.us/images/members/200/1225.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1225
 name: Kevin J. Boyle
 other_identifiers:
 - identifier: PAL000272

--- a/data/pa/legislature/Kim-L-Ward-c48a0179-5770-410d-ba97-bdbc05d20786.yml
+++ b/data/pa/legislature/Kim-L-Ward-c48a0179-5770-410d-ba97-bdbc05d20786.yml
@@ -16,7 +16,7 @@ given_name: Kim
 id: ocd-person/c48a0179-5770-410d-ba97-bdbc05d20786
 image: https://www.legis.state.pa.us/images/members/200/1188.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1188
 name: Kim L. Ward
 other_identifiers:
 - identifier: PAL000043

--- a/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
+++ b/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
@@ -22,7 +22,7 @@ contact_details:
   note: District Office
   voice: 717-741-4648
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1801
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1801

--- a/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
+++ b/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4088
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1856
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1856

--- a/data/pa/legislature/Kurt-A-Masser-9a9f48d2-5aaf-4dc4-af1d-955adba80cee.yml
+++ b/data/pa/legislature/Kurt-A-Masser-9a9f48d2-5aaf-4dc4-af1d-955adba80cee.yml
@@ -15,7 +15,7 @@ given_name: Kurt
 id: ocd-person/9a9f48d2-5aaf-4dc4-af1d-955adba80cee
 image: https://www.legis.state.pa.us/images/members/200/1216.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1216
 name: Kurt A. Masser
 other_identifiers:
 - identifier: PAL000292

--- a/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
+++ b/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-5043
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1844
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1844

--- a/data/pa/legislature/Lawrence-M-Farnese-204aaf07-1a83-44dc-a663-fd8810f78646.yml
+++ b/data/pa/legislature/Lawrence-M-Farnese-204aaf07-1a83-44dc-a663-fd8810f78646.yml
@@ -17,7 +17,7 @@ given_name: Lawrence
 id: ocd-person/204aaf07-1a83-44dc-a663-fd8810f78646
 image: https://www.legis.state.pa.us/images/members/200/1183.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1183
 name: Lawrence M. Farnese
 other_identifiers:
 - identifier: PAL000013

--- a/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
+++ b/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
@@ -16,7 +16,7 @@ given_name: Leanne
 id: ocd-person/8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93
 image: https://www.legis.state.pa.us/images/members/200/1735.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1735
 name: Leanne Krueger
 other_identifiers:
 - identifier: PAL000527

--- a/data/pa/legislature/Lindsey-Williams-bc64322a-faaf-4b33-b6c2-cf5059f4121c.yml
+++ b/data/pa/legislature/Lindsey-Williams-bc64322a-faaf-4b33-b6c2-cf5059f4121c.yml
@@ -17,7 +17,7 @@ contact_details:
   note: District Office
   voice: 412-364-0469
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1803
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1803

--- a/data/pa/legislature/Lisa-Baker-aa421a2c-4203-45b7-9766-8826c02a659d.yml
+++ b/data/pa/legislature/Lisa-Baker-aa421a2c-4203-45b7-9766-8826c02a659d.yml
@@ -17,7 +17,7 @@ given_name: Lisa
 id: ocd-person/aa421a2c-4203-45b7-9766-8826c02a659d
 image: https://www.legis.state.pa.us/images/members/200/1077.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1077
 name: Lisa Baker
 other_identifiers:
 - identifier: PAL000003

--- a/data/pa/legislature/Lisa-M-Boscola-de81d407-bc84-48e6-9796-4a56be984cbd.yml
+++ b/data/pa/legislature/Lisa-M-Boscola-de81d407-bc84-48e6-9796-4a56be984cbd.yml
@@ -17,7 +17,7 @@ given_name: Lisa
 id: ocd-person/de81d407-bc84-48e6-9796-4a56be984cbd
 image: https://www.legis.state.pa.us/images/members/200/179.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=179
 name: Lisa M. Boscola
 other_identifiers:
 - identifier: PAL000004

--- a/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
+++ b/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-4102
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1834
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1834

--- a/data/pa/legislature/Lori-A-Mizgorski-fd509949-cdd5-40d6-8d95-774f9ce1b2c2.yml
+++ b/data/pa/legislature/Lori-A-Mizgorski-fd509949-cdd5-40d6-8d95-774f9ce1b2c2.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-260-6407
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1827
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1827

--- a/data/pa/legislature/Louis-C-Schmitt-e19d3bae-7d48-4e27-af66-e9453633edca.yml
+++ b/data/pa/legislature/Louis-C-Schmitt-e19d3bae-7d48-4e27-af66-e9453633edca.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-6419
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1839
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1839

--- a/data/pa/legislature/Lynda-Schlegel-Culver-02117eb4-a7b3-4095-831b-1857910660fb.yml
+++ b/data/pa/legislature/Lynda-Schlegel-Culver-02117eb4-a7b3-4095-831b-1857910660fb.yml
@@ -15,7 +15,7 @@ given_name: Lynda
 id: ocd-person/02117eb4-a7b3-4095-831b-1857910660fb
 image: https://www.legis.state.pa.us/images/members/200/1202.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1202
 name: Lynda Schlegel Culver
 other_identifiers:
 - identifier: PAL000275

--- a/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
+++ b/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-9471
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1860
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1860

--- a/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
+++ b/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
@@ -15,7 +15,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-7686
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1868
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1868

--- a/data/pa/legislature/Marcia-M-Hahn-6eb3565c-2fc1-4b6f-97df-7159822678bc.yml
+++ b/data/pa/legislature/Marcia-M-Hahn-6eb3565c-2fc1-4b6f-97df-7159822678bc.yml
@@ -15,7 +15,7 @@ given_name: Marcia
 id: ocd-person/6eb3565c-2fc1-4b6f-97df-7159822678bc
 image: https://www.legis.state.pa.us/images/members/200/1195.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1195
 name: Marcia M. Hahn
 other_identifiers:
 - identifier: PAL000123

--- a/data/pa/legislature/Marcy-Toepel-fcb339a3-7976-4718-a67d-454cf05a265c.yml
+++ b/data/pa/legislature/Marcy-Toepel-fcb339a3-7976-4718-a67d-454cf05a265c.yml
@@ -15,7 +15,7 @@ given_name: Marcy
 id: ocd-person/fcb339a3-7976-4718-a67d-454cf05a265c
 image: https://www.legis.state.pa.us/images/members/200/1196.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1196
 name: Marcy Toepel
 other_identifiers:
 - identifier: PAL000238

--- a/data/pa/legislature/Margo-L-Davidson-79ca6d9b-0e7e-46c1-bb1e-c9848dc40413.yml
+++ b/data/pa/legislature/Margo-L-Davidson-79ca6d9b-0e7e-46c1-bb1e-c9848dc40413.yml
@@ -17,7 +17,7 @@ given_name: Margo
 id: ocd-person/79ca6d9b-0e7e-46c1-bb1e-c9848dc40413
 image: https://www.legis.state.pa.us/images/members/200/1203.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1203
 name: Margo L. Davidson
 other_identifiers:
 - identifier: PAL000264

--- a/data/pa/legislature/Maria-Collett-323c52e8-f841-4a0b-a49e-91103949fbc8.yml
+++ b/data/pa/legislature/Maria-Collett-323c52e8-f841-4a0b-a49e-91103949fbc8.yml
@@ -17,7 +17,7 @@ contact_details:
   note: District Office
   voice: 215-674-1246
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1799
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1799

--- a/data/pa/legislature/Maria-P-Donatucci-a0b28ef8-7e12-464d-9c46-f30691f73a32.yml
+++ b/data/pa/legislature/Maria-P-Donatucci-a0b28ef8-7e12-464d-9c46-f30691f73a32.yml
@@ -16,7 +16,7 @@ given_name: Maria
 id: ocd-person/a0b28ef8-7e12-464d-9c46-f30691f73a32
 image: https://www.legis.state.pa.us/images/members/200/1233.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1233
 name: Maria P. Donatucci
 other_identifiers:
 - identifier: PAL000303

--- a/data/pa/legislature/Mario-M-Scavello-a1a2fe56-b323-4f81-aa6d-6c44c2a85024.yml
+++ b/data/pa/legislature/Mario-M-Scavello-a1a2fe56-b323-4f81-aa6d-6c44c2a85024.yml
@@ -18,7 +18,7 @@ given_name: Mario
 id: ocd-person/a1a2fe56-b323-4f81-aa6d-6c44c2a85024
 image: https://www.legis.state.pa.us/images/members/200/972.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=972
 name: Mario M. Scavello
 other_identifiers:
 - identifier: PAL000219

--- a/data/pa/legislature/Mark-K-Keller-06d8c39a-1584-4009-a575-6a079a07f2d4.yml
+++ b/data/pa/legislature/Mark-K-Keller-06d8c39a-1584-4009-a575-6a079a07f2d4.yml
@@ -16,7 +16,7 @@ given_name: Mark
 id: ocd-person/06d8c39a-1584-4009-a575-6a079a07f2d4
 image: https://www.legis.state.pa.us/images/members/200/1020.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1020
 name: Mark K. Keller
 other_identifiers:
 - identifier: PAL000141

--- a/data/pa/legislature/Mark-Longietti-a2d7cc21-9e96-408f-b5d8-27228892c7bd.yml
+++ b/data/pa/legislature/Mark-Longietti-a2d7cc21-9e96-408f-b5d8-27228892c7bd.yml
@@ -14,7 +14,7 @@ given_name: Mark
 id: ocd-person/a2d7cc21-9e96-408f-b5d8-27228892c7bd
 image: https://www.legis.state.pa.us/images/members/200/1084.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1084
 name: Mark Longietti
 other_identifiers:
 - identifier: PAL000153

--- a/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
+++ b/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
@@ -15,7 +15,7 @@ given_name: Mark
 id: ocd-person/cd92c819-d5aa-4df3-ba96-2315dbdf4555
 image: https://www.legis.state.pa.us/images/members/200/1209.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1209
 name: Mark M. Gillen
 other_identifiers:
 - identifier: PAL000281

--- a/data/pa/legislature/Mark-Rozzi-06b77ec4-3497-434f-8fdc-6fee29b517e4.yml
+++ b/data/pa/legislature/Mark-Rozzi-06b77ec4-3497-434f-8fdc-6fee29b517e4.yml
@@ -16,7 +16,7 @@ given_name: Mark
 id: ocd-person/06b77ec4-3497-434f-8fdc-6fee29b517e4
 image: https://www.legis.state.pa.us/images/members/200/1647.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1647
 name: Mark Rozzi
 other_identifiers:
 - identifier: PAL000465

--- a/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
+++ b/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
@@ -15,7 +15,7 @@ given_name: Martin
 id: ocd-person/171af8ac-41e0-4047-be38-654cc912053b
 image: https://www.legis.state.pa.us/images/members/200/982.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=982
 name: Martin T. Causer
 other_identifiers:
 - identifier: PAL000073

--- a/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
+++ b/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
@@ -15,7 +15,7 @@ given_name: Martina
 id: ocd-person/93435394-e853-45f2-9e88-65399b3f9042
 image: https://www.legis.state.pa.us/images/members/200/1732.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1732
 name: Martina A. White
 other_identifiers:
 - identifier: PAL000521

--- a/data/pa/legislature/Marty-Flynn-7061c75d-7eeb-40aa-841e-8121edba5d8a.yml
+++ b/data/pa/legislature/Marty-Flynn-7061c75d-7eeb-40aa-841e-8121edba5d8a.yml
@@ -16,7 +16,7 @@ given_name: Marty
 id: ocd-person/7061c75d-7eeb-40aa-841e-8121edba5d8a
 image: https://www.legis.state.pa.us/images/members/200/1626.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1626
 name: Marty Flynn
 other_identifiers:
 - identifier: PAL000448

--- a/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
+++ b/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-9475
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1622
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1622

--- a/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
+++ b/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-8098
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1857
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1857

--- a/data/pa/legislature/Matt-Gabler-13d6a122-6dd9-4eaa-b168-e42838a1323b.yml
+++ b/data/pa/legislature/Matt-Gabler-13d6a122-6dd9-4eaa-b168-e42838a1323b.yml
@@ -15,7 +15,7 @@ given_name: Matt
 id: ocd-person/13d6a122-6dd9-4eaa-b168-e42838a1323b
 image: https://www.legis.state.pa.us/images/members/200/1170.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1170
 name: Matt Gabler
 other_identifiers:
 - identifier: PAL000109

--- a/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
+++ b/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
@@ -16,7 +16,7 @@ given_name: Matthew
 id: ocd-person/a15da78b-2475-4606-854f-7477dfc4233d
 image: https://www.legis.state.pa.us/images/members/200/1161.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1161
 name: Matthew D. Bradford
 other_identifiers:
 - identifier: PAL000063

--- a/data/pa/legislature/Matthew-D-Dowling-c0fd7df3-1131-46be-ae5e-0314c8e2ffce.yml
+++ b/data/pa/legislature/Matthew-D-Dowling-c0fd7df3-1131-46be-ae5e-0314c8e2ffce.yml
@@ -15,7 +15,7 @@ given_name: Matthew
 id: ocd-person/c0fd7df3-1131-46be-ae5e-0314c8e2ffce
 image: https://www.legis.state.pa.us/images/members/200/1746.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1746
 name: Matthew D. Dowling
 other_identifiers:
 - identifier: PAL000542

--- a/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
+++ b/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
@@ -16,7 +16,7 @@ given_name: Maureen
 id: ocd-person/8ec333cd-97c4-4f5a-92de-13bf8cbc0020
 image: https://www.legis.state.pa.us/images/members/200/1753.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1753
 name: Maureen E. Madden
 other_identifiers:
 - identifier: PAL000564

--- a/data/pa/legislature/Meghan-Schroeder-a9fe3ee7-4079-47fb-8cfc-5ce3cb7803aa.yml
+++ b/data/pa/legislature/Meghan-Schroeder-a9fe3ee7-4079-47fb-8cfc-5ce3cb7803aa.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-705-7170
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1826
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1826

--- a/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
+++ b/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-7524
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1851
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1851

--- a/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
+++ b/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
@@ -16,7 +16,7 @@ given_name: Michael
 id: ocd-person/fc1f0752-9166-4d7f-987a-ec15b8bf4048
 image: https://www.legis.state.pa.us/images/members/200/1649.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1649
 name: Michael H. Schlossberg
 other_identifiers:
 - identifier: PAL000467

--- a/data/pa/legislature/Michael-J-Driscoll-f2a2178d-048a-4a18-a1f5-6b1f6db5ff1b.yml
+++ b/data/pa/legislature/Michael-J-Driscoll-f2a2178d-048a-4a18-a1f5-6b1f6db5ff1b.yml
@@ -12,7 +12,7 @@ given_name: Michael
 id: ocd-person/f2a2178d-048a-4a18-a1f5-6b1f6db5ff1b
 image: https://www.legis.state.pa.us/images/members/200/1688.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1688
 name: Michael J. Driscoll
 other_identifiers:
 - identifier: PAL000510

--- a/data/pa/legislature/Michael-J-Puskaric-f79a1291-4cef-4295-94fc-7beb24d58307.yml
+++ b/data/pa/legislature/Michael-J-Puskaric-f79a1291-4cef-4295-94fc-7beb24d58307.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-260-6122
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1829
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1829

--- a/data/pa/legislature/Michael-P-Zabel-c8094871-b8f3-4d60-9dac-5e9bd35fa43e.yml
+++ b/data/pa/legislature/Michael-P-Zabel-c8094871-b8f3-4d60-9dac-5e9bd35fa43e.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-8099
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1854
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1854

--- a/data/pa/legislature/Michael-Peifer-13dd4c57-34f0-45dd-a2ce-6f262b6680ea.yml
+++ b/data/pa/legislature/Michael-Peifer-13dd4c57-34f0-45dd-a2ce-6f262b6680ea.yml
@@ -14,7 +14,7 @@ given_name: Michael
 id: ocd-person/13dd4c57-34f0-45dd-a2ce-6f262b6680ea
 image: https://www.legis.state.pa.us/images/members/200/1117.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1117
 name: Michael Peifer
 other_identifiers:
 - identifier: PAL000191

--- a/data/pa/legislature/Michele-Brooks-406baa79-8352-4fa4-a1fa-70cc55e34406.yml
+++ b/data/pa/legislature/Michele-Brooks-406baa79-8352-4fa4-a1fa-70cc55e34406.yml
@@ -14,7 +14,7 @@ given_name: Michele
 id: ocd-person/406baa79-8352-4fa4-a1fa-70cc55e34406
 image: https://www.legis.state.pa.us/images/members/200/1087.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1087
 name: Michele Brooks
 other_identifiers:
 - identifier: PAL000066

--- a/data/pa/legislature/Mike-Carroll--44bc84e2-8deb-43a0-9d9a-dfe4f7a39eb2.yml
+++ b/data/pa/legislature/Mike-Carroll--44bc84e2-8deb-43a0-9d9a-dfe4f7a39eb2.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-3589
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1111
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1111

--- a/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
+++ b/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-8389
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1842
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1842

--- a/data/pa/legislature/Mike-Reese-5984c1b9-4780-49eb-9394-ef8a49d5fcab.yml
+++ b/data/pa/legislature/Mike-Reese-5984c1b9-4780-49eb-9394-ef8a49d5fcab.yml
@@ -14,7 +14,7 @@ given_name: Mike
 id: ocd-person/5984c1b9-4780-49eb-9394-ef8a49d5fcab
 image: https://www.legis.state.pa.us/images/members/200/1178.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1178
 name: Mike Reese
 other_identifiers:
 - identifier: PAL000206

--- a/data/pa/legislature/Mike-Regan-ce0d90e3-b4dc-436f-a808-dc40946b6352.yml
+++ b/data/pa/legislature/Mike-Regan-ce0d90e3-b4dc-436f-a808-dc40946b6352.yml
@@ -16,7 +16,7 @@ given_name: Mike
 id: ocd-person/ce0d90e3-b4dc-436f-a808-dc40946b6352
 image: https://www.legis.state.pa.us/images/members/200/1646.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1646
 name: Mike Regan
 other_identifiers:
 - identifier: PAL000552

--- a/data/pa/legislature/Mike-Tobash-03a77af0-1587-4279-a952-771912dd888f.yml
+++ b/data/pa/legislature/Mike-Tobash-03a77af0-1587-4279-a952-771912dd888f.yml
@@ -15,7 +15,7 @@ given_name: Mike
 id: ocd-person/03a77af0-1587-4279-a952-771912dd888f
 image: https://www.legis.state.pa.us/images/members/200/1222.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1222
 name: Mike Tobash
 other_identifiers:
 - identifier: PAL000298

--- a/data/pa/legislature/Mike-Turzai-6999f0e9-d396-45aa-af34-78ebf9d81178.yml
+++ b/data/pa/legislature/Mike-Turzai-6999f0e9-d396-45aa-af34-78ebf9d81178.yml
@@ -15,7 +15,7 @@ given_name: Mike
 id: ocd-person/6999f0e9-d396-45aa-af34-78ebf9d81178
 image: https://www.legis.state.pa.us/images/members/200/289.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=289
 name: Mike Turzai
 other_identifiers:
 - identifier: PAL000240

--- a/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
+++ b/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
@@ -15,7 +15,7 @@ given_name: Mindy
 id: ocd-person/f5b2ec4d-1d69-483a-a6ec-143d50ad395b
 image: https://www.legis.state.pa.us/images/members/200/1625.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1625
 name: Mindy Fee
 other_identifiers:
 - identifier: PAL000447

--- a/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
+++ b/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
@@ -15,7 +15,7 @@ given_name: Morgan
 id: ocd-person/05326e52-202a-46cd-bbbe-cc8d01d9a44b
 image: https://www.legis.state.pa.us/images/members/200/1759.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1759
 name: Morgan Cephas
 other_identifiers:
 - identifier: PAL000561

--- a/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
+++ b/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
@@ -11,7 +11,7 @@ roles:
   start_date: '2019-01-08'
   type: lower
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1830
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1830

--- a/data/pa/legislature/Neal-P-Goodman-dc5a36a1-3ebb-474c-a875-aa7b8a5cdc3f.yml
+++ b/data/pa/legislature/Neal-P-Goodman-dc5a36a1-3ebb-474c-a875-aa7b8a5cdc3f.yml
@@ -15,7 +15,7 @@ given_name: Neal
 id: ocd-person/dc5a36a1-3ebb-474c-a875-aa7b8a5cdc3f
 image: https://www.legis.state.pa.us/images/members/200/1029.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1029
 name: Neal P. Goodman
 other_identifiers:
 - identifier: PAL000119

--- a/data/pa/legislature/P-Michael-Sturla-e214c588-7732-4df5-a44b-d1e71fce84a2.yml
+++ b/data/pa/legislature/P-Michael-Sturla-e214c588-7732-4df5-a44b-d1e71fce84a2.yml
@@ -16,7 +16,7 @@ given_name: P. Michael
 id: ocd-person/e214c588-7732-4df5-a44b-d1e71fce84a2
 image: https://www.legis.state.pa.us/images/members/200/274.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=274
 name: P. Michael Sturla
 other_identifiers:
 - identifier: PAL000232

--- a/data/pa/legislature/Pam-Iovino-836d57fc-a5ea-4218-9599-1ddb148da3ec.yml
+++ b/data/pa/legislature/Pam-Iovino-836d57fc-a5ea-4218-9599-1ddb148da3ec.yml
@@ -11,7 +11,7 @@ roles:
   start_date: '2019-04-29'
   type: upper
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1867
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1867

--- a/data/pa/legislature/Pam-Snyder--a2e4a1b2-f0fd-4c35-9e0c-bb009778792f.yml
+++ b/data/pa/legislature/Pam-Snyder--a2e4a1b2-f0fd-4c35-9e0c-bb009778792f.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-3797
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1651
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1651

--- a/data/pa/legislature/Pamela-A-DeLissio-40e6e70a-81fb-401f-9367-27b61e4f50eb.yml
+++ b/data/pa/legislature/Pamela-A-DeLissio-40e6e70a-81fb-401f-9367-27b61e4f50eb.yml
@@ -16,7 +16,7 @@ given_name: Pamela
 id: ocd-person/40e6e70a-81fb-401f-9367-27b61e4f50eb
 image: https://www.legis.state.pa.us/images/members/200/1205.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1205
 name: Pamela A. DeLissio
 other_identifiers:
 - identifier: PAL000277

--- a/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
+++ b/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
@@ -14,7 +14,7 @@ given_name: Parke
 id: ocd-person/8f7a2783-e165-4bf2-aead-113d98dd7dd2
 image: https://www.legis.state.pa.us/images/members/200/1709.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1709
 name: Parke Wentling
 other_identifiers:
 - identifier: PAL000505

--- a/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
+++ b/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
@@ -14,7 +14,7 @@ given_name: Patrick
 id: ocd-person/c4a1a8f4-cb29-4700-8235-b103fcb40279
 image: https://www.legis.state.pa.us/images/members/200/1081.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1081
 name: Patrick J. Harkins
 other_identifiers:
 - identifier: PAL000128

--- a/data/pa/legislature/Patrick-J-Stefano-14106428-709f-4018-8881-5c31ee078ff8.yml
+++ b/data/pa/legislature/Patrick-J-Stefano-14106428-709f-4018-8881-5c31ee078ff8.yml
@@ -15,7 +15,7 @@ given_name: Patrick
 id: ocd-person/14106428-709f-4018-8881-5c31ee078ff8
 image: https://www.legis.state.pa.us/images/members/200/1697.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1697
 name: Patrick J. Stefano
 other_identifiers:
 - identifier: PAL000494

--- a/data/pa/legislature/Patrick-M-Browne-dbe6be87-c8d6-4620-9266-770e59cb3c18.yml
+++ b/data/pa/legislature/Patrick-M-Browne-dbe6be87-c8d6-4620-9266-770e59cb3c18.yml
@@ -16,7 +16,7 @@ given_name: Patrick
 id: ocd-person/dbe6be87-c8d6-4620-9266-770e59cb3c18
 image: https://www.legis.state.pa.us/images/members/200/76.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=76
 name: Patrick M. Browne
 other_identifiers:
 - identifier: PAL000005

--- a/data/pa/legislature/Patty-Kim-b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29.yml
+++ b/data/pa/legislature/Patty-Kim-b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29.yml
@@ -16,7 +16,7 @@ given_name: Patty
 id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
 image: https://www.legis.state.pa.us/images/members/200/1636.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1636
 name: Patty Kim
 other_identifiers:
 - identifier: PAL000454

--- a/data/pa/legislature/Paul-Schemel-37a38b6a-84c8-427b-bc6f-2256fffe9062.yml
+++ b/data/pa/legislature/Paul-Schemel-37a38b6a-84c8-427b-bc6f-2256fffe9062.yml
@@ -15,7 +15,7 @@ given_name: Paul
 id: ocd-person/37a38b6a-84c8-427b-bc6f-2256fffe9062
 image: https://www.legis.state.pa.us/images/members/200/1705.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1705
 name: Paul Schemel
 other_identifiers:
 - identifier: PAL000493

--- a/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
+++ b/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
@@ -14,7 +14,7 @@ given_name: Perry
 id: ocd-person/e2bc8bc4-33ab-46dd-8f67-da218949efb6
 image: https://www.legis.state.pa.us/images/members/200/1743.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1743
 name: Perry S. Warren
 other_identifiers:
 - identifier: PAL000555

--- a/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
+++ b/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
@@ -15,7 +15,7 @@ given_name: Peter
 id: ocd-person/63936c68-ec65-40a9-9a68-0d956939404a
 image: https://www.legis.state.pa.us/images/members/200/1706.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1706
 name: Peter Schweyer
 other_identifiers:
 - identifier: PAL000497

--- a/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
+++ b/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
@@ -15,7 +15,7 @@ given_name: R.
 id: ocd-person/b29f8685-d054-4c6c-a8ad-d64f80bd840f
 image: https://www.legis.state.pa.us/images/members/200/1634.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1634
 name: R. Lee James
 other_identifiers:
 - identifier: PAL000453

--- a/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
+++ b/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
@@ -15,7 +15,7 @@ given_name: Rich
 id: ocd-person/ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc
 image: https://www.legis.state.pa.us/images/members/200/1691.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1691
 name: Rich Irvin
 other_identifiers:
 - identifier: PAL000508

--- a/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
+++ b/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
@@ -15,7 +15,7 @@ given_name: Rob
 id: ocd-person/17e1e676-8e83-4883-8cf5-4c8ddcce076e
 image: https://www.legis.state.pa.us/images/members/200/1022.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1022
 name: Rob W. Kauffman
 other_identifiers:
 - identifier: PAL000140

--- a/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
+++ b/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-4358
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1822
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1822

--- a/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
+++ b/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
@@ -16,7 +16,7 @@ given_name: Robert
 id: ocd-person/a7b2e50f-90a6-4f35-b1fb-c33406dc4277
 image: https://www.legis.state.pa.us/images/members/200/1173.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1173
 name: Robert F. Matzie
 other_identifiers:
 - identifier: PAL000162

--- a/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
+++ b/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
@@ -14,7 +14,7 @@ given_name: Robert
 id: ocd-person/13bfe11c-06e2-4a1d-844d-d195ef18dc06
 image: https://www.legis.state.pa.us/images/members/200/136.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=136
 name: Robert Freeman
 other_identifiers:
 - identifier: PAL000107

--- a/data/pa/legislature/Robert-M-Tomlinson-b6147932-2059-4dc5-8b00-bd85a847a78b.yml
+++ b/data/pa/legislature/Robert-M-Tomlinson-b6147932-2059-4dc5-8b00-bd85a847a78b.yml
@@ -16,7 +16,7 @@ given_name: Robert
 id: ocd-person/b6147932-2059-4dc5-8b00-bd85a847a78b
 image: https://www.legis.state.pa.us/images/members/200/151.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=151
 name: Robert M. Tomlinson
 other_identifiers:
 - identifier: PAL000040

--- a/data/pa/legislature/Rosemary-M-Brown-3e2840e6-f904-43be-911e-235b906458a5.yml
+++ b/data/pa/legislature/Rosemary-M-Brown-3e2840e6-f904-43be-911e-235b906458a5.yml
@@ -15,7 +15,7 @@ given_name: Rosemary
 id: ocd-person/3e2840e6-f904-43be-911e-235b906458a5
 image: https://www.legis.state.pa.us/images/members/200/1200.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1200
 name: Rosemary M. Brown
 other_identifiers:
 - identifier: PAL000273

--- a/data/pa/legislature/Rosita-C-Youngblood-176f8196-5064-410e-a4c9-d151f6000f40.yml
+++ b/data/pa/legislature/Rosita-C-Youngblood-176f8196-5064-410e-a4c9-d151f6000f40.yml
@@ -16,7 +16,7 @@ given_name: Rosita
 id: ocd-person/176f8196-5064-410e-a4c9-d151f6000f40
 image: https://www.legis.state.pa.us/images/members/200/264.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=264
 name: Rosita C. Youngblood
 other_identifiers:
 - identifier: PAL000251

--- a/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
+++ b/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
@@ -15,7 +15,7 @@ given_name: Russ
 id: ocd-person/5348e28d-bbbe-493f-8f77-a509cb315abe
 image: https://www.legis.state.pa.us/images/members/200/1686.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1686
 name: Russ Diamond
 other_identifiers:
 - identifier: PAL000482

--- a/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
+++ b/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
@@ -16,7 +16,7 @@ given_name: Ryan
 id: ocd-person/32370423-acb8-4a8e-8336-67af5ed32bb9
 image: https://www.legis.state.pa.us/images/members/200/1619.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1619
 name: Ryan A. Bizzarro
 other_identifiers:
 - identifier: PAL000441

--- a/data/pa/legislature/Ryan-E-Mackenzie-7c9d9526-f375-446d-afd5-e2601c585f9a.yml
+++ b/data/pa/legislature/Ryan-E-Mackenzie-7c9d9526-f375-446d-afd5-e2601c585f9a.yml
@@ -16,7 +16,7 @@ given_name: Ryan
 id: ocd-person/7c9d9526-f375-446d-afd5-e2601c585f9a
 image: https://www.legis.state.pa.us/images/members/200/1614.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1614
 name: Ryan E. Mackenzie
 other_identifiers:
 - identifier: PAL000376

--- a/data/pa/legislature/Ryan-P-Aument-84be9cf4-8e9f-4e9c-91f0-f371efba7895.yml
+++ b/data/pa/legislature/Ryan-P-Aument-84be9cf4-8e9f-4e9c-91f0-f371efba7895.yml
@@ -16,7 +16,7 @@ given_name: Ryan
 id: ocd-person/84be9cf4-8e9f-4e9c-91f0-f371efba7895
 image: https://www.legis.state.pa.us/images/members/200/1198.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1198
 name: Ryan P. Aument
 other_identifiers:
 - identifier: PAL000270

--- a/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
+++ b/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
@@ -16,7 +16,7 @@ given_name: Ryan
 id: ocd-person/0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f
 image: https://www.legis.state.pa.us/images/members/200/1708.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1708
 name: Ryan Warner
 other_identifiers:
 - identifier: PAL000487

--- a/data/pa/legislature/Sara-Innamorato-360e9298-ab15-4ea9-a647-3d70828021b8.yml
+++ b/data/pa/legislature/Sara-Innamorato-360e9298-ab15-4ea9-a647-3d70828021b8.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-9114
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1824
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1824

--- a/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
+++ b/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
@@ -15,7 +15,7 @@ given_name: Scott
 id: ocd-person/97b012cd-5cd7-4039-a9ae-fed936aabe37
 image: https://www.legis.state.pa.us/images/members/200/1096.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1096
 name: Scott Conklin
 other_identifiers:
 - identifier: PAL000077

--- a/data/pa/legislature/Scott-E-Hutchinson-5d3e2203-b11c-4471-8f35-5106c30263ec.yml
+++ b/data/pa/legislature/Scott-E-Hutchinson-5d3e2203-b11c-4471-8f35-5106c30263ec.yml
@@ -15,7 +15,7 @@ given_name: Scott
 id: ocd-person/5d3e2203-b11c-4471-8f35-5106c30263ec
 image: https://www.legis.state.pa.us/images/members/200/1629.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1629
 name: Scott E. Hutchinson
 other_identifiers:
 - identifier: PAL000137

--- a/data/pa/legislature/Scott-Martin-c2fcd2dc-22f8-4ec2-b70a-439bc6d60802.yml
+++ b/data/pa/legislature/Scott-Martin-c2fcd2dc-22f8-4ec2-b70a-439bc6d60802.yml
@@ -15,7 +15,7 @@ given_name: Scott
 id: ocd-person/c2fcd2dc-22f8-4ec2-b70a-439bc6d60802
 image: https://www.legis.state.pa.us/images/members/200/1763.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1763
 name: Scott Martin
 other_identifiers:
 - identifier: PAL000556

--- a/data/pa/legislature/Seth-M-Grove-f10a1cb3-df7f-432c-8d33-e6d3293b7f88.yml
+++ b/data/pa/legislature/Seth-M-Grove-f10a1cb3-df7f-432c-8d33-e6d3293b7f88.yml
@@ -16,7 +16,7 @@ given_name: Seth
 id: ocd-person/f10a1cb3-df7f-432c-8d33-e6d3293b7f88
 image: https://www.legis.state.pa.us/images/members/200/1171.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1171
 name: Seth M. Grove
 other_identifiers:
 - identifier: PAL000121

--- a/data/pa/legislature/Sharif-Street-b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a.yml
+++ b/data/pa/legislature/Sharif-Street-b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a.yml
@@ -18,7 +18,7 @@ given_name: Sharif
 id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
 image: https://www.legis.state.pa.us/images/members/200/1767.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1767
 name: Sharif Street
 other_identifiers:
 - identifier: PAL000545

--- a/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
+++ b/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
@@ -15,7 +15,7 @@ given_name: Sheryl
 id: ocd-person/9e4954ab-971c-4620-9f9d-ebb68311e3f1
 image: https://www.legis.state.pa.us/images/members/200/1167.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1167
 name: Sheryl M. Delozier
 other_identifiers:
 - identifier: PAL000091

--- a/data/pa/legislature/Stan-Saylor-7eb6b713-88cf-4ac0-bfeb-538ae3fdef90.yml
+++ b/data/pa/legislature/Stan-Saylor-7eb6b713-88cf-4ac0-bfeb-538ae3fdef90.yml
@@ -16,7 +16,7 @@ given_name: Stan
 id: ocd-person/7eb6b713-88cf-4ac0-bfeb-538ae3fdef90
 image: https://www.legis.state.pa.us/images/members/200/200.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=200
 name: Stan Saylor
 other_identifiers:
 - identifier: PAL000218

--- a/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
+++ b/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-9925
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1838
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1838

--- a/data/pa/legislature/Stephen-Barrar-c2d85063-a729-4284-9e04-ffe04a5e2ce0.yml
+++ b/data/pa/legislature/Stephen-Barrar-c2d85063-a729-4284-9e04-ffe04a5e2ce0.yml
@@ -15,7 +15,7 @@ given_name: Stephen
 id: ocd-person/c2d85063-a729-4284-9e04-ffe04a5e2ce0
 image: https://www.legis.state.pa.us/images/members/200/127.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=127
 name: Stephen Barrar
 other_identifiers:
 - identifier: PAL000054

--- a/data/pa/legislature/Stephen-Kinsey-c4d4f765-8eeb-4b55-9ad4-c130e6afa697.yml
+++ b/data/pa/legislature/Stephen-Kinsey-c4d4f765-8eeb-4b55-9ad4-c130e6afa697.yml
@@ -16,7 +16,7 @@ given_name: Stephen
 id: ocd-person/c4d4f765-8eeb-4b55-9ad4-c130e6afa697
 image: https://www.legis.state.pa.us/images/members/200/1637.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1637
 name: Stephen Kinsey
 other_identifiers:
 - identifier: PAL000455

--- a/data/pa/legislature/Stephen-McCarter-46d46e2f-4172-4c00-b28e-6a90028d53ef.yml
+++ b/data/pa/legislature/Stephen-McCarter-46d46e2f-4172-4c00-b28e-6a90028d53ef.yml
@@ -16,7 +16,7 @@ given_name: Stephen
 id: ocd-person/46d46e2f-4172-4c00-b28e-6a90028d53ef
 image: https://www.legis.state.pa.us/images/members/200/1639.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1639
 name: Stephen McCarter
 other_identifiers:
 - identifier: PAL000457

--- a/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
+++ b/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
@@ -14,7 +14,7 @@ given_name: Steve
 id: ocd-person/34472dfb-dae9-4db4-8901-088457d74904
 image: https://www.legis.state.pa.us/images/members/200/80.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=80
 name: Steve Samuelson
 other_identifiers:
 - identifier: PAL000215

--- a/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
+++ b/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
@@ -15,7 +15,7 @@ given_name: Steven
 id: ocd-person/4463dd94-6a9d-41bd-830f-0d03e192f896
 image: https://www.legis.state.pa.us/images/members/200/1642.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1642
 name: Steven C. Mentzer
 other_identifiers:
 - identifier: PAL000460

--- a/data/pa/legislature/Steven-J-Santarsiero-91f290d0-3405-4091-bb16-822a97f45af5.yml
+++ b/data/pa/legislature/Steven-J-Santarsiero-91f290d0-3405-4091-bb16-822a97f45af5.yml
@@ -16,7 +16,7 @@ contact_details:
   note: District Office
   voice: 215-497-9490
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1179
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1179

--- a/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
+++ b/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-8515
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1832
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1832

--- a/data/pa/legislature/Summer-Lee-67abfeb8-5be8-4377-837c-6af5bd4c0f93.yml
+++ b/data/pa/legislature/Summer-Lee-67abfeb8-5be8-4377-837c-6af5bd4c0f93.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-1914
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1828
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1828

--- a/data/pa/legislature/Susan-C-Helm-a1eefae5-717a-497a-8e74-565d2f47bdf6.yml
+++ b/data/pa/legislature/Susan-C-Helm-a1eefae5-717a-497a-8e74-565d2f47bdf6.yml
@@ -16,7 +16,7 @@ given_name: Susan
 id: ocd-person/a1eefae5-717a-497a-8e74-565d2f47bdf6
 image: https://www.legis.state.pa.us/images/members/200/1107.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1107
 name: Susan C. Helm
 other_identifiers:
 - identifier: PAL000131

--- a/data/pa/legislature/Tarah-Toohil-c78eab44-932e-4646-bcbc-fdd867660f91.yml
+++ b/data/pa/legislature/Tarah-Toohil-c78eab44-932e-4646-bcbc-fdd867660f91.yml
@@ -16,7 +16,7 @@ given_name: Tarah
 id: ocd-person/c78eab44-932e-4646-bcbc-fdd867660f91
 image: https://www.legis.state.pa.us/images/members/200/1223.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1223
 name: Tarah Toohil
 other_identifiers:
 - identifier: PAL000299

--- a/data/pa/legislature/Thomas-H-Killion-4b59a2bf-aa0a-4498-9c64-06ebc1e4a968.yml
+++ b/data/pa/legislature/Thomas-H-Killion-4b59a2bf-aa0a-4498-9c64-06ebc1e4a968.yml
@@ -14,7 +14,7 @@ given_name: Thomas
 id: ocd-person/4b59a2bf-aa0a-4498-9c64-06ebc1e4a968
 image: https://www.legis.state.pa.us/images/members/200/1011.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1011
 name: Thomas H. Killion
 other_identifiers:
 - identifier: PAL000144

--- a/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
+++ b/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
@@ -14,7 +14,7 @@ given_name: Thomas
 id: ocd-person/bda0ab75-036f-49bd-9dd5-cfc9c55eec02
 image: https://www.legis.state.pa.us/images/members/200/1751.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1751
 name: Thomas L. Mehaffie
 other_identifiers:
 - identifier: PAL000546

--- a/data/pa/legislature/Thomas-P-Murt--6c1c14f4-c12d-4aa4-b25b-e406e8ebda25.yml
+++ b/data/pa/legislature/Thomas-P-Murt--6c1c14f4-c12d-4aa4-b25b-e406e8ebda25.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-6886
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1124
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1124

--- a/data/pa/legislature/Thomas-R-Caltagirone-3f7f9dbf-299a-440f-9404-39d821d6d3ad.yml
+++ b/data/pa/legislature/Thomas-R-Caltagirone-3f7f9dbf-299a-440f-9404-39d821d6d3ad.yml
@@ -16,7 +16,7 @@ given_name: Thomas
 id: ocd-person/3f7f9dbf-299a-440f-9404-39d821d6d3ad
 image: https://www.legis.state.pa.us/images/members/200/72.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=72
 name: Thomas R. Caltagirone
 other_identifiers:
 - identifier: PAL000070

--- a/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
+++ b/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
@@ -16,7 +16,7 @@ given_name: Tim
 id: ocd-person/5c752a95-ba5d-4f1f-81aa-6cb1c7875581
 image: https://www.legis.state.pa.us/images/members/200/1159.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1159
 name: Tim Briggs
 other_identifiers:
 - identifier: PAL000065

--- a/data/pa/legislature/Tim-Hennessey-a55b1267-167e-42b1-be35-e605d5c2d222.yml
+++ b/data/pa/legislature/Tim-Hennessey-a55b1267-167e-42b1-be35-e605d5c2d222.yml
@@ -14,7 +14,7 @@ given_name: Tim
 id: ocd-person/a55b1267-167e-42b1-be35-e605d5c2d222
 image: https://www.legis.state.pa.us/images/members/200/41.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=41
 name: Tim Hennessey
 other_identifiers:
 - identifier: PAL000132

--- a/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
+++ b/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
@@ -12,7 +12,7 @@ given_name: Timothy
 id: ocd-person/2c5551d6-71a8-4099-b1a4-a30721320869
 image: https://www.legis.state.pa.us/images/members/200/1797.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1797
 name: Timothy J. O'Neal
 other_identifiers:
 - identifier: PAL000573

--- a/data/pa/legislature/Timothy-P-Kearney-f9f2479f-0c37-47d1-a4eb-666146e2856f.yml
+++ b/data/pa/legislature/Timothy-P-Kearney-f9f2479f-0c37-47d1-a4eb-666146e2856f.yml
@@ -14,7 +14,7 @@ contact_details:
   note: District Office
   voice: 610-352-3409
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1800
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1800

--- a/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
+++ b/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
@@ -13,7 +13,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-6438
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1877
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1877

--- a/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
+++ b/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
@@ -16,7 +16,7 @@ given_name: Tina
 id: ocd-person/f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7
 image: https://www.legis.state.pa.us/images/members/200/1204.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1204
 name: Tina M. Davis
 other_identifiers:
 - identifier: PAL000276

--- a/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
+++ b/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
@@ -15,7 +15,7 @@ given_name: Tina
 id: ocd-person/8e174923-d514-4240-b6cd-cbb7927410ba
 image: https://www.legis.state.pa.us/images/members/200/97.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=97
 name: Tina Pickett
 other_identifiers:
 - identifier: PAL000197

--- a/data/pa/legislature/Todd-Stephens-5cc97f46-ae76-42b2-9f86-3d6b8c862f11.yml
+++ b/data/pa/legislature/Todd-Stephens-5cc97f46-ae76-42b2-9f86-3d6b8c862f11.yml
@@ -15,7 +15,7 @@ given_name: Todd
 id: ocd-person/5cc97f46-ae76-42b2-9f86-3d6b8c862f11
 image: https://www.legis.state.pa.us/images/members/200/1221.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1221
 name: Todd Stephens
 other_identifiers:
 - identifier: PAL000297

--- a/data/pa/legislature/Tommy-Sankey-eabb3b38-afcc-4a15-a748-f232f3994ba9.yml
+++ b/data/pa/legislature/Tommy-Sankey-eabb3b38-afcc-4a15-a748-f232f3994ba9.yml
@@ -15,7 +15,7 @@ given_name: Tommy
 id: ocd-person/eabb3b38-afcc-4a15-a748-f232f3994ba9
 image: https://www.legis.state.pa.us/images/members/200/1648.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1648
 name: Tommy Sankey
 other_identifiers:
 - identifier: PAL000466

--- a/data/pa/legislature/Torren-C-Ecker-6f375652-451b-4c39-9b29-6ba5a07073c6.yml
+++ b/data/pa/legislature/Torren-C-Ecker-6f375652-451b-4c39-9b29-6ba5a07073c6.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-783-8875
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1862
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1862

--- a/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
+++ b/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
@@ -17,7 +17,7 @@ contact_details:
   note: Capitol Office
   voice: 717-787-6651
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1831
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1831

--- a/data/pa/legislature/Vincent-J-Hughes-53a598e0-3595-4b19-8f65-4a538bdc7a74.yml
+++ b/data/pa/legislature/Vincent-J-Hughes-53a598e0-3595-4b19-8f65-4a538bdc7a74.yml
@@ -18,7 +18,7 @@ given_name: Vincent
 id: ocd-person/53a598e0-3595-4b19-8f65-4a538bdc7a74
 image: https://www.legis.state.pa.us/images/members/200/152.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=152
 name: Vincent J. Hughes
 other_identifiers:
 - identifier: PAL000019

--- a/data/pa/legislature/Wayne-D-Fontana-b93e4f38-764f-4e95-bd51-4d40dba0aaa4.yml
+++ b/data/pa/legislature/Wayne-D-Fontana-b93e4f38-764f-4e95-bd51-4d40dba0aaa4.yml
@@ -16,7 +16,7 @@ given_name: Wayne
 id: ocd-person/b93e4f38-764f-4e95-bd51-4d40dba0aaa4
 image: https://www.legis.state.pa.us/images/members/200/1041.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1041
 name: Wayne D. Fontana
 other_identifiers:
 - identifier: PAL000016

--- a/data/pa/legislature/Wayne-Langerholc-7b3a6244-335b-4407-957d-b7d6b6ab1d97.yml
+++ b/data/pa/legislature/Wayne-Langerholc-7b3a6244-335b-4407-957d-b7d6b6ab1d97.yml
@@ -18,7 +18,7 @@ given_name: Wayne
 id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
 image: https://www.legis.state.pa.us/images/members/200/1764.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/senators_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/Senate_bio.cfm?id=1764
 name: Wayne Langerholc
 other_identifiers:
 - identifier: PAL000544

--- a/data/pa/legislature/Wendi-Thomas-8d5a3aa9-d48c-4aa8-8b47-3971dfe2a95f.yml
+++ b/data/pa/legislature/Wendi-Thomas-8d5a3aa9-d48c-4aa8-8b47-3971dfe2a95f.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-9926
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1859
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1859

--- a/data/pa/legislature/Wendy-Ullman-3cbd6f30-7809-4d66-941e-af1632a3346c.yml
+++ b/data/pa/legislature/Wendy-Ullman-3cbd6f30-7809-4d66-941e-af1632a3346c.yml
@@ -16,7 +16,7 @@ contact_details:
   note: Capitol Office
   voice: 717-772-8060
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1845
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1845

--- a/data/pa/legislature/William-C-Kortz-aff134c3-074e-4788-945c-def9fdf7670e.yml
+++ b/data/pa/legislature/William-C-Kortz-aff134c3-074e-4788-945c-def9fdf7670e.yml
@@ -16,7 +16,7 @@ given_name: William
 id: ocd-person/aff134c3-074e-4788-945c-def9fdf7670e
 image: https://www.legis.state.pa.us/images/members/200/1091.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1091
 name: William C. Kortz
 other_identifiers:
 - identifier: PAL000147

--- a/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
+++ b/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
@@ -15,7 +15,7 @@ given_name: Zachary
 id: ocd-person/c3b27985-614c-434d-b3c0-3e032fad4d6c
 image: https://www.legis.state.pa.us/images/members/200/1758.jpg
 links:
-- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
+- url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1758
 name: Zachary Mako
 other_identifiers:
 - identifier: PAL000548


### PR DESCRIPTION
The existing links for PA legislators went to the generic page for all House/Senate members, and not the specific page for each member. Each member's link will now be for their specific page and not the generic page.