### PR TITLE
Add given and family names for Brandy Fluker Oakley

### DIFF
--- a/data/ma/legislature/Brandy-Fluker-Oakley-99c9c9e7-f0e3-480b-ad38-de297e6c635a.yml
+++ b/data/ma/legislature/Brandy-Fluker-Oakley-99c9c9e7-f0e3-480b-ad38-de297e6c635a.yml
@@ -1,5 +1,7 @@
 id: ocd-person/99c9c9e7-f0e3-480b-ad38-de297e6c635a
 name: Brandy Fluker Oakley
+given_name: Brandy
+family_name: Fluker Oakley
 email: Brandy.FlukerOakley@mahouse.gov
 image: https://malegislature.gov/Legislators/Profile/170/BFO1.jpg
 party:


### PR DESCRIPTION
This makes it clear that Fluker is not her middle name, but part of her surname.