### PR TITLE
KS: Add 5 missing senators

### DIFF
--- a/data/ks/legislature/Aaron-Coleman-4824d856-5fdc-43a5-abee-ff60e648e112.yml
+++ b/data/ks/legislature/Aaron-Coleman-4824d856-5fdc-43a5-abee-ff60e648e112.yml
@@ -21,3 +21,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_coleman_aaron_1.jpg
 extras:
   occupation: Free-lance Dishwasher
+given_name: Aaron
+family_name: Coleman

--- a/data/ks/legislature/Alicia-Straub-1b272330-b7d2-4d33-8828-2e45e68c7afa.yml
+++ b/data/ks/legislature/Alicia-Straub-1b272330-b7d2-4d33-8828-2e45e68c7afa.yml
@@ -7,11 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower
   start_date: 2019-03-19
-  end_date: '2020-12-31'
+  end_date: '2021-01-11'
 - district: '33'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-  end_date: '2020-12-31'
+  start_date: 2021-01-11
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/rep_straub_alicia_1/
 - url: http://www.kslegislature.org/li/b2021_22/members/sen_straub_alicia_1/
@@ -24,3 +24,7 @@ extras:
 given_name: Alicia
 family_name: Straub
 email: Alicia.Straub@senate.ks.gov
+contact_details:
+- note: Capitol Office
+  address: Room 237-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7682

--- a/data/ks/legislature/Avery-Anderson-4544fc4e-fff8-4bbe-bc29-4e28c6be3179.yml
+++ b/data/ks/legislature/Avery-Anderson-4544fc4e-fff8-4bbe-bc29-4e28c6be3179.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_anderson_avery_1.jpg
 extras:
   occupation: Entrepreneur
+given_name: Avery
+family_name: Anderson

--- a/data/ks/legislature/Beverly-Gossage-35630402-1f6a-4a3e-b6cf-48c1b93bd6ae.yml
+++ b/data/ks/legislature/Beverly-Gossage-35630402-1f6a-4a3e-b6cf-48c1b93bd6ae.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_gossage_beverly_1.jpg
 extras:
   occupation: Insurance Agent
+given_name: Beverly
+family_name: Gossage

--- a/data/ks/legislature/Brenda-Dietrich-57c530cc-4575-431e-9118-11f64fa3a573.yml
+++ b/data/ks/legislature/Brenda-Dietrich-57c530cc-4575-431e-9118-11f64fa3a573.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_dietrich_brenda_1.jpg
 extras:
   occupation: Retired Superintendent
+given_name: Brenda
+family_name: Dietrich

--- a/data/ks/legislature/Brett-Fairchild-ca3f1bf6-44e0-4d67-b242-3cd29905723c.yml
+++ b/data/ks/legislature/Brett-Fairchild-ca3f1bf6-44e0-4d67-b242-3cd29905723c.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_fairchild_brett_1.jpg
 extras:
   occupation: Farmer
+given_name: Brett
+family_name: Fairchild

--- a/data/ks/legislature/Brian-Bergkamp-ee28d684-dc5b-4923-a56f-7fef74c9ef67.yml
+++ b/data/ks/legislature/Brian-Bergkamp-ee28d684-dc5b-4923-a56f-7fef74c9ef67.yml
@@ -17,3 +17,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_bergkamp_brian_1.jpg
 extras:
   occupation: Project Manager
+given_name: Brian
+family_name: Bergkamp

--- a/data/ks/legislature/Carl-Turner-71b474cb-1732-41fc-b525-4d53911cbbbe.yml
+++ b/data/ks/legislature/Carl-Turner-71b474cb-1732-41fc-b525-4d53911cbbbe.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_turner_carl_1.jpg
 extras:
   occupation: Financial/Process Improvement/Project Management
+given_name: Carl
+family_name: Turner

--- a/data/ks/legislature/Charles-Smith-8b617466-af12-4848-8cca-ed088fb196da.yml
+++ b/data/ks/legislature/Charles-Smith-8b617466-af12-4848-8cca-ed088fb196da.yml
@@ -1,5 +1,5 @@
 id: ocd-person/8b617466-af12-4848-8cca-ed088fb196da
-name: Charles  Smith
+name: Charles Smith
 email: chuck.smith@house.ks.gov
 party:
 - name: Republican
@@ -18,3 +18,7 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_smith_charles_1.jpg
 extras:
   occupation: Teacher-Coach
+other_names:
+- name: Charles  Smith
+given_name: Charles
+family_name: Smith

--- a/data/ks/legislature/Christina-Haswood-dd195ea4-3f71-41f2-af19-95d60b252348.yml
+++ b/data/ks/legislature/Christina-Haswood-dd195ea4-3f71-41f2-af19-95d60b252348.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_haswood_christina_1.jpg
 extras:
   occupation: Public Health Worker
+given_name: Christina
+family_name: Haswood

--- a/data/ks/legislature/Cindy-Holscher-9c36b31f-b9e7-43cd-8aab-6148c8f6cac8.yml
+++ b/data/ks/legislature/Cindy-Holscher-9c36b31f-b9e7-43cd-8aab-6148c8f6cac8.yml
@@ -6,11 +6,11 @@ roles:
 - district: '16'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower
-  end_date: '2020-12-31'
+  end_date: '2021-01-11'
 - district: '8'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-  end_date: '2020-12-31'
+  start_date: 2021-01-11
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/rep_holscher_cindy_1/
 - url: http://www.kslegislature.org/li/b2021_22/members/sen_holscher_cindy_1/
@@ -26,3 +26,7 @@ other_identifiers:
 given_name: Cindy
 family_name: Holscher
 email: Cindy.Holscher@senate.ks.gov
+contact_details:
+- note: Capitol Office
+  address: Room 124-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7659

--- a/data/ks/legislature/Clarke-Sanders-3df522a5-5542-4ad4-b1bf-54736e60c601.yml
+++ b/data/ks/legislature/Clarke-Sanders-3df522a5-5542-4ad4-b1bf-54736e60c601.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_sanders_clarke_1.jpg
 extras:
   occupation: ''
+given_name: Clarke
+family_name: Sanders

--- a/data/ks/legislature/Ethan-Corson-76d729c5-1b4d-4966-8c99-5ac8b74d8719.yml
+++ b/data/ks/legislature/Ethan-Corson-76d729c5-1b4d-4966-8c99-5ac8b74d8719.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_corson_ethan_1.jpg
 extras:
   occupation: Attorney
+given_name: Ethan
+family_name: Corson

--- a/data/ks/legislature/JR-Claeys-2bbf4d79-672b-46f7-8745-ee91db3169e3.yml
+++ b/data/ks/legislature/JR-Claeys-2bbf4d79-672b-46f7-8745-ee91db3169e3.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_claeys_jr_1.jpg
 extras:
   occupation: Nonprofit Management
+given_name: J.R.
+family_name: Claeys

--- a/data/ks/legislature/Jeff-Pittman-8a4754a1-0c05-43f9-93a8-30afd24676b7.yml
+++ b/data/ks/legislature/Jeff-Pittman-8a4754a1-0c05-43f9-93a8-30afd24676b7.yml
@@ -6,11 +6,11 @@ roles:
 - district: '41'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower
-  end_date: '2020-12-31'
+  end_date: 2021-01-11
 - district: '5'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-  end_date: '2020-12-31'
+  start_date: 2021-01-11
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/rep_pittman_jeff_1/
 - url: http://www.kslegislature.org/li/b2021_22/members/sen_pittman_jeff_1/
@@ -19,10 +19,14 @@ sources:
 - url: http://www.kslegislature.org/li/api/v11/rev-1/members/sen_pittman_jeff_1
 image: http://www.kslegislature.org/li/m/images/pics/sen_pittman_jeff_1.jpg
 extras:
-  occupation: Supply chain technologist
+  occupation: Supply Chain Engineer
 other_identifiers:
 - identifier: KSL000325
   scheme: legacy_openstates
 given_name: Jeff
 family_name: Pittman
 email: Jeff.Pittman@senate.ks.gov
+contact_details:
+- note: Capitol Office
+  address: Room 124-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7522

--- a/data/ks/legislature/Jennifer-Day-a02c7225-d932-45d4-87ea-51ab268dbf45.yml
+++ b/data/ks/legislature/Jennifer-Day-a02c7225-d932-45d4-87ea-51ab268dbf45.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_day_jennifer_1.jpg
 extras:
   occupation: Real Estate Investor
+given_name: Jennifer
+family_name: Day

--- a/data/ks/legislature/Jesse-Borjon-0c2ba27f-4208-475d-a625-a12c5f0581b5.yml
+++ b/data/ks/legislature/Jesse-Borjon-0c2ba27f-4208-475d-a625-a12c5f0581b5.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_borjon_jesse_1.jpg
 extras:
   occupation: Business Owner
+given_name: Jesse
+family_name: Borjon

--- a/data/ks/legislature/Jim-Minnix-ca29b8ff-9845-40ba-a196-458cef943041.yml
+++ b/data/ks/legislature/Jim-Minnix-ca29b8ff-9845-40ba-a196-458cef943041.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_minnix_jim_1.jpg
 extras:
   occupation: Farmer, Stockman
+given_name: Jim
+family_name: Minnix

--- a/data/ks/legislature/Jo-Ella-Hoye-f66696d0-6a3c-4b91-9f41-ed016e74d4ef.yml
+++ b/data/ks/legislature/Jo-Ella-Hoye-f66696d0-6a3c-4b91-9f41-ed016e74d4ef.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_hoye_jo_ella_1.jpg
 extras:
   occupation: ''
+given_name: Jo
+family_name: Hoye

--- a/data/ks/legislature/Kellie-Warren-85a66c0d-6f9e-4a55-947e-4d3dc28af0d8.yml
+++ b/data/ks/legislature/Kellie-Warren-85a66c0d-6f9e-4a55-947e-4d3dc28af0d8.yml
@@ -7,11 +7,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower
   start_date: '2019-01-14'
-  end_date: '2020-12-31'
+  end_date: '2021-01-11'
 - district: '11'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-  end_date: '2020-12-31'
+  start_date: 2021-01-11
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/rep_warren_kellie_1/
 - url: http://www.kslegislature.org/li/b2021_22/members/sen_warren_kellie_1/
@@ -24,3 +24,7 @@ extras:
 given_name: Kellie
 family_name: Warren
 email: Kellie.Warren@senate.ks.gov
+contact_details:
+- note: Capitol Office
+  address: Room 441-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7646

--- a/data/ks/legislature/Kristen-OShea-e31b1197-a570-4004-bda7-932b05758a36.yml
+++ b/data/ks/legislature/Kristen-OShea-e31b1197-a570-4004-bda7-932b05758a36.yml
@@ -8,9 +8,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
 contact_details:
-- address: Room 441-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  note: Capitol Office
-  voice: 785-296-7365
+- note: Capitol Office
+  address: Room 441-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7656
 links:
 - url: http://www.kslegislature.org/li/b2021_22/members/sen_oshea_kristen_1/
 sources:
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_oshea_kristen_1.jpg
 extras:
   occupation: Consultant & Business Owner
+given_name: Kristen
+family_name: O'Shea

--- a/data/ks/legislature/Lance-W-Neelly-a1546322-9d4b-467c-a65a-57dddcc9c4cf.yml
+++ b/data/ks/legislature/Lance-W-Neelly-a1546322-9d4b-467c-a65a-57dddcc9c4cf.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_neelly_lance_1.jpg
 extras:
   occupation: Security Supervisor
+given_name: Lance
+family_name: Neelly

--- a/data/ks/legislature/Linda-Featherston-dd5d95d7-16a3-4094-8c3f-d1319fb5b61a.yml
+++ b/data/ks/legislature/Linda-Featherston-dd5d95d7-16a3-4094-8c3f-d1319fb5b61a.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_featherston_linda_1.jpg
 extras:
   occupation: Piano Teacher
+given_name: Linda
+family_name: Featherston

--- a/data/ks/legislature/Lindsay-Vaughn-4a16a87e-2567-4361-9874-aaee47278840.yml
+++ b/data/ks/legislature/Lindsay-Vaughn-4a16a87e-2567-4361-9874-aaee47278840.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_vaughn_lindsay_1.jpg
 extras:
   occupation: Volunteer Manager
+given_name: Lindsay
+family_name: Vaughn

--- a/data/ks/legislature/Lisa-Moser-019607dd-e8e2-4c2e-b4cc-e95ccddb54a2.yml
+++ b/data/ks/legislature/Lisa-Moser-019607dd-e8e2-4c2e-b4cc-e95ccddb54a2.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_moser_lisa_1.jpg
 extras:
   occupation: Rancher
+given_name: Lisa
+family_name: Moser

--- a/data/ks/legislature/Mari-Lynn-Poskin-46d9caea-ab2c-4a6e-a08c-ebc927403dc8.yml
+++ b/data/ks/legislature/Mari-Lynn-Poskin-46d9caea-ab2c-4a6e-a08c-ebc927403dc8.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_poskin_mari_lynn_1.jpg
 extras:
   occupation: Education Consultant
+given_name: Mari-Lynn
+family_name: Poskin

--- a/data/ks/legislature/Mark-Steffen-3cfa0ac0-ff53-4f3b-9389-6962e409988a.yml
+++ b/data/ks/legislature/Mark-Steffen-3cfa0ac0-ff53-4f3b-9389-6962e409988a.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_steffen_mark_1.jpg
 extras:
   occupation: Physician
+given_name: Mark
+family_name: Steffen

--- a/data/ks/legislature/Michael-Dodson-75d4404f-3551-462a-bfce-840afa89f75f.yml
+++ b/data/ks/legislature/Michael-Dodson-75d4404f-3551-462a-bfce-840afa89f75f.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_dodson_michael_1.jpg
 extras:
   occupation: Retired
+given_name: Michael
+family_name: Dodson

--- a/data/ks/legislature/Michael-Fagg-a0787678-986f-459f-bba3-38d46ef55d8b.yml
+++ b/data/ks/legislature/Michael-Fagg-a0787678-986f-459f-bba3-38d46ef55d8b.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_fagg_michael_1.jpg
 extras:
   occupation: Retired (Banking)
+given_name: Michael
+family_name: Fagg

--- a/data/ks/legislature/Michael-Murphy-8b446a75-944d-4292-8af0-f5114be39021.yml
+++ b/data/ks/legislature/Michael-Murphy-8b446a75-944d-4292-8af0-f5114be39021.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_murphy_michael_1.jpg
 extras:
   occupation: B&B Owner/Operator
+given_name: Michael
+family_name: Murphy

--- a/data/ks/legislature/Pat-Proctor-fcd23935-0e7e-4896-9381-45ca745e8903.yml
+++ b/data/ks/legislature/Pat-Proctor-fcd23935-0e7e-4896-9381-45ca745e8903.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_proctor_pat_1.jpg
 extras:
   occupation: Professor
+given_name: Pat
+family_name: Proctor

--- a/data/ks/legislature/Patrick-Penn-d7d7bc12-659e-454e-8c26-0f02ba0d5f84.yml
+++ b/data/ks/legislature/Patrick-Penn-d7d7bc12-659e-454e-8c26-0f02ba0d5f84.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_penn_patrick_1.jpg
 extras:
   occupation: ''
+given_name: Patrick
+family_name: Penn

--- a/data/ks/legislature/Rick-Kloos-5281ab3e-91a8-43be-bcc7-5d9d4c2a2545.yml
+++ b/data/ks/legislature/Rick-Kloos-5281ab3e-91a8-43be-bcc7-5d9d4c2a2545.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_kloos_rick_1.jpg
 extras:
   occupation: Director of God's Storehouse
+given_name: Rick
+family_name: Kloos

--- a/data/ks/legislature/Samantha-M-Poetter-31351496-5fc5-44fc-911f-0e7547a50a72.yml
+++ b/data/ks/legislature/Samantha-M-Poetter-31351496-5fc5-44fc-911f-0e7547a50a72.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_poetter_samantha_1.jpg
 extras:
   occupation: ''
+given_name: Samantha
+family_name: Poetter

--- a/data/ks/legislature/Stephanie-Byers-e38aa75d-32c5-4e57-8da8-6d9ae4e19ade.yml
+++ b/data/ks/legislature/Stephanie-Byers-e38aa75d-32c5-4e57-8da8-6d9ae4e19ade.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_byers_stephanie_1.jpg
 extras:
   occupation: Teacher (Retired)
+given_name: Stephanie
+family_name: Byers

--- a/data/ks/legislature/Steven-K-Howe-e5b4d1e8-40a3-4f75-af3a-36fc7e84a228.yml
+++ b/data/ks/legislature/Steven-K-Howe-e5b4d1e8-40a3-4f75-af3a-36fc7e84a228.yml
@@ -17,4 +17,6 @@ sources:
 - url: http://www.kslegislature.org/li/api/v11/rev-1/members/rep_howe_steven_1
 image: http://www.kslegislature.org/li/m/images/pics/rep_howe_steven_1.jpg
 extras:
-  occupation: Teacher
+  occupation: ''
+given_name: Steven
+family_name: Howe

--- a/data/ks/legislature/Susan-Estes-075f264c-efcf-408f-baf8-b3f9306bae36.yml
+++ b/data/ks/legislature/Susan-Estes-075f264c-efcf-408f-baf8-b3f9306bae36.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_estes_susan_2.jpg
 extras:
   occupation: ''
+given_name: Susan
+family_name: Estes

--- a/data/ks/legislature/Tatum-Lee-Hahn-7252d7aa-a266-408d-aa89-1d1c274d195b.yml
+++ b/data/ks/legislature/Tatum-Lee-Hahn-7252d7aa-a266-408d-aa89-1d1c274d195b.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_leehahn_tatum_1.jpg
 extras:
   occupation: Development Director, R-CALF USA
+given_name: Tatum
+family_name: Lee-Hahn

--- a/data/ks/legislature/Timothy-Johnson-ecff64bf-dfd7-4df4-a1c2-681348e68fa8.yml
+++ b/data/ks/legislature/Timothy-Johnson-ecff64bf-dfd7-4df4-a1c2-681348e68fa8.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_johnson_timothy_1.jpg
 extras:
   occupation: Teacher (Retired)
+given_name: Timothy
+family_name: Johnson

--- a/data/ks/legislature/Tom-Kessler-9cef565d-6e73-4090-80bc-a752310efc4c.yml
+++ b/data/ks/legislature/Tom-Kessler-9cef565d-6e73-4090-80bc-a752310efc4c.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/rep_kessler_tom_1.jpg
 extras:
   occupation: 'Toms Wine and Spirits LLC '
+given_name: Tom
+family_name: Kessler

--- a/data/ks/legislature/Vic-Miller-68dbfc96-2c1d-49e9-af6e-3d4f33b4bce8.yml
+++ b/data/ks/legislature/Vic-Miller-68dbfc96-2c1d-49e9-af6e-3d4f33b4bce8.yml
@@ -11,11 +11,11 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
   start_date: '2019-01-14'
-  end_date: '2020-12-31'
+  end_date: '2021-01-11'
 - district: '58'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: lower
-  end_date: '2020-12-31'
+  start_date: 2021-01-11
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/sen_miller_vic_1/
 - url: http://www.kslegislature.org/li/b2021_22/members/rep_miller_vic_1/
@@ -31,3 +31,7 @@ other_identifiers:
 given_name: Vic
 family_name: Miller
 email: Vic.Miller@house.ks.gov
+contact_details:
+- note: Capitol Office
+  address: Room 50-S;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
+  voice: 785-296-7365

--- a/data/ks/legislature/Virgil-Peck-90f4cf61-cce8-4f87-8495-c0dc298c8d27.yml
+++ b/data/ks/legislature/Virgil-Peck-90f4cf61-cce8-4f87-8495-c0dc298c8d27.yml
@@ -18,3 +18,5 @@ sources:
 image: http://www.kslegislature.org/li/m/images/pics/sen_peck_virgil_1.jpg
 extras:
   occupation: Insurance Agent
+given_name: Virgil
+family_name: Peck

--- a/data/ks/retired/Freda-Warfield-95f18169-9161-4f5f-90ce-549ecd98d976.yml
+++ b/data/ks/retired/Freda-Warfield-95f18169-9161-4f5f-90ce-549ecd98d976.yml
@@ -10,10 +10,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   start_date: '2019-01-14'
   type: lower
-contact_details:
-- note: Capitol Office
-  address: Room 559-S;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  voice: 785-296-7656
+  end_date: '2021-01-11'
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/rep_warfield_freda_1/
 sources:

--- a/data/ks/retired/Jim-Denning-b5659779-e028-418e-8c1b-c93c84afd43c.yml
+++ b/data/ks/retired/Jim-Denning-b5659779-e028-418e-8c1b-c93c84afd43c.yml
@@ -6,10 +6,7 @@ roles:
 - district: '8'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-contact_details:
-- note: Capitol Office
-  address: Room 330-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  voice: 785-296-2497
+  end_date: '2021-01-11'
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/sen_denning_jim_1/
 sources:

--- a/data/ks/retired/John-Skubal-67afcef7-9acb-4e47-9409-510eafa5126b.yml
+++ b/data/ks/retired/John-Skubal-67afcef7-9acb-4e47-9409-510eafa5126b.yml
@@ -6,10 +6,7 @@ roles:
 - district: '11'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-contact_details:
-- note: Capitol Office
-  address: Room 124-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  voice: 785-296-7301
+  end_date: '2021-01-11'
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/sen_skubal_john_1/
 sources:

--- a/data/ks/retired/Kevin-Braun-6e4ab232-e6e3-41c5-b816-09ebf2edf85c.yml
+++ b/data/ks/retired/Kevin-Braun-6e4ab232-e6e3-41c5-b816-09ebf2edf85c.yml
@@ -7,10 +7,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
   start_date: '2019-01-14'
-contact_details:
-- note: Capitol Office
-  address: Room 124-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  voice: 785-296-7357
+  end_date: '2021-01-11'
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/sen_braun_kevin_1/
 sources:

--- a/data/ks/retired/Mary-Jo-Taylor-b13ec4f6-cd5c-4774-b41f-0ec65054e1c2.yml
+++ b/data/ks/retired/Mary-Jo-Taylor-b13ec4f6-cd5c-4774-b41f-0ec65054e1c2.yml
@@ -6,10 +6,7 @@ roles:
 - district: '33'
   jurisdiction: ocd-jurisdiction/country:us/state:ks/government
   type: upper
-contact_details:
-- note: Capitol Office
-  address: Room 441-E;Kansas State Capitol Building;300 SW 10th St.;Topeka, KS 66612
-  voice: 785-296-7667
+  end_date: '2021-01-11'
 links:
 - url: http://www.kslegislature.org/li/b2019_20/members/sen_taylor_mary_1/
 sources:


### PR DESCRIPTION
Some new senators were inadvertently moved to retired status, with their predecessors remaining active. These have been corrected, and some given/family names added. Fixes https://github.com/openstates/issues/issues/253.