### PR TITLE
Update N.Y. Governor

### DIFF
--- a/data/ny/executive/Kathy-Hochul-ccdd914d-9853-4fd2-9a80-ce6c962cdd18.yml
+++ b/data/ny/executive/Kathy-Hochul-ccdd914d-9853-4fd2-9a80-ce6c962cdd18.yml
@@ -1,0 +1,25 @@
+id: ocd-person/ccdd914d-9853-4fd2-9a80-ce6c962cdd18
+name: Kathy Hochul
+given_name: Kathy
+family_name: Hochul
+birth_date: 1958-08-27
+party:
+- name: Democratic
+roles:
+- start_date: '2021-08-24'
+  end_date: '2022-12-31'
+  type: governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ny/government
+links:
+- url: https://www.governor.ny.gov/
+- url: https://www.governor.ny.gov/content/governor-contact-form
+  note: webform
+ids:
+  twitter: GovKathyHochul
+sources:
+- url: https://www.governor.ny.gov/
+offices:
+- address: The Honorable Kathy Hochul; Governor of New York State; NYS State Capitol
+    Building; Albany, NY 12224
+  voice: 518-474-8390
+  classification: capitol

--- a/data/ny/retired/Andrew-Cuomo-72354c6b-937f-49eb-900f-2800210c14c6.yml
+++ b/data/ny/retired/Andrew-Cuomo-72354c6b-937f-49eb-900f-2800210c14c6.yml
@@ -7,7 +7,7 @@ party:
 - name: Democratic
 roles:
 - start_date: '2011-01-01'
-  end_date: '2022-12-31'
+  end_date: '2021-08-23'
   type: governor
   jurisdiction: ocd-jurisdiction/country:us/state:ny/government
 links:


### PR DESCRIPTION
Andrew Cuomo [resigned on August 23, 2021](https://apnews.com/article/andrew-cuomo-resigns-17161f546bb83c32a337036ecf8d2a34); was replaced on the next day by [Gov. Kathy Hochul](https://www.governor.ny.gov).