### PR TITLE
AR: Fix voting alias and party affiliation

### DIFF
--- a/data/ar/legislature/Howard-M-Beaty-Jr-95d21faa-0431-4285-8cee-36fc918959b6.yml
+++ b/data/ar/legislature/Howard-M-Beaty-Jr-95d21faa-0431-4285-8cee-36fc918959b6.yml
@@ -20,3 +20,4 @@ family_name: Beaty
 other_names:
 - name: Howard M. Beaty Jr.
 - name: Beaty Jr.
+- name: Beatty Jr.

--- a/data/ar/legislature/Jim-Hendren-9bfb23d9-4082-4c5c-89d7-dc670101ca2e.yml
+++ b/data/ar/legislature/Jim-Hendren-9bfb23d9-4082-4c5c-89d7-dc670101ca2e.yml
@@ -1,7 +1,7 @@
 id: ocd-person/9bfb23d9-4082-4c5c-89d7-dc670101ca2e
 name: Jim Hendren
 party:
-- name: Republican
+- name: Independent
 roles:
 - district: '2'
   jurisdiction: ocd-jurisdiction/country:us/state:ar/government

--- a/data/ar/legislature/Stan-Berry-f738465d-9f00-4ea5-9e93-dbfeb4e8f47d.yml
+++ b/data/ar/legislature/Stan-Berry-f738465d-9f00-4ea5-9e93-dbfeb4e8f47d.yml
@@ -22,3 +22,4 @@ family_name: Berry
 email: stan.berry@arkansashouse.org
 other_names:
 - name: Berry
+- name: S. Berry


### PR DESCRIPTION
Fixed voting aliases for two members and changed the party of Senator Jim Hendren who recently left the Republican party.

The last PR seems to have fixed the voting records of most members this session, save for these 5 members:
Senator Joyce Elliott
Rep. Howard M. Beaty, Jr.
Rep. Stan Berry
Rep. Karilyn Brown
Rep. Jamie Scott

Hoping this PR will fix the records for Beaty Jr. and Berry, but I'm not sure what would need to be done to fix the other 3 members as they seem to have the correct voting aliases.

Example voting events:
Senate:
https://openstates.org/vote/44220451-c352-40a3-be69-8d7ca3509057/
House:
https://openstates.org/vote/3a35b9b5-4176-42f9-b82a-b6444dd41bfb/