### PR TITLE
AK: Rename Senate Judiciary finance subcommittee

### DIFF
--- a/data/ak/committees/upper-Judiciary-06922c15-5f1a-4613-8228-4249351cb04d.yml
+++ b/data/ak/committees/upper-Judiciary-06922c15-5f1a-4613-8228-4249351cb04d.yml
@@ -1,7 +1,7 @@
 id: ocd-organization/06922c15-5f1a-4613-8228-4249351cb04d
 jurisdiction: ocd-jurisdiction/country:us/state:ak/government
 classification: subcommittee
-name: Judiciary
+name: Judiciary (Finance) (duplicate)
 chamber: upper
 parent: ocd-organization/8c6a3bc2-a2ae-4dc4-8440-1003ff340d8b
 sources:


### PR DESCRIPTION
See https://github.com/openstates/issues/issues/598; there's a duplicate Senate Judiciary finance subcommittee now but this should work as a stopgap.