### PR TITLE
FL: Retire 2 legislators and updates to URLs, emails, and offices

### DIFF
--- a/data/fl/legislature/Adam-Botana-c94b1151-5034-482b-8d7b-f91f9bb5f951.yml
+++ b/data/fl/legislature/Adam-Botana-c94b1151-5034-482b-8d7b-f91f9bb5f951.yml
@@ -17,3 +17,7 @@ offices:
   address: Sunshine Professional Center, Suite 2215; 9240 Bonita Beach Road Southeast;
     Bonita Springs, FL 34135-4251
   voice: 239-949-6279
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4782&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4782&LegislativeTermId=89

--- a/data/fl/legislature/Allison-Tant-c26599eb-5ef8-44c3-93a6-77cf23a9567e.yml
+++ b/data/fl/legislature/Allison-Tant-c26599eb-5ef8-44c3-93a6-77cf23a9567e.yml
@@ -13,3 +13,7 @@ offices:
 - classification: capitol
   address: 1001 The Capitol; 402 South Monroe Street; Tallahassee, FL 32399-1300
   voice: 850-717-5009
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4765&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4765&LegislativeTermId=89

--- a/data/fl/legislature/Ana-Maria-Rodriguez-c4c4b831-6a8a-4819-afe4-063decb1273c.yml
+++ b/data/fl/legislature/Ana-Maria-Rodriguez-c4c4b831-6a8a-4819-afe4-063decb1273c.yml
@@ -23,6 +23,7 @@ offices:
 links:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4719&LegislativeTermId=88
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4719&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/s39
 other_identifiers:
 - scheme: openstates
   identifier: ocd-person/66fc895c-89ee-45db-a15f-f289dfeb383c
@@ -31,3 +32,4 @@ sources:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/representatives.aspx
 - url: https://www.myfloridahouse.gov/Representatives
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4719&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/s39

--- a/data/fl/legislature/Andrew-Learned-ce92851c-c8f4-4dcd-b7b9-e081e31a4313.yml
+++ b/data/fl/legislature/Andrew-Learned-ce92851c-c8f4-4dcd-b7b9-e081e31a4313.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 205; 6152 Delancey Station Street; Riverview, FL 33578-4206
   voice: 813-657-7781
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4777&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4777&LegislativeTermId=89

--- a/data/fl/legislature/Angela-Angie-Nixon-66c3a112-3008-4332-a6b0-8990a7d992d5.yml
+++ b/data/fl/legislature/Angela-Angie-Nixon-66c3a112-3008-4332-a6b0-8990a7d992d5.yml
@@ -16,3 +16,7 @@ offices:
   voice: 904-924-1500
 other_names:
 - name: Nixon
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4766&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4766&LegislativeTermId=89

--- a/data/fl/legislature/Anna-V-Eskamani-1f8e10ad-0047-4854-b696-38e15fda7afa.yml
+++ b/data/fl/legislature/Anna-V-Eskamani-1f8e10ad-0047-4854-b696-38e15fda7afa.yml
@@ -1,5 +1,6 @@
 id: ocd-person/1f8e10ad-0047-4854-b696-38e15fda7afa
 name: Anna V. Eskamani
+email: anna.eskamani@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4746.jpg
 party:
 - name: Democratic

--- a/data/fl/legislature/Christine-Hunschofsky-89d7d4d0-82e7-4535-bb79-3260a7b432b5.yml
+++ b/data/fl/legislature/Christine-Hunschofsky-89d7d4d0-82e7-4535-bb79-3260a7b432b5.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: 4800 West Copans Road; Coconut Creek, FL 33063-3879
   voice: 954-956-5600
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4799&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4799&LegislativeTermId=89

--- a/data/fl/legislature/Christopher-Benjamin-0bf9f192-10f8-4fc8-84ab-7d910363bba9.yml
+++ b/data/fl/legislature/Christopher-Benjamin-0bf9f192-10f8-4fc8-84ab-7d910363bba9.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 204; 610 Northwest 183rd Street; Miami Gardens, FL 33169-4472
   voice: 305-654-7100
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4795&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4795&LegislativeTermId=89

--- a/data/fl/legislature/Daisy-Morales-714bbab7-b106-4fbc-a1e9-9b10b50cf080.yml
+++ b/data/fl/legislature/Daisy-Morales-714bbab7-b106-4fbc-a1e9-9b10b50cf080.yml
@@ -2,6 +2,7 @@ id: ocd-person/714bbab7-b106-4fbc-a1e9-9b10b50cf080
 name: Daisy Morales
 given_name: Daisy
 family_name: Morales
+email: Daisy.Morales@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4775.jpg
 party:
 - name: Democratic
@@ -16,3 +17,7 @@ offices:
 - classification: district
   address: Suite 221; 5449 South Semoran Boulevard; Orlando, FL 32822-1779
   voice: 407-207-3840
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4775&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4775&LegislativeTermId=89

--- a/data/fl/legislature/Dana-Lee-Trabulsy-767d2aef-21ee-4b6d-b64b-ed9350abaa60.yml
+++ b/data/fl/legislature/Dana-Lee-Trabulsy-767d2aef-21ee-4b6d-b64b-ed9350abaa60.yml
@@ -19,3 +19,7 @@ offices:
 other_names:
 - name: Trabulsy
 - name: Dana Lee Trabulsy
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4788&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4788&LegislativeTermId=89

--- a/data/fl/legislature/Danny-Burgess-55815523-33b5-4d42-9864-28e00b805e68.yml
+++ b/data/fl/legislature/Danny-Burgess-55815523-33b5-4d42-9864-28e00b805e68.yml
@@ -17,3 +17,7 @@ offices:
 - classification: district
   address: 38507 Fifth Avenue; Zephyrhills, FL 33542
   voice: 813-779-7059
+links:
+- url: https://www.flsenate.gov/Senators/S20
+sources:
+- url: https://www.flsenate.gov/Senators/S20

--- a/data/fl/legislature/Darryl-Ervin-Rouson-3de11937-c291-4561-bee5-4f747665cb37.yml
+++ b/data/fl/legislature/Darryl-Ervin-Rouson-3de11937-c291-4561-bee5-4f747665cb37.yml
@@ -25,6 +25,9 @@ offices:
   address: 212 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5019
 - classification: district
+  address: 535 Central Avenue Suite 302; St. Petersburg, FL 33701
+  voice: 727-822-6828
+- classification: district
   address: By Appointment Only; The Cuban Club; 2010 Avenida Republica de Cuba; Tampa,
     FL 33605
   voice: 727-822-6828

--- a/data/fl/legislature/Daryl-Campbell-41f4c740-28bf-4a44-98ad-fde0cb65aa11.yml
+++ b/data/fl/legislature/Daryl-Campbell-41f4c740-28bf-4a44-98ad-fde0cb65aa11.yml
@@ -17,3 +17,7 @@ offices:
 - classification: district
   address: 128 Southeast 1st Street; Fort Lauderdale, FL 33301-1924
   voice: 954-467-4205
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4843&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4843&LegislativeTermId=89

--- a/data/fl/legislature/David-Borrero-686a3de8-6df1-4144-85bc-edaad7fe1708.yml
+++ b/data/fl/legislature/David-Borrero-686a3de8-6df1-4144-85bc-edaad7fe1708.yml
@@ -16,3 +16,10 @@ offices:
 - classification: district
   address: Suite 301C; 1405 Southwest 107th Avenue; Miami, FL 33174-2541
   voice: 305-222-4116
+- classification: district
+  address: Suite 123; 4715 Golden Gate Parkway; Naples, FL 34116-6901
+  voice: 239-417-6231
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4794&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4794&LegislativeTermId=89

--- a/data/fl/legislature/Demi-Busatta-Cabrera-8407b440-b679-4d84-b642-de35869461a4.yml
+++ b/data/fl/legislature/Demi-Busatta-Cabrera-8407b440-b679-4d84-b642-de35869461a4.yml
@@ -16,3 +16,7 @@ offices:
   voice: 305-442-6808
 other_names:
 - name: Busatta Cabrera
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4800&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4800&LegislativeTermId=89

--- a/data/fl/legislature/Dennis-Baxley-8da77b3a-e4d7-4b04-80bd-403d1e56ff6c.yml
+++ b/data/fl/legislature/Dennis-Baxley-8da77b3a-e4d7-4b04-80bd-403d1e56ff6c.yml
@@ -15,6 +15,9 @@ offices:
   address: 412 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5012
 - classification: district
+  address: 206 South Hwy 27/441; Lady Lake, FL 32159
+  voice: 352-750-3133
+- classification: district
   address: 315 SE 25th Avenue; Ocala, FL 34471
   voice: 352-789-6720
 links:

--- a/data/fl/legislature/Felicia-Simone-Robinson-1d219f7c-140b-48fd-ac39-4683c48dbc87.yml
+++ b/data/fl/legislature/Felicia-Simone-Robinson-1d219f7c-140b-48fd-ac39-4683c48dbc87.yml
@@ -16,3 +16,7 @@ offices:
   voice: 305-620-3711
 other_names:
 - name: Robinson, F.
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4791&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4791&LegislativeTermId=89

--- a/data/fl/legislature/Fiona-McFarland-741003ec-e46f-4ae8-a3af-ce2a2aba5cd4.yml
+++ b/data/fl/legislature/Fiona-McFarland-741003ec-e46f-4ae8-a3af-ce2a2aba5cd4.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 206; 3131 South Tamiami Trail; Sarasota, FL 34239-5101
   voice: 941-361-2465
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4780&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4780&LegislativeTermId=89

--- a/data/fl/legislature/Fred-Hawkins-5fc9e9fc-1d3e-44f0-8769-71c1413d5370.yml
+++ b/data/fl/legislature/Fred-Hawkins-5fc9e9fc-1d3e-44f0-8769-71c1413d5370.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 2; 1211 12th Street; St. Cloud, FL 34769-3713
   voice: 407-892-0409
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4773&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4773&LegislativeTermId=89

--- a/data/fl/legislature/Ileana-Garcia-3b65ecb0-8a3d-469c-9db4-b70c8724610f.yml
+++ b/data/fl/legislature/Ileana-Garcia-3b65ecb0-8a3d-469c-9db4-b70c8724610f.yml
@@ -17,3 +17,7 @@ offices:
 - classification: district
   address: 2828 Coral Way; Suite 208; Miami, FL 33145
   voice: 305-442-6841
+links:
+- url: https://www.flsenate.gov/Senators/S37
+sources:
+- url: https://www.flsenate.gov/Senators/S37

--- a/data/fl/legislature/James-Vernon-Jim-Mooney-Jr-d03b8661-852b-44ab-b7c2-aa3bf14acd39.yml
+++ b/data/fl/legislature/James-Vernon-Jim-Mooney-Jr-d03b8661-852b-44ab-b7c2-aa3bf14acd39.yml
@@ -17,3 +17,7 @@ offices:
   voice: 305-453-1202
 other_names:
 - name: Mooney
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4797&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4797&LegislativeTermId=89

--- a/data/fl/legislature/Jason-Brodeur-cd669d62-d957-4a41-b7e7-9fe2bd6a94ab.yml
+++ b/data/fl/legislature/Jason-Brodeur-cd669d62-d957-4a41-b7e7-9fe2bd6a94ab.yml
@@ -17,3 +17,7 @@ offices:
 - classification: district
   address: 922 Williston Park Point; Suite 1300; Lake Mary, FL 32746
   voice: 407-333-1802
+links:
+- url: https://www.flsenate.gov/Senators/S9
+sources:
+- url: https://www.flsenate.gov/Senators/S9

--- a/data/fl/legislature/Jason-Shoaf-2bae38cc-f703-446b-93ec-576c0e388760.yml
+++ b/data/fl/legislature/Jason-Shoaf-2bae38cc-f703-446b-93ec-576c0e388760.yml
@@ -17,6 +17,9 @@ offices:
   address: Send mail to Tallahassee Office; 20816 Central Avenue East; Blountstown,
     FL 32424-2288
   voice: 850-508-3207
+- classification: district
+  address: Send mail to Tallahassee Office; 103 East Ellis Street; Perry, FL 32347-3313
+  voice: 850-295-5680
 links:
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4756&LegislativeTermId=88
 sources:

--- a/data/fl/legislature/Jayer-Williamson-e79e92f3-49c7-440c-af58-be60aff7c03b.yml
+++ b/data/fl/legislature/Jayer-Williamson-e79e92f3-49c7-440c-af58-be60aff7c03b.yml
@@ -2,6 +2,7 @@ id: ocd-person/e79e92f3-49c7-440c-af58-be60aff7c03b
 name: Jayer Williamson
 given_name: Jayer
 family_name: Williamson
+email: jayer.williamson@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4622.jpg
 party:
 - name: Republican

--- a/data/fl/legislature/Jenna-Persons-Mulicka-bc54a6ff-f7b3-4bbf-a23a-4acc9caa8064.yml
+++ b/data/fl/legislature/Jenna-Persons-Mulicka-bc54a6ff-f7b3-4bbf-a23a-4acc9caa8064.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 208; 2120 Main Street; Fort Myers, FL 33901-3010
   voice: 239-338-2328
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4785&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4785&LegislativeTermId=89

--- a/data/fl/legislature/Jennifer-Bradley-4fa3d065-c48d-46a7-9dca-ab85fad5c5f8.yml
+++ b/data/fl/legislature/Jennifer-Bradley-4fa3d065-c48d-46a7-9dca-ab85fad5c5f8.yml
@@ -16,5 +16,12 @@ offices:
   voice: 850-487-5005
   fax: 888-263-0641
 - classification: district
+  address: Kingsley Center; 1279 Kingsley Avenue Suite 117; Orange Park, FL 32073
+  voice: 904-278-2085
+- classification: district
   address: 124 Northwest Madison Street; Lake City, FL 32055
   voice: 386-719-2708
+links:
+- url: https://www.flsenate.gov/Senators/S5
+sources:
+- url: https://www.flsenate.gov/Senators/S5

--- a/data/fl/legislature/Jervonte-Tae-Edmonds-bb2ae855-2e7a-4744-9271-a8ae1af89428.yml
+++ b/data/fl/legislature/Jervonte-Tae-Edmonds-bb2ae855-2e7a-4744-9271-a8ae1af89428.yml
@@ -14,3 +14,10 @@ offices:
 - classification: capitol
   address: 1402 The Capitol; 402 South Monroe Street; Tallahassee, FL 32399-1300
   voice: 850-717-5088
+- classification: district
+  address: Suite 206; 5725 Corporate Way; West Palm Beach, FL 33407-2035
+  voice: 561-242-5530
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4842&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4842&LegislativeTermId=89

--- a/data/fl/legislature/Jim-Boyd-c70f231f-92e2-4a55-a59b-fcf113ab51af.yml
+++ b/data/fl/legislature/Jim-Boyd-c70f231f-92e2-4a55-a59b-fcf113ab51af.yml
@@ -24,6 +24,7 @@ offices:
   voice: 941-742-6445
 links:
 - url: http://www.flhouse.gov/Sections/Representatives/details.aspx?MemberId=4511&LegislativeTermId=87
+- url: https://www.flsenate.gov/Senators/S21
 other_identifiers:
 - scheme: legacy_openstates
   identifier: FLL000561
@@ -32,3 +33,4 @@ other_identifiers:
 sources:
 - url: http://www.flhouse.gov/Sections/Representatives/details.aspx?MemberId=4511&LegislativeTermId=87
 - url: http://www.flhouse.gov/Sections/Representatives/representatives.aspx
+- url: https://www.flsenate.gov/Senators/S21

--- a/data/fl/legislature/Joe-Harding-b48e6128-df30-4f9b-88b8-b458de063cab.yml
+++ b/data/fl/legislature/Joe-Harding-b48e6128-df30-4f9b-88b8-b458de063cab.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 104; 3001 Southwest College Road; Ocala, FL 34474-4415
   voice: 352-291-4436
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4769&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4769&LegislativeTermId=89

--- a/data/fl/legislature/John-Snyder-5055fc3a-3cdd-4f4d-addb-23634fd1df92.yml
+++ b/data/fl/legislature/John-Snyder-5055fc3a-3cdd-4f4d-addb-23634fd1df92.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: '#201; 4239 Southwest High Meadows Avenue; Palm City, FL 34990-3728'
   voice: 772-210-5626
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4787&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4787&LegislativeTermId=89

--- a/data/fl/legislature/Kathleen-Passidomo-ae123d54-1076-49b2-84f9-2897b7d60ebd.yml
+++ b/data/fl/legislature/Kathleen-Passidomo-ae123d54-1076-49b2-84f9-2897b7d60ebd.yml
@@ -15,6 +15,9 @@ offices:
   address: 400 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5028
 - classification: district
+  address: 3299 East Tamiami Trail; Suite 203; Naples, FL 34112
+  voice: 239-417-6205
+- classification: district
   address: 25 East Hickpoochee Avenue; Room J-101; LaBelle, FL 33935
   voice: 863-674-7122
 links:

--- a/data/fl/legislature/Kaylee-Tuck-7bf7d958-fabd-430b-9326-97586b0c0880.yml
+++ b/data/fl/legislature/Kaylee-Tuck-7bf7d958-fabd-430b-9326-97586b0c0880.yml
@@ -16,3 +16,10 @@ offices:
 - classification: district
   address: Suite B; 205 South Commerce Avenue; Sebring, FL 33870-3626
   voice: 863-386-6000
+- classification: district
+  address: 55 South Parrott Avenue; Okeechobee, FL 34974-2968
+  voice: 863-462-5019
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4776&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4776&LegislativeTermId=89

--- a/data/fl/legislature/Keith-L-Truenow-9c87088c-e5a4-4902-b3cb-4477e062de66.yml
+++ b/data/fl/legislature/Keith-L-Truenow-9c87088c-e5a4-4902-b3cb-4477e062de66.yml
@@ -16,3 +16,7 @@ offices:
   voice: 352-742-6275
 other_names:
 - name: Truenow
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4772&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4772&LegislativeTermId=89

--- a/data/fl/legislature/Keith-Perry-5700b358-60e2-4058-91c3-18e14656d40c.yml
+++ b/data/fl/legislature/Keith-Perry-5700b358-60e2-4058-91c3-18e14656d40c.yml
@@ -15,6 +15,9 @@ offices:
   address: 406 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5008
 - classification: district
+  address: 2610 NW 43rd Street; Suite 2B; Gainesville, FL 32606
+  voice: 352-264-4040
+- classification: district
   address: By Appointment Only; Putnam County Government Complex; 2509 Crill Avenue;
     Palatka, FL 32177
   voice: 352-264-4040

--- a/data/fl/legislature/Kelly-Skidmore-232b7507-aca7-41d0-8efd-95276b13081a.yml
+++ b/data/fl/legislature/Kelly-Skidmore-232b7507-aca7-41d0-8efd-95276b13081a.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 209; 8177 Glades Road; Boca Raton, FL 33434-4022
   voice: 561-470-2086
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4786&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4786&LegislativeTermId=89

--- a/data/fl/legislature/Kevin-D-Chambliss-313e81ee-19af-4d9d-9186-fbbca7e6d65d.yml
+++ b/data/fl/legislature/Kevin-D-Chambliss-313e81ee-19af-4d9d-9186-fbbca7e6d65d.yml
@@ -16,3 +16,7 @@ offices:
   voice: 305-256-6300
 other_names:
 - name: Chambliss
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4798&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4798&LegislativeTermId=89

--- a/data/fl/legislature/Kristen-Aston-Arrington-1fbfb34c-7357-48fd-ab09-a6b7f7027ff1.yml
+++ b/data/fl/legislature/Kristen-Aston-Arrington-1fbfb34c-7357-48fd-ab09-a6b7f7027ff1.yml
@@ -16,3 +16,7 @@ offices:
   voice: 407-846-5016
 other_names:
 - name: Arrington
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4774&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4774&LegislativeTermId=89

--- a/data/fl/legislature/Lauren-Melo-f835385b-0837-4cfc-a81c-54982ba185d7.yml
+++ b/data/fl/legislature/Lauren-Melo-f835385b-0837-4cfc-a81c-54982ba185d7.yml
@@ -17,3 +17,10 @@ offices:
   address: Harmon Turner Building, Suite 212; 3299 Tamiami Trail East; Naples, FL
     34112-5746
   voice: 239-417-6270
+- classification: district
+  address: Hendry County Courthouse; 25 East Hickpochee Avenue; La Belle, FL 33935-5015
+  voice: 863-675-5267
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4784&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4784&LegislativeTermId=89

--- a/data/fl/legislature/Linda-Chaney-02a076d1-b8da-4eb5-8fde-1dc0408cc36a.yml
+++ b/data/fl/legislature/Linda-Chaney-02a076d1-b8da-4eb5-8fde-1dc0408cc36a.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite C-105; 6798 Crosswinds Drive; St. Petersburg, FL 33710-5477
   voice: 727-341-7385
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4778&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4778&LegislativeTermId=89

--- a/data/fl/legislature/Marie-Paule-Woodson-5eb39c7e-3582-4269-a012-7a88c54623c9.yml
+++ b/data/fl/legislature/Marie-Paule-Woodson-5eb39c7e-3582-4269-a012-7a88c54623c9.yml
@@ -16,3 +16,7 @@ offices:
   voice: 954-965-3700
 other_names:
 - name: Woodson
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4789&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4789&LegislativeTermId=89

--- a/data/fl/legislature/Michael-Grieco-7613c23d-5734-498a-9f69-8037010cba4a.yml
+++ b/data/fl/legislature/Michael-Grieco-7613c23d-5734-498a-9f69-8037010cba4a.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 300; 1666 79th Street Causeway; North Bay Village, FL 33141-4189
   voice: 305-993-1905
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4715&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4715&LegislativeTermId=89

--- a/data/fl/legislature/Michele-K-Rayner-fa91b661-cde0-4c09-a382-3e334c1f9162.yml
+++ b/data/fl/legislature/Michele-K-Rayner-fa91b661-cde0-4c09-a382-3e334c1f9162.yml
@@ -16,3 +16,7 @@ offices:
   voice: 727-892-2468
 other_names:
 - name: Rayner
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4781&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4781&LegislativeTermId=89

--- a/data/fl/legislature/Michelle-Salzman-a3c0aa9f-c261-4904-b73b-4dc127778222.yml
+++ b/data/fl/legislature/Michelle-Salzman-a3c0aa9f-c261-4904-b73b-4dc127778222.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite G; 3101 West Michigan Avenue; Pensacola, FL 32526-1876
   voice: 850-941-6091
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4763&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4763&LegislativeTermId=89

--- a/data/fl/legislature/Mike-Beltran-5cd475cc-449f-481e-9e65-97f3a2352556.yml
+++ b/data/fl/legislature/Mike-Beltran-5cd475cc-449f-481e-9e65-97f3a2352556.yml
@@ -2,6 +2,7 @@ id: ocd-person/5cd475cc-449f-481e-9e65-97f3a2352556
 name: Mike Beltran
 given_name: Mike
 family_name: Beltran
+email: mike.beltran@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4747.jpg
 party:
 - name: Republican

--- a/data/fl/legislature/Mike-Giallombardo-4815dd20-5f86-4af4-a8a5-44878855e734.yml
+++ b/data/fl/legislature/Mike-Giallombardo-4815dd20-5f86-4af4-a8a5-44878855e734.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 310; 1039 Southeast 9th Place; Cape Coral, FL 33990-3131
   voice: 239-772-1291
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4783&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4783&LegislativeTermId=89

--- a/data/fl/legislature/Ray-Wesley-Rodrigues-e7abf8d0-2c63-4fdc-848b-eb1ce643eb85.yml
+++ b/data/fl/legislature/Ray-Wesley-Rodrigues-e7abf8d0-2c63-4fdc-848b-eb1ce643eb85.yml
@@ -25,6 +25,7 @@ offices:
 links:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4572&LegislativeTermId=88
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4572&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S27
 other_identifiers:
 - scheme: legacy_openstates
   identifier: FLL000549
@@ -35,3 +36,4 @@ sources:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/representatives.aspx
 - url: https://www.myfloridahouse.gov/Representatives
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4572&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S27

--- a/data/fl/legislature/Robert-Charles-Chuck-Brannan-III-caf95c6f-3143-433e-8654-c17d39b94f88.yml
+++ b/data/fl/legislature/Robert-Charles-Chuck-Brannan-III-caf95c6f-3143-433e-8654-c17d39b94f88.yml
@@ -14,6 +14,9 @@ offices:
 - classification: district
   address: 1262 Southeast Baya Drive; Lake City, FL 32025-5555
   voice: 386-758-0405
+- classification: district
+  address: Suite 117, Baker County Courthouse; 339 East Macclenny Avenue; Macclenny, FL 32063-2231
+  voice: 904-259-0995
 links:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4708&LegislativeTermId=88
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4708&LegislativeTermId=88

--- a/data/fl/legislature/Robin-Bartleman-67c201cf-9aaa-4a06-8dda-28e93ea27f6b.yml
+++ b/data/fl/legislature/Robin-Bartleman-67c201cf-9aaa-4a06-8dda-28e93ea27f6b.yml
@@ -2,6 +2,7 @@ id: ocd-person/67c201cf-9aaa-4a06-8dda-28e93ea27f6b
 name: Robin Bartleman
 given_name: Robin
 family_name: Bartleman
+email: robin.bartleman@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4793.jpg
 party:
 - name: Democratic
@@ -16,3 +17,7 @@ offices:
 - classification: district
   address: Suite 225; 1725 Main Street; Weston, FL 33326-3671
   voice: 954-424-6828
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4793&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4793&LegislativeTermId=89

--- a/data/fl/legislature/Rosalind-Osgood-ba43e456-b4d3-408d-aeba-d4b7482dacd0.yml
+++ b/data/fl/legislature/Rosalind-Osgood-ba43e456-b4d3-408d-aeba-d4b7482dacd0.yml
@@ -18,3 +18,7 @@ offices:
 - classification: district
   address: 8491 West Commercial Blvd.; Tamarac, FL 33351
   voice: 954-321-2705
+links:
+- url: https://www.flsenate.gov/Senators/S33
+sources:
+- url: https://www.flsenate.gov/Senators/S33

--- a/data/fl/legislature/Sam-Garrison-965e180a-177f-49ac-baba-0f0c7fe9a836.yml
+++ b/data/fl/legislature/Sam-Garrison-965e180a-177f-49ac-baba-0f0c7fe9a836.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 104; 1279 Kingsley Avenue; Orange Park, FL 32073-4657
   voice: 904-278-5761
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4767&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4767&LegislativeTermId=89

--- a/data/fl/legislature/Scott-Plakon-aa13b168-50b8-4cb1-9e46-461bf199910a.yml
+++ b/data/fl/legislature/Scott-Plakon-aa13b168-50b8-4cb1-9e46-461bf199910a.yml
@@ -2,6 +2,7 @@ id: ocd-person/aa13b168-50b8-4cb1-9e46-461bf199910a
 name: Scott Plakon
 given_name: Scott
 family_name: Plakon
+email: scott.plakon@myfloridahouse.gov
 image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4430.jpg
 party:
 - name: Republican

--- a/data/fl/legislature/Shevrin-D-Shev-Jones-a8a2eaa4-449b-441f-96bb-d8a3e8191479.yml
+++ b/data/fl/legislature/Shevrin-D-Shev-Jones-a8a2eaa4-449b-441f-96bb-d8a3e8191479.yml
@@ -19,11 +19,15 @@ offices:
   address: 214 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5035
 - classification: district
+  address: 606 NW 183rd Street; Miami Gardens, FL 33169
+  voice: 305-493-6002
+- classification: district
   address: 1965 South State Road 7; West Park, FL 33023
   voice: 954-893-5003
 links:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4559&LegislativeTermId=88
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4559&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S35
 other_identifiers:
 - scheme: legacy_openstates
   identifier: FLL000625
@@ -32,3 +36,4 @@ sources:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/representatives.aspx
 - url: https://www.myfloridahouse.gov/Representatives
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4559&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S35

--- a/data/fl/legislature/Thomas-Patterson-Patt-Maney-ed56c597-3652-45a5-9c01-de0bf3eb8ab9.yml
+++ b/data/fl/legislature/Thomas-Patterson-Patt-Maney-ed56c597-3652-45a5-9c01-de0bf3eb8ab9.yml
@@ -19,3 +19,7 @@ offices:
 other_names:
 - name: Maney
 - name: Thomas Patterson "Patt" Maney
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4764&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4764&LegislativeTermId=89

--- a/data/fl/legislature/Tina-Scott-Polsky-f0abfae1-3634-4595-9260-d90fea4ccffa.yml
+++ b/data/fl/legislature/Tina-Scott-Polsky-f0abfae1-3634-4595-9260-d90fea4ccffa.yml
@@ -23,6 +23,7 @@ offices:
 links:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4751&LegislativeTermId=88
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4751&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S29
 other_identifiers:
 - scheme: openstates
   identifier: ocd-person/6e502939-0a96-4ebc-b7db-8dee040e4a08
@@ -31,3 +32,4 @@ sources:
 - url: http://www.myfloridahouse.gov/Sections/Representatives/representatives.aspx
 - url: https://www.myfloridahouse.gov/Representatives
 - url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4751&LegislativeTermId=88
+- url: https://www.flsenate.gov/Senators/S29

--- a/data/fl/legislature/Tom-A-Wright-4ae2bacf-d265-42a5-888d-5050015a6602.yml
+++ b/data/fl/legislature/Tom-A-Wright-4ae2bacf-d265-42a5-888d-5050015a6602.yml
@@ -13,6 +13,9 @@ offices:
   address: 320 Senate Building; 404 South Monroe Street; Tallahassee, FL 32399-1100
   voice: 850-487-5014
 - classification: district
+  address: 4606 Clyde Morris Boulevard; Suite 2-J; Port Orange, FL 32129
+  voice: 386-304-7630
+- classification: district
   address: By Appointment Only; Eastern Florida State College Room 110, Building 5;
     1311 North U.S. 1; Titusville, FL 32796
   voice: 386-304-7630

--- a/data/fl/legislature/Tom-Fabricio-35f68144-b99b-4f86-b223-726897926bfa.yml
+++ b/data/fl/legislature/Tom-Fabricio-35f68144-b99b-4f86-b223-726897926bfa.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 161; 11300 Northwest 87th Court; Hialeah, FL 33018-4521
   voice: 305-364-3064
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4792&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4792&LegislativeTermId=89

--- a/data/fl/legislature/Traci-Koster-217f848d-99c2-43aa-98d2-6fee2812c1e6.yml
+++ b/data/fl/legislature/Traci-Koster-217f848d-99c2-43aa-98d2-6fee2812c1e6.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite 3; 3135 State Road 580; Safety Harbor, FL 34695-4917
   voice: 727-669-9040
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4779&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4779&LegislativeTermId=89

--- a/data/fl/legislature/Travaris-L-Tray-McCurdy-f7e97bcf-0bde-494d-983b-28cfe35a9944.yml
+++ b/data/fl/legislature/Travaris-L-Tray-McCurdy-f7e97bcf-0bde-494d-983b-28cfe35a9944.yml
@@ -16,3 +16,7 @@ offices:
   voice: 407-445-5254
 other_names:
 - name: McCurdy
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4801&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4801&LegislativeTermId=89

--- a/data/fl/legislature/Webster-Barnaby-f2b23850-7feb-484e-8ed2-68e2f6108fbf.yml
+++ b/data/fl/legislature/Webster-Barnaby-f2b23850-7feb-484e-8ed2-68e2f6108fbf.yml
@@ -16,3 +16,7 @@ offices:
 - classification: district
   address: Suite C; 2730 Enterprise Road; Orange City, FL 32763-8320
   voice: 386-851-0799
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4770&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4770&LegislativeTermId=89

--- a/data/fl/legislature/Yvonne-Hayes-Hinson-0f5d2710-6b7c-4444-8a45-ea3e917805ba.yml
+++ b/data/fl/legislature/Yvonne-Hayes-Hinson-0f5d2710-6b7c-4444-8a45-ea3e917805ba.yml
@@ -16,3 +16,7 @@ offices:
   voice: 352-264-4001
 other_names:
 - name: Hinson
+links:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4768&LegislativeTermId=89
+sources:
+- url: https://www.myfloridahouse.gov/Sections/Representatives/details.aspx?MemberId=4768&LegislativeTermId=89

--- a/data/fl/retired/Cord-Byrd-52b678b9-cb9c-4e65-bd81-32bc7c2bdf0c.yml
+++ b/data/fl/retired/Cord-Byrd-52b678b9-cb9c-4e65-bd81-32bc7c2bdf0c.yml
@@ -6,7 +6,8 @@ image: https://www.myfloridahouse.gov//FileStores/Web/Imaging/Member/4632.jpg
 party:
 - name: Republican
 roles:
-- type: lower
+- end_date: 2022-05-16
+  type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '11'
 offices:

--- a/data/fl/retired/Jr-Diaz-Manny-715945a3-b639-4aed-90e8-0358641018d4.yml
+++ b/data/fl/retired/Jr-Diaz-Manny-715945a3-b639-4aed-90e8-0358641018d4.yml
@@ -12,6 +12,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '103'
 - start_date: 2018-11-06
+  end_date: 2022-05-31
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '36'
@@ -37,3 +38,4 @@ sources:
 - url: http://www.flhouse.gov/Sections/Representatives/representatives.aspx
 - url: http://www.flsenate.gov/Senators/
 - url: http://www.flsenate.gov/Senators/s36
+- url: https://www.flsenate.gov/Senators/2020-2022/S36/5343


### PR DESCRIPTION
FL legislator updates:
- Retired 2 legislators: Manny Diaz Jr. and Cord Byrd
- Added link and source URLs for many legislators
- Added emails and additional offices for some legislators