### PR TITLE
Update dates to make lint pass

### DIFF
--- a/data/al/municipalities/Frank-V-Bracato-4196f1a1-282a-4bdb-953d-cb1de7ed6271.yml
+++ b/data/al/municipalities/Frank-V-Bracato-4196f1a1-282a-4bdb-953d-cb1de7ed6271.yml
@@ -3,7 +3,7 @@ name: Frank V. Bracato
 given_name: Frank V.
 family_name: Bracato
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:al/place:hoover/government
   type: mayor
 contact_details:

--- a/data/al/municipalities/Paul-Finley-be7626e6-7def-44ab-bed8-1b95db427439.yml
+++ b/data/al/municipalities/Paul-Finley-be7626e6-7def-44ab-bed8-1b95db427439.yml
@@ -3,7 +3,7 @@ name: Paul Finley
 given_name: Paul
 family_name: Finley
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:al/place:madison/government
   type: mayor
 contact_details:

--- a/data/al/municipalities/Tommy-Battle-31e8aca6-31e9-469e-b8b2-c75bbe456993.yml
+++ b/data/al/municipalities/Tommy-Battle-31e8aca6-31e9-469e-b8b2-c75bbe456993.yml
@@ -3,7 +3,7 @@ name: Tommy Battle
 given_name: Tommy
 family_name: Battle
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:al/place:huntsville/government
   type: mayor
 contact_details:

--- a/data/ar/municipalities/Bart-Castleberry-c6b6a980-098d-455a-82f3-5f982416428e.yml
+++ b/data/ar/municipalities/Bart-Castleberry-c6b6a980-098d-455a-82f3-5f982416428e.yml
@@ -3,7 +3,7 @@ name: Bart Castleberry
 given_name: Bart
 family_name: Castleberry
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ar/place:conway/government
   type: mayor
 contact_details:

--- a/data/ar/municipalities/Doug-Sprouse-f5203d52-9a31-4e26-b155-8bf773096083.yml
+++ b/data/ar/municipalities/Doug-Sprouse-f5203d52-9a31-4e26-b155-8bf773096083.yml
@@ -3,7 +3,7 @@ name: Doug Sprouse
 given_name: Doug
 family_name: Sprouse
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ar/place:springdale/government
   type: mayor
 contact_details:

--- a/data/ar/municipalities/Greg-Hines-913ca0fb-8255-4973-9b96-f65abdbe8a4a.yml
+++ b/data/ar/municipalities/Greg-Hines-913ca0fb-8255-4973-9b96-f65abdbe8a4a.yml
@@ -3,7 +3,7 @@ name: Greg Hines
 given_name: Greg
 family_name: Hines
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ar/place:rogers/government
   type: mayor
 contact_details:

--- a/data/ar/municipalities/Lioneld-Jordan-3e34b4e9-fe1b-494f-b121-a39c004dfdf6.yml
+++ b/data/ar/municipalities/Lioneld-Jordan-3e34b4e9-fe1b-494f-b121-a39c004dfdf6.yml
@@ -3,7 +3,7 @@ name: Lioneld Jordan
 given_name: Lioneld
 family_name: Jordan
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ar/place:fayetteville/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Coral-Evans-355d5767-e6d5-4128-8268-152b74cf2417.yml
+++ b/data/az/municipalities/Coral-Evans-355d5767-e6d5-4128-8268-152b74cf2417.yml
@@ -3,7 +3,7 @@ name: Coral Evans
 given_name: Coral
 family_name: Evans
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:flagstaff/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Jackie-A-Meck-28d6a529-941e-494c-822b-66304b713abb.yml
+++ b/data/az/municipalities/Jackie-A-Meck-28d6a529-941e-494c-822b-66304b713abb.yml
@@ -3,7 +3,7 @@ name: Jackie A. Meck
 given_name: Jackie A.
 family_name: Meck
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:buckeye/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Jenn-Daniels-97888dc7-2dca-41da-b2f7-2555a7b08111.yml
+++ b/data/az/municipalities/Jenn-Daniels-97888dc7-2dca-41da-b2f7-2555a7b08111.yml
@@ -3,7 +3,7 @@ name: Jenn Daniels
 given_name: Jenn
 family_name: Daniels
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:gilbert/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Jerry-Weiers-5d724fe6-d337-4eae-820a-37ce92dd363c.yml
+++ b/data/az/municipalities/Jerry-Weiers-5d724fe6-d337-4eae-820a-37ce92dd363c.yml
@@ -3,7 +3,7 @@ name: Jerry Weiers
 given_name: Jerry
 family_name: Weiers
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:glendale/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/John-Giles-5c1097a1-137c-422f-9906-99b9c9503687.yml
+++ b/data/az/municipalities/John-Giles-5c1097a1-137c-422f-9906-99b9c9503687.yml
@@ -3,7 +3,7 @@ name: John Giles
 given_name: John
 family_name: Giles
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:mesa/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Kate-Gallego-c2f0b9d9-5063-41a0-925f-d708470c281a.yml
+++ b/data/az/municipalities/Kate-Gallego-c2f0b9d9-5063-41a0-925f-d708470c281a.yml
@@ -3,7 +3,7 @@ name: Kate Gallego
 given_name: Kate
 family_name: Gallego
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:phoenix/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Kenn-Weise-6ad30dae-169d-47b4-a55b-864d7da80e64.yml
+++ b/data/az/municipalities/Kenn-Weise-6ad30dae-169d-47b4-a55b-864d7da80e64.yml
@@ -3,7 +3,7 @@ name: Kenn Weise
 given_name: Kenn
 family_name: Weise
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:avondale/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/Skip-Hall-c8749066-415a-4840-bb17-96042d99703f.yml
+++ b/data/az/municipalities/Skip-Hall-c8749066-415a-4840-bb17-96042d99703f.yml
@@ -3,7 +3,7 @@ name: Skip Hall
 given_name: Skip
 family_name: Hall
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:surprise/government
   type: mayor
 contact_details:

--- a/data/az/municipalities/WJ-Jim-Lane-4525aa85-69bc-4dfb-8665-6ff821082e49.yml
+++ b/data/az/municipalities/WJ-Jim-Lane-4525aa85-69bc-4dfb-8665-6ff821082e49.yml
@@ -3,7 +3,7 @@ name: W.J. "Jim" Lane
 given_name: W.J. "Jim"
 family_name: Lane
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:az/place:scottsdale/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Adrian-Fine-fa56b40f-5b69-4b90-a5f8-e0f2edb5ba2e.yml
+++ b/data/ca/municipalities/Adrian-Fine-fa56b40f-5b69-4b90-a5f8-e0f2edb5ba2e.yml
@@ -3,7 +3,7 @@ name: Adrian Fine
 given_name: Adrian
 family_name: Fine
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:palo_alto/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Albert-Robles-c4294ca0-11cc-4153-8562-d5cc3f3365c4.yml
+++ b/data/ca/municipalities/Albert-Robles-c4294ca0-11cc-4153-8562-d5cc3f3365c4.yml
@@ -3,7 +3,7 @@ name: Albert Robles
 given_name: Albert
 family_name: Robles
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:carson/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Alex-Vargas-da110bd6-314f-46f2-afa9-14458a029889.yml
+++ b/data/ca/municipalities/Alex-Vargas-da110bd6-314f-46f2-afa9-14458a029889.yml
@@ -3,7 +3,7 @@ name: Alex Vargas
 given_name: Alex
 family_name: Vargas
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:hawthorne/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Alice-M-Patino-9c39fc64-2e95-4d61-9ab9-eaa765bc46bd.yml
+++ b/data/ca/municipalities/Alice-M-Patino-9c39fc64-2e95-4d61-9ab9-eaa765bc46bd.yml
@@ -3,7 +3,7 @@ name: Alice M. Patino
 given_name: Alice M.
 family_name: Patino
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:santa_maria/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Andre-Quintero-050cfd79-f1e6-4ab4-8247-9d73d2644dcd.yml
+++ b/data/ca/municipalities/Andre-Quintero-050cfd79-f1e6-4ab4-8247-9d73d2644dcd.yml
@@ -3,7 +3,7 @@ name: Andre Quintero
 given_name: Andre
 family_name: Quintero
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:el_monte/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Bill-Zimmerman-bb6e1e33-cab7-4a3c-949e-a5ded8b3dce4.yml
+++ b/data/ca/municipalities/Bill-Zimmerman-bb6e1e33-cab7-4a3c-949e-a5ded8b3dce4.yml
@@ -3,7 +3,7 @@ name: Bill Zimmerman
 given_name: Bill
 family_name: Zimmerman
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:menifee/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Bob-Sampayan-c2b76e53-7687-4df9-97b8-1a5f9333fde5.yml
+++ b/data/ca/municipalities/Bob-Sampayan-c2b76e53-7687-4df9-97b8-1a5f9333fde5.yml
@@ -3,7 +3,7 @@ name: Bob Sampayan
 given_name: Bob
 family_name: Sampayan
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:vallejo/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Cameron-Smyth-882872bc-9b00-4bc0-9046-c8e5c8ad7488.yml
+++ b/data/ca/municipalities/Cameron-Smyth-882872bc-9b00-4bc0-9046-c8e5c8ad7488.yml
@@ -3,7 +3,7 @@ name: Cameron Smyth
 given_name: Cameron
 family_name: Smyth
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:santa_clarita/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Carol-Dutra-Vernaci-40737603-029c-4a1b-a295-c7a73450b4c4.yml
+++ b/data/ca/municipalities/Carol-Dutra-Vernaci-40737603-029c-4a1b-a295-c7a73450b4c4.yml
@@ -3,7 +3,7 @@ name: Carol Dutra-Vernaci
 given_name: Carol
 family_name: Dutra-Vernaci
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:union_city/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Catherine-S-Blakespear-3ebe9403-f6f4-471e-90f3-f50863da8aef.yml
+++ b/data/ca/municipalities/Catherine-S-Blakespear-3ebe9403-f6f4-471e-90f3-f50863da8aef.yml
@@ -3,7 +3,7 @@ name: Catherine S. Blakespear
 given_name: Catherine S.
 family_name: Blakespear
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:encinitas/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Christina-L-Shea-de9479ee-68db-48d1-a29e-e1e1bbe6d3dd.yml
+++ b/data/ca/municipalities/Christina-L-Shea-de9479ee-68db-48d1-a29e-e1e1bbe6d3dd.yml
@@ -3,7 +3,7 @@ name: Christina L. Shea
 given_name: Christina L.
 family_name: Shea
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:irvine/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Dan-Bane-fe1caac7-76e7-4e7d-92e0-b236f13b0ff2.yml
+++ b/data/ca/municipalities/Dan-Bane-fe1caac7-76e7-4e7d-92e0-b236f13b0ff2.yml
@@ -3,7 +3,7 @@ name: Dan Bane
 given_name: Dan
 family_name: Bane
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_clemente/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/David-Haubert-347f30d8-1bbf-4427-b118-a2866e554b81.yml
+++ b/data/ca/municipalities/David-Haubert-347f30d8-1bbf-4427-b118-a2866e554b81.yml
@@ -3,7 +3,7 @@ name: David Haubert
 given_name: David
 family_name: Haubert
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:dublin/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Debbie-Stone-ddee5b7c-b863-44d4-a49a-c2c0b08137c1.yml
+++ b/data/ca/municipalities/Debbie-Stone-ddee5b7c-b863-44d4-a49a-c2c0b08137c1.yml
@@ -3,7 +3,7 @@ name: Debbie Stone
 given_name: Debbie
 family_name: Stone
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:upland/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Deborah-Robertson-6aa6bb44-60fa-4e8b-845f-155c714c9221.yml
+++ b/data/ca/municipalities/Deborah-Robertson-6aa6bb44-60fa-4e8b-845f-155c714c9221.yml
@@ -3,7 +3,7 @@ name: Deborah Robertson
 given_name: Deborah
 family_name: Robertson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:rialto/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Eunice-M-Ulloa-8c89f809-f477-4fe2-af13-fbf8f7889863.yml
+++ b/data/ca/municipalities/Eunice-M-Ulloa-8c89f809-f477-4fe2-af13-fbf8f7889863.yml
@@ -3,7 +3,7 @@ name: Eunice M. Ulloa
 given_name: Eunice M.
 family_name: Ulloa
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:chino/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Gary-O-Phillips-6a840748-2c03-4a6b-bba3-fcd26f85cc79.yml
+++ b/data/ca/municipalities/Gary-O-Phillips-6a840748-2c03-4a6b-bba3-fcd26f85cc79.yml
@@ -3,7 +3,7 @@ name: Gary O. Phillips
 given_name: Gary O.
 family_name: Phillips
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_rafael/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Gran-Eriksson-a55c574c-d49c-48ef-a27e-2a377a8a86f8.yml
+++ b/data/ca/municipalities/Gran-Eriksson-a55c574c-d49c-48ef-a27e-2a377a8a86f8.yml
@@ -3,7 +3,7 @@ name: "G\xF6ran Eriksson"
 given_name: "G\xF6ran"
 family_name: Eriksson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:culver_city/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Gustavo-V-Camacho-45c53ad5-23cb-48a6-aa53-514d581af870.yml
+++ b/data/ca/municipalities/Gustavo-V-Camacho-45c53ad5-23cb-48a6-aa53-514d581af870.yml
@@ -3,7 +3,7 @@ name: Gustavo V. Camacho
 given_name: Gustavo V.
 family_name: Camacho
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:pico_rivera/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Heidi-Harmon-3d7703c6-e657-4d05-b7e3-5e1e25b03821.yml
+++ b/data/ca/municipalities/Heidi-Harmon-3d7703c6-e657-4d05-b7e3-5e1e25b03821.yml
@@ -3,7 +3,7 @@ name: Heidi Harmon
 given_name: Heidi
 family_name: Harmon
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_luis_obispo/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jan-Pepper-bc515d57-1f6b-4d2c-bfaa-d1559c8874bf.yml
+++ b/data/ca/municipalities/Jan-Pepper-bc515d57-1f6b-4d2c-bfaa-d1559c8874bf.yml
@@ -3,7 +3,7 @@ name: Jan Pepper
 given_name: Jan
 family_name: Pepper
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:los_altos/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jeff-Slowey-255902ad-4df3-4faf-a1e5-987c59bfcc94.yml
+++ b/data/ca/municipalities/Jeff-Slowey-255902ad-4df3-4faf-a1e5-987c59bfcc94.yml
@@ -3,7 +3,7 @@ name: Jeff Slowey
 given_name: Jeff
 family_name: Slowey
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:citrus_heights/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jelani-Killings-dc32522e-03f4-4e79-8e09-2f51466f6053.yml
+++ b/data/ca/municipalities/Jelani-Killings-dc32522e-03f4-4e79-8e09-2f51466f6053.yml
@@ -3,7 +3,7 @@ name: Jelani Killings
 given_name: Jelani
 family_name: Killings
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:pittsburg/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jerry-Thorne-3f01681a-e1cd-4b1d-84e2-9194049c3f44.yml
+++ b/data/ca/municipalities/Jerry-Thorne-3f01681a-e1cd-4b1d-84e2-9194049c3f44.yml
@@ -3,7 +3,7 @@ name: Jerry Thorne
 given_name: Jerry
 family_name: Thorne
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:pleasanton/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jesse-Arreguin-4e9583ae-f1e1-4f3c-8498-1593fcf691c9.yml
+++ b/data/ca/municipalities/Jesse-Arreguin-4e9583ae-f1e1-4f3c-8498-1593fcf691c9.yml
@@ -3,7 +3,7 @@ name: Jesse Arreguin
 given_name: Jesse
 family_name: Arreguin
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:berkeley/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Jill-Techel-c45b85c6-9b74-46ed-b959-59a898c1f6e5.yml
+++ b/data/ca/municipalities/Jill-Techel-c45b85c6-9b74-46ed-b959-59a898c1f6e5.yml
@@ -3,7 +3,7 @@ name: Jill Techel
 given_name: Jill
 family_name: Techel
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:napa/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Joe-Goethals-f5baa3bf-923b-48f0-918f-e8b0c1210cd0.yml
+++ b/data/ca/municipalities/Joe-Goethals-f5baa3bf-923b-48f0-918f-e8b0c1210cd0.yml
@@ -3,7 +3,7 @@ name: Joe Goethals
 given_name: Joe
 family_name: Goethals
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_mateo/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Joe-Gunter-49d50ba9-8872-4daa-ae7a-370e99f44929.yml
+++ b/data/ca/municipalities/Joe-Gunter-49d50ba9-8872-4daa-ae7a-370e99f44929.yml
@@ -3,7 +3,7 @@ name: Joe Gunter
 given_name: Joe
 family_name: Gunter
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:salinas/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/John-B-Allard-II-09d7189b-d62f-4256-9581-9131356094c0.yml
+++ b/data/ca/municipalities/John-B-Allard-II-09d7189b-d62f-4256-9581-9131356094c0.yml
@@ -3,7 +3,7 @@ name: John B. Allard II
 given_name: John B.
 family_name: Allard II
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:roseville/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/John-P-Marchand-745d432d-d984-4a5e-bc9e-ae8afc43fda5.yml
+++ b/data/ca/municipalities/John-P-Marchand-745d432d-d984-4a5e-bc9e-ae8afc43fda5.yml
@@ -3,7 +3,7 @@ name: John P. Marchand
 given_name: John P.
 family_name: Marchand
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:livermore/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Joseph-T-Callinan-c1a1113e-6f57-4814-99d4-087c6a24ba1b.yml
+++ b/data/ca/municipalities/Joseph-T-Callinan-c1a1113e-6f57-4814-99d4-087c6a24ba1b.yml
@@ -3,7 +3,7 @@ name: Joseph T. Callinan
 given_name: Joseph T.
 family_name: Callinan
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:rohnert_park/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Karen-Goh-2d23f8d3-861a-4907-a5d9-bc3e383eab55.yml
+++ b/data/ca/municipalities/Karen-Goh-2d23f8d3-861a-4907-a5d9-bc3e383eab55.yml
@@ -3,7 +3,7 @@ name: Karen Goh
 given_name: Karen
 family_name: Goh
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:bakersfield/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Katrina-Foley-848e7034-dd8d-4995-a9d8-d3d5b12853e7.yml
+++ b/data/ca/municipalities/Katrina-Foley-848e7034-dd8d-4995-a9d8-d3d5b12853e7.yml
@@ -3,7 +3,7 @@ name: Katrina Foley
 given_name: Katrina
 family_name: Foley
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:costa_mesa/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Keith-L-Mashburn-620b158c-0118-4da8-8153-5e91e5b40f24.yml
+++ b/data/ca/municipalities/Keith-L-Mashburn-620b158c-0118-4da8-8153-5e91e5b40f24.yml
@@ -3,7 +3,7 @@ name: Keith L. Mashburn
 given_name: Keith L.
 family_name: Mashburn
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:simi_valley/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Kevin-Faulconer-19544661-c24a-402a-aed6-ad9a1aaacc5a.yml
+++ b/data/ca/municipalities/Kevin-Faulconer-19544661-c24a-402a-aed6-ad9a1aaacc5a.yml
@@ -3,7 +3,7 @@ name: Kevin Faulconer
 given_name: Kevin
 family_name: Faulconer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_diego/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Lance-Walker-cdca00d0-3274-44f7-9b74-5c039c3abe87.yml
+++ b/data/ca/municipalities/Lance-Walker-cdca00d0-3274-44f7-9b74-5c039c3abe87.yml
@@ -3,14 +3,14 @@ name: Lance Walker
 given_name: Lance
 family_name: Walker
 roles:
-  - end_date: "2023-01-01"
-    jurisdiction: ocd-jurisdiction/country:us/state:ca/place:greenfield/government
-    type: mayor
+- end_date: '2023-01-01'
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/place:greenfield/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: 599 El Camino Real;P.O. Box 127;Greenfield, CA 93927
-    voice: 831-674-5591
+- note: Primary Office
+  address: 599 El Camino Real;P.O. Box 127;Greenfield, CA 93927
+  voice: 831-674-5591
 sources:
-  - url: https://ci.greenfield.ca.us/284/Lance-Walker-Biography
+- url: https://ci.greenfield.ca.us/284/Lance-Walker-Biography
 links: []
 email: lwalker@ci.greenfield.ca.us

--- a/data/ca/municipalities/Laurie-Davies-0ac6b6d4-745c-43fd-b4d2-730ffac09043.yml
+++ b/data/ca/municipalities/Laurie-Davies-0ac6b6d4-745c-43fd-b4d2-730ffac09043.yml
@@ -3,7 +3,7 @@ name: Laurie Davies
 given_name: Laurie
 family_name: Davies
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:laguna_niguel/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Lee-Brand-f5df2d88-970a-4aa3-8ab6-01781c892446.yml
+++ b/data/ca/municipalities/Lee-Brand-f5df2d88-970a-4aa3-8ab6-01781c892446.yml
@@ -3,7 +3,7 @@ name: Lee Brand
 given_name: Lee
 family_name: Brand
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:fresno/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Lily-Mei-d211d641-45d9-450d-8159-7520aebb6e85.yml
+++ b/data/ca/municipalities/Lily-Mei-d211d641-45d9-450d-8159-7520aebb6e85.yml
@@ -3,7 +3,7 @@ name: Lily Mei
 given_name: Lily
 family_name: Mei
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:fremont/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Manuel-Lozano-0165697d-322d-4ad6-ac7b-f450951c003d.yml
+++ b/data/ca/municipalities/Manuel-Lozano-0165697d-322d-4ad6-ac7b-f450951c003d.yml
@@ -3,7 +3,7 @@ name: Manuel Lozano
 given_name: Manuel
 family_name: Lozano
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:baldwin_park/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Margaret-Abe-Koga-f66b9645-c4d3-44ec-9f5a-93302b6424a0.yml
+++ b/data/ca/municipalities/Margaret-Abe-Koga-f66b9645-c4d3-44ec-9f5a-93302b6424a0.yml
@@ -3,7 +3,7 @@ name: Margaret Abe-Koga
 given_name: Margaret
 family_name: Abe-Koga
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:mountain_view/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Mark-A-Murphy-fa8a1861-00fa-4f5a-afdc-2b21e1be9e33.yml
+++ b/data/ca/municipalities/Mark-A-Murphy-fa8a1861-00fa-4f5a-afdc-2b21e1be9e33.yml
@@ -3,7 +3,7 @@ name: Mark A. Murphy
 given_name: Mark A.
 family_name: Murphy
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:orange/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Maryann-Edwards-08de737a-6043-4b60-bbe4-f1b43a450e51.yml
+++ b/data/ca/municipalities/Maryann-Edwards-08de737a-6043-4b60-bbe4-f1b43a450e51.yml
@@ -3,7 +3,7 @@ name: Maryann Edwards
 given_name: Maryann
 family_name: Edwards
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:temecula/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Michael-M-Vargas-82b1f1c9-1eb4-434f-aae2-f10b3fb55940.yml
+++ b/data/ca/municipalities/Michael-M-Vargas-82b1f1c9-1eb4-434f-aae2-f10b3fb55940.yml
@@ -3,7 +3,7 @@ name: Michael M Vargas
 given_name: Michael M
 family_name: Vargas
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:perris/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Michael-Tubbs-8699fb16-1f52-4b8a-bce6-19b40308be16.yml
+++ b/data/ca/municipalities/Michael-Tubbs-8699fb16-1f52-4b8a-bce6-19b40308be16.yml
@@ -3,7 +3,7 @@ name: Michael Tubbs
 given_name: Michael
 family_name: Tubbs
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:stockton/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Michael-Winkler-408871df-24bd-4f38-a53d-9d4d583a5f59.yml
+++ b/data/ca/municipalities/Michael-Winkler-408871df-24bd-4f38-a53d-9d4d583a5f59.yml
@@ -3,7 +3,7 @@ name: Michael Winkler
 given_name: Michael
 family_name: Winkler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:arcata/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Miguel-A-Pulido-43ad0fe7-aac0-4a8f-9c9f-268a20da336b.yml
+++ b/data/ca/municipalities/Miguel-A-Pulido-43ad0fe7-aac0-4a8f-9c9f-268a20da336b.yml
@@ -3,7 +3,7 @@ name: Miguel A. Pulido
 given_name: Miguel A.
 family_name: Pulido
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:santa_ana/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Mike-Murphy-59be524a-36fb-48fe-933d-b5d1a8c6d290.yml
+++ b/data/ca/municipalities/Mike-Murphy-59be524a-36fb-48fe-933d-b5d1a8c6d290.yml
@@ -3,7 +3,7 @@ name: Mike Murphy
 given_name: Mike
 family_name: Murphy
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:merced/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Paula-Perotte-ce969639-2585-4b1f-b874-146bdba67acb.yml
+++ b/data/ca/municipalities/Paula-Perotte-ce969639-2585-4b1f-b874-146bdba67acb.yml
@@ -3,7 +3,7 @@ name: Paula Perotte
 given_name: Paula
 family_name: Perotte
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:goleta/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Peter-Weiss-53a9cb14-70d7-4f86-a93e-24c07aa75dff.yml
+++ b/data/ca/municipalities/Peter-Weiss-53a9cb14-70d7-4f86-a93e-24c07aa75dff.yml
@@ -3,7 +3,7 @@ name: Peter Weiss
 given_name: Peter
 family_name: Weiss
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:oceanside/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Randall-Stone-6f44f64e-3749-4c8d-9f64-b3567ecb4a1f.yml
+++ b/data/ca/municipalities/Randall-Stone-6f44f64e-3749-4c8d-9f64-b3567ecb4a1f.yml
@@ -3,7 +3,7 @@ name: Randall Stone
 given_name: Randall
 family_name: Stone
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:chico/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Rebecca-J-Garcia-1065f09c-f9d3-46ab-bc84-9b97165458e4.yml
+++ b/data/ca/municipalities/Rebecca-J-Garcia-1065f09c-f9d3-46ab-bc84-9b97165458e4.yml
@@ -3,7 +3,7 @@ name: Rebecca J. Garcia
 given_name: Rebecca J.
 family_name: Garcia
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:watsonville/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Rich-Tran-03de2cdf-e5e6-4808-8780-0e3b4a7e3b14.yml
+++ b/data/ca/municipalities/Rich-Tran-03de2cdf-e5e6-4808-8780-0e3b4a7e3b14.yml
@@ -3,7 +3,7 @@ name: Rich Tran
 given_name: Rich
 family_name: Tran
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:milpitas/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Robert-R-Link-490363f7-fae6-4ca8-8c56-e42f1216e8fb.yml
+++ b/data/ca/municipalities/Robert-R-Link-490363f7-fae6-4ca8-8c56-e42f1216e8fb.yml
@@ -3,7 +3,7 @@ name: Robert R. Link
 given_name: Robert R.
 family_name: Link
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:visalia/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Robert-Rickman-9a9c62a3-573b-4634-9200-f01b8af7ae49.yml
+++ b/data/ca/municipalities/Robert-Rickman-9a9c62a3-573b-4634-9200-f01b8af7ae49.yml
@@ -3,7 +3,7 @@ name: Robert Rickman
 given_name: Robert
 family_name: Rickman
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:tracy/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Robert-S-Joe-d960264e-153a-4a39-8c93-6f66ecc37908.yml
+++ b/data/ca/municipalities/Robert-S-Joe-d960264e-153a-4a39-8c93-6f66ecc37908.yml
@@ -3,7 +3,7 @@ name: Robert S. Joe
 given_name: Robert S.
 family_name: Joe
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:south_pasadena/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Robert-Taylor-db0e5cae-4216-495d-be60-85a0f7251af7.yml
+++ b/data/ca/municipalities/Robert-Taylor-db0e5cae-4216-495d-be60-85a0f7251af7.yml
@@ -3,7 +3,7 @@ name: Robert Taylor
 given_name: Robert
 family_name: Taylor
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:brentwood/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Roger-Chandler-c956ae34-b184-47fc-b69d-379bb72c1b39.yml
+++ b/data/ca/municipalities/Roger-Chandler-c956ae34-b184-47fc-b69d-379bb72c1b39.yml
@@ -3,7 +3,7 @@ name: Roger Chandler
 given_name: Roger
 family_name: Chandler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:arcadia/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Roland-Velasco-1e0ef850-ebc7-478b-a81b-c0d0d7e3bbd3.yml
+++ b/data/ca/municipalities/Roland-Velasco-1e0ef850-ebc7-478b-a81b-c0d0d7e3bbd3.yml
@@ -3,7 +3,7 @@ name: Roland Velasco
 given_name: Roland
 family_name: Velasco
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:gilroy/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Rusty-Bailey-2d3f9341-e660-4a2d-be8e-5302223ad4bb.yml
+++ b/data/ca/municipalities/Rusty-Bailey-2d3f9341-e660-4a2d-be8e-5302223ad4bb.yml
@@ -3,7 +3,7 @@ name: Rusty Bailey
 given_name: Rusty
 family_name: Bailey
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:riverside/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Sean-Wright-b1c87955-b229-4d12-b331-f089cfc8bd16.yml
+++ b/data/ca/municipalities/Sean-Wright-b1c87955-b229-4d12-b331-f089cfc8bd16.yml
@@ -3,7 +3,7 @@ name: Sean Wright
 given_name: Sean
 family_name: Wright
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:antioch/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Steve-Ly-b0936113-1901-4d06-abb4-d7cf29b0ac16.yml
+++ b/data/ca/municipalities/Steve-Ly-b0936113-1901-4d06-abb4-d7cf29b0ac16.yml
@@ -3,7 +3,7 @@ name: Steve Ly
 given_name: Steve
 family_name: Ly
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:elk_grove/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Steven-Hofbauer-33ff247c-501f-48db-8d9c-04bfddb1ba36.yml
+++ b/data/ca/municipalities/Steven-Hofbauer-33ff247c-501f-48db-8d9c-04bfddb1ba36.yml
@@ -3,7 +3,7 @@ name: Steven Hofbauer
 given_name: Steven
 family_name: Hofbauer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:palmdale/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Steven-R-Jones-405e3c6e-40f3-434f-8f14-87df8f2c44c7.yml
+++ b/data/ca/municipalities/Steven-R-Jones-405e3c6e-40f3-434f-8f14-87df8f2c44c7.yml
@@ -3,7 +3,7 @@ name: Steven R. Jones
 given_name: Steven R.
 family_name: Jones
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:garden_grove/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Ted-Brandvold-b60f14cb-894c-4276-a311-87ba759ddae9.yml
+++ b/data/ca/municipalities/Ted-Brandvold-b60f14cb-894c-4276-a311-87ba759ddae9.yml
@@ -3,7 +3,7 @@ name: Ted Brandvold
 given_name: Ted
 family_name: Brandvold
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:modesto/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Terry-Tornek-a382fa95-64b4-4dba-9fc1-06715d4a3eab.yml
+++ b/data/ca/municipalities/Terry-Tornek-a382fa95-64b4-4dba-9fc1-06715d4a3eab.yml
@@ -3,7 +3,7 @@ name: Terry Tornek
 given_name: Terry
 family_name: Tornek
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:pasadena/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Tim-Sandoval-e8440ecf-39f1-4429-9ae3-e9371d0c8519.yml
+++ b/data/ca/municipalities/Tim-Sandoval-e8440ecf-39f1-4429-9ae3-e9371d0c8519.yml
@@ -3,7 +3,7 @@ name: Tim Sandoval
 given_name: Tim
 family_name: Sandoval
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:pomona/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Timothy-Flynn-b89e4314-3e53-4ced-9ede-e252316bdfc5.yml
+++ b/data/ca/municipalities/Timothy-Flynn-b89e4314-3e53-4ced-9ede-e252316bdfc5.yml
@@ -3,7 +3,7 @@ name: Timothy Flynn
 given_name: Timothy
 family_name: Flynn
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:oxnard/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Tri-Ta-75229920-399d-4216-9b76-c27ea398665a.yml
+++ b/data/ca/municipalities/Tri-Ta-75229920-399d-4216-9b76-c27ea398665a.yml
@@ -3,7 +3,7 @@ name: Tri Ta
 given_name: Tri
 family_name: Ta
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:westminster/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Victor-Linares-bba12279-db30-4e1a-ba79-d775bb47c6df.yml
+++ b/data/ca/municipalities/Victor-Linares-bba12279-db30-4e1a-ba79-d775bb47c6df.yml
@@ -3,14 +3,14 @@ name: Victor Linares
 given_name: Victor
 family_name: Linares
 roles:
-  - end_date: "2021-04-06"
-    jurisdiction: ocd-jurisdiction/country:us/state:ca/place:covina/government
-    type: mayor
+- end_date: '2021-04-06'
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/place:covina/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: 125 E. College Street;Covina, CA 91723
-    voice: 626-384-5410
+- note: Primary Office
+  address: 125 E. College Street;Covina, CA 91723
+  voice: 626-384-5410
 sources:
-  - url: https://covinaca.gov/bc-citycouncil/page/mayor-victor-linares
+- url: https://covinaca.gov/bc-citycouncil/page/mayor-victor-linares
 links: []
 email: vlinares@covinaca.gov

--- a/data/ca/municipalities/William-Bill-Clarkson-c2614c3e-057f-4528-b9c4-309c178ba8b0.yml
+++ b/data/ca/municipalities/William-Bill-Clarkson-c2614c3e-057f-4528-b9c4-309c178ba8b0.yml
@@ -3,7 +3,7 @@ name: William 'Bill' Clarkson
 given_name: William 'Bill'
 family_name: Clarkson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_ramon/government
   type: mayor
 contact_details:

--- a/data/ca/municipalities/Yxstian-Gutierrez-b14d8e73-6c60-4074-8939-0eb407c49c04.yml
+++ b/data/ca/municipalities/Yxstian-Gutierrez-b14d8e73-6c60-4074-8939-0eb407c49c04.yml
@@ -3,7 +3,7 @@ name: Yxstian Gutierrez
 given_name: Yxstian
 family_name: Gutierrez
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:moreno_valley/government
   type: mayor
 contact_details:

--- a/data/co/municipalities/Jason-Gray-8ff37a6c-88c7-412e-9ef0-9f8a560539cb.yml
+++ b/data/co/municipalities/Jason-Gray-8ff37a6c-88c7-412e-9ef0-9f8a560539cb.yml
@@ -3,7 +3,7 @@ name: Jason Gray
 given_name: Jason
 family_name: Gray
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:co/place:castle_rock/government
   type: mayor
 contact_details:

--- a/data/co/municipalities/Mike-Waid-aa7a082a-4484-44ce-be99-90e0f3691ec7.yml
+++ b/data/co/municipalities/Mike-Waid-aa7a082a-4484-44ce-be99-90e0f3691ec7.yml
@@ -3,7 +3,7 @@ name: Mike Waid
 given_name: Mike
 family_name: Waid
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:co/place:parker/government
   type: mayor
 contact_details:

--- a/data/co/municipalities/Nicholas-A-Gradisar-5ef6d780-061e-42cc-be9c-94bc320a5041.yml
+++ b/data/co/municipalities/Nicholas-A-Gradisar-5ef6d780-061e-42cc-be9c-94bc320a5041.yml
@@ -3,7 +3,7 @@ name: Nicholas A. Gradisar
 given_name: Nicholas A.
 family_name: Gradisar
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:co/place:pueblo/government
   type: mayor
 contact_details:

--- a/data/de/executive/John-Carney-7aefad2a-28f2-45e9-8d44-3eb1ee21f849.yml
+++ b/data/de/executive/John-Carney-7aefad2a-28f2-45e9-8d44-3eb1ee21f849.yml
@@ -6,7 +6,7 @@ birth_date: '1956-05-20'
 party:
 - name: Democratic
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:de/government
   start_date: '2017-01-17'
   type: governor

--- a/data/de/municipalities/Michael-S-Purzycki-a52abb05-f515-4f28-ba86-a5710f58856f.yml
+++ b/data/de/municipalities/Michael-S-Purzycki-a52abb05-f515-4f28-ba86-a5710f58856f.yml
@@ -3,7 +3,7 @@ name: Michael S. Purzycki
 given_name: Michael S.
 family_name: Purzycki
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:de/place:wilmington/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Daniel-J-Stermer-f3e6cf85-4092-4ab2-b020-b77afc75d1bc.yml
+++ b/data/fl/municipalities/Daniel-J-Stermer-f3e6cf85-4092-4ab2-b020-b77afc75d1bc.yml
@@ -3,7 +3,7 @@ name: Daniel J. Stermer
 given_name: Daniel J.
 family_name: Stermer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:weston/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Donald-O-Burnette-cacfede5-d771-43dc-a644-f7bd8350f3d5.yml
+++ b/data/fl/municipalities/Donald-O-Burnette-cacfede5-d771-43dc-a644-f7bd8350f3d5.yml
@@ -3,7 +3,7 @@ name: Donald O. Burnette
 given_name: Donald O.
 family_name: Burnette
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:port_orange/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Jose-A-Alvarez-dfc9e666-bd1f-4b79-93aa-1f2ad9b6e689.yml
+++ b/data/fl/municipalities/Jose-A-Alvarez-dfc9e666-bd1f-4b79-93aa-1f2ad9b6e689.yml
@@ -3,7 +3,7 @@ name: Jose A. Alvarez
 given_name: Jose A.
 family_name: Alvarez
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:kissimmee/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Josh-Levy-fdc549a6-0c02-415e-8bfa-b5b7d8db14c5.yml
+++ b/data/fl/municipalities/Josh-Levy-fdc549a6-0c02-415e-8bfa-b5b7d8db14c5.yml
@@ -3,7 +3,7 @@ name: Josh Levy
 given_name: Josh
 family_name: Levy
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:hollywood/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Juan-Carlos-Bermudez-2d204dc1-26c7-4875-a588-39786e1322bf.yml
+++ b/data/fl/municipalities/Juan-Carlos-Bermudez-2d204dc1-26c7-4875-a588-39786e1322bf.yml
@@ -3,7 +3,7 @@ name: Juan Carlos Bermudez
 given_name: Juan Carlos
 family_name: Bermudez
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:doral/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Kathy-Meehan-748a8d71-a44f-44a4-95e0-9cd97d4431b9.yml
+++ b/data/fl/municipalities/Kathy-Meehan-748a8d71-a44f-44a4-95e0-9cd97d4431b9.yml
@@ -3,7 +3,7 @@ name: Kathy Meehan
 given_name: Kathy
 family_name: Meehan
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:melbourne/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Louis-Woody-Brown-630069bc-52e2-437b-8a93-0dac2366f035.yml
+++ b/data/fl/municipalities/Louis-Woody-Brown-630069bc-52e2-437b-8a93-0dac2366f035.yml
@@ -3,7 +3,7 @@ name: Louis "Woody" Brown
 given_name: Louis "Woody"
 family_name: Brown
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:largo/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Lynn-Stoner-36ae944e-275d-4cf0-9178-192f1e7f189b.yml
+++ b/data/fl/municipalities/Lynn-Stoner-36ae944e-275d-4cf0-9178-192f1e7f189b.yml
@@ -3,7 +3,7 @@ name: Lynn Stoner
 given_name: Lynn
 family_name: Stoner
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:plantation/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Matt-Morgan-2ccb2964-20f6-483a-9ba6-452d97faa1d9.yml
+++ b/data/fl/municipalities/Matt-Morgan-2ccb2964-20f6-483a-9ba6-452d97faa1d9.yml
@@ -3,7 +3,7 @@ name: Matt Morgan
 given_name: Matt
 family_name: Morgan
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:longwood/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Michael-J-Ryan-637a41fa-8580-48bb-bdc0-1fab49f716fd.yml
+++ b/data/fl/municipalities/Michael-J-Ryan-637a41fa-8580-48bb-bdc0-1fab49f716fd.yml
@@ -3,7 +3,7 @@ name: Michael J. Ryan
 given_name: Michael J.
 family_name: Ryan
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:sunrise/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Milissa-Holland-cc609bb4-961e-4318-86c3-f46b4d706c44.yml
+++ b/data/fl/municipalities/Milissa-Holland-cc609bb4-961e-4318-86c3-f46b4d706c44.yml
@@ -3,7 +3,7 @@ name: Milissa Holland
 given_name: Milissa
 family_name: Holland
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:palm_coast/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Oliver-G-Gilbert-III-da5a6f21-b17c-446a-8777-d748fec14935.yml
+++ b/data/fl/municipalities/Oliver-G-Gilbert-III-da5a6f21-b17c-446a-8777-d748fec14935.yml
@@ -3,7 +3,7 @@ name: Oliver G. Gilbert III
 given_name: Oliver G.
 family_name: Gilbert III
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:miami_gardens/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Patricia-Bates-9bf86452-1d75-4cef-845e-44f921fb5b7e.yml
+++ b/data/fl/municipalities/Patricia-Bates-9bf86452-1d75-4cef-845e-44f921fb5b7e.yml
@@ -3,7 +3,7 @@ name: Patricia Bates
 given_name: Patricia
 family_name: Bates
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:altamonte_springs/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Rex-Hardin-d1113068-433f-48e9-9668-8e2c8d68ce15.yml
+++ b/data/fl/municipalities/Rex-Hardin-d1113068-433f-48e9-9668-8e2c8d68ce15.yml
@@ -3,7 +3,7 @@ name: Rex Hardin
 given_name: Rex
 family_name: Hardin
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:pompano_beach/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Scott-Brook-83eeaf33-7437-4fe6-98d6-763a990275b2.yml
+++ b/data/fl/municipalities/Scott-Brook-83eeaf33-7437-4fe6-98d6-763a990275b2.yml
@@ -3,7 +3,7 @@ name: Scott Brook
 given_name: Scott
 family_name: Brook
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:coral_springs/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/Tim-Pospichal-1eb9840d-381f-4d8a-a519-b1f08db85cd8.yml
+++ b/data/fl/municipalities/Tim-Pospichal-1eb9840d-381f-4d8a-a519-b1f08db85cd8.yml
@@ -3,14 +3,14 @@ name: Tim Pospichal
 given_name: Tim
 family_name: Pospichal
 roles:
-  - end_date: "2021-01-04"
-    jurisdiction: ocd-jurisdiction/country:us/state:fl/place:auburndale/government
-    type: mayor
+- end_date: '2021-03-01'
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/place:auburndale/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: P.O. Box 186;Auburndale, FL 33823
-    voice: 863-965-5530
+- note: Primary Office
+  address: P.O. Box 186;Auburndale, FL 33823
+  voice: 863-965-5530
 sources:
-  - url: http://www.auburndalefl.com/cmo/
+- url: http://www.auburndalefl.com/cmo/
 links: []
 email: cmo@auburndalefl.com

--- a/data/fl/municipalities/Wayne-H-Poston-70f53818-0639-45ec-9cac-03f62f29f5e8.yml
+++ b/data/fl/municipalities/Wayne-H-Poston-70f53818-0639-45ec-9cac-03f62f29f5e8.yml
@@ -3,7 +3,7 @@ name: Wayne H. Poston
 given_name: Wayne H.
 family_name: Poston
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:bradenton/government
   type: mayor
 contact_details:

--- a/data/fl/municipalities/William-Capote-16bd7cfc-1eb8-469c-97c2-3a142c70f7ef.yml
+++ b/data/fl/municipalities/William-Capote-16bd7cfc-1eb8-469c-97c2-3a142c70f7ef.yml
@@ -3,7 +3,7 @@ name: William Capote
 given_name: William
 family_name: Capote
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:palm_bay/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Al-Thurman-4c34a20f-aed1-49d7-8b72-94b998fc7edb.yml
+++ b/data/ga/municipalities/Al-Thurman-4c34a20f-aed1-49d7-8b72-94b998fc7edb.yml
@@ -3,7 +3,7 @@ name: Al Thurman
 given_name: Al
 family_name: Thurman
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:powder_springs/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Edward-Johnson-6a65bb2a-5564-446e-bcc6-01e92ca16a5b.yml
+++ b/data/ga/municipalities/Edward-Johnson-6a65bb2a-5564-446e-bcc6-01e92ca16a5b.yml
@@ -3,7 +3,7 @@ name: Edward Johnson
 given_name: Edward
 family_name: Johnson
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:fayetteville/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/James-Kelly-4d69903a-49aa-4579-abdc-2cf21e803f65.yml
+++ b/data/ga/municipalities/James-Kelly-4d69903a-49aa-4579-abdc-2cf21e803f65.yml
@@ -3,7 +3,7 @@ name: James Kelly
 given_name: James
 family_name: Kelly
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:dallas/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Jimmy-Burnette-a95f3d1f-c7e1-4bf0-9782-71cfe41d48f1.yml
+++ b/data/ga/municipalities/Jimmy-Burnette-a95f3d1f-c7e1-4bf0-9782-71cfe41d48f1.yml
@@ -3,7 +3,7 @@ name: Jimmy Burnette
 given_name: Jimmy
 family_name: Burnette
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:suwanee/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Patricia-Wheeler-707fb5b7-5d81-402a-bb61-72e7e27fb9ef.yml
+++ b/data/ga/municipalities/Patricia-Wheeler-707fb5b7-5d81-402a-bb61-72e7e27fb9ef.yml
@@ -3,7 +3,7 @@ name: Patricia Wheeler
 given_name: Patricia
 family_name: Wheeler
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:stone_mountain/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Tim-Dunn-d2eb8749-7fcf-456b-8af2-b1f7ee9386b0.yml
+++ b/data/ga/municipalities/Tim-Dunn-d2eb8749-7fcf-456b-8af2-b1f7ee9386b0.yml
@@ -3,7 +3,7 @@ name: Tim Dunn
 given_name: Tim
 family_name: Dunn
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:lilburn/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Troy-Brumbalow-79efc049-40f4-482b-908f-4977a7126547.yml
+++ b/data/ga/municipalities/Troy-Brumbalow-79efc049-40f4-482b-908f-4977a7126547.yml
@@ -3,7 +3,7 @@ name: Troy Brumbalow
 given_name: Troy
 family_name: Brumbalow
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:cumming/government
   type: mayor
 contact_details:

--- a/data/ga/municipalities/Vince-Evans-7ef47bf7-ad61-4aa2-9574-e37946a8b623.yml
+++ b/data/ga/municipalities/Vince-Evans-7ef47bf7-ad61-4aa2-9574-e37946a8b623.yml
@@ -3,7 +3,7 @@ name: Vince Evans
 given_name: Vince
 family_name: Evans
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ga/place:conyers/government
   type: mayor
 contact_details:

--- a/data/id/municipalities/Joe-Stear-c000024f-7bbe-4863-aecd-3e46f5ec6c1e.yml
+++ b/data/id/municipalities/Joe-Stear-c000024f-7bbe-4863-aecd-3e46f5ec6c1e.yml
@@ -3,15 +3,15 @@ name: Joe Stear
 given_name: Joe
 family_name: Stear
 roles:
-  - end_date: "2023-12-31"
-    jurisdiction: ocd-jurisdiction/country:us/state:id/place:kuna/government
-    type: mayor
+- end_date: '2023-12-31'
+  jurisdiction: ocd-jurisdiction/country:us/state:id/place:kuna/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: P.O. Box 13;Kuna, ID 83634
-    voice: 208-922-5546
+- note: Primary Office
+  address: P.O. Box 13;Kuna, ID 83634
+  voice: 208-922-5546
 sources:
-  - url: http://kunacity.id.gov/
+- url: http://kunacity.id.gov/
 links:
-  - url: http://kunacity.id.gov/
+- url: http://kunacity.id.gov/
 email: MayorStear@kunaID.gov

--- a/data/in/executive/Eric-Holcomb-92942c69-8eaf-4148-8c23-eb8b4cd13602.yml
+++ b/data/in/executive/Eric-Holcomb-92942c69-8eaf-4148-8c23-eb8b4cd13602.yml
@@ -6,7 +6,7 @@ birth_date: '1968-05-02'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:in/government
   start_date: '2017-01-09'
   type: governor

--- a/data/ks/municipalities/Jennifer-Ananda-27bc481a-da4b-41ef-9d93-4e088836f1cc.yml
+++ b/data/ks/municipalities/Jennifer-Ananda-27bc481a-da4b-41ef-9d93-4e088836f1cc.yml
@@ -3,7 +3,7 @@ name: Jennifer Ananda
 given_name: Jennifer
 family_name: Ananda
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/place:lawrence/government
   type: mayor
 contact_details:

--- a/data/ks/municipalities/Peggy-J-Dunn-16e023ed-e1cf-4414-85b6-b45ca0fac14c.yml
+++ b/data/ks/municipalities/Peggy-J-Dunn-16e023ed-e1cf-4414-85b6-b45ca0fac14c.yml
@@ -3,7 +3,7 @@ name: Peggy J. Dunn
 given_name: Peggy J.
 family_name: Dunn
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/place:leawood/government
   type: mayor
 contact_details:

--- a/data/ky/municipalities/Bruce-Wilkerson-a5799fe1-1c67-4b37-aa31-4028851b4e5d.yml
+++ b/data/ky/municipalities/Bruce-Wilkerson-a5799fe1-1c67-4b37-aa31-4028851b4e5d.yml
@@ -3,7 +3,7 @@ name: Bruce Wilkerson
 given_name: Bruce
 family_name: Wilkerson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ky/place:bowling_green/government
   type: mayor
 contact_details:

--- a/data/ky/municipalities/Tom-Watson-17eb7992-d943-42f8-b3ae-c3fb993cf4cf.yml
+++ b/data/ky/municipalities/Tom-Watson-17eb7992-d943-42f8-b3ae-c3fb993cf4cf.yml
@@ -3,7 +3,7 @@ name: Tom Watson
 given_name: Tom
 family_name: Watson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ky/place:owensboro/government
   type: mayor
 contact_details:

--- a/data/la/municipalities/Sharon-Weston-Broome-1526d628-9a5d-455e-ade8-802b5e8efc85.yml
+++ b/data/la/municipalities/Sharon-Weston-Broome-1526d628-9a5d-455e-ade8-802b5e8efc85.yml
@@ -3,7 +3,7 @@ name: Sharon Weston Broome
 given_name: Sharon Weston
 family_name: Broome
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:la/place:baton_rouge/government
   type: mayor
 contact_details:

--- a/data/ma/municipalities/Michael-Cahill-c6fe5141-dd20-4e91-9a66-8db2452e6b81.yml
+++ b/data/ma/municipalities/Michael-Cahill-c6fe5141-dd20-4e91-9a66-8db2452e6b81.yml
@@ -3,14 +3,14 @@ name: Michael P. Cahill
 given_name: Michael
 family_name: Cahill
 roles:
-  - end_date: "2022-01-02"
-    jurisdiction: ocd-jurisdiction/country:us/state:ma/place:beverly/government
-    type: mayor
+- end_date: '2022-01-02'
+  jurisdiction: ocd-jurisdiction/country:us/state:ma/place:beverly/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: 191 Cabot St;Beverly, MA 01915
-    voice: 978-921-6000
-    fax: 978-921-6052
+- note: Primary Office
+  address: 191 Cabot St;Beverly, MA 01915
+  voice: 978-921-6000
+  fax: 978-921-6052
 sources:
-  - url: http://www.beverlyma.gov/departments/mayors-office/
+- url: http://www.beverlyma.gov/departments/mayors-office/
 email: mayorcahill@beverlyma.gov

--- a/data/md/municipalities/Bernard-C-Jack-Young-efe4fd67-fb73-439d-af22-15cb0fe3e884.yml
+++ b/data/md/municipalities/Bernard-C-Jack-Young-efe4fd67-fb73-439d-af22-15cb0fe3e884.yml
@@ -3,7 +3,7 @@ name: Bernard C. "Jack" Young
 given_name: Bernard C. "Jack"
 family_name: Young
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:md/place:baltimore/government
   type: mayor
 contact_details:

--- a/data/md/municipalities/Brandon-Paulin-bdc44e72-db97-4102-b1e4-c56089784ed4.yml
+++ b/data/md/municipalities/Brandon-Paulin-bdc44e72-db97-4102-b1e4-c56089784ed4.yml
@@ -3,7 +3,7 @@ name: Brandon Paulin
 given_name: Brandon
 family_name: Paulin
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:md/place:waldorf/government
   type: mayor
 contact_details:

--- a/data/md/municipalities/Robert-E-Bruchey-II-6c46257e-93bd-4d93-8614-5d47baeff968.yml
+++ b/data/md/municipalities/Robert-E-Bruchey-II-6c46257e-93bd-4d93-8614-5d47baeff968.yml
@@ -3,7 +3,7 @@ name: Robert E. Bruchey II
 given_name: Robert E.
 family_name: Bruchey II
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:md/place:hagerstown/government
   type: mayor
 contact_details:

--- a/data/mi/municipalities/Christopher-Taylor-fe834eb8-c116-4dbf-84d2-dd4b1f5d72cb.yml
+++ b/data/mi/municipalities/Christopher-Taylor-fe834eb8-c116-4dbf-84d2-dd4b1f5d72cb.yml
@@ -3,7 +3,7 @@ name: Christopher Taylor
 given_name: Christopher
 family_name: Taylor
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mi/place:ann_arbor/government
   type: mayor
 contact_details:

--- a/data/mi/municipalities/Sup-Board-of-Trustees-Janet-I-Dunn-b58df1ab-d35f-4dd7-82a6-4729d659d4bc.yml
+++ b/data/mi/municipalities/Sup-Board-of-Trustees-Janet-I-Dunn-b58df1ab-d35f-4dd7-82a6-4729d659d4bc.yml
@@ -3,7 +3,7 @@ name: 'Sup. Board of Trustees: Janet I. Dunn'
 given_name: 'Sup. Board of Trustees: Janet I.'
 family_name: Dunn
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mi/place:macomb/government
   type: mayor
 contact_details:

--- a/data/mi/municipalities/Will-Joseph-79a0650c-3dab-41a9-b525-415a9a2ccf21.yml
+++ b/data/mi/municipalities/Will-Joseph-79a0650c-3dab-41a9-b525-415a9a2ccf21.yml
@@ -3,7 +3,7 @@ name: Will Joseph
 given_name: Will
 family_name: Joseph
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mi/place:mount_pleasant/government
   type: mayor
 contact_details:

--- a/data/mi/municipalities/William-E-Hosler-1d022505-bc32-407b-a639-e313ab80ba82.yml
+++ b/data/mi/municipalities/William-E-Hosler-1d022505-bc32-407b-a639-e313ab80ba82.yml
@@ -3,7 +3,7 @@ name: William E. Hosler
 given_name: William E.
 family_name: Hosler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mi/place:bloomfield_hills/government
   type: mayor
 contact_details:

--- a/data/mi/municipalities/William-E-Hosler-b5e7a6b4-9f49-445d-8250-aa6d0b38ca2b.yml
+++ b/data/mi/municipalities/William-E-Hosler-b5e7a6b4-9f49-445d-8250-aa6d0b38ca2b.yml
@@ -3,7 +3,7 @@ name: William E. Hosler
 given_name: William E.
 family_name: Hosler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mi/place:west_bloomfield/government
   type: mayor
 contact_details:

--- a/data/mn/municipalities/Dave-Kleis-ec1496da-ff83-42ab-b27c-256c780075b6.yml
+++ b/data/mn/municipalities/Dave-Kleis-ec1496da-ff83-42ab-b27c-256c780075b6.yml
@@ -3,7 +3,7 @@ name: Dave Kleis
 given_name: Dave
 family_name: Kleis
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mn/place:saint_cloud/government
   type: mayor
 contact_details:

--- a/data/mn/municipalities/Elizabeth-B-Kautz-feef2d76-44ab-4340-be1b-9d8b8d58fa36.yml
+++ b/data/mn/municipalities/Elizabeth-B-Kautz-feef2d76-44ab-4340-be1b-9d8b8d58fa36.yml
@@ -3,7 +3,7 @@ name: Elizabeth B. Kautz
 given_name: Elizabeth B.
 family_name: Kautz
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mn/place:burnsville/government
   type: mayor
 contact_details:

--- a/data/mo/executive/Mike-Parson-49049354-68cd-45da-849f-b8ddbc629bab.yml
+++ b/data/mo/executive/Mike-Parson-49049354-68cd-45da-849f-b8ddbc629bab.yml
@@ -6,7 +6,7 @@ birth_date: '1955-09-17'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:mo/government
   start_date: '2018-06-01'
   type: governor

--- a/data/mt/executive/Greg-Gianforte-c40b88ef-ba7b-415f-a6d4-581bfecf0ea7.yml
+++ b/data/mt/executive/Greg-Gianforte-c40b88ef-ba7b-415f-a6d4-581bfecf0ea7.yml
@@ -1,0 +1,20 @@
+id: ocd-person/c40b88ef-ba7b-415f-a6d4-581bfecf0ea7
+name: Greg Gianforte
+given_name: Greg
+family_name: Gianforte
+birth_date: '1961-04-17'
+party:
+- name: Republican
+roles:
+- jurisdiction: ocd-jurisdiction/country:us/state:mt/government
+  start_date: '2021-01-04'
+  end_date: '2025-01-01'
+  type: governor
+ids:
+  twitter: GregForMontana
+sources:
+- url: https://governor.mt.gov/
+links:
+- url: https://governor.mt.gov/
+- note: webform
+  url: https://svc.mt.gov/gov/contact/shareopinion

--- a/data/mt/retired/Steve-Bullock-0583e12a-b1d0-4312-a078-7add5c155cf6.yml
+++ b/data/mt/retired/Steve-Bullock-0583e12a-b1d0-4312-a078-7add5c155cf6.yml
@@ -6,15 +6,10 @@ birth_date: '1966-04-11'
 party:
 - name: Democratic
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-01-04'
   jurisdiction: ocd-jurisdiction/country:us/state:mt/government
   start_date: '2013-01-07'
   type: governor
-contact_details:
-- note: Capitol Office
-  address: Office of the Governor; PO Box 200801; Helena MT 59620-0801
-  fax: 406-444-5529
-  voice: 406-444-3111
 ids:
   twitter: GovernorBullock
 sources:

--- a/data/nc/executive/Roy-Cooper-afc05c54-5d87-475e-805d-78ce3f115468.yml
+++ b/data/nc/executive/Roy-Cooper-afc05c54-5d87-475e-805d-78ce3f115468.yml
@@ -6,7 +6,7 @@ birth_date: '1957-06-13'
 party:
 - name: Democratic
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nc/government
   start_date: '2017-01-01'
   type: governor

--- a/data/nc/municipalities/Allen-Joines-84a15e4d-daca-4983-8208-9152cb45c6ad.yml
+++ b/data/nc/municipalities/Allen-Joines-84a15e4d-daca-4983-8208-9152cb45c6ad.yml
@@ -3,7 +3,7 @@ name: Allen Joines
 given_name: Allen
 family_name: Joines
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nc/place:winston_salem/government
   type: mayor
 contact_details:

--- a/data/nc/municipalities/Jay-W-Wagner-8264becb-ec1a-4ff3-b757-74e4f2ecf331.yml
+++ b/data/nc/municipalities/Jay-W-Wagner-8264becb-ec1a-4ff3-b757-74e4f2ecf331.yml
@@ -3,7 +3,7 @@ name: Jay W. Wagner
 given_name: Jay W.
 family_name: Wagner
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nc/place:high_point/government
   type: mayor
 contact_details:

--- a/data/nc/municipalities/Rennie-Brantz-07cc76b3-eca0-4f2b-8793-01ef1147fbf7.yml
+++ b/data/nc/municipalities/Rennie-Brantz-07cc76b3-eca0-4f2b-8793-01ef1147fbf7.yml
@@ -3,7 +3,7 @@ name: Rennie Brantz
 given_name: Rennie
 family_name: Brantz
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nc/place:boone/government
   type: mayor
 contact_details:

--- a/data/nc/municipalities/Ron-Pappas-4904a348-59e4-4c30-b9a4-ac870995633a.yml
+++ b/data/nc/municipalities/Ron-Pappas-4904a348-59e4-4c30-b9a4-ac870995633a.yml
@@ -3,7 +3,7 @@ name: Ron Pappas
 given_name: Ron
 family_name: Pappas
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nc/place:waxhaw/government
   type: mayor
 contact_details:

--- a/data/nd/executive/Doug-Burgum-60943317-fcc2-4cdf-be4e-54c6335483f6.yml
+++ b/data/nd/executive/Doug-Burgum-60943317-fcc2-4cdf-be4e-54c6335483f6.yml
@@ -6,7 +6,7 @@ birth_date: '1956-08-01'
 party:
 - name: Republican
 roles:
-- end_date: '2020-12-31'
+- end_date: '2024-12-31'
   jurisdiction: ocd-jurisdiction/country:us/state:nd/government
   start_date: '2016-12-15'
   type: governor

--- a/data/nh/executive/Chris-Sununu-7a90d1a3-a8c9-47d7-9724-fa951eff016e.yml
+++ b/data/nh/executive/Chris-Sununu-7a90d1a3-a8c9-47d7-9724-fa951eff016e.yml
@@ -6,7 +6,7 @@ birth_date: '1974-11-05'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2023-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nh/government
   start_date: '2017-01-05'
   type: governor

--- a/data/nj/municipalities/Brad-J-Cohen-ef2bd899-b101-412f-837f-34807d140858.yml
+++ b/data/nj/municipalities/Brad-J-Cohen-ef2bd899-b101-412f-837f-34807d140858.yml
@@ -3,7 +3,7 @@ name: Brad J. Cohen
 given_name: Brad J.
 family_name: Cohen
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:east_brunswick/government
   type: mayor
 contact_details:

--- a/data/nj/municipalities/Brian-C-Wahler-b82cc24d-9b01-43cb-97ba-4eba7b3ebaa6.yml
+++ b/data/nj/municipalities/Brian-C-Wahler-b82cc24d-9b01-43cb-97ba-4eba7b3ebaa6.yml
@@ -3,7 +3,7 @@ name: Brian C. Wahler
 given_name: Brian C.
 family_name: Wahler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:piscataway/government
   type: mayor
 contact_details:

--- a/data/nj/municipalities/J-Christian-Bollwage-67901f88-09b0-4551-bbb7-05491fcddb80.yml
+++ b/data/nj/municipalities/J-Christian-Bollwage-67901f88-09b0-4551-bbb7-05491fcddb80.yml
@@ -3,7 +3,7 @@ name: J. Christian Bollwage
 given_name: J. Christian
 family_name: Bollwage
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:elizabeth/government
   type: mayor
 contact_details:

--- a/data/nj/municipalities/Liz-Lempert-305dc4d6-26af-4df9-8e72-7c5715852a7b.yml
+++ b/data/nj/municipalities/Liz-Lempert-305dc4d6-26af-4df9-8e72-7c5715852a7b.yml
@@ -3,7 +3,7 @@ name: Liz Lempert
 given_name: Liz
 family_name: Lempert
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:princeton/government
   type: mayor
 contact_details:

--- a/data/nj/municipalities/Raymond-G-Coles-80ab3982-1428-4869-9d78-8544e0d7ef4a.yml
+++ b/data/nj/municipalities/Raymond-G-Coles-80ab3982-1428-4869-9d78-8544e0d7ef4a.yml
@@ -3,7 +3,7 @@ name: Raymond G. Coles
 given_name: Raymond G.
 family_name: Coles
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:lakewood/government
   type: mayor
 contact_details:

--- a/data/nj/municipalities/Victor-De-Luca-1db5aef8-560b-4de7-91a6-24e723a17ca7.yml
+++ b/data/nj/municipalities/Victor-De-Luca-1db5aef8-560b-4de7-91a6-24e723a17ca7.yml
@@ -3,7 +3,7 @@ name: Victor De Luca
 given_name: Victor
 family_name: De Luca
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:nj/place:maplewood/government
   type: mayor
 contact_details:

--- a/data/ny/municipalities/Bob-Corby-69eb3eaf-e3c3-4ba5-8c29-77c97750121f.yml
+++ b/data/ny/municipalities/Bob-Corby-69eb3eaf-e3c3-4ba5-8c29-77c97750121f.yml
@@ -3,7 +3,7 @@ name: Bob Corby
 given_name: Bob
 family_name: Corby
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ny/place:pittsford/government
   type: mayor
 contact_details:

--- a/data/ny/municipalities/Lawrence-J-Montreuil-f2c2e684-9f6f-4aaf-8314-6088c05d9fdb.yml
+++ b/data/ny/municipalities/Lawrence-J-Montreuil-f2c2e684-9f6f-4aaf-8314-6088c05d9fdb.yml
@@ -3,7 +3,7 @@ name: Lawrence J. Montreuil
 given_name: Lawrence J.
 family_name: Montreuil
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ny/place:new_hyde_park/government
   type: mayor
 contact_details:

--- a/data/ny/municipalities/Michael-A-Lavorata-edb95c47-eb14-429d-8926-101a25c0cfef.yml
+++ b/data/ny/municipalities/Michael-A-Lavorata-edb95c47-eb14-429d-8926-101a25c0cfef.yml
@@ -3,7 +3,7 @@ name: Michael A. Lavorata
 given_name: Michael A.
 family_name: Lavorata
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ny/place:lindenhurst/government
   type: mayor
 contact_details:

--- a/data/ny/municipalities/Robert-Weitzner-f1c517ba-82ca-4601-bff5-dc1b9f4b6c16.yml
+++ b/data/ny/municipalities/Robert-Weitzner-f1c517ba-82ca-4601-bff5-dc1b9f4b6c16.yml
@@ -3,7 +3,7 @@ name: Robert Weitzner
 given_name: Robert
 family_name: Weitzner
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ny/place:port_washington/government
   type: mayor
 contact_details:

--- a/data/ny/municipalities/Tim-Rogers-f5fd32a4-e326-4732-a64e-9bc159c1a798.yml
+++ b/data/ny/municipalities/Tim-Rogers-f5fd32a4-e326-4732-a64e-9bc159c1a798.yml
@@ -3,7 +3,7 @@ name: Tim Rogers
 given_name: Tim
 family_name: Rogers
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ny/place:new_paltz/government
   type: mayor
 contact_details:

--- a/data/oh/municipalities/Mike-Aspacher-5a485908-fec2-409c-a9a1-5af5df17556e.yml
+++ b/data/oh/municipalities/Mike-Aspacher-5a485908-fec2-409c-a9a1-5af5df17556e.yml
@@ -3,7 +3,7 @@ name: Mike Aspacher
 given_name: Mike
 family_name: Aspacher
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:oh/place:bowling_green/government
   type: mayor
 contact_details:

--- a/data/ok/municipalities/GT-Bynum-1f256cb2-4ada-49fa-8226-a581ba422439.yml
+++ b/data/ok/municipalities/GT-Bynum-1f256cb2-4ada-49fa-8226-a581ba422439.yml
@@ -3,7 +3,7 @@ name: G.T. Bynum
 given_name: G.T.
 family_name: Bynum
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ok/place:tulsa/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Gary-H-Wheeler-366d0358-118f-434a-9853-a92d89da27da.yml
+++ b/data/or/municipalities/Gary-H-Wheeler-366d0358-118f-434a-9853-a92d89da27da.yml
@@ -3,7 +3,7 @@ name: Gary H. Wheeler
 given_name: Gary H.
 family_name: Wheeler
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:medford/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/John-Stromberg-a14bd522-e45f-4eb5-a99e-a35f730c9a0f.yml
+++ b/data/or/municipalities/John-Stromberg-a14bd522-e45f-4eb5-a99e-a35f730c9a0f.yml
@@ -3,7 +3,7 @@ name: John Stromberg
 given_name: John
 family_name: Stromberg
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:ashland/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Kent-Studebaker-40f2aa06-452b-4152-8ee2-d935e9d37495.yml
+++ b/data/or/municipalities/Kent-Studebaker-40f2aa06-452b-4152-8ee2-d935e9d37495.yml
@@ -3,7 +3,7 @@ name: Kent Studebaker
 given_name: Kent
 family_name: Studebaker
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:lake_oswego/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Lucy-Vinis-e5418034-5202-49af-b7c3-f7c3aee6ed32.yml
+++ b/data/or/municipalities/Lucy-Vinis-e5418034-5202-49af-b7c3-f7c3aee6ed32.yml
@@ -3,7 +3,7 @@ name: Lucy Vinis
 given_name: Lucy
 family_name: Vinis
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:eugene/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Sally-Russell-e6a7a4a5-4261-45c5-81c5-2cb108e715ab.yml
+++ b/data/or/municipalities/Sally-Russell-e6a7a4a5-4261-45c5-81c5-2cb108e715ab.yml
@@ -3,7 +3,7 @@ name: Sally Russell
 given_name: Sally
 family_name: Russell
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:bend/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Sharon-Konopa-349e4687-2522-4fbb-9a8b-e3867af961ef.yml
+++ b/data/or/municipalities/Sharon-Konopa-349e4687-2522-4fbb-9a8b-e3867af961ef.yml
@@ -3,7 +3,7 @@ name: Sharon Konopa
 given_name: Sharon
 family_name: Konopa
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:albany/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Steve-Callaway-da2d9c36-c61b-47b3-8745-b19725bacc96.yml
+++ b/data/or/municipalities/Steve-Callaway-da2d9c36-c61b-47b3-8745-b19725bacc96.yml
@@ -3,7 +3,7 @@ name: Steve Callaway
 given_name: Steve
 family_name: Callaway
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:or/place:hillsboro/government
   type: mayor
 contact_details:

--- a/data/or/municipalities/Ted-Wheeler-5eb15e9d-6fe9-432c-82a0-257148be4f4d.yml
+++ b/data/or/municipalities/Ted-Wheeler-5eb15e9d-6fe9-432c-82a0-257148be4f4d.yml
@@ -3,14 +3,14 @@ name: Ted Wheeler
 given_name: Ted
 family_name: Wheeler
 roles:
-  - end_date: "2021-01-01"
-    jurisdiction: ocd-jurisdiction/country:us/state:or/place:portland/government
-    type: mayor
+- end_date: '2021-03-01'
+  jurisdiction: ocd-jurisdiction/country:us/state:or/place:portland/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: 1221 SW 4th Ave;Room 340;Portland, OR 97204
-    voice: 503-823-4120
+- note: Primary Office
+  address: 1221 SW 4th Ave;Room 340;Portland, OR 97204
+  voice: 503-823-4120
 sources:
-  - url: https://www.portland.gov/wheeler/about-ted
+- url: https://www.portland.gov/wheeler/about-ted
 links: []
 email: mayorwheeler@portlandoregon.gov

--- a/data/pa/municipalities/Jack-Ritter-34d26b0a-8171-4d01-acee-dce8a32c077d.yml
+++ b/data/pa/municipalities/Jack-Ritter-34d26b0a-8171-4d01-acee-dce8a32c077d.yml
@@ -3,7 +3,7 @@ name: Jack Ritter
 given_name: Jack
 family_name: Ritter
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:pa/place:mechanicsburg/government
   type: mayor
 contact_details:

--- a/data/pa/municipalities/Peter-Urscheler-4351e834-4540-4d96-93b3-bf7256da05df.yml
+++ b/data/pa/municipalities/Peter-Urscheler-4351e834-4540-4d96-93b3-bf7256da05df.yml
@@ -3,7 +3,7 @@ name: Peter Urscheler
 given_name: Peter
 family_name: Urscheler
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:pa/place:phoenixville/government
   type: mayor
 contact_details:

--- a/data/pa/municipalities/Phil-Dague-8d58da11-82c5-441f-b8ec-ee61adb2cf5a.yml
+++ b/data/pa/municipalities/Phil-Dague-8d58da11-82c5-441f-b8ec-ee61adb2cf5a.yml
@@ -3,7 +3,7 @@ name: Phil Dague
 given_name: Phil
 family_name: Dague
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:pa/place:downingtown/government
   type: mayor
 contact_details:

--- a/data/pa/municipalities/Robert-A-McMahon-bd5eb71a-2012-4a3f-8b71-5291c88276a9.yml
+++ b/data/pa/municipalities/Robert-A-McMahon-bd5eb71a-2012-4a3f-8b71-5291c88276a9.yml
@@ -3,7 +3,7 @@ name: Robert A. McMahon
 given_name: Robert A.
 family_name: McMahon
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:pa/place:media/government
   type: mayor
 contact_details:

--- a/data/pa/municipalities/Ron-Strouse-9039e317-cc46-4d15-b636-595ee7ba71a1.yml
+++ b/data/pa/municipalities/Ron-Strouse-9039e317-cc46-4d15-b636-595ee7ba71a1.yml
@@ -3,7 +3,7 @@ name: Ron Strouse
 given_name: Ron
 family_name: Strouse
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:pa/place:doylestown/government
   type: mayor
 contact_details:

--- a/data/pr/executive/Pedro-Pierluisi-d3472067-f01e-4526-88c3-0b502fc68517.yml
+++ b/data/pr/executive/Pedro-Pierluisi-d3472067-f01e-4526-88c3-0b502fc68517.yml
@@ -1,0 +1,18 @@
+id: ocd-person/d3472067-f01e-4526-88c3-0b502fc68517
+name: Pedro Pierluisi
+given_name: Pedro
+family_name: Pierluisi
+birth_date: '1959-04-26'
+party:
+- name: Partido Nuevo Progresista
+roles:
+- jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
+  type: governor
+  start_date: '2021-01-02'
+  end_date: '2025-01-01'
+ids:
+  twitter: pedropierluisi
+sources:
+- url: https://www.fortaleza.pr.gov/
+links:
+- url: https://www.fortaleza.pr.gov/

--- a/data/pr/retired/Wanda-Vazquez-Garced-c10b9ca5-196e-4906-ad49-39e171d74563.yml
+++ b/data/pr/retired/Wanda-Vazquez-Garced-c10b9ca5-196e-4906-ad49-39e171d74563.yml
@@ -7,14 +7,10 @@ party:
 - name: Partido Nuevo Progresista
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-01-02'
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   start_date: '2019-08-07'
   type: governor
-contact_details:
-- note: Capitol Office
-  fax: 787-721-5072
-  voice: 787-721-2400
 ids:
   twitter: wandavazquezg
 sources:

--- a/data/ri/municipalities/Allan-W-Fung-0ee16d97-05f8-435d-a0f3-c03ec39662cf.yml
+++ b/data/ri/municipalities/Allan-W-Fung-0ee16d97-05f8-435d-a0f3-c03ec39662cf.yml
@@ -3,7 +3,7 @@ name: Allan W. Fung
 given_name: Allan W.
 family_name: Fung
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ri/place:cranston/government
   type: mayor
 contact_details:

--- a/data/ri/municipalities/Joseph-J-Solomon-331c83c6-0a5c-4ba0-b646-95aa3c9fbbe7.yml
+++ b/data/ri/municipalities/Joseph-J-Solomon-331c83c6-0a5c-4ba0-b646-95aa3c9fbbe7.yml
@@ -3,7 +3,7 @@ name: Joseph J. Solomon
 given_name: Joseph J.
 family_name: Solomon
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ri/place:warwick/government
   type: mayor
 contact_details:

--- a/data/tn/municipalities/Jamie-Clary-44d2c3f5-14c1-4799-9ba0-55df1630628e.yml
+++ b/data/tn/municipalities/Jamie-Clary-44d2c3f5-14c1-4799-9ba0-55df1630628e.yml
@@ -3,7 +3,7 @@ name: Jamie Clary
 given_name: Jamie
 family_name: Clary
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tn/place:hendersonville/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Anthony-Williams-3d0d6c1c-7516-4334-944f-c5a78ac2ccfc.yml
+++ b/data/tx/municipalities/Anthony-Williams-3d0d6c1c-7516-4334-944f-c5a78ac2ccfc.yml
@@ -3,7 +3,7 @@ name: Anthony Williams
 given_name: Anthony
 family_name: Williams
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:abilene/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Bruno-Lozano-e16ae00c-6ef7-4bc5-bfc9-768daf7f5696.yml
+++ b/data/tx/municipalities/Bruno-Lozano-e16ae00c-6ef7-4bc5-bfc9-768daf7f5696.yml
@@ -3,15 +3,15 @@ name: Bruno Lozano
 given_name: Bruno
 family_name: Lozano
 roles:
-  - end_date: "2022-05-07"
-    jurisdiction: ocd-jurisdiction/country:us/state:tx/place:del_rio/government
-    type: mayor
+- end_date: '2022-05-07'
+  jurisdiction: ocd-jurisdiction/country:us/state:tx/place:del_rio/government
+  type: mayor
 contact_details:
-  - note: Primary Office
-    address: P109 W. Broadway;Del Rio, TX 78840
-    voice: 830-774-8790
+- note: Primary Office
+  address: P109 W. Broadway;Del Rio, TX 78840
+  voice: 830-774-8790
 sources:
-  - url: https://www.cityofdelrio.com/government/mayor
+- url: https://www.cityofdelrio.com/government/mayor
 links:
-  - url: https://www.cityofdelrio.com/government/mayor
+- url: https://www.cityofdelrio.com/government/mayor
 email: delriomayor@cityofdelrio.com

--- a/data/tx/municipalities/Chris-Watts-953e12ad-724d-48ed-b89f-3d3860277638.yml
+++ b/data/tx/municipalities/Chris-Watts-953e12ad-724d-48ed-b89f-3d3860277638.yml
@@ -3,7 +3,7 @@ name: Chris Watts
 given_name: Chris
 family_name: Watts
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:denton/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Corbin-Van-Arsdale-7d4c6c9a-09c0-4cf2-945e-1b0fa77745ee.yml
+++ b/data/tx/municipalities/Corbin-Van-Arsdale-7d4c6c9a-09c0-4cf2-945e-1b0fa77745ee.yml
@@ -3,7 +3,7 @@ name: Corbin Van Arsdale
 given_name: Corbin
 family_name: Van Arsdale
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:cedar_park/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Craig-Morgan-77685432-0259-476f-afac-3bccfa3bd38b.yml
+++ b/data/tx/municipalities/Craig-Morgan-77685432-0259-476f-afac-3bccfa3bd38b.yml
@@ -3,7 +3,7 @@ name: Craig Morgan
 given_name: Craig
 family_name: Morgan
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:round_rock/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Dale-Ross-7bf10bf8-abea-4a00-bbbc-11acab4b562d.yml
+++ b/data/tx/municipalities/Dale-Ross-7bf10bf8-abea-4a00-bbbc-11acab4b562d.yml
@@ -3,7 +3,7 @@ name: Dale Ross
 given_name: Dale
 family_name: Ross
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:georgetown/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Dan-Pope-3ed263b1-ae24-4229-8619-80448f7d3135.yml
+++ b/data/tx/municipalities/Dan-Pope-3ed263b1-ae24-4229-8619-80448f7d3135.yml
@@ -3,7 +3,7 @@ name: Dan Pope
 given_name: Dan
 family_name: Pope
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:lubbock/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/David-Turner-21cf891c-21ac-4257-be93-397f32675ee2.yml
+++ b/data/tx/municipalities/David-Turner-21cf891c-21ac-4257-be93-397f32675ee2.yml
@@ -3,7 +3,7 @@ name: David Turner
 given_name: David
 family_name: Turner
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:odessa/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Debbie-Stout-810efa00-8573-4659-ad74-2c0577f316fb.yml
+++ b/data/tx/municipalities/Debbie-Stout-810efa00-8573-4659-ad74-2c0577f316fb.yml
@@ -3,7 +3,7 @@ name: Debbie Stout
 given_name: Debbie
 family_name: Stout
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:allen/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Eric-Hogue-de535d69-be54-445b-937d-61be9dc24398.yml
+++ b/data/tx/municipalities/Eric-Hogue-de535d69-be54-445b-937d-61be9dc24398.yml
@@ -3,7 +3,7 @@ name: Eric Hogue
 given_name: Eric
 family_name: Hogue
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:wylie/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Jane-Hughson-ad66c53e-ae5a-41c2-8f2d-7150c51b387c.yml
+++ b/data/tx/municipalities/Jane-Hughson-ad66c53e-ae5a-41c2-8f2d-7150c51b387c.yml
@@ -3,7 +3,7 @@ name: Jane Hughson
 given_name: Jane
 family_name: Hughson
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:san_marcos/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Jeff-Cheney-8f4cc828-656a-4037-82ab-9f1ed324c825.yml
+++ b/data/tx/municipalities/Jeff-Cheney-8f4cc828-656a-4037-82ab-9f1ed324c825.yml
@@ -3,7 +3,7 @@ name: Jeff Cheney
 given_name: Jeff
 family_name: Cheney
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:frisco/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Joe-McComb-218be081-dc49-4d04-ba26-12726a24a2ee.yml
+++ b/data/tx/municipalities/Joe-McComb-218be081-dc49-4d04-ba26-12726a24a2ee.yml
@@ -3,7 +3,7 @@ name: Joe McComb
 given_name: Joe
 family_name: McComb
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:corpus_christi/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Joe-R-Zimmerman-e02a6719-869a-4962-b067-196cab655e3a.yml
+++ b/data/tx/municipalities/Joe-R-Zimmerman-e02a6719-869a-4962-b067-196cab655e3a.yml
@@ -3,7 +3,7 @@ name: Joe R. Zimmerman
 given_name: Joe R.
 family_name: Zimmerman
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:sugar_land/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Jose-L-Segarra-f6caa3e2-52f1-4304-bee7-f80da1d35b4d.yml
+++ b/data/tx/municipalities/Jose-L-Segarra-f6caa3e2-52f1-4304-bee7-f80da1d35b4d.yml
@@ -3,7 +3,7 @@ name: Jose L. Segarra
 given_name: Jose L.
 family_name: Segarra
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:killeen/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Kevin-Falconer-276f9e68-9f1b-455c-9be7-b835bafdf18b.yml
+++ b/data/tx/municipalities/Kevin-Falconer-276f9e68-9f1b-455c-9be7-b835bafdf18b.yml
@@ -3,7 +3,7 @@ name: Kevin Falconer
 given_name: Kevin
 family_name: Falconer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:carrollton/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Kyle-Deaver-ef254205-d4c6-4773-acdc-b1a36bad75dc.yml
+++ b/data/tx/municipalities/Kyle-Deaver-ef254205-d4c6-4773-acdc-b1a36bad75dc.yml
@@ -3,7 +3,7 @@ name: Kyle Deaver
 given_name: Kyle
 family_name: Deaver
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:waco/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Linda-Lipp-Martin-0104eab4-4eb3-446b-a54d-6943964d953c.yml
+++ b/data/tx/municipalities/Linda-Lipp-Martin-0104eab4-4eb3-446b-a54d-6943964d953c.yml
@@ -3,7 +3,7 @@ name: Linda Lipp Martin
 given_name: Linda Lipp
 family_name: Martin
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:euless/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Martin-Heines-333029e2-3f6a-4c51-9724-d238782acbda.yml
+++ b/data/tx/municipalities/Martin-Heines-333029e2-3f6a-4c51-9724-d238782acbda.yml
@@ -3,7 +3,7 @@ name: Martin Heines
 given_name: Martin
 family_name: Heines
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:tyler/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Merle-Aaron-91bf313c-8a7d-4f2a-aa3e-46cca03fce92.yml
+++ b/data/tx/municipalities/Merle-Aaron-91bf313c-8a7d-4f2a-aa3e-46cca03fce92.yml
@@ -3,7 +3,7 @@ name: Merle Aaron
 given_name: Merle
 family_name: Aaron
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:humble/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Oscar-Trevino-5bbf3602-f6e9-4cb3-994f-555c35ede11a.yml
+++ b/data/tx/municipalities/Oscar-Trevino-5bbf3602-f6e9-4cb3-994f-555c35ede11a.yml
@@ -3,7 +3,7 @@ name: Oscar Trevino
 given_name: Oscar
 family_name: Trevino
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:north_richland_hills/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Pat-McGrail-db19208a-ee2d-451a-8a41-8c6020eb1502.yml
+++ b/data/tx/municipalities/Pat-McGrail-db19208a-ee2d-451a-8a41-8c6020eb1502.yml
@@ -3,7 +3,7 @@ name: Pat McGrail
 given_name: Pat
 family_name: McGrail
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:keller/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Rick-Stopfer-52ffb6dd-053d-42ba-91fd-719a46d13364.yml
+++ b/data/tx/municipalities/Rick-Stopfer-52ffb6dd-053d-42ba-91fd-719a46d13364.yml
@@ -3,7 +3,7 @@ name: Rick Stopfer
 given_name: Rick
 family_name: Stopfer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:irving/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Rusty-Brockman-99e4f353-333b-47ca-bb15-de34e3a8ba00.yml
+++ b/data/tx/municipalities/Rusty-Brockman-99e4f353-333b-47ca-bb15-de34e3a8ba00.yml
@@ -3,7 +3,7 @@ name: Rusty Brockman
 given_name: Rusty
 family_name: Brockman
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:new_braunfels/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Stephen-Santellana-718125bb-1f51-452f-8458-4afc721fcb05.yml
+++ b/data/tx/municipalities/Stephen-Santellana-718125bb-1f51-452f-8458-4afc721fcb05.yml
@@ -3,7 +3,7 @@ name: Stephen Santellana
 given_name: Stephen
 family_name: Santellana
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:wichita_falls/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Toby-Powell-cf772386-4efe-4ff1-a984-3b799b8d4af0.yml
+++ b/data/tx/municipalities/Toby-Powell-cf772386-4efe-4ff1-a984-3b799b8d4af0.yml
@@ -3,7 +3,7 @@ name: Toby Powell
 given_name: Toby
 family_name: Powell
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:conroe/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Tom-Reid-95d327a3-2047-4f0b-8a5b-860883bc2e41.yml
+++ b/data/tx/municipalities/Tom-Reid-95d327a3-2047-4f0b-8a5b-860883bc2e41.yml
@@ -3,7 +3,7 @@ name: Tom Reid
 given_name: Tom
 family_name: Reid
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:pearland/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/Travis-Mitchell-b25fec9e-a818-4da4-826a-68750bd3760e.yml
+++ b/data/tx/municipalities/Travis-Mitchell-b25fec9e-a818-4da4-826a-68750bd3760e.yml
@@ -3,7 +3,7 @@ name: Travis Mitchell
 given_name: Travis
 family_name: Mitchell
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:kyle/government
   type: mayor
 contact_details:

--- a/data/tx/municipalities/William-M-Bill-Hastings-afe491a7-a30e-4d38-ad39-54724a714fdb.yml
+++ b/data/tx/municipalities/William-M-Bill-Hastings-afe491a7-a30e-4d38-ad39-54724a714fdb.yml
@@ -3,7 +3,7 @@ name: William M. "Bill" Hastings
 given_name: William M. "Bill"
 family_name: Hastings
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:katy/government
   type: mayor
 contact_details:

--- a/data/ut/executive/Spencer-Cox-52dd3ff2-e7a2-458e-b8f1-797fdab69e4a.yml
+++ b/data/ut/executive/Spencer-Cox-52dd3ff2-e7a2-458e-b8f1-797fdab69e4a.yml
@@ -3,9 +3,9 @@ name: Spencer Cox
 given_name: Spencer
 family_name: Cox
 roles:
-- end_date: '2021-12-31'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:ut/government
-  type: chief election officer
+  type: governor
 email: spencercox@utah.gov
 contact_details:
 - note: Capitol Office
@@ -15,8 +15,8 @@ contact_details:
 ids:
   twitter: SpencerJCox
 sources:
-- url: https://www.utah.gov/government/secretary-of-state.html
+- url: https://governor.utah.gov/
 links:
-- url: https://www.utah.gov/government/secretary-of-state.html
+- url: https://governor.utah.gov/
 party:
 - name: Republican

--- a/data/ut/retired/Gary-Herbert-9d247dcc-ca8f-4a06-8d74-a9c8d89737b6.yml
+++ b/data/ut/retired/Gary-Herbert-9d247dcc-ca8f-4a06-8d74-a9c8d89737b6.yml
@@ -6,15 +6,10 @@ birth_date: '1947-05-07'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-01-04'
   jurisdiction: ocd-jurisdiction/country:us/state:ut/government
   start_date: '2009-08-11'
   type: governor
-contact_details:
-- note: Capitol Office
-  address: Utah State Capitol; Suite 200; Salt Lake City, UT 84114
-  fax: 801-538-1557
-  voice: 801-538-1000
 ids:
   twitter: govherbert
 sources:

--- a/data/va/municipalities/David-Tarter-a0e8549f-6f93-4e1e-92d8-664bfa8f680a.yml
+++ b/data/va/municipalities/David-Tarter-a0e8549f-6f93-4e1e-92d8-664bfa8f680a.yml
@@ -3,7 +3,7 @@ name: David Tarter
 given_name: David
 family_name: Tarter
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:falls_church/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Deanna-R-Reed-c69281e8-8f25-4308-bbf5-3031d3891ec8.yml
+++ b/data/va/municipalities/Deanna-R-Reed-c69281e8-8f25-4308-bbf5-3031d3891ec8.yml
@@ -3,7 +3,7 @@ name: Deanna R. Reed
 given_name: Deanna R.
 family_name: Reed
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:harrisonburg/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Harry-Hal-J-Parrish-II-dd7d2c08-6a5d-4474-a819-47f77a9cf3ec.yml
+++ b/data/va/municipalities/Harry-Hal-J-Parrish-II-dd7d2c08-6a5d-4474-a819-47f77a9cf3ec.yml
@@ -3,7 +3,7 @@ name: Harry 'Hal' J. Parrish II
 given_name: Harry 'Hal' J.
 family_name: Parrish II
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:manassas/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/John-David-Smith-Jr-d97d9800-e1bc-4384-a0ac-a72ca5326c61.yml
+++ b/data/va/municipalities/John-David-Smith-Jr-d97d9800-e1bc-4384-a0ac-a72ca5326c61.yml
@@ -3,7 +3,7 @@ name: John David Smith, Jr.
 given_name: John David
 family_name: Smith, Jr.
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:winchester/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Kelly-Burk-8e9dd82f-2935-4b29-8928-25fe6921935f.yml
+++ b/data/va/municipalities/Kelly-Burk-8e9dd82f-2935-4b29-8928-25fe6921935f.yml
@@ -3,7 +3,7 @@ name: Kelly Burk
 given_name: Kelly
 family_name: Burk
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:leesburg/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Levar-Stoney-a5d8e296-97b6-4e8d-83f3-ab225fca731d.yml
+++ b/data/va/municipalities/Levar-Stoney-a5d8e296-97b6-4e8d-83f3-ab225fca731d.yml
@@ -3,7 +3,7 @@ name: Levar Stoney
 given_name: Levar
 family_name: Stoney
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:richmond/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Libby-Garvey-3007e393-68fe-41a1-827a-ee94cd9b8086.yml
+++ b/data/va/municipalities/Libby-Garvey-3007e393-68fe-41a1-827a-ee94cd9b8086.yml
@@ -3,7 +3,7 @@ name: Libby Garvey
 given_name: Libby
 family_name: Garvey
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:arlington/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Lisa-C-Merkel-96153366-6a55-4e6a-8188-516a6e36c217.yml
+++ b/data/va/municipalities/Lisa-C-Merkel-96153366-6a55-4e6a-8188-516a6e36c217.yml
@@ -3,7 +3,7 @@ name: Lisa C. Merkel
 given_name: Lisa C.
 family_name: Merkel
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:herndon/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Nikuyah-Walker-ffa95a4e-963c-4823-a0d5-895e3ed46df9.yml
+++ b/data/va/municipalities/Nikuyah-Walker-ffa95a4e-963c-4823-a0d5-895e3ed46df9.yml
@@ -3,7 +3,7 @@ name: Nikuyah Walker
 given_name: Nikuyah
 family_name: Walker
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:charlottesville/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Robert-Bobby-Dyer-6b86ceaa-6ba7-40f9-bccc-6d4a992f4416.yml
+++ b/data/va/municipalities/Robert-Bobby-Dyer-6b86ceaa-6ba7-40f9-bccc-6d4a992f4416.yml
@@ -3,7 +3,7 @@ name: Robert "Bobby" Dyer
 given_name: Robert "Bobby"
 family_name: Dyer
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:virginia_beach/government
   type: mayor
 contact_details:

--- a/data/va/municipalities/Sherman-P-Lea-Sr-9bfe74aa-ef9d-4c1d-98ce-d3cdf9f6b7ce.yml
+++ b/data/va/municipalities/Sherman-P-Lea-Sr-9bfe74aa-ef9d-4c1d-98ce-d3cdf9f6b7ce.yml
@@ -3,7 +3,7 @@ name: Sherman P. Lea Sr.
 given_name: Sherman P.
 family_name: Lea Sr.
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:va/place:roanoke/government
   type: mayor
 contact_details:

--- a/data/vt/executive/Phil-Scott-f3e613ff-3cd6-4b2c-b268-f6460d029f05.yml
+++ b/data/vt/executive/Phil-Scott-f3e613ff-3cd6-4b2c-b268-f6460d029f05.yml
@@ -6,7 +6,7 @@ birth_date: '1958-08-04'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2023-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:vt/government
   start_date: '2017-01-05'
   type: governor

--- a/data/wa/executive/Jay-Inslee-e7e4b677-33e1-41a0-9c12-5618de42819a.yml
+++ b/data/wa/executive/Jay-Inslee-e7e4b677-33e1-41a0-9c12-5618de42819a.yml
@@ -6,7 +6,7 @@ birth_date: '1951-02-09'
 party:
 - name: Democratic
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wa/government
   start_date: '2013-01-16'
   type: governor

--- a/data/wa/municipalities/Liam-Olsen-d2c6c36e-094e-4ff5-928c-faa4b2b20d9b.yml
+++ b/data/wa/municipalities/Liam-Olsen-d2c6c36e-094e-4ff5-928c-faa4b2b20d9b.yml
@@ -3,7 +3,7 @@ name: Liam Olsen
 given_name: Liam
 family_name: Olsen
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wa/place:bothell/government
   type: mayor
 contact_details:

--- a/data/wa/municipalities/Lynne-Robinson-ffefec62-d4ed-4263-a0cc-c0c221c9bcc0.yml
+++ b/data/wa/municipalities/Lynne-Robinson-ffefec62-d4ed-4263-a0cc-c0c221c9bcc0.yml
@@ -3,7 +3,7 @@ name: Lynne Robinson
 given_name: Lynne
 family_name: Robinson
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wa/place:bellevue/government
   type: mayor
 contact_details:

--- a/data/wa/municipalities/Penny-Sweet-31c845c4-8275-45a4-b401-c68d022f8e12.yml
+++ b/data/wa/municipalities/Penny-Sweet-31c845c4-8275-45a4-b401-c68d022f8e12.yml
@@ -3,7 +3,7 @@ name: Penny Sweet
 given_name: Penny
 family_name: Sweet
 roles:
-- end_date: '2021-01-01'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wa/place:kirkland/government
   type: mayor
 contact_details:

--- a/data/wv/executive/Jim-Justice-9767d4ee-34a8-40b6-9886-8cf1cf56c090.yml
+++ b/data/wv/executive/Jim-Justice-9767d4ee-34a8-40b6-9886-8cf1cf56c090.yml
@@ -6,7 +6,7 @@ birth_date: '1951-04-27'
 party:
 - name: Republican
 roles:
-- end_date: '2021-01-01'
+- end_date: '2025-01-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wv/government
   start_date: '2017-01-16'
   type: governor

--- a/data/wv/municipalities/Steve-Williams-0487814b-a1e7-4448-9834-ff0c900ff042.yml
+++ b/data/wv/municipalities/Steve-Williams-0487814b-a1e7-4448-9834-ff0c900ff042.yml
@@ -3,7 +3,7 @@ name: Steve Williams
 given_name: Steve
 family_name: Williams
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wv/place:huntington/government
   type: mayor
 contact_details:

--- a/data/wv/municipalities/Tom-Joyce-b0d1480c-6ffa-4132-9566-3d436e9af481.yml
+++ b/data/wv/municipalities/Tom-Joyce-b0d1480c-6ffa-4132-9566-3d436e9af481.yml
@@ -3,7 +3,7 @@ name: Tom Joyce
 given_name: Tom
 family_name: Joyce
 roles:
-- end_date: '2020-12-31'
+- end_date: '2021-03-01'
   jurisdiction: ocd-jurisdiction/country:us/state:wv/place:parkersburg/government
   type: mayor
 contact_details:

--- a/settings.yml
+++ b/settings.yml
@@ -18,35 +18,35 @@ ga:
   vacancies:
     - chamber: upper
       district: 4
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
 ma:
   vacancies:
     - chamber: upper
       district: Plymouth and Barnstable
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: upper
       district: Second Hampden and Hampshire
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: lower
       district: Third Bristol
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: lower
       district: Thirty-Seventh Middlesex
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
 mo:
   vacancies:
     - chamber: upper
       district: 3
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: upper
       district: 7
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: upper
       district: 9
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
     - chamber: lower
       district: 34
-      vacant_until: 2021-01-01
+      vacant_until: 2021-03-01
 md:
   vacancies:
     - chamber: lower


### PR DESCRIPTION
Push end dates that have passed for mayors and vacancies to March 1, and update governors that were up for election in November.