### PR TITLE
CT: Add images

### DIFF
--- a/data/ct/executive/Denise-Merrill-330c3bb4-3f34-40ee-8a6f-71cd84849d80.yml
+++ b/data/ct/executive/Denise-Merrill-330c3bb4-3f34-40ee-8a6f-71cd84849d80.yml
@@ -3,6 +3,7 @@ name: Denise Merrill
 given_name: Denise
 family_name: Merrill
 email: denise.merrill@ct.gov
+image: https://portal.ct.gov/lib/sots/capitol2011to2015/headshot/dm_official_headshot_2016.jpg
 party:
 - name: Democratic
 roles:

--- a/data/ct/executive/Ned-Lamont-4cd3e60f-3830-4121-965f-f29d9b5ec6e7.yml
+++ b/data/ct/executive/Ned-Lamont-4cd3e60f-3830-4121-965f-f29d9b5ec6e7.yml
@@ -3,6 +3,7 @@ name: Ned Lamont
 given_name: Ned
 family_name: Lamont
 birth_date: 1954-01-03
+image: https://portal.ct.gov/-/media/Office-of-the-Governor/About/govlamont.jpg
 party:
 - name: Democratic
 roles:

--- a/data/ct/legislature/Aimee-Berger-Girvalo-b43c741a-89b2-4e46-abfc-1d75f26189fe.yml
+++ b/data/ct/legislature/Aimee-Berger-Girvalo-b43c741a-89b2-4e46-abfc-1d75f26189fe.yml
@@ -3,6 +3,7 @@ name: Aimee Berger-Girvalo
 given_name: Aimee
 family_name: Berger-Girvalo
 email: Aimee.Berger-Girvalo@cga.ct.gov
+image: http://www2.housedems.ct.gov/Berger-Girvalo/images/Berger-Girvalo_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Berger-Girvalo
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27111%27&dist_name=Berger-Girvalo,%20Aimee
 other_names:
 - name: Berger-girvalo, Aimee
 sources:

--- a/data/ct/legislature/Alphonse-Paolillo-Jr-3e0a00e8-0ec8-418d-a2e3-a7eef0a5d186.yml
+++ b/data/ct/legislature/Alphonse-Paolillo-Jr-3e0a00e8-0ec8-418d-a2e3-a7eef0a5d186.yml
@@ -3,6 +3,7 @@ name: Alphonse Paolillo Jr.
 given_name: Alphonse
 family_name: Paolillo
 email: Alphonse.Paolillo@cga.ct.gov
+image: http://www2.housedems.ct.gov/Paolillo/images/Paolillo_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Paolillo
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27097%27&dist_name=Paolillo,%20Alphonse
 other_names:
 - name: Paolillo, Alphonse
 other_identifiers:

--- a/data/ct/legislature/Amy-Morrin-Bello-ff1c4d90-5cc3-4ff9-8f31-454d03803816.yml
+++ b/data/ct/legislature/Amy-Morrin-Bello-ff1c4d90-5cc3-4ff9-8f31-454d03803816.yml
@@ -1,6 +1,7 @@
 id: ocd-person/ff1c4d90-5cc3-4ff9-8f31-454d03803816
 name: Amy Morrin Bello
 email: amy.morrinbello@cga.ct.gov
+image: http://www2.housedems.ct.gov/MorrinBello/images/MorrinBello_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/morrinbello
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27028%27&dist_name=Morrin%20Bello,%20Amy
 other_names:
 - name: Morrin Bello, Amy
 sources:

--- a/data/ct/legislature/Andre-F-Baker-Jr-e823b0bf-1132-4ed8-b860-e0febf9a275a.yml
+++ b/data/ct/legislature/Andre-F-Baker-Jr-e823b0bf-1132-4ed8-b860-e0febf9a275a.yml
@@ -3,6 +3,7 @@ name: Andre F. Baker Jr.
 given_name: Andre
 family_name: Baker
 email: Andre.Baker@cga.ct.gov
+image: http://www2.housedems.ct.gov/Baker/images/Baker_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Baker
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27124%27&dist_name=Baker,%20Andre%20F.
 other_names:
 - name: Baker, Andre F.
 other_identifiers:

--- a/data/ct/legislature/Anne-Dauphinais-087a813d-b14a-4205-a08f-cec795647318.yml
+++ b/data/ct/legislature/Anne-Dauphinais-087a813d-b14a-4205-a08f-cec795647318.yml
@@ -3,6 +3,7 @@ name: Anne Dauphinais
 given_name: Anne
 family_name: Dauphinais
 email: Anne.Dauphinais@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/044.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Dauphinais/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27044%27&dist_name=Dauphinais,%20Anne
 other_names:
 - name: Dauphinais, Anne
 other_identifiers:

--- a/data/ct/legislature/Anne-Hughes-ce2070f7-9487-4856-976b-9bbd6a2f1617.yml
+++ b/data/ct/legislature/Anne-Hughes-ce2070f7-9487-4856-976b-9bbd6a2f1617.yml
@@ -3,6 +3,7 @@ name: Anne M. Hughes
 given_name: Anne
 family_name: Hughes
 email: Anne.Hughes@cga.ct.gov
+image: http://www2.housedems.ct.gov/Hughes/images/Hughes_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/hughes
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27135%27&dist_name=Hughes,%20Anne%20M.
 other_names:
 - name: Hughes, Anne M.
 sources:

--- a/data/ct/legislature/Anthony-L-Nolan-c7160abf-d376-484d-b87e-600a398ab503.yml
+++ b/data/ct/legislature/Anthony-L-Nolan-c7160abf-d376-484d-b87e-600a398ab503.yml
@@ -3,6 +3,7 @@ name: Anthony L. Nolan
 given_name: Anthony
 family_name: Nolan
 email: Anthony.Nolan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Nolan/images/Nolan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -22,6 +23,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/nolan
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27039%27&dist_name=Nolan,%20Anthony%20L.
 other_names:
 - name: Nolan, Anthony L.
 sources:

--- a/data/ct/legislature/Antonio-Felipe-caaba025-7a5a-401d-8714-73f627651196.yml
+++ b/data/ct/legislature/Antonio-Felipe-caaba025-7a5a-401d-8714-73f627651196.yml
@@ -3,6 +3,7 @@ name: Antonio Felipe
 given_name: Antonio
 family_name: Felipe
 email: antonio.felipe@cga.ct.gov
+image: http://www2.housedems.ct.gov/Felipe/images/Felipe_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -22,6 +23,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/felipe
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27130%27&dist_name=Felipe,%20Antonio
 other_names:
 - name: Felipe, Antonio
 sources:

--- a/data/ct/legislature/Ben-McGorty-240d52a3-33df-495c-b1a0-142cc43f3fce.yml
+++ b/data/ct/legislature/Ben-McGorty-240d52a3-33df-495c-b1a0-142cc43f3fce.yml
@@ -3,6 +3,7 @@ name: Ben McGorty
 given_name: Ben
 family_name: McGorty
 email: Ben.McGorty@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/122.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/McGorty/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27122%27&dist_name=McGorty,%20Ben
 other_names:
 - name: Mcgorty, Ben
 other_identifiers:

--- a/data/ct/legislature/Bill-Buckbee-1c270bf3-7cc6-4e11-93fb-e35f5d9a1774.yml
+++ b/data/ct/legislature/Bill-Buckbee-1c270bf3-7cc6-4e11-93fb-e35f5d9a1774.yml
@@ -3,6 +3,7 @@ name: Bill Buckbee
 given_name: Bill
 family_name: Buckbee
 email: Bill.Buckbee@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/067.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Buckbee/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27067%27&dist_name=Buckbee,%20Bill
 other_names:
 - name: Buckbee, Bill
 other_identifiers:

--- a/data/ct/legislature/Bob-Duff-7836916c-08a2-430a-99eb-580f7cf50e81.yml
+++ b/data/ct/legislature/Bob-Duff-7836916c-08a2-430a-99eb-580f7cf50e81.yml
@@ -3,6 +3,7 @@ name: Bob Duff
 given_name: Bob
 family_name: Duff
 email: Bob.Duff@cga.ct.gov
+image: http://www.senatedems.ct.gov/templates/duff/images/duff-headshot.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Duff
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S25%27&dist_name=Duff,%20Bob
 other_names:
 - name: Duff, Bob
 other_identifiers:

--- a/data/ct/legislature/Bob-Godfrey-97e1ed70-218e-41d6-abad-73cf8c717c5b.yml
+++ b/data/ct/legislature/Bob-Godfrey-97e1ed70-218e-41d6-abad-73cf8c717c5b.yml
@@ -3,6 +3,7 @@ name: Bob Godfrey
 given_name: Bob
 family_name: Godfrey
 email: Bob.Godfrey@cga.ct.gov
+image: http://www2.housedems.ct.gov/Godfrey/images/Godfrey_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Godfrey
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27110%27&dist_name=Godfrey,%20Bob
 other_names:
 - name: Godfrey, Bob
 other_identifiers:

--- a/data/ct/legislature/Bobby-G-Gibson-Jr-6e4977fe-2ed9-4e1c-93ce-c837766d2896.yml
+++ b/data/ct/legislature/Bobby-G-Gibson-Jr-6e4977fe-2ed9-4e1c-93ce-c837766d2896.yml
@@ -3,6 +3,7 @@ name: Bobby G. Gibson Jr.
 given_name: Bobby
 family_name: Gibson
 email: Bobby.Gibson@cga.ct.gov
+image: http://www2.housedems.ct.gov/Gibson/images/Gibson_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/gibson
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27015%27&dist_name=Gibson,%20Bobby%20G.
 other_names:
 - name: Gibson, Bobby G.
 other_identifiers:

--- a/data/ct/legislature/Brandon-Chafee-e8ce793e-671a-41fa-818a-42b534fa9c6b.yml
+++ b/data/ct/legislature/Brandon-Chafee-e8ce793e-671a-41fa-818a-42b534fa9c6b.yml
@@ -3,6 +3,7 @@ name: Brandon Chafee
 given_name: Brandon
 family_name: Chafee
 email: Brandon.Chafee@cga.ct.gov
+image: http://www2.housedems.ct.gov/Chafee/images/Chafee_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Chafee
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27033%27&dist_name=Chafee,%20Brandon
 other_names:
 - name: Chafee, Brandon
 sources:

--- a/data/ct/legislature/Brian-Lanoue-fc3ba144-870e-4603-b2a4-26d3e80b5c70.yml
+++ b/data/ct/legislature/Brian-Lanoue-fc3ba144-870e-4603-b2a4-26d3e80b5c70.yml
@@ -3,6 +3,7 @@ name: Brian Lanoue
 given_name: Brian
 family_name: Lanoue
 email: Brian.Lanoue@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/045.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/lanoue/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27045%27&dist_name=Lanoue,%20Brian
 other_names:
 - name: Lanoue, Brian
 sources:

--- a/data/ct/legislature/Brian-T-Smith-8abc69af-2775-4342-9191-6902690d03ed.yml
+++ b/data/ct/legislature/Brian-T-Smith-8abc69af-2775-4342-9191-6902690d03ed.yml
@@ -3,6 +3,7 @@ name: Brian T. Smith
 given_name: Brian
 family_name: Smith
 email: brian.smith@cga.ct.gov
+image: http://www2.housedems.ct.gov/Smith/images/Smith_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -22,6 +23,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/smith
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27048%27&dist_name=Smith,%20Brian%20T.
 other_names:
 - name: Smith, Brian T.
 sources:

--- a/data/ct/legislature/Cara-Christine-Pavalock-DAmato-e9c9ef28-807a-4efe-983f-d194c54ed41a.yml
+++ b/data/ct/legislature/Cara-Christine-Pavalock-DAmato-e9c9ef28-807a-4efe-983f-d194c54ed41a.yml
@@ -3,6 +3,7 @@ name: Cara Christine Pavalock-D'Amato
 given_name: Cara
 family_name: Pavalock-D'Amato
 email: Cara.Pavalock-DAmato@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/077.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Pavalock/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27077%27&dist_name=Pavalock-D%27Amato,%20Cara%20Christine
 other_names:
 - name: Pavalock-d'amato, Cara Christine
 other_identifiers:

--- a/data/ct/legislature/Carol-Hall-5e47f657-ab56-4673-bebb-5a7c1a0410db.yml
+++ b/data/ct/legislature/Carol-Hall-5e47f657-ab56-4673-bebb-5a7c1a0410db.yml
@@ -3,6 +3,7 @@ name: Carol Hall
 given_name: Carol
 family_name: Hall
 email: Carol.Hall@housegop.ct.gov
+image: https://www.cthousegop.com/hall/wp-content/uploads/sites/34/2016/11/hall-bio-pict-big.jpg
 party:
 - name: Republican
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.cthousegop.com/Hall/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27059%27&dist_name=Hall,%20Carol
 other_names:
 - name: Hall, Carol
 other_identifiers:

--- a/data/ct/legislature/Catherine-A-Osten-aec1fe1b-02ac-4802-be69-8714ec0b848e.yml
+++ b/data/ct/legislature/Catherine-A-Osten-aec1fe1b-02ac-4802-be69-8714ec0b848e.yml
@@ -2,6 +2,7 @@ id: ocd-person/aec1fe1b-02ac-4802-be69-8714ec0b848e
 name: Catherine A. Osten
 given_name: Catherine
 family_name: Osten
+image: http://www.senatedems.ct.gov/templates/osten/images/osten1x1.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Osten
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S19%27&dist_name=Osten,%20Catherine%20A.
 other_names:
 - name: Osten, Catherine A.
 other_identifiers:

--- a/data/ct/legislature/Catherine-F-Abercrombie-85ce898d-f0fc-499d-9b09-1238b29f152c.yml
+++ b/data/ct/legislature/Catherine-F-Abercrombie-85ce898d-f0fc-499d-9b09-1238b29f152c.yml
@@ -3,6 +3,7 @@ name: Catherine F. Abercrombie
 given_name: Catherine
 family_name: Abercrombie
 email: Catherine.Abercrombie@cga.ct.gov
+image: http://www2.housedems.ct.gov/Abercrombie/images/Abercrombie_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Abercrombie
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27083%27&dist_name=Abercrombie,%20Catherine%20F.
 other_names:
 - name: Abercrombie, Catherine F.
 other_identifiers:

--- a/data/ct/legislature/Charles-J-Ferraro-bc0526f4-43f7-4ad1-b518-ceb1680771f8.yml
+++ b/data/ct/legislature/Charles-J-Ferraro-bc0526f4-43f7-4ad1-b518-ceb1680771f8.yml
@@ -3,6 +3,7 @@ name: Charles J. Ferraro
 given_name: Charles
 family_name: Ferraro
 email: Charles.Ferraro@housegop.ct.gov
+image: https://www.cthousegop.com/ferraro/wp-content/uploads/sites/27/2016/11/Ferraro_Web_Bio.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Ferraro/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27117%27&dist_name=Ferraro,%20Charles%20J.
 other_names:
 - name: Ferraro, Charles J.
 other_identifiers:

--- a/data/ct/legislature/Charlie-L-Stallworth-ddbee7da-746c-4fd1-8ee2-21ec3c6672d1.yml
+++ b/data/ct/legislature/Charlie-L-Stallworth-ddbee7da-746c-4fd1-8ee2-21ec3c6672d1.yml
@@ -3,6 +3,7 @@ name: Charlie L. Stallworth
 given_name: Charlie
 family_name: Stallworth
 email: Charlie.Stallworth@cga.ct.gov
+image: http://www2.housedems.ct.gov/Stallworth/images/Stallworth_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/stallworth
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27126%27&dist_name=Stallworth,%20Charlie%20L.
 other_names:
 - name: Stallworth, Charlie L.
 other_identifiers:

--- a/data/ct/legislature/Chris-Perone-15f3df31-84bc-4ae6-b399-c9b9c58ecec6.yml
+++ b/data/ct/legislature/Chris-Perone-15f3df31-84bc-4ae6-b399-c9b9c58ecec6.yml
@@ -3,6 +3,7 @@ name: Chris Perone
 given_name: Chris
 family_name: Perone
 email: Chris.Perone@cga.ct.gov
+image: http://www2.housedems.ct.gov/Perone/images/Perone_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Perone
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27137%27&dist_name=Perone,%20Chris
 other_names:
 - name: Perone, Chris
 other_identifiers:

--- a/data/ct/legislature/Christie-M-Carpino-88d052d8-3d97-4e23-8abd-53311294acfd.yml
+++ b/data/ct/legislature/Christie-M-Carpino-88d052d8-3d97-4e23-8abd-53311294acfd.yml
@@ -3,6 +3,7 @@ name: Christie M. Carpino
 given_name: Christie
 family_name: Carpino
 email: christie.carpino@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/032.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Carpino/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27032%27&dist_name=Carpino,%20Christie%20M.
 other_names:
 - name: Carpino, Christie M.
 other_identifiers:

--- a/data/ct/legislature/Christine-Cohen-5e2acad1-d976-4a7d-997b-52b5b400a654.yml
+++ b/data/ct/legislature/Christine-Cohen-5e2acad1-d976-4a7d-997b-52b5b400a654.yml
@@ -2,6 +2,7 @@ id: ocd-person/5e2acad1-d976-4a7d-997b-52b5b400a654
 name: Christine Cohen
 given_name: Christine
 family_name: Cohen
+image: http://www.senatedems.ct.gov/templates/Cohen/images/Cohen-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -16,6 +17,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.senatedems.ct.gov/cohen
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S12%27&dist_name=Cohen,%20Christine
 other_names:
 - name: Cohen, Christine
 sources:

--- a/data/ct/legislature/Christine-Conley-276eaeb3-5dae-40f3-acbb-3effe375988b.yml
+++ b/data/ct/legislature/Christine-Conley-276eaeb3-5dae-40f3-acbb-3effe375988b.yml
@@ -3,6 +3,7 @@ name: Christine Conley
 given_name: Christine
 family_name: Conley
 email: Christine.Conley@cga.ct.gov
+image: http://www2.housedems.ct.gov/Conley/images/Conley_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Conley
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27040%27&dist_name=Conley,%20Christine
 other_names:
 - name: Conley, Christine
 other_identifiers:

--- a/data/ct/legislature/Christine-Goupil-48533eeb-45fb-4bb6-915d-fdd8009a9fca.yml
+++ b/data/ct/legislature/Christine-Goupil-48533eeb-45fb-4bb6-915d-fdd8009a9fca.yml
@@ -3,6 +3,7 @@ name: Christine Goupil
 given_name: Christine
 family_name: Goupil
 email: Christine.Goupil@cga.ct.gov
+image: http://www2.housedems.ct.gov/Goupil/images/Goupil_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/goupil
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27035%27&dist_name=Goupil,%20Christine
 other_names:
 - name: Goupil, Christine
 sources:

--- a/data/ct/legislature/Christine-Palm-d125d3d7-3ad3-487e-a993-c0e3107c9202.yml
+++ b/data/ct/legislature/Christine-Palm-d125d3d7-3ad3-487e-a993-c0e3107c9202.yml
@@ -3,6 +3,7 @@ name: Christine Palm
 given_name: Christine
 family_name: Palm
 email: Christine.Palm@cga.ct.gov
+image: http://www2.housedems.ct.gov/Palm/images/Palm_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,8 +21,8 @@ offices:
   voice: 860-836-2145
   name: 'District Office #1'
 links:
-- url: http:////www.housedems.ct.gov/palm
 - url: http://www.housedems.ct.gov/palm
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27036%27&dist_name=Palm,%20Christine
 other_names:
 - name: Palm, Christine
 sources:

--- a/data/ct/legislature/Christopher-Rosario-ea0027a9-6952-4b74-a771-a14ced4e647e.yml
+++ b/data/ct/legislature/Christopher-Rosario-ea0027a9-6952-4b74-a771-a14ced4e647e.yml
@@ -3,6 +3,7 @@ name: Christopher Rosario
 given_name: Christopher
 family_name: Rosario
 email: Christopher.Rosario@cga.ct.gov
+image: http://www2.housedems.ct.gov/Rosario/images/Rosario_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Rosario
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27128%27&dist_name=Rosario,%20Christopher
 other_names:
 - name: Rosario, Christopher
 other_identifiers:

--- a/data/ct/legislature/Christopher-Ziogas-506de26d-cebf-48cf-a0e0-3f7f8efb6a6a.yml
+++ b/data/ct/legislature/Christopher-Ziogas-506de26d-cebf-48cf-a0e0-3f7f8efb6a6a.yml
@@ -3,6 +3,7 @@ name: Christopher Ziogas
 given_name: Christopher
 family_name: Ziogas
 email: Chris.Ziogas@cga.ct.gov
+image: http://www2.housedems.ct.gov/Ziogas/images/Ziogas_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Ziogas
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27079%27&dist_name=Ziogas,%20Christopher
 other_names:
 - name: Ziogas, Christopher
 other_identifiers:

--- a/data/ct/legislature/Cindy-Harrison-7aae96d8-45b7-4be6-9483-3ade2191578b.yml
+++ b/data/ct/legislature/Cindy-Harrison-7aae96d8-45b7-4be6-9483-3ade2191578b.yml
@@ -3,6 +3,7 @@ name: Cindy Harrison
 given_name: Cindy
 family_name: Harrison
 email: Cindy.Harrison@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/069.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/Harrison
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27069%27&dist_name=Harrison,%20Cindy
 other_names:
 - name: Harrison, Cindy
 sources:

--- a/data/ct/legislature/Corey-P-Paris-fcc3d3fa-4b4d-4d3c-b512-003a58657a85.yml
+++ b/data/ct/legislature/Corey-P-Paris-fcc3d3fa-4b4d-4d3c-b512-003a58657a85.yml
@@ -3,6 +3,7 @@ name: Corey P. Paris
 given_name: Corey
 family_name: Paris
 email: corey.paris@cga.ct.gov
+image: http://www2.housedems.ct.gov/Paris/images/Paris_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/paris
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27145%27&dist_name=Paris,%20Corey%20P.
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Craig-C-Fishbein-02ce0fa3-ac25-42dd-9f5e-ee44b7e9d542.yml
+++ b/data/ct/legislature/Craig-C-Fishbein-02ce0fa3-ac25-42dd-9f5e-ee44b7e9d542.yml
@@ -3,6 +3,7 @@ name: Craig C. Fishbein
 given_name: Craig
 family_name: Fishbein
 email: Craig.Fishbein@housegop.ct.gov
+image: https://www.cthousegop.com/fishbein/wp-content/uploads/sites/28/2019/01/sm_Fishbein-headshot-020117-7754.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Fishbein/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27090%27&dist_name=Fishbein,%20Craig%20C.
 other_names:
 - name: Fishbein, Craig C.
 other_identifiers:

--- a/data/ct/legislature/Craig-Miner-9b22e360-54e1-4e6a-a733-d2c0a7e94d5a.yml
+++ b/data/ct/legislature/Craig-Miner-9b22e360-54e1-4e6a-a733-d2c0a7e94d5a.yml
@@ -3,6 +3,7 @@ name: Craig Miner
 given_name: Craig
 family_name: Miner
 email: Craig.Miner@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2017/01/Miner-2017-01-04.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-Miner
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S30%27&dist_name=Miner,%20Craig
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CTL000336

--- a/data/ct/legislature/Cristin-McCarthy-Vahey-dfc1bead-50cd-4c34-9dc6-5d80c7a09589.yml
+++ b/data/ct/legislature/Cristin-McCarthy-Vahey-dfc1bead-50cd-4c34-9dc6-5d80c7a09589.yml
@@ -3,6 +3,7 @@ name: Cristin McCarthy Vahey
 given_name: Cristin
 family_name: McCarthy Vahey
 email: Cristin.McCarthyVahey@cga.ct.gov
+image: http://www2.housedems.ct.gov/McCarthyVahey/images/McCarthyVahey_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/McCarthyVahey
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27133%27&dist_name=McCarthy%20Vahey,%20Cristin
 other_names:
 - name: Mccarthy Vahey, Cristin
 other_identifiers:

--- a/data/ct/legislature/Dan-Champagne-9e96a931-c06f-4245-859b-dbe02d3e2342.yml
+++ b/data/ct/legislature/Dan-Champagne-9e96a931-c06f-4245-859b-dbe02d3e2342.yml
@@ -3,6 +3,7 @@ name: Dan Champagne
 given_name: Dan
 family_name: Champagne
 email: Dan.Champagne@cga.ct.gov
+image: https://www.cga.ct.gov/legpics/S35.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-champagne
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S35%27&dist_name=Champagne,%20Dan
 other_names:
 - name: Champagne, Dan
 sources:

--- a/data/ct/legislature/Daniel-J-Fox-b0817ed7-2898-4824-934c-c49615c8b1ea.yml
+++ b/data/ct/legislature/Daniel-J-Fox-b0817ed7-2898-4824-934c-c49615c8b1ea.yml
@@ -3,6 +3,7 @@ name: Daniel J. Fox
 given_name: Daniel
 family_name: Fox
 email: Dan.Fox@cga.ct.gov
+image: http://www2.housedems.ct.gov/Fox/images/Fox_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Fox
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27148%27&dist_name=Fox,%20Daniel%20J.
 other_names:
 - name: Fox, Daniel J.
 other_identifiers:

--- a/data/ct/legislature/Dave-W-Yaccarino-12835342-bb95-428a-ace3-78c51c3e8443.yml
+++ b/data/ct/legislature/Dave-W-Yaccarino-12835342-bb95-428a-ace3-78c51c3e8443.yml
@@ -3,6 +3,7 @@ name: Dave W. Yaccarino
 given_name: Dave
 family_name: Yaccarino
 email: dave.yaccarino@housegop.ct.gov
+image: https://www.cthousegop.com/yaccarino/wp-content/uploads/sites/70/2020/11/Yaccarino-Headshot-240x300.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Yaccarino/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27087%27&dist_name=Yaccarino,%20Dave%20W.
 other_names:
 - name: Yaccarino, Dave W.
 other_identifiers:

--- a/data/ct/legislature/David-Arconti-Jr-586dc1fb-0c17-412b-964a-f5de187d4158.yml
+++ b/data/ct/legislature/David-Arconti-Jr-586dc1fb-0c17-412b-964a-f5de187d4158.yml
@@ -3,6 +3,7 @@ name: David Arconti Jr.
 given_name: David
 family_name: Arconti
 email: David.Arconti@cga.ct.gov
+image: http://www2.housedems.ct.gov/Arconti/images/Arconti_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Arconti
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27109%27&dist_name=Arconti,%20David
 other_names:
 - name: Arconti, David
 other_identifiers:

--- a/data/ct/legislature/David-K-Labriola-0d2a3f7f-31d4-4e47-ba1f-7bfce484f6f9.yml
+++ b/data/ct/legislature/David-K-Labriola-0d2a3f7f-31d4-4e47-ba1f-7bfce484f6f9.yml
@@ -3,6 +3,7 @@ name: David K. Labriola
 given_name: David
 family_name: Labriola
 email: David.Labriola@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/131.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Labriola/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27131%27&dist_name=Labriola,%20David%20K.
 other_names:
 - name: Labriola, David K.
 other_identifiers:

--- a/data/ct/legislature/David-Michel-2e21841e-7d65-4010-a0b2-c3bb779523c5.yml
+++ b/data/ct/legislature/David-Michel-2e21841e-7d65-4010-a0b2-c3bb779523c5.yml
@@ -3,6 +3,7 @@ name: David Michel
 given_name: David
 family_name: Michel
 email: David.Michel@cga.ct.gov
+image: http://www2.housedems.ct.gov/Michel/images/Michel_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/michel
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27146%27&dist_name=Michel,%20David
 other_names:
 - name: Michel, David
 sources:

--- a/data/ct/legislature/David-Rutigliano-01bfbaf3-d536-45f0-8478-96cd8fbd4518.yml
+++ b/data/ct/legislature/David-Rutigliano-01bfbaf3-d536-45f0-8478-96cd8fbd4518.yml
@@ -3,6 +3,7 @@ name: David Rutigliano
 given_name: David
 family_name: Rutigliano
 email: David.Rutigliano@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/123.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Rutigliano/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27123%27&dist_name=Rutigliano,%20David
 other_names:
 - name: Rutigliano, David
 other_identifiers:

--- a/data/ct/legislature/David-T-Wilson-520fc855-8f97-4698-9521-039c9ea9918c.yml
+++ b/data/ct/legislature/David-T-Wilson-520fc855-8f97-4698-9521-039c9ea9918c.yml
@@ -3,6 +3,7 @@ name: David T. Wilson
 given_name: David
 family_name: Wilson
 email: David.Wilson@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/066.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Wilson/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27066%27&dist_name=Wilson,%20David%20T.
 other_names:
 - name: Wilson, David T.
 other_identifiers:

--- a/data/ct/legislature/Dennis-Bradley-fa722794-9212-4794-b381-04d0f1d65cff.yml
+++ b/data/ct/legislature/Dennis-Bradley-fa722794-9212-4794-b381-04d0f1d65cff.yml
@@ -2,6 +2,7 @@ id: ocd-person/fa722794-9212-4794-b381-04d0f1d65cff
 name: Dennis A. Bradley
 given_name: Dennis
 family_name: Bradley
+image: http://www.senatedems.ct.gov/templates/Bradley/images/Bradley-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/bradley
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S23%27&dist_name=Bradley,%20Dennis%20A.
 other_names:
 - name: Bradley, Dennis A.
 sources:

--- a/data/ct/legislature/Derek-Slap-a33a2113-e60b-4000-9dc7-eb58a775d986.yml
+++ b/data/ct/legislature/Derek-Slap-a33a2113-e60b-4000-9dc7-eb58a775d986.yml
@@ -2,6 +2,7 @@ id: ocd-person/a33a2113-e60b-4000-9dc7-eb58a775d986
 name: Derek Slap
 given_name: Derek
 family_name: Slap
+image: http://www.senatedems.ct.gov/templates/slap/images/slap-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -24,6 +25,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/slap
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S05%27&dist_name=Slap,%20Derek
 other_names:
 - name: Slap, Derek
 other_identifiers:

--- a/data/ct/legislature/Devin-R-Carney-79d4059c-5faa-443f-a842-7b494ea2d57e.yml
+++ b/data/ct/legislature/Devin-R-Carney-79d4059c-5faa-443f-a842-7b494ea2d57e.yml
@@ -3,6 +3,7 @@ name: Devin R. Carney
 given_name: Devin
 family_name: Carney
 email: Devin.Carney@housegop.ct.gov
+image: https://www.cthousegop.com/carney/wp-content/uploads/sites/13/2016/11/Carney-2017-Web-Bio-Pict-216x300.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Carney/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27023%27&dist_name=Carney,%20Devin%20R.
 other_names:
 - name: Carney, Devin R.
 other_identifiers:

--- a/data/ct/legislature/Donna-Veach-63461ed0-da6d-4423-82bc-5b83c2a811cf.yml
+++ b/data/ct/legislature/Donna-Veach-63461ed0-da6d-4423-82bc-5b83c2a811cf.yml
@@ -3,6 +3,7 @@ name: Donna Veach
 given_name: Donna
 family_name: Veach
 email: Donna.Veach@housegop.ct.gov
+image: https://cga.ct.gov/legpics/030.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/veach
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27030%27&dist_name=Veach,%20Donna
 other_names:
 - name: Veach, Donna
 sources:

--- a/data/ct/legislature/Dorinda-Borer-4868bf1f-ad1d-4cad-96fa-040ede0d1641.yml
+++ b/data/ct/legislature/Dorinda-Borer-4868bf1f-ad1d-4cad-96fa-040ede0d1641.yml
@@ -3,6 +3,7 @@ name: Dorinda Borer
 given_name: Dorinda
 family_name: Borer
 email: Dorinda.Borer@cga.ct.gov
+image: http://www2.housedems.ct.gov/Borer/images/Borer_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/Borer
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27115%27&dist_name=Borer,%20Dorinda
 other_names:
 - name: Borer, Dorinda
 other_identifiers:

--- a/data/ct/legislature/Doug-Dubitsky-2342cde8-078f-4dd8-8879-f9fdaa036a94.yml
+++ b/data/ct/legislature/Doug-Dubitsky-2342cde8-078f-4dd8-8879-f9fdaa036a94.yml
@@ -3,6 +3,7 @@ name: Doug Dubitsky
 given_name: Doug
 family_name: Dubitsky
 email: Doug.Dubitsky@housegop.ct.gov
+image: https://www.cthousegop.com/dubitsky/wp-content/uploads/sites/23/2019/01/2-Dubitsky-headshot-cropped-v2-050318-5673-265x300.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Dubitsky/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27047%27&dist_name=Dubitsky,%20Doug
 other_names:
 - name: Dubitsky, Doug
 other_identifiers:

--- a/data/ct/legislature/Douglas-McCrory-83a4e876-4df7-48ef-8a84-7d7940585af9.yml
+++ b/data/ct/legislature/Douglas-McCrory-83a4e876-4df7-48ef-8a84-7d7940585af9.yml
@@ -3,6 +3,7 @@ name: Douglas McCrory
 given_name: Douglas
 family_name: McCrory
 email: douglas.mccrory@cga.ct.gov
+image: http://www.senatedems.ct.gov/templates/mccrory/images/mccrory-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/McCrory
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S02%27&dist_name=McCrory,%20Douglas
 other_names:
 - name: Mccrory, Douglas
 other_identifiers:

--- a/data/ct/legislature/Edwin-Vargas-7689046b-7757-475e-ba24-1e20ecf169b4.yml
+++ b/data/ct/legislature/Edwin-Vargas-7689046b-7757-475e-ba24-1e20ecf169b4.yml
@@ -3,6 +3,7 @@ name: Edwin Vargas
 given_name: Edwin
 family_name: Vargas
 email: Edwin.Vargas@cga.ct.gov
+image: http://www2.housedems.ct.gov/Vargas/images/Vargas_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Vargas
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27006%27&dist_name=Vargas,%20Edwin
 other_names:
 - name: Vargas, Edwin
 other_identifiers:

--- a/data/ct/legislature/Eleni-Kavros-DeGraw-2a3c062a-ac41-4295-9c26-195f78369242.yml
+++ b/data/ct/legislature/Eleni-Kavros-DeGraw-2a3c062a-ac41-4295-9c26-195f78369242.yml
@@ -1,6 +1,7 @@
 id: ocd-person/2a3c062a-ac41-4295-9c26-195f78369242
 name: Eleni Kavros DeGraw
 email: Eleni.KavrosDeGraw@cga.ct.gov
+image: http://www2.housedems.ct.gov/KavrosDeGraw/images/KavrosDeGraw_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/KavrosDegraw
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27017%27&dist_name=Kavros%20DeGraw,%20Eleni
 other_names:
 - name: Kavros Degraw, Eleni
 sources:

--- a/data/ct/legislature/Emmanuel-Sanchez-140d2d97-aae9-433a-b012-ce3775aa81a8.yml
+++ b/data/ct/legislature/Emmanuel-Sanchez-140d2d97-aae9-433a-b012-ce3775aa81a8.yml
@@ -3,6 +3,7 @@ name: Emmanuel Sanchez
 given_name: Emmanuel
 family_name: Sanchez
 email: emmanuel.sanchez@cga.ct.gov
+image: http://www2.housedems.ct.gov/SanchezM/images/SanchezM_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/SanchezM
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27024%27&dist_name=Sanchez,%20Emmanuel
 other_names:
 - name: Sanchez, Emmanuel
 sources:

--- a/data/ct/legislature/Emmett-D-Riley-81708fd7-b28e-4c83-b972-80e77a91da3c.yml
+++ b/data/ct/legislature/Emmett-D-Riley-81708fd7-b28e-4c83-b972-80e77a91da3c.yml
@@ -3,6 +3,7 @@ name: Emmett D. Riley
 given_name: Emmett
 family_name: Riley
 email: Emmett.Riley@cga.ct.gov
+image: http://www2.housedems.ct.gov/Riley/images/Riley_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Riley
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27046%27&dist_name=Riley,%20Emmett%20D.
 other_names:
 - name: Riley, Emmett D.
 other_identifiers:

--- a/data/ct/legislature/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
+++ b/data/ct/legislature/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
@@ -3,6 +3,7 @@ name: Eric C. Berthel
 given_name: Eric
 family_name: Berthel
 email: Eric.Berthel@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2019/01/Berthel2019forWeb.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-Berthel
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S32%27&dist_name=Berthel,%20Eric%20C.
 other_names:
 - name: Berthel, Eric C.
 other_identifiers:

--- a/data/ct/legislature/Frank-Smith-c09f368c-d954-48e1-b94b-18728ab9b6bd.yml
+++ b/data/ct/legislature/Frank-Smith-c09f368c-d954-48e1-b94b-18728ab9b6bd.yml
@@ -3,6 +3,7 @@ name: Frank Smith
 given_name: Frank
 family_name: Smith
 email: Frank.Smith@cga.ct.gov
+image: http://www2.housedems.ct.gov/SmithF/images/SmithF_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/SmithF
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27118%27&dist_name=Smith,%20Frank
 other_names:
 - name: Smith, Frank
 sources:

--- a/data/ct/legislature/Gale-L-Mastrofrancesco-c60ec8d2-fcc3-414e-a122-cca6aeef901d.yml
+++ b/data/ct/legislature/Gale-L-Mastrofrancesco-c60ec8d2-fcc3-414e-a122-cca6aeef901d.yml
@@ -3,6 +3,7 @@ name: Gale L. Mastrofrancesco
 given_name: Gale
 family_name: Mastrofrancesco
 email: Gale.Mastrofrancesco@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/080.png?ver=
 party:
 - name: Republican
 roles:
@@ -17,6 +18,7 @@ offices:
   address: 300 Capitol Ave, Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.cthousegop.com/mastrofrancesco/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27080%27&dist_name=Mastrofrancesco,%20Gale%20L.
 other_names:
 - name: Mastrofrancesco, Gale L.
 sources:

--- a/data/ct/legislature/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
+++ b/data/ct/legislature/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
@@ -3,6 +3,7 @@ name: Gary A. Winfield
 given_name: Gary
 family_name: Winfield
 email: gary.winfield@cga.ct.gov
+image: http://www.senatedems.ct.gov/templates/winfield/images/winfield-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Winfield
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S10%27&dist_name=Winfield,%20Gary%20A.
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CTL000279

--- a/data/ct/legislature/Gary-Turco-36b9eb8c-9fd8-4f6e-ba6b-fddb03bf3be3.yml
+++ b/data/ct/legislature/Gary-Turco-36b9eb8c-9fd8-4f6e-ba6b-fddb03bf3be3.yml
@@ -3,6 +3,7 @@ name: Gary A. Turco Jr.
 given_name: Gary
 family_name: Turco
 email: Gary.Turco@cga.ct.gov
+image: http://www2.housedems.ct.gov/Turco/images/Turco_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/turco
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27027%27&dist_name=Turco,%20Gary%20A.
 other_names:
 - name: Turco, Gary A.
 sources:

--- a/data/ct/legislature/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
+++ b/data/ct/legislature/Geoff-Luxenberg-37f6cb6c-888c-44c1-8c21-b273d967a62d.yml
@@ -3,6 +3,7 @@ name: Geoff Luxenberg
 given_name: Geoff
 family_name: Luxenberg
 email: Geoff.Luxenberg@cga.ct.gov
+image: http://www2.housedems.ct.gov/Luxenberg/images/Luxenberg_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -22,6 +23,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/luxenberg
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27012%27&dist_name=Luxenberg,%20Geoff
 other_names:
 - name: Luxenberg, Geoff
 other_identifiers:

--- a/data/ct/legislature/Geraldo-C-Reyes-Jr-f11b5a17-e613-4aa8-9b91-7e2583e1ced5.yml
+++ b/data/ct/legislature/Geraldo-C-Reyes-Jr-f11b5a17-e613-4aa8-9b91-7e2583e1ced5.yml
@@ -3,6 +3,7 @@ name: Geraldo C. Reyes Jr.
 given_name: Geraldo
 family_name: Reyes
 email: Geraldo.Reyes@cga.ct.gov
+image: http://www2.housedems.ct.gov/Reyes/images/Reyes_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Reyes
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27075%27&dist_name=Reyes,%20Geraldo%20C.
 other_names:
 - name: Reyes, Geraldo C.
 other_identifiers:

--- a/data/ct/legislature/Greg-Howard-d8829ada-0b6e-4cbf-8aa6-e88c70d76e89.yml
+++ b/data/ct/legislature/Greg-Howard-d8829ada-0b6e-4cbf-8aa6-e88c70d76e89.yml
@@ -3,6 +3,7 @@ name: Greg S. Howard
 given_name: Greg
 family_name: Howard
 email: Greg.Howard@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/043.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/howard
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27043%27&dist_name=Howard,%20Greg%20S.
 other_names:
 - name: Howard, Greg S.
 - name: Greg Howard

--- a/data/ct/legislature/Gregory-Haddad-63a8e4ab-dfcd-4a69-8317-53b8e9a69729.yml
+++ b/data/ct/legislature/Gregory-Haddad-63a8e4ab-dfcd-4a69-8317-53b8e9a69729.yml
@@ -3,6 +3,7 @@ name: Gregory Haddad
 given_name: Gregory
 family_name: Haddad
 email: Gregory.Haddad@cga.ct.gov
+image: http://www2.housedems.ct.gov/Haddad/images/Haddad_19.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/haddad
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27054%27&dist_name=Haddad,%20Gregory
 other_names:
 - name: Haddad, Gregory
 other_identifiers:

--- a/data/ct/legislature/Harry-Arora-2253e194-1b93-4973-a76e-7fc39ad1727b.yml
+++ b/data/ct/legislature/Harry-Arora-2253e194-1b93-4973-a76e-7fc39ad1727b.yml
@@ -3,6 +3,7 @@ name: Harry Arora
 given_name: Harry
 family_name: Arora
 email: harry.arora@housegop.ct.gov
+image: https://www.cthousegop.com/arora/wp-content/uploads/sites/85/2020/03/State-Rep.-Harry-Arora-2020-Headshot-220x300.jpg
 party:
 - name: Republican
 roles:
@@ -18,6 +19,7 @@ offices:
   address: 300 Capitol Ave., LOB; Hartford, CT 06106
 links:
 - url: http://www.cthousegop.com/arora
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27151%27&dist_name=Arora,%20Harry
 other_names:
 - name: Arora, Harry
 sources:

--- a/data/ct/legislature/Heather-B-Somers-a648c360-3b9e-408d-ba2a-c171edada365.yml
+++ b/data/ct/legislature/Heather-B-Somers-a648c360-3b9e-408d-ba2a-c171edada365.yml
@@ -3,6 +3,7 @@ name: Heather S. Somers
 given_name: Heather
 family_name: Somers
 email: Heather.Somers@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2020/12/HeatherHeadshot-e1608139012865.jpg
 party:
 - name: Republican
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.ctsenaterepublicans.com/home-Somers
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S18%27&dist_name=Somers,%20Heather%20S.
 other_names:
 - name: Somers, Heather S.
 other_identifiers:

--- a/data/ct/legislature/Henri-Martin-ca8be710-988a-4415-bc37-6d3a92d1afcd.yml
+++ b/data/ct/legislature/Henri-Martin-ca8be710-988a-4415-bc37-6d3a92d1afcd.yml
@@ -3,6 +3,7 @@ name: Henri Martin
 given_name: Henri
 family_name: Martin
 email: Henri.Martin@cga.ct.gov
+image: https://cga.ct.gov/legpics/S31.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-Martin
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S31%27&dist_name=Martin,%20Henri
 other_names:
 - name: Martin, Henri
 other_identifiers:

--- a/data/ct/legislature/Henry-J-Genga-c07f613b-b79d-4e11-b959-589c8cefac41.yml
+++ b/data/ct/legislature/Henry-J-Genga-c07f613b-b79d-4e11-b959-589c8cefac41.yml
@@ -3,6 +3,7 @@ name: Henry J. Genga
 given_name: Henry
 family_name: Genga
 email: henry.genga@cga.ct.gov
+image: http://www2.housedems.ct.gov/Genga/images/Genga_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Genga
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27010%27&dist_name=Genga,%20Henry%20J.
 other_names:
 - name: Genga, Henry J.
 other_identifiers:

--- a/data/ct/legislature/Hilda-E-Santiago-568f232d-2133-4eee-a886-c1927f7f88bc.yml
+++ b/data/ct/legislature/Hilda-E-Santiago-568f232d-2133-4eee-a886-c1927f7f88bc.yml
@@ -3,6 +3,7 @@ name: Hilda E. Santiago
 given_name: Hilda
 family_name: Santiago
 email: Hilda.Santiago@cga.ct.gov
+image: http://www2.housedems.ct.gov/SantiagoH/images/SantiagoH_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/SantiagoH
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27084%27&dist_name=Santiago,%20Hilda%20E.
 other_names:
 - name: Santiago, Hilda E.
 other_identifiers:

--- a/data/ct/legislature/Holly-H-Cheeseman-4382243c-e60c-4b2a-b41b-cd3b6d658f9d.yml
+++ b/data/ct/legislature/Holly-H-Cheeseman-4382243c-e60c-4b2a-b41b-cd3b6d658f9d.yml
@@ -3,6 +3,7 @@ name: Holly H. Cheeseman
 given_name: Holly
 family_name: Cheeseman
 email: Holly.Cheeseman@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/037.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Cheeseman/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27037%27&dist_name=Cheeseman,%20Holly%20H.
 other_names:
 - name: Cheeseman, Holly H.
 other_identifiers:

--- a/data/ct/legislature/Hubert-Delany-b666accd-c7f7-41e9-ade0-f64f6e438669.yml
+++ b/data/ct/legislature/Hubert-Delany-b666accd-c7f7-41e9-ade0-f64f6e438669.yml
@@ -3,6 +3,7 @@ name: Hubert D. Delany
 given_name: Hubert
 family_name: Delany
 email: Hubert.Delany@cga.ct.gov
+image: http://www2.housedems.ct.gov/Delany/images/Delany_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -16,6 +17,7 @@ offices:
   voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/delany
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27144%27&dist_name=144%20-%Delany,%Hubert
 other_names:
 - name: Hubert Delany
 sources:

--- a/data/ct/legislature/Irene-Haines-02cd12d5-6a88-4834-b9b5-11fb491f6b4b.yml
+++ b/data/ct/legislature/Irene-Haines-02cd12d5-6a88-4834-b9b5-11fb491f6b4b.yml
@@ -3,6 +3,7 @@ name: Irene M. Haines
 given_name: Irene
 family_name: Haines
 email: Irene.Haines@housegop.ct.gov
+image: https://www.cthousegop.com/haines/wp-content/uploads/sites/77/2021/12/BD3A1188-sized-232x300.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/haines/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27034%27&dist_name=Haines,%20Irene%20M.
 other_names:
 - name: Haines, Irene M.
 sources:

--- a/data/ct/legislature/Jaime-Foster-784a12cd-3ecc-4fed-8b47-4e090038c2f8.yml
+++ b/data/ct/legislature/Jaime-Foster-784a12cd-3ecc-4fed-8b47-4e090038c2f8.yml
@@ -3,6 +3,7 @@ name: Jaime S. Foster
 given_name: Jaime
 family_name: Foster
 email: Jaime.Foster@cga.ct.gov
+image: http://www2.housedems.ct.gov/Foster/images/Foster_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Foster
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27057%27&dist_name=057%20-%Foster,%Jaime
 other_names:
 - name: Foster, Jaime S.
 - name: Jaime Foster

--- a/data/ct/legislature/James-J-Maroney-f37ce303-e106-4972-b453-4287b7915762.yml
+++ b/data/ct/legislature/James-J-Maroney-f37ce303-e106-4972-b453-4287b7915762.yml
@@ -2,6 +2,7 @@ id: ocd-person/f37ce303-e106-4972-b453-4287b7915762
 name: James J. Maroney
 given_name: James
 family_name: Maroney
+image: http://www.senatedems.ct.gov/templates/Maroney/images/Maroney-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/maroney
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S14%27&dist_name=Maroney,%20James%20J.
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Jane-M-Garibay-fee3a7d8-7e51-4c5a-af29-190694152ccc.yml
+++ b/data/ct/legislature/Jane-M-Garibay-fee3a7d8-7e51-4c5a-af29-190694152ccc.yml
@@ -3,6 +3,7 @@ name: Jane M. Garibay
 given_name: Jane
 family_name: Garibay
 email: Jane.Garibay@cga.ct.gov
+image: http://www2.housedems.ct.gov/Garibay/images/Garibay_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/garibay
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27060%27&dist_name=060%20-%Garibay,%Jane
 other_names:
 - name: Garibay, Jane M.
 sources:

--- a/data/ct/legislature/Jason-Doucette-33a50ad7-61f8-4e5a-92fc-a24efddc15f1.yml
+++ b/data/ct/legislature/Jason-Doucette-33a50ad7-61f8-4e5a-92fc-a24efddc15f1.yml
@@ -3,6 +3,7 @@ name: Jason Doucette
 given_name: Jason
 family_name: Doucette
 email: Jason.Doucette@cga.ct.gov
+image: http://www2.housedems.ct.gov/Doucette/images/Doucette_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://housedems.ct.gov/doucette
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27013%27&dist_name=013%20-%Doucette,%Jason
 other_names:
 - name: Doucette, Jason
 sources:

--- a/data/ct/legislature/Jason-Perillo-78bb88a9-cde1-4691-aa7a-e423ee16a147.yml
+++ b/data/ct/legislature/Jason-Perillo-78bb88a9-cde1-4691-aa7a-e423ee16a147.yml
@@ -3,6 +3,7 @@ name: Jason Perillo
 given_name: Jason
 family_name: Perillo
 email: jason.perillo@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/113.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Perillo/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27113%27&dist_name=Jason,%20Perillo
 other_names:
 - name: Perillo, Jason
 other_identifiers:

--- a/data/ct/legislature/Jason-Rojas-94b3daf5-cbc7-4016-9297-8c0b8bc54944.yml
+++ b/data/ct/legislature/Jason-Rojas-94b3daf5-cbc7-4016-9297-8c0b8bc54944.yml
@@ -3,6 +3,7 @@ name: Jason Rojas
 given_name: Jason
 family_name: Rojas
 email: Jason.Rojas@cga.ct.gov
+image: http://www2.housedems.ct.gov/Rojas/images/Rojas_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Rojas
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27009%27&dist_name=009%20-%Rojas,%Jason
 other_names:
 - name: Rojas, Jason
 other_identifiers:

--- a/data/ct/legislature/Jay-M-Case-fc3cb4e1-f784-46ac-9d54-1dd44cb817b0.yml
+++ b/data/ct/legislature/Jay-M-Case-fc3cb4e1-f784-46ac-9d54-1dd44cb817b0.yml
@@ -3,6 +3,7 @@ name: Jay M. Case
 given_name: Jay
 family_name: Case
 email: Jay.Case@housegop.ct.gov
+image: https://www.cthousegop.com/case/wp-content/uploads/sites/15/2016/11/Case-2017-Web-Bio-Pict.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Case/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27063%27&dist_name=Jay,%20Case
 other_names:
 - name: Case, Jay M.
 other_identifiers:

--- a/data/ct/legislature/Jeff-Currey-0589b926-29e0-4281-b0f9-73369fe7f989.yml
+++ b/data/ct/legislature/Jeff-Currey-0589b926-29e0-4281-b0f9-73369fe7f989.yml
@@ -3,6 +3,7 @@ name: Jeff Currey
 given_name: Jeff
 family_name: Currey
 email: Jeff.Currey@cga.ct.gov
+image: http://www2.housedems.ct.gov/Currey/images/Currey_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Currey
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27011%27&dist_name=011%20-%Currey,%Jeff
 other_names:
 - name: Currey, Jeff
 other_identifiers:

--- a/data/ct/legislature/Jennifer-Leeper-15c5ac01-eb03-4dd3-8ab6-d162e7420559.yml
+++ b/data/ct/legislature/Jennifer-Leeper-15c5ac01-eb03-4dd3-8ab6-d162e7420559.yml
@@ -3,6 +3,7 @@ name: Jennifer Leeper
 given_name: Jennifer
 family_name: Leeper
 email: Jennifer.Leeper@cga.ct.gov
+image: http://www2.housedems.ct.gov/Leeper/images/Leeper_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Leeper
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27132%27&dist_name=132%20-%Leeper,%Jennifer
 other_names:
 - name: Leeper, Jennifer
 sources:

--- a/data/ct/legislature/Jill-Barry-629f89a2-138d-43b1-a39f-b420bd7bc061.yml
+++ b/data/ct/legislature/Jill-Barry-629f89a2-138d-43b1-a39f-b420bd7bc061.yml
@@ -3,6 +3,7 @@ name: Jill Barry
 given_name: Jill
 family_name: Barry
 email: Jill.Barry@cga.ct.gov
+image: http://www2.housedems.ct.gov/Barry/images/Barry_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/barry
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27031%27&dist_name=031%20-%Barry,%Jill
 other_names:
 - name: Barry, Jill
 sources:

--- a/data/ct/legislature/Jillian-Gilchrest-26149cc4-f15a-46fb-a9a5-7bc0544dc287.yml
+++ b/data/ct/legislature/Jillian-Gilchrest-26149cc4-f15a-46fb-a9a5-7bc0544dc287.yml
@@ -3,6 +3,7 @@ name: Jillian Gilchrest
 given_name: Jillian
 family_name: Gilchrest
 email: Jillian.Gilchrest@cga.ct.gov
+image: http://www2.housedems.ct.gov/Gilchrest/images/Gilchrest_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/gilchrest
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27018%27&dist_name=018%20-%Gilchrest,%Jillian
 other_names:
 - name: Gilchrest, Jillian
 sources:

--- a/data/ct/legislature/Joan-V-Hartley-2c22d680-9e92-423b-a943-20571186c91a.yml
+++ b/data/ct/legislature/Joan-V-Hartley-2c22d680-9e92-423b-a943-20571186c91a.yml
@@ -3,6 +3,7 @@ name: Joan V. Hartley
 given_name: Joan
 family_name: Hartley
 email: Hartley@senatedems.ct.gov
+image: http://www.senatedems.ct.gov/templates/hartley/images/hartley-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -27,6 +28,7 @@ other_identifiers:
   identifier: CTL000015
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S15%27&dist_name=Hartley,%20Joan%20V.
 extras:
   gender: Female
   title: Chief Deputy President Pro Tempore

--- a/data/ct/legislature/Joe-Polletta-df318645-047c-46a5-be61-682a7272e6b6.yml
+++ b/data/ct/legislature/Joe-Polletta-df318645-047c-46a5-be61-682a7272e6b6.yml
@@ -3,6 +3,7 @@ name: Joe Polletta
 given_name: Joe
 family_name: Polletta
 email: Joe.Polletta@housegop.ct.gov
+image: https://www.cthousegop.com/polletta/wp-content/uploads/sites/74/2017/04/Polletta-Web-Bio.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Polletta/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27068%27&dist_name=Polletta,%20Joe
 other_names:
 - name: Polletta, Joe
 other_identifiers:

--- a/data/ct/legislature/Joe-de-la-Cruz-4361534b-c294-475d-b2d8-384bc355ad17.yml
+++ b/data/ct/legislature/Joe-de-la-Cruz-4361534b-c294-475d-b2d8-384bc355ad17.yml
@@ -3,6 +3,7 @@ name: Joe de la Cruz
 given_name: Joe
 family_name: de la Cruz
 email: Joe.delaCruz@cga.ct.gov
+image: http://www2.housedems.ct.gov/delacruz/images/delaCruz_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/delaCruz
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27041%27&dist_name=041%20-%de%20la%20Cruz,%Joe
 other_names:
 - name: De La Cruz, Joe
 other_identifiers:

--- a/data/ct/legislature/John-A-Kissel-da65a738-37c7-41c1-8cd4-abae65ef0167.yml
+++ b/data/ct/legislature/John-A-Kissel-da65a738-37c7-41c1-8cd4-abae65ef0167.yml
@@ -3,6 +3,7 @@ name: John A. Kissel
 given_name: John
 family_name: Kissel
 email: John.A.Kissel@cga.ct.gov
+image: https://cga.ct.gov/legpics/S07.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-kissel
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S07%27&dist_name=Kissel,%20John%20A.
 other_names:
 - name: Kissel, John A.
 other_identifiers:

--- a/data/ct/legislature/John-E-Piscopo-e7f7ad52-69a8-4306-8dfe-02368f74d75b.yml
+++ b/data/ct/legislature/John-E-Piscopo-e7f7ad52-69a8-4306-8dfe-02368f74d75b.yml
@@ -3,6 +3,7 @@ name: John E. Piscopo
 given_name: John
 family_name: Piscopo
 email: John.Piscopo@housegop.ct.gov
+image: https://www.cthousegop.com/piscopo/wp-content/uploads/sites/52/2016/11/Piscopo-Bio-Pict-Web.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Piscopo/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27076%27&dist_name=Piscopo,%20John
 other_names:
 - name: Piscopo, John E.
 other_identifiers:

--- a/data/ct/legislature/John-Fusco-0185c242-1a49-4731-841f-9df14573fa7f.yml
+++ b/data/ct/legislature/John-Fusco-0185c242-1a49-4731-841f-9df14573fa7f.yml
@@ -3,6 +3,7 @@ name: John Fusco
 given_name: John
 family_name: Fusco
 email: John.Fusco@housegop.ct.gov
+image: https://www.cthousegop.com/fusco/wp-content/uploads/sites/32/2019/01/sm_Fusco-headshot-020117-7826.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Fusco/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27081%27&dist_name=Fusco,%20John
 other_names:
 - name: Fusco, John
 other_identifiers:

--- a/data/ct/legislature/John-Jack-F-Hennessy-3d61a53f-2d06-4910-b6ae-943cc8741d9b.yml
+++ b/data/ct/legislature/John-Jack-F-Hennessy-3d61a53f-2d06-4910-b6ae-943cc8741d9b.yml
@@ -3,6 +3,7 @@ name: John "Jack" F. Hennessy
 given_name: John
 family_name: Hennessy
 email: Jack.Hennessy@cga.ct.gov
+image: http://www2.housedems.ct.gov/Hennessy/images/Hennessy_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Hennessy
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27127%27&dist_name=127%20-%Hennessy,%Jack
 other_names:
 - name: Hennessy, John "jack" F.
 other_identifiers:

--- a/data/ct/legislature/John-K-Hampton-f9ecbfe5-3d3b-4c2a-b58d-71083baf8c9d.yml
+++ b/data/ct/legislature/John-K-Hampton-f9ecbfe5-3d3b-4c2a-b58d-71083baf8c9d.yml
@@ -3,6 +3,7 @@ name: John K. Hampton
 given_name: John
 family_name: Hampton
 email: John.Hampton@cga.ct.gov
+image: http://www2.housedems.ct.gov/Hampton/images/Hampton_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Hampton
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27016%27&dist_name=016%20-%Hampton,%John
 other_names:
 - name: Hampton, John K.
 other_identifiers:

--- a/data/ct/legislature/John-Michael-Parker-7e0711c4-57d1-405e-afe7-33df0bf064d6.yml
+++ b/data/ct/legislature/John-Michael-Parker-7e0711c4-57d1-405e-afe7-33df0bf064d6.yml
@@ -3,6 +3,7 @@ name: John-Michael Parker
 given_name: John-Michael
 family_name: Parker
 email: JohnMichael.Parker@cga.ct.gov
+image: http://www2.housedems.ct.gov/Parker/images/Parker_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Parker
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27101%27&dist_name=101%20-%Parker,%John-Michael
 other_names:
 - name: Parker, John-michael
 sources:

--- a/data/ct/legislature/John-W-Fonfara-749be8b3-0b40-41ec-8670-7dfbfbc90b6e.yml
+++ b/data/ct/legislature/John-W-Fonfara-749be8b3-0b40-41ec-8670-7dfbfbc90b6e.yml
@@ -2,6 +2,7 @@ id: ocd-person/749be8b3-0b40-41ec-8670-7dfbfbc90b6e
 name: John W. Fonfara
 given_name: John
 family_name: Fonfara
+image: http://www.senatedems.ct.gov/templates/fonfara/images/fonfara-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Fonfara
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S01%27&dist_name=Fonfara,%20John%20W.
 other_names:
 - name: Fonfara, John W.
 other_identifiers:

--- a/data/ct/legislature/Jonathan-Steinberg-22b7b95d-3488-4c14-8365-c5157b3cb099.yml
+++ b/data/ct/legislature/Jonathan-Steinberg-22b7b95d-3488-4c14-8365-c5157b3cb099.yml
@@ -3,6 +3,7 @@ name: Jonathan Steinberg
 given_name: Jonathan
 family_name: Steinberg
 email: Jonathan.Steinberg@cga.ct.gov
+image: http://www2.housedems.ct.gov/Steinberg/images/Steinberg_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Steinberg
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27136%27&dist_name=136%20-%Steinberg,%Jonathan
 other_names:
 - name: Steinberg, Jonathan
 other_identifiers:

--- a/data/ct/legislature/Jorge-Cabrera-bb280880-afa9-43f3-91bf-b05af25b023d.yml
+++ b/data/ct/legislature/Jorge-Cabrera-bb280880-afa9-43f3-91bf-b05af25b023d.yml
@@ -2,6 +2,7 @@ id: ocd-person/bb280880-afa9-43f3-91bf-b05af25b023d
 name: Jorge Cabrera
 given_name: Jorge
 family_name: Cabrera
+image: http://www.senatedems.ct.gov/templates/cabrera/images/cabrera-hi.png
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/cabrera
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S17%27&dist_name=Cabrera,%20Jorge
 other_names:
 - name: Cabrera, Jorge
 sources:

--- a/data/ct/legislature/Joseph-H-Zullo-391a83ee-0e23-4669-b3ae-b29bd9c77294.yml
+++ b/data/ct/legislature/Joseph-H-Zullo-391a83ee-0e23-4669-b3ae-b29bd9c77294.yml
@@ -3,6 +3,7 @@ name: Joseph H. Zullo
 given_name: Joseph
 family_name: Zullo
 email: joe.zullo@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/099.png?ver=
 party:
 - name: Republican
 roles:
@@ -22,6 +23,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/zullo/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27099%27&dist_name=Zullo,%20Joseph%20H.
 other_names:
 - name: Zullo, Joseph H.
 sources:

--- a/data/ct/legislature/Joseph-P-Gresko-06bb6ad8-3238-4ba7-8f83-47507541a300.yml
+++ b/data/ct/legislature/Joseph-P-Gresko-06bb6ad8-3238-4ba7-8f83-47507541a300.yml
@@ -3,6 +3,7 @@ name: Joseph P. Gresko
 given_name: Joseph
 family_name: Gresko
 email: Joseph.Gresko@cga.ct.gov
+image: http://www2.housedems.ct.gov/Gresko/images/gresko_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Gresko
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27121%27&dist_name=121%20-%Gresko,%Joseph%20P.
 other_names:
 - name: Gresko, Joseph P.
 other_identifiers:

--- a/data/ct/legislature/Josh-Elliott-57461c01-e706-4ce5-9dfd-8982e1f29021.yml
+++ b/data/ct/legislature/Josh-Elliott-57461c01-e706-4ce5-9dfd-8982e1f29021.yml
@@ -3,6 +3,7 @@ name: Josh Elliott
 given_name: Josh
 family_name: Elliott
 email: Josh.Elliott@cga.ct.gov
+image: http://www2.housedems.ct.gov/Elliott/images/Elliott_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Elliott
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27088%27&dist_name=088%20-%Elliott,%Josh
 other_names:
 - name: Elliott, Josh
 other_identifiers:

--- a/data/ct/legislature/Joshua-M-Hall-acb9a83b-c921-4631-826e-ffd02e2203b9.yml
+++ b/data/ct/legislature/Joshua-M-Hall-acb9a83b-c921-4631-826e-ffd02e2203b9.yml
@@ -3,6 +3,7 @@ name: Joshua M. Hall
 given_name: Joshua
 family_name: Hall
 email: Joshua.Hall@cga.ct.gov
+image: http://www2.housedems.ct.gov/Hall/images/Hall_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Hall
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27007%27&dist_name=007%20-%Hall,%Joshua
 other_names:
 - name: Hall, Joshua M.
 other_identifiers:

--- a/data/ct/legislature/Juan-R-Candelaria-6af561a7-e6d7-4a29-8f65-9a22a5734639.yml
+++ b/data/ct/legislature/Juan-R-Candelaria-6af561a7-e6d7-4a29-8f65-9a22a5734639.yml
@@ -3,6 +3,7 @@ name: Juan R. Candelaria
 given_name: Juan
 family_name: Candelaria
 email: Juan.Candelaria@cga.ct.gov
+image: http://www2.housedems.ct.gov/Candelaria/images/Candelaria_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Candelaria
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27095%27&dist_name=095%20-%Candelaria,%Juan%20R.
 other_names:
 - name: Candelaria, Juan R.
 other_identifiers:

--- a/data/ct/legislature/Julie-Kushner-34ca88f1-c2bc-430e-9f7c-93e8f3563e33.yml
+++ b/data/ct/legislature/Julie-Kushner-34ca88f1-c2bc-430e-9f7c-93e8f3563e33.yml
@@ -2,6 +2,7 @@ id: ocd-person/34ca88f1-c2bc-430e-9f7c-93e8f3563e33
 name: Julie Kushner
 given_name: Julie
 family_name: Kushner
+image: http://www.senatedems.ct.gov/templates/Kushner/images/Kushner-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/kushner
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S24%27&dist_name=Kushner,%20Julie
 other_names:
 - name: Kushner, Julie
 sources:

--- a/data/ct/legislature/Julio-A-Concepcion-d44bd84a-b02c-4c1b-94ee-05c8b1008e57.yml
+++ b/data/ct/legislature/Julio-A-Concepcion-d44bd84a-b02c-4c1b-94ee-05c8b1008e57.yml
@@ -3,6 +3,7 @@ name: Julio A. Concepcion
 given_name: Julio
 family_name: Concepcion
 email: julio.concepcion@cga.ct.gov
+image: http://www2.housedems.ct.gov/Concepcion/images/Concepcion_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/concepcion
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27004%27&dist_name=004%20-%Concepcion,%Julio
 other_names:
 - name: Concepcion, Julio A.
 other_identifiers:

--- a/data/ct/legislature/Kara-Rochelle-3969673d-4a3e-487e-a572-42ce9f79e6dd.yml
+++ b/data/ct/legislature/Kara-Rochelle-3969673d-4a3e-487e-a572-42ce9f79e6dd.yml
@@ -3,6 +3,7 @@ name: Kara Rochelle
 given_name: Kara
 family_name: Rochelle
 email: Kara.Rochelle@cga.ct.gov
+image: http://www2.housedems.ct.gov/Rochelle/images/Rochelle_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/rochelle
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27104%27&dist_name=104%20-%Rochelle,%Kara
 other_names:
 - name: Rochelle, Kara
 sources:

--- a/data/ct/legislature/Kate-Farrar-96fa444a-7e86-4ead-9d2e-c3ffef258be2.yml
+++ b/data/ct/legislature/Kate-Farrar-96fa444a-7e86-4ead-9d2e-c3ffef258be2.yml
@@ -3,6 +3,7 @@ name: Kate Farrar
 given_name: Kate
 family_name: Farrar
 email: Kate.Farrar@cga.ct.gov
+image: http://www2.housedems.ct.gov/Farrar/images/Farrar_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Farrar
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27020%27&dist_name=020%20-%Farrar,%Kate
 other_names:
 - name: Farrar, Kate
 sources:

--- a/data/ct/legislature/Kathleen-M-McCarty-f04c3831-624c-49a1-a7c2-3185a43de06f.yml
+++ b/data/ct/legislature/Kathleen-M-McCarty-f04c3831-624c-49a1-a7c2-3185a43de06f.yml
@@ -3,6 +3,7 @@ name: Kathleen M. McCarty
 given_name: Kathleen
 family_name: McCarty
 email: Kathleen.McCarty@housegop.ct.gov
+image: https://www.cthousegop.com/mccarty/wp-content/uploads/sites/44/2016/11/McCarty-Bio-Pict-Web.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/McCarty/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27038%27&dist_name=McCarty,%20Kathleen%20M
 other_names:
 - name: Mccarty, Kathleen M.
 other_identifiers:

--- a/data/ct/legislature/Kathy-Kennedy-f0517411-fc60-49ad-86e6-1f025ab4579b.yml
+++ b/data/ct/legislature/Kathy-Kennedy-f0517411-fc60-49ad-86e6-1f025ab4579b.yml
@@ -3,6 +3,7 @@ name: Kathy Kennedy
 given_name: Kathy
 family_name: Kennedy
 email: Kathy.Kennedy@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/119.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/kennedy/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27119%27
 other_names:
 - name: Kennedy, Kathy
 sources:

--- a/data/ct/legislature/Kenneth-M-Gucker-1d3bcf34-6da4-4392-aead-077d833fa7fb.yml
+++ b/data/ct/legislature/Kenneth-M-Gucker-1d3bcf34-6da4-4392-aead-077d833fa7fb.yml
@@ -3,6 +3,7 @@ name: Kenneth M. Gucker
 given_name: Kenneth
 family_name: Gucker
 email: Kenneth.Gucker@cga.ct.gov
+image: http://www2.housedems.ct.gov/Gucker/images/Gucker_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/gucker
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27138%27&dist_name=138%20-%Gucker,%Kenneth
 other_names:
 - name: Gucker, Kenneth M
 sources:

--- a/data/ct/legislature/Kerry-S-Wood-d71060b1-2bb9-4239-ab9b-fad7d1a4d903.yml
+++ b/data/ct/legislature/Kerry-S-Wood-d71060b1-2bb9-4239-ab9b-fad7d1a4d903.yml
@@ -3,6 +3,7 @@ name: Kerry S. Wood
 given_name: Kerry
 family_name: Wood
 email: Kerry.Wood@cga.ct.gov
+image: http://www2.housedems.ct.gov/Wood/images/Wood_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/wood
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27029%27&dist_name=029%20-%Wood,%Kerry
 other_names:
 - name: Wood, Kerry S.
 sources:

--- a/data/ct/legislature/Kevin-C-Kelly-5acf728f-8ec5-4db5-b7eb-8dec668d0626.yml
+++ b/data/ct/legislature/Kevin-C-Kelly-5acf728f-8ec5-4db5-b7eb-8dec668d0626.yml
@@ -3,6 +3,7 @@ name: Kevin C. Kelly
 given_name: Kevin
 family_name: Kelly
 email: Kevin.Kelly@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2022/02/KellyHeadshotSmall.png
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-kelly
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S21%27&dist_name=Kelly,%20Kevin%20C.
 other_names:
 - name: Kelly, Kevin C.
 other_identifiers:

--- a/data/ct/legislature/Kevin-D-Witkos-77479a85-ce39-422f-9094-bbdbce7d5276.yml
+++ b/data/ct/legislature/Kevin-D-Witkos-77479a85-ce39-422f-9094-bbdbce7d5276.yml
@@ -3,6 +3,7 @@ name: Kevin D. Witkos
 given_name: Kevin
 family_name: Witkos
 email: Kevin.Witkos@cga.ct.gov
+image: https://cga.ct.gov/legpics/S08.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-witkos
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S08%27&dist_name=Witkos,%20Kevin%20D.
 other_names:
 - name: Witkos, Kevin D.
 other_identifiers:

--- a/data/ct/legislature/Kevin-Ryan-2d99a0ff-740d-4c97-8d0c-524842f99f73.yml
+++ b/data/ct/legislature/Kevin-Ryan-2d99a0ff-740d-4c97-8d0c-524842f99f73.yml
@@ -3,6 +3,7 @@ name: Kevin Ryan
 given_name: Kevin
 family_name: Ryan
 email: Kevin.Ryan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Ryan/images/Ryan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Ryan
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27139%27&dist_name=139%20-%Ryan,%Kevin
 other_names:
 - name: Ryan, Kevin
 other_identifiers:

--- a/data/ct/legislature/Kimberly-Fiorello-afcd681c-4285-440b-82be-54a7d2064111.yml
+++ b/data/ct/legislature/Kimberly-Fiorello-afcd681c-4285-440b-82be-54a7d2064111.yml
@@ -3,6 +3,7 @@ name: Kimberly Fiorello
 given_name: Kimberly
 family_name: Fiorello
 email: Kimberly.Fiorello@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/149.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/Fiorello
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27149%27&dist_name=Fiorello,%20Kimberly
 other_names:
 - name: Fiorello, Kimberly
 sources:

--- a/data/ct/legislature/Kurt-Vail-ffa361d0-7471-450e-aee8-cb0c32ee2742.yml
+++ b/data/ct/legislature/Kurt-Vail-ffa361d0-7471-450e-aee8-cb0c32ee2742.yml
@@ -3,6 +3,7 @@ name: Kurt Vail
 given_name: Kurt
 family_name: Vail
 email: Kurt.Vail@housegop.ct.gov
+image: https://www.cthousegop.com/vail/wp-content/uploads/sites/66/2016/11/Vail-Bio-Web.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Vail/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27052%27&dist_name=Kurt,%20Vail
 other_names:
 - name: Vail, Kurt
 other_identifiers:

--- a/data/ct/legislature/Larry-B-Butler-47282285-14de-4306-b33f-a82754702ec5.yml
+++ b/data/ct/legislature/Larry-B-Butler-47282285-14de-4306-b33f-a82754702ec5.yml
@@ -3,6 +3,7 @@ name: Larry B. Butler
 given_name: Larry
 family_name: Butler
 email: Larry.Butler@cga.ct.gov
+image: http://www2.housedems.ct.gov/Butler/images/Butler_HS.jpg?ver=
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Butler
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27072%27&dist_name=072%20-%Butler,%Larry%20B.
 other_names:
 - name: Butler, Larry B.
 other_identifiers:

--- a/data/ct/legislature/Laura-M-Devlin-c1eb186b-4a6d-4a5f-9afe-a52005a4bc62.yml
+++ b/data/ct/legislature/Laura-M-Devlin-c1eb186b-4a6d-4a5f-9afe-a52005a4bc62.yml
@@ -3,6 +3,7 @@ name: Laura M. Devlin
 given_name: Laura
 family_name: Devlin
 email: Laura.Devlin@housegop.ct.gov
+image: https://www.cthousegop.com/devlin/wp-content/uploads/sites/22/2021/09/Devlin_ApprovedHeadshot-300x291.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Devlin/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27134%27&dist_name=Devlin,%20Laura%20M.
 other_names:
 - name: Devlin, Laura M.
 other_identifiers:

--- a/data/ct/legislature/Lezlye-Zupkus-cddc0b8f-51e5-4ed1-af05-41de718801f3.yml
+++ b/data/ct/legislature/Lezlye-Zupkus-cddc0b8f-51e5-4ed1-af05-41de718801f3.yml
@@ -3,6 +3,7 @@ name: Lezlye Zupkus
 given_name: Lezlye
 family_name: Zupkus
 email: Lezlye.Zupkus@housegop.ct.gov
+image: https://www.cthousegop.com/zupkus/wp-content/uploads/sites/73/2016/11/Zupkus_Bio_Web.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Zupkus/
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27089%27&dist_name=089-Lezlye%20Zupkus
 other_names:
 - name: Zupkus, Lezlye
 other_identifiers:

--- a/data/ct/legislature/Liz-Linehan-96e6350e-71c4-4031-8af8-a989d0ec3a01.yml
+++ b/data/ct/legislature/Liz-Linehan-96e6350e-71c4-4031-8af8-a989d0ec3a01.yml
@@ -3,6 +3,7 @@ name: Liz Linehan
 given_name: Liz
 family_name: Linehan
 email: Liz.Linehan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Linehan/images/Linehan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/Linehan
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27103%27&dist_name=103%20-%Linehan,%Liz
 other_names:
 - name: Linehan, Liz
 other_identifiers:

--- a/data/ct/legislature/Lucy-Dathan-2ed1f7b0-a1e3-4754-93a5-46b5a3fb9836.yml
+++ b/data/ct/legislature/Lucy-Dathan-2ed1f7b0-a1e3-4754-93a5-46b5a3fb9836.yml
@@ -3,6 +3,7 @@ name: Lucy Dathan
 given_name: Lucy
 family_name: Dathan
 email: Lucy.Dathan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Dathan/images/Dathan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/dathan
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27142%27&dist_name=142%20-%Dathan,%Lucy
 other_names:
 - name: Dathan, Lucy
 sources:

--- a/data/ct/legislature/Mae-Flexer-77713b68-e8ef-455e-80a6-1614488fb71a.yml
+++ b/data/ct/legislature/Mae-Flexer-77713b68-e8ef-455e-80a6-1614488fb71a.yml
@@ -2,6 +2,7 @@ id: ocd-person/77713b68-e8ef-455e-80a6-1614488fb71a
 name: Mae Flexer
 given_name: Mae
 family_name: Flexer
+image: http://www.senatedems.ct.gov/templates/flexer/images/flexer-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Flexer
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S29%27&dist_name=Flexer,%20Mae
 other_names:
 - name: Flexer, Mae
 other_identifiers:

--- a/data/ct/legislature/Maria-P-Horn-283ad876-68be-4235-a108-e0aedbadde40.yml
+++ b/data/ct/legislature/Maria-P-Horn-283ad876-68be-4235-a108-e0aedbadde40.yml
@@ -3,6 +3,7 @@ name: Maria P. Horn
 given_name: Maria
 family_name: Horn
 email: Maria.Horn@cga.ct.gov
+image: http://www2.housedems.ct.gov/Horn/images/Horn_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/horn
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27064%27&dist_name=064%20-%Horn,%Maria
 other_names:
 - name: Horn, Maria P.
 sources:

--- a/data/ct/legislature/Marilyn-V-Moore-41d83b98-d5ab-48db-b847-3a3e08194b4c.yml
+++ b/data/ct/legislature/Marilyn-V-Moore-41d83b98-d5ab-48db-b847-3a3e08194b4c.yml
@@ -2,6 +2,7 @@ id: ocd-person/41d83b98-d5ab-48db-b847-3a3e08194b4c
 name: Marilyn V. Moore
 given_name: Marilyn
 family_name: Moore
+image: http://www.senatedems.ct.gov/templates/moore/images/moore-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Moore
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S22%27&dist_name=Moore,%20Marilyn%20V.
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CTL000329

--- a/data/ct/legislature/Mark-W-Anderson-135d2f43-c892-4a34-9651-a523e85dd6de.yml
+++ b/data/ct/legislature/Mark-W-Anderson-135d2f43-c892-4a34-9651-a523e85dd6de.yml
@@ -1,6 +1,7 @@
 id: ocd-person/135d2f43-c892-4a34-9651-a523e85dd6de
 name: Mark W. Anderson
 email: Mark.Anderson@housegop.ct.gov
+image: https://cga.ct.gov/legpics/062.png?ver=
 party:
 - name: Republican
 roles:
@@ -18,6 +19,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/Anderson
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27062%27&dist_name=Anderson,%20Mark%20W
 other_names:
 - name: Anderson, Mark W
 sources:

--- a/data/ct/legislature/Martin-M-Looney-2d21e401-cb76-4001-b836-e57f667f550f.yml
+++ b/data/ct/legislature/Martin-M-Looney-2d21e401-cb76-4001-b836-e57f667f550f.yml
@@ -3,6 +3,7 @@ name: Martin M. Looney
 given_name: Martin
 family_name: Looney
 email: Looney@senatedems.ct.gov
+image: http://www.senatedems.ct.gov/templates/looney/images/looney-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Looney
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S11%27&dist_name=Looney,%20Martin%20M.
 other_names:
 - name: Looney, Martin M.
 other_identifiers:

--- a/data/ct/legislature/Mary-D-Abrams-9b559d02-1ab6-4a26-ba08-5445cb703037.yml
+++ b/data/ct/legislature/Mary-D-Abrams-9b559d02-1ab6-4a26-ba08-5445cb703037.yml
@@ -2,6 +2,7 @@ id: ocd-person/9b559d02-1ab6-4a26-ba08-5445cb703037
 name: Mary Daugherty Abrams
 given_name: Mary
 family_name: Abrams
+image: https://cga.ct.gov/legpics/S13.png?ver=
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/abrams
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S13%27&dist_name=Daugherty%20Abrams,%20Mary
 other_names:
 - name: Daugherty Abrams, Mary
 sources:

--- a/data/ct/legislature/Mary-M-Mushinsky-817e17bf-a01c-4bf1-b70f-3e16aeef088e.yml
+++ b/data/ct/legislature/Mary-M-Mushinsky-817e17bf-a01c-4bf1-b70f-3e16aeef088e.yml
@@ -3,6 +3,7 @@ name: Mary M. Mushinsky
 given_name: Mary
 family_name: Mushinsky
 email: Mary.Mushinsky@cga.ct.gov
+image: http://www2.housedems.ct.gov/Mushinsky/images/Mushinsky_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Mushinsky
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27085%27&dist_name=085%20-%Mushinsky,%Mary%20M.
 other_names:
 - name: Mushinsky, Mary M.
 other_identifiers:

--- a/data/ct/legislature/Mary-Welander-53fa49be-9042-4e23-a1ff-a85f98a3d9f7.yml
+++ b/data/ct/legislature/Mary-Welander-53fa49be-9042-4e23-a1ff-a85f98a3d9f7.yml
@@ -3,6 +3,7 @@ name: Mary Welander
 given_name: Mary
 family_name: Welander
 email: Mary.Welander@cga.ct.gov
+image: http://www2.housedems.ct.gov/Welander/images/Welander_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Welander
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27114%27&dist_name=114%20-%Welander,%Mary
 other_names:
 - name: Welander, Mary
 sources:

--- a/data/ct/legislature/Maryam-Khan-298d6d03-248e-44c2-be42-269bc417745c.yml
+++ b/data/ct/legislature/Maryam-Khan-298d6d03-248e-44c2-be42-269bc417745c.yml
@@ -3,6 +3,7 @@ name: Maryam Khan
 given_name: Maryam
 family_name: Khan
 email: Maryam.Khan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Khan/images/Khan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   address: 25 Colton Street; Windsor, CT 06095
 links:
 - url: http://www.housedems.ct.gov/khan
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27005%27&dist_name=005%20-%Khan,%Maryam
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Matt-Blumenthal-9c5e5d75-a622-41d2-b607-2adbc12ee11f.yml
+++ b/data/ct/legislature/Matt-Blumenthal-9c5e5d75-a622-41d2-b607-2adbc12ee11f.yml
@@ -3,6 +3,7 @@ name: Matt Blumenthal
 given_name: Matt
 family_name: Blumenthal
 email: Matt.Blumenthal@cga.ct.gov
+image: http://www2.housedems.ct.gov/Blumenthal/images/Blumenthal_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/blumenthal
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27147%27&dist_name=147%20-%Blumenthal,%Matt
 other_names:
 - name: Blumenthal, Matt
 sources:

--- a/data/ct/legislature/Matt-Lesser-f55ef0f9-f0ed-48ba-80b9-23ac643626cc.yml
+++ b/data/ct/legislature/Matt-Lesser-f55ef0f9-f0ed-48ba-80b9-23ac643626cc.yml
@@ -2,6 +2,7 @@ id: ocd-person/f55ef0f9-f0ed-48ba-80b9-23ac643626cc
 name: Matthew L. Lesser
 given_name: Matthew
 family_name: Lesser
+image: http://www.senatedems.ct.gov/templates/Lesser/images/Lesser1x1.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/lesser
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S09%27&dist_name=Lesser,%20Matthew%20L.
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Matthew-Ritter-2a91c3d6-433a-4e8f-b5a5-38fc80b8ea57.yml
+++ b/data/ct/legislature/Matthew-Ritter-2a91c3d6-433a-4e8f-b5a5-38fc80b8ea57.yml
@@ -3,6 +3,7 @@ name: Matthew Ritter
 given_name: Matthew
 family_name: Ritter
 email: Matthew.Ritter@cga.ct.gov
+image: http://www2.housedems.ct.gov/Ritter/images/Ritter_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Ritter
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27001%27&dist_name=001%20-%Ritter,%Matt
 other_names:
 - name: Ritter, Matthew
 other_identifiers:

--- a/data/ct/legislature/Michael-D-Quinn-155c99fd-9d59-47e7-9134-12872a72426f.yml
+++ b/data/ct/legislature/Michael-D-Quinn-155c99fd-9d59-47e7-9134-12872a72426f.yml
@@ -1,6 +1,7 @@
 id: ocd-person/155c99fd-9d59-47e7-9134-12872a72426f
 name: Michael D. Quinn
 email: MichaelD.Quinn@cga.ct.gov
+image: http://www2.housedems.ct.gov/Quinn/images/Quinn_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Quinn
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27082%27&dist_name=082%20-%Quinn,%Michael%20D.
 other_names:
 - name: Quinn, Michael D
 sources:

--- a/data/ct/legislature/Michael-DAgostino-62869ad5-5744-4a50-95f5-56ecf5549e31.yml
+++ b/data/ct/legislature/Michael-DAgostino-62869ad5-5744-4a50-95f5-56ecf5549e31.yml
@@ -3,6 +3,7 @@ name: Michael D'Agostino
 given_name: Michael
 family_name: D'Agostino
 email: Michael.DAgostino@cga.ct.gov
+image: http://www2.housedems.ct.gov/DAgostino/images/DAgostino_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/DAgostino
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27091%27&dist_name=091%20-%D%27Agostino,%Mike
 other_names:
 - name: D'agostino, Michael
 other_identifiers:

--- a/data/ct/legislature/Michael-DiGiovancarlo-1e5a518e-ddf5-4976-b239-9a5324339a47.yml
+++ b/data/ct/legislature/Michael-DiGiovancarlo-1e5a518e-ddf5-4976-b239-9a5324339a47.yml
@@ -3,6 +3,7 @@ name: Michael DiGiovancarlo
 given_name: Michael
 family_name: DiGiovancarlo
 email: Michael.DiGiovancarlo@cga.ct.gov
+image: http://www2.housedems.ct.gov/DiGiovancarlo/images/DiGiovancarlo_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -15,6 +16,7 @@ offices:
   voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/digiovancarlo
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27074%27&dist_name=074%20-%DiGiovancarlo,%Michael
 other_names:
 - name: Digiovancarlo, Michael
 sources:

--- a/data/ct/legislature/Michael-Winkler-ee35378a-f19c-4edf-a6ed-826d62adcced.yml
+++ b/data/ct/legislature/Michael-Winkler-ee35378a-f19c-4edf-a6ed-826d62adcced.yml
@@ -3,6 +3,7 @@ name: Michael A. Winkler
 given_name: Michael
 family_name: Winkler
 email: Michael.Winkler@cga.ct.gov
+image: http://www2.housedems.ct.gov/Winkler/images/Winkler_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Winkler
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27056%27&dist_name=056%20-%Winkler,%Michael
 other_names:
 - name: Winkler, Michael A.
 other_identifiers:

--- a/data/ct/legislature/Michelle-L-Cook-daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6.yml
+++ b/data/ct/legislature/Michelle-L-Cook-daf39ec5-3fcd-4d88-bd79-a5a9da8e45e6.yml
@@ -3,6 +3,7 @@ name: Michelle L. Cook
 given_name: Michelle
 family_name: Cook
 email: Michelle.Cook@cga.ct.gov
+image: http://www2.housedems.ct.gov/Cook/images/Cook_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Cook
+- url: https://www.cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27065%27&dist_name=065%20-%Cook,%Michelle%20L.
 other_names:
 - name: Cook, Michelle L.
 other_identifiers:

--- a/data/ct/legislature/Mike-Demicco-ca9357d4-dffa-456a-a715-d4a7671c1f84.yml
+++ b/data/ct/legislature/Mike-Demicco-ca9357d4-dffa-456a-a715-d4a7671c1f84.yml
@@ -3,6 +3,7 @@ name: Mike Demicco
 given_name: Mike
 family_name: Demicco
 email: Mike.Demicco@cga.ct.gov
+image: http://www2.housedems.ct.gov/Demicco/images/Demicco_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Demicco
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27021%27&dist_name=Demicco,%20Mike
 other_names:
 - name: Demicco, Mike
 other_identifiers:

--- a/data/ct/legislature/Mike-France-f9285869-efa5-474f-86b4-9cd79867ed7f.yml
+++ b/data/ct/legislature/Mike-France-f9285869-efa5-474f-86b4-9cd79867ed7f.yml
@@ -3,6 +3,7 @@ name: Mike France
 given_name: Mike
 family_name: France
 email: Mike.France@housegop.ct.gov
+image: https://www.cthousegop.com/france/wp-content/uploads/sites/30/2016/11/BIOFrance-headshot-032015-1755wl.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/France/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27042%27&dist_name=France,%20Mike
 other_names:
 - name: France, Mike
 other_identifiers:

--- a/data/ct/legislature/Minnie-Gonzalez-57900db1-ade5-4107-8025-a0c664f41a32.yml
+++ b/data/ct/legislature/Minnie-Gonzalez-57900db1-ade5-4107-8025-a0c664f41a32.yml
@@ -3,6 +3,7 @@ name: Minnie Gonzalez
 given_name: Minnie
 family_name: Gonzalez
 email: Minnie.Gonzalez@cga.ct.gov
+image: http://www2.housedems.ct.gov/Gonzalez/images/Gonzalez_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Gonzalez
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27003%27&dist_name=Gonzalez,%20Minnie
 other_names:
 - name: Gonzalez, Minnie
 other_identifiers:

--- a/data/ct/legislature/Mitch-Bolinsky-5af50689-4e90-49b1-8544-7a00048dad99.yml
+++ b/data/ct/legislature/Mitch-Bolinsky-5af50689-4e90-49b1-8544-7a00048dad99.yml
@@ -3,6 +3,7 @@ name: Mitch Bolinsky
 given_name: Mitch
 family_name: Bolinsky
 email: Mitch.Bolinsky@housegop.ct.gov
+image: https://www.cthousegop.com/bolinsky/wp-content/uploads/sites/8/2016/12/Bolinsky-Bio-Web-Sized.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Bolinsky/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27106%27&dist_name=Bolinsky,%20Mitch
 other_names:
 - name: Bolinsky, Mitch
 other_identifiers:

--- a/data/ct/legislature/Nicole-Klarides-Ditria-71c15656-a6f4-4b95-9537-69a82b2cb54c.yml
+++ b/data/ct/legislature/Nicole-Klarides-Ditria-71c15656-a6f4-4b95-9537-69a82b2cb54c.yml
@@ -3,6 +3,7 @@ name: Nicole Klarides-Ditria
 given_name: Nicole
 family_name: Klarides-Ditria
 email: Nicole.Klarides-Ditria@housegop.ct.gov
+image: https://cga.ct.gov/legpics/105.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Klarides-Ditria/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27105%27&dist_name=Klarides-Ditria,%20Nicole
 other_names:
 - name: Klarides-ditria, Nicole
 other_identifiers:

--- a/data/ct/legislature/Norman-Needleman-109295ad-521f-463a-b0af-66c9f0598a97.yml
+++ b/data/ct/legislature/Norman-Needleman-109295ad-521f-463a-b0af-66c9f0598a97.yml
@@ -2,6 +2,7 @@ id: ocd-person/109295ad-521f-463a-b0af-66c9f0598a97
 name: Norman Needleman
 given_name: Norman
 family_name: Needleman
+image: http://www.senatedems.ct.gov/templates/Needleman/images/Needleman-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/needleman
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S33%27&dist_name=Needleman,%20Norman
 other_names:
 - name: Needleman, Norman
 sources:

--- a/data/ct/legislature/Patricia-A-Dillon-23d08488-597c-4c35-b41a-f8aef1c264c4.yml
+++ b/data/ct/legislature/Patricia-A-Dillon-23d08488-597c-4c35-b41a-f8aef1c264c4.yml
@@ -3,6 +3,7 @@ name: Patricia A. Dillon
 given_name: Patricia
 family_name: Dillon
 email: Patricia.Dillon@cga.ct.gov
+image: http://www2.housedems.ct.gov/Dillon/images/Dillon_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Dillon
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27092%27&dist_name=Dillon,%20Patricia%20A.
 other_names:
 - name: Dillon, Patricia A.
 other_identifiers:

--- a/data/ct/legislature/Patricia-Billie-Miller-fcf63a22-3979-4cbf-a719-0d414d13e1ac.yml
+++ b/data/ct/legislature/Patricia-Billie-Miller-fcf63a22-3979-4cbf-a719-0d414d13e1ac.yml
@@ -3,6 +3,7 @@ name: Patricia Billie Miller
 given_name: Patricia
 family_name: Miller
 email: Patricia.Miller@cga.ct.gov
+image: http://www.senatedems.ct.gov/templates/miller/images/miller-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,9 +21,8 @@ offices:
 - classification: district
   address: 95 Liberty Street; Stamford, CT 06902
 links:
-- url: http://www.housedems.ct.gov/Miller
-- url: http://www.housedems.ct.gov/MillerPat
 - url: http://www.senatedems.ct.gov/miller
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S27%27&dist_name=Miller,%20Patricia%20Billie
 other_names:
 - name: Miller, Patricia Billie
 other_identifiers:

--- a/data/ct/legislature/Patrick-Callahan-72191c68-6a23-4fa2-93d4-ba8dc07c2025.yml
+++ b/data/ct/legislature/Patrick-Callahan-72191c68-6a23-4fa2-93d4-ba8dc07c2025.yml
@@ -3,6 +3,7 @@ name: Patrick E. Callahan
 given_name: Patrick
 family_name: Callahan
 email: Patrick.Callahan@housegop.ct.gov
+image: https://www.cga.ct.gov/legpics/108.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/Callahan
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27108%27&dist_name=Callahan,%20Patrick%20E.
 other_names:
 - name: Callahan, Patrick E.
 - name: Patrick Callahan

--- a/data/ct/legislature/Patrick-S-Boyd-50e78f89-a9e7-43f5-9566-a9f2cb23a5c9.yml
+++ b/data/ct/legislature/Patrick-S-Boyd-50e78f89-a9e7-43f5-9566-a9f2cb23a5c9.yml
@@ -3,6 +3,7 @@ name: Patrick S. Boyd
 given_name: Patrick
 family_name: Boyd
 email: Pat.Boyd@cga.ct.gov
+image: http://www2.housedems.ct.gov/Boyd/images/Boyd_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Boyd
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27050%27&dist_name=Boyd,%20Patrick%20S.
 other_names:
 - name: Boyd, Patrick S.
 other_identifiers:

--- a/data/ct/legislature/Paul-Cicarella-ca523a61-6db3-47c6-bf1f-8fd7638e999f.yml
+++ b/data/ct/legislature/Paul-Cicarella-ca523a61-6db3-47c6-bf1f-8fd7638e999f.yml
@@ -3,6 +3,7 @@ name: Paul Cicarella
 given_name: Paul
 family_name: Cicarella
 email: Paul.Cicarella@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2020/11/Paul-Cicarella.jpg
 party:
 - name: Republican
 roles:
@@ -15,6 +16,7 @@ offices:
   voice: 860-240-8800
 links:
 - url: http://ctsenaterepublicans.com/home-cicarella
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S34%27&dist_name=Cicarella,%20Paul
 other_names:
 - name: Cicarella, Paul
 sources:

--- a/data/ct/legislature/Paul-M-Formica-bdea553b-35fa-4076-88e8-fd995d2d7631.yml
+++ b/data/ct/legislature/Paul-M-Formica-bdea553b-35fa-4076-88e8-fd995d2d7631.yml
@@ -3,6 +3,7 @@ name: Paul M. Formica
 given_name: Paul
 family_name: Formica
 email: Paul.Formica@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2020/02/webFormica2020-e1582140422879.png
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-Formica
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S20%27&dist_name=Formica,%20Paul%20M.
 other_names:
 - name: Formica, Paul M.
 other_identifiers:

--- a/data/ct/legislature/Peter-A-Tercyak-0a4ae3cc-c2dc-4ef4-8ba8-95be03126a02.yml
+++ b/data/ct/legislature/Peter-A-Tercyak-0a4ae3cc-c2dc-4ef4-8ba8-95be03126a02.yml
@@ -3,6 +3,7 @@ name: Peter A. Tercyak
 given_name: Peter
 family_name: Tercyak
 email: Peter.Tercyak@cga.ct.gov
+image: http://www2.housedems.ct.gov/Tercyak/images/Tercyak_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Tercyak
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27026%27&dist_name=Tercyak,%20Peter%20A.
 other_names:
 - name: Tercyak, Peter A.
 other_identifiers:

--- a/data/ct/legislature/Philip-L-Young-III-d2a3535f-bdff-414c-8aaa-c3f3f203bc14.yml
+++ b/data/ct/legislature/Philip-L-Young-III-d2a3535f-bdff-414c-8aaa-c3f3f203bc14.yml
@@ -3,6 +3,7 @@ name: Philip L. Young III
 given_name: Philip
 family_name: Young
 email: phil.young@cga.ct.gov
+image: http://www2.housedems.ct.gov/Young/images/Young_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/young
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27120%27&dist_name=Young,%20Philip%20L.
 other_names:
 - name: Young, Philip L.
 other_identifiers:

--- a/data/ct/legislature/Quentin-W-Phipps-46678375-9195-4d3a-8aef-6476397f1491.yml
+++ b/data/ct/legislature/Quentin-W-Phipps-46678375-9195-4d3a-8aef-6476397f1491.yml
@@ -3,6 +3,7 @@ name: Quentin Williams
 given_name: Quentin
 family_name: Williams
 email: Quentin.Williams@cga.ct.gov
+image: http://www2.housedems.ct.gov/Phipps/images/Phipps_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -22,6 +23,7 @@ offices:
 links:
 - url: http://www.housedems.ct.gov/phipps
 - url: http://www.housedems.ct.gov/williams
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27100%27&dist_name=Williams,%20Quentin
 other_names:
 - name: Phipps, Quentin W.
 - name: Quentin W. Phipps

--- a/data/ct/legislature/Raghib-Allie-Brennan-1a01451b-8c85-4bde-9cef-ab083d99ae84.yml
+++ b/data/ct/legislature/Raghib-Allie-Brennan-1a01451b-8c85-4bde-9cef-ab083d99ae84.yml
@@ -3,6 +3,7 @@ name: Raghib Allie-Brennan
 given_name: Raghib
 family_name: Allie-Brennan
 email: Raghib.Allie-Brennan@cga.ct.gov
+image: http://www2.housedems.ct.gov/Allie-Brennan/images/Allie-Brennan_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/allie-brennan
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27002%27&dist_name=Allie-Brennan,%20Raghib
 other_names:
 - name: Allie-brennan, Raghib
 sources:

--- a/data/ct/legislature/Rick-L-Hayes-c30bb3b3-de40-4c0a-89a5-da36532694c9.yml
+++ b/data/ct/legislature/Rick-L-Hayes-c30bb3b3-de40-4c0a-89a5-da36532694c9.yml
@@ -3,6 +3,7 @@ name: Rick L. Hayes
 given_name: Rick
 family_name: Hayes
 email: rick.hayes@housegop.ct.gov
+image: https://www.cthousegop.com/hayes/wp-content/uploads/sites/78/2019/01/Re.-Elect-Rick-Hayes-201x300.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/hayes/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27051%27&dist_name=Hayes,%20Rick%20L.
 other_names:
 - name: Hayes, Rick L.
 sources:

--- a/data/ct/legislature/Rick-Lopes-bdc5f5a0-0285-45d2-a6fd-d29d8b31cd43.yml
+++ b/data/ct/legislature/Rick-Lopes-bdc5f5a0-0285-45d2-a6fd-d29d8b31cd43.yml
@@ -3,6 +3,7 @@ name: Rick Lopes
 given_name: Rick
 family_name: Lopes
 email: Rick.Lopes@cga.ct.gov
+image: http://www.senatedems.ct.gov/templates/lopes/images/lopes-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
 links:
 - url: http://www.housedems.ct.gov/Lopes
 - url: http://www.senatedems.ct.gov/lopes
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S06%27&dist_name=Lopes,%20Rick
 other_names:
 - name: Lopes, Rick
 other_identifiers:

--- a/data/ct/legislature/Rob-Sampson-0cdb540d-c360-4981-b7a9-2a67e2f91121.yml
+++ b/data/ct/legislature/Rob-Sampson-0cdb540d-c360-4981-b7a9-2a67e2f91121.yml
@@ -3,6 +3,7 @@ name: Rob Sampson
 given_name: Rob
 family_name: Sampson
 email: rob.sampson@cga.ct.gov
+image: https://cga.ct.gov/legpics/S16.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-sampson
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S16%27&dist_name=Sampson,%20Rob
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Robert-Sanchez-8703dbac-ef19-414d-afe4-1081451f124e.yml
+++ b/data/ct/legislature/Robert-Sanchez-8703dbac-ef19-414d-afe4-1081451f124e.yml
@@ -3,6 +3,7 @@ name: Robert Sanchez
 given_name: Robert
 family_name: Sanchez
 email: Bobby.Sanchez@cga.ct.gov
+image: http://www2.housedems.ct.gov/Sanchez/images/Sanchez_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Sanchez
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27025%27&dist_name=Sanchez,%20Robert
 other_names:
 - name: Sanchez, Robert
 other_identifiers:

--- a/data/ct/legislature/Robin-E-Comey-5d963d6d-74c1-4282-9ad4-592c3760bead.yml
+++ b/data/ct/legislature/Robin-E-Comey-5d963d6d-74c1-4282-9ad4-592c3760bead.yml
@@ -3,6 +3,7 @@ name: Robin E. Comey
 given_name: Robin
 family_name: Comey
 email: Robin.Comey@cga.ct.gov
+image: http://www2.housedems.ct.gov/Comey/images/Comey_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://housedems.ct.gov/comey
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27102%27&dist_name=Comey,%20Robin%20E.
 other_names:
 - name: Comey, Robin E.
 sources:

--- a/data/ct/legislature/Robin-Green-f664d091-23ab-46d0-a019-6009e0480a81.yml
+++ b/data/ct/legislature/Robin-Green-f664d091-23ab-46d0-a019-6009e0480a81.yml
@@ -3,6 +3,7 @@ name: Robin Green
 given_name: Robin
 family_name: Green
 email: Robin.Green@housegop.ct.gov
+image: https://www.cthousegop.com/green/wp-content/uploads/sites/33/2019/01/sized__RG-Headshot-2-263x300.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Green/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27055%27&dist_name=Green,%20Robin
 other_names:
 - name: Green, Robin
 other_identifiers:

--- a/data/ct/legislature/Robyn-A-Porter-c78a6285-02a8-4b73-bac9-9f5807c2aacf.yml
+++ b/data/ct/legislature/Robyn-A-Porter-c78a6285-02a8-4b73-bac9-9f5807c2aacf.yml
@@ -3,6 +3,7 @@ name: Robyn A. Porter
 given_name: Robyn
 family_name: Porter
 email: robyn.porter@cga.ct.gov
+image: http://www2.housedems.ct.gov/Porter/images/Porter_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Porter
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27094%27&dist_name=Porter,%20Robyn%20A.
 other_names:
 - name: Porter, Robyn A.
 other_identifiers:

--- a/data/ct/legislature/Roland-J-Lemar-273e9a65-2254-43f1-ae88-744e1fa3738a.yml
+++ b/data/ct/legislature/Roland-J-Lemar-273e9a65-2254-43f1-ae88-744e1fa3738a.yml
@@ -3,6 +3,7 @@ name: Roland J. Lemar
 given_name: Roland
 family_name: Lemar
 email: roland.lemar@cga.ct.gov
+image: http://www2.housedems.ct.gov/Lemar/images/Lemar_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/lemar
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27096%27&dist_name=Lemar,%20Roland%20J.
 other_names:
 - name: Lemar, Roland J.
 other_identifiers:

--- a/data/ct/legislature/Ronald-A-Napoli-Jr-71fb3504-679f-419d-86bf-d1ae7d573244.yml
+++ b/data/ct/legislature/Ronald-A-Napoli-Jr-71fb3504-679f-419d-86bf-d1ae7d573244.yml
@@ -3,6 +3,7 @@ name: Ronald A. Napoli Jr.
 given_name: Ronald
 family_name: Napoli
 email: Ron.Napoli@cga.ct.gov
+image: http://www2.housedems.ct.gov/Napoli/images/Napoli_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/napoli
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27073%27&dist_name=Napoli,%20Ronald%20A.
 other_names:
 - name: Napoli, Ronald A.
 sources:

--- a/data/ct/legislature/Rosa-C-Rebimbas-Esq-0f203a11-5ba7-452a-89b4-720a617973fb.yml
+++ b/data/ct/legislature/Rosa-C-Rebimbas-Esq-0f203a11-5ba7-452a-89b4-720a617973fb.yml
@@ -3,6 +3,7 @@ name: Rosa C. Rebimbas
 given_name: Rosa
 family_name: Rebimbas
 email: Rosa.Rebimbas@housegop.ct.gov
+image: https://cga.ct.gov/legpics/070.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Rebimbas/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27070%27&dist_name=Rebimbas,%20Rosa%20C.
 other_names:
 - name: Rebimbas, Rosa C.
 other_identifiers:

--- a/data/ct/legislature/Ryan-Fazio-c5800b0c-c84a-4e63-83fa-8aaad9b6535f.yml
+++ b/data/ct/legislature/Ryan-Fazio-c5800b0c-c84a-4e63-83fa-8aaad9b6535f.yml
@@ -3,6 +3,7 @@ name: Ryan Fazio
 given_name: Ryan
 family_name: Fazio
 email: Ryan.Fazio@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2021/08/225217195_346200893664334_4626743322505851539_n-scaled-e1629858004858.jpg
 party:
 - name: Republican
 roles:
@@ -15,6 +16,7 @@ offices:
   voice: 860-240-8800
 links:
 - url: http://www.ctsenaterepublicans.com/home-fazio
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S36%27&dist_name=Fazio,%20Ryan
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Saud-Anwar-686df3d6-3199-4d48-a27e-7b3e7c65de66.yml
+++ b/data/ct/legislature/Saud-Anwar-686df3d6-3199-4d48-a27e-7b3e7c65de66.yml
@@ -2,6 +2,7 @@ id: ocd-person/686df3d6-3199-4d48-a27e-7b3e7c65de66
 name: Saud Anwar
 given_name: Saud
 family_name: Anwar
+image: http://www.senatedems.ct.gov/templates/anwar/images/anwar-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/anwar
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S03%27&dist_name=Anwar,%20Saud
 other_names:
 - name: Anwar, Saud
 sources:

--- a/data/ct/legislature/Sean-Scanlon-b56af509-8913-42b4-85bc-3df186448b01.yml
+++ b/data/ct/legislature/Sean-Scanlon-b56af509-8913-42b4-85bc-3df186448b01.yml
@@ -3,6 +3,7 @@ name: Sean Scanlon
 given_name: Sean
 family_name: Scanlon
 email: Sean.Scanlon@cga.ct.gov
+image: http://www2.housedems.ct.gov/Scanlon/images/Scanlon_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Scanlon
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27098%27&dist_name=Scanlon,%20Sean
 other_names:
 - name: Scanlon, Sean
 other_identifiers:

--- a/data/ct/legislature/Stephanie-Thomas-ea5497d0-5a3b-4dcc-9d13-5d50a586cf2b.yml
+++ b/data/ct/legislature/Stephanie-Thomas-ea5497d0-5a3b-4dcc-9d13-5d50a586cf2b.yml
@@ -3,6 +3,7 @@ name: Stephanie Thomas
 given_name: Stephanie
 family_name: Thomas
 email: Stephanie.Thomas@cga.ct.gov
+image: http://www2.housedems.ct.gov/Thomas/images/Thomas_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Thomas
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27143%27&dist_name=Thomas,%20Stephanie
 other_names:
 - name: Thomas, Stephanie
 sources:

--- a/data/ct/legislature/Stephen-G-Harding-Jr-f0f89d15-9682-4a2e-8096-57700ac5b8dc.yml
+++ b/data/ct/legislature/Stephen-G-Harding-Jr-f0f89d15-9682-4a2e-8096-57700ac5b8dc.yml
@@ -3,6 +3,7 @@ name: Stephen G. Harding Jr.
 given_name: Stephen
 family_name: Harding
 email: Stephen.Harding@housegop.ct.gov
+image: https://www.cthousegop.com/harding/wp-content/uploads/sites/35/2016/11/Harding_Bio_Photo_Web.jpg
 party:
 - name: Republican
 roles:
@@ -20,8 +21,10 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Harding/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27107%27&dist_name=Harding,%20Stephen%20G.
 other_names:
 - name: Harding, Stephen G.
+- name: Steve Harding
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CTL000307

--- a/data/ct/legislature/Stephen-R-Meskers-77dbf0fd-d45c-445c-9966-0135fff8feaa.yml
+++ b/data/ct/legislature/Stephen-R-Meskers-77dbf0fd-d45c-445c-9966-0135fff8feaa.yml
@@ -3,6 +3,7 @@ name: Stephen R. Meskers
 given_name: Stephen
 family_name: Meskers
 email: Stephen.Meskers@cga.ct.gov
+image: http://www2.housedems.ct.gov/Meskers/images/Meskers_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -15,8 +16,10 @@ offices:
   voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/meskers
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27150%27&dist_name=Meskers,%20Stephen%20R
 other_names:
 - name: Meskers, Stephen R
+- name: Steve Meskers
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Steve-Cassano-50c1a448-665c-492b-8a2c-0cfbfd587c4c.yml
+++ b/data/ct/legislature/Steve-Cassano-50c1a448-665c-492b-8a2c-0cfbfd587c4c.yml
@@ -2,6 +2,7 @@ id: ocd-person/50c1a448-665c-492b-8a2c-0cfbfd587c4c
 name: Steve Cassano
 given_name: Steve
 family_name: Cassano
+image: http://www.senatedems.ct.gov/templates/cassano/images/cassano-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/Cassano
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S04%27&dist_name=Cassano,%20Steve
 other_names:
 - name: Cassano, Steve
 other_identifiers:

--- a/data/ct/legislature/Steven-J-Stafstrom-cb252e7b-fffb-4bda-b951-d2b54a3c37e3.yml
+++ b/data/ct/legislature/Steven-J-Stafstrom-cb252e7b-fffb-4bda-b951-d2b54a3c37e3.yml
@@ -3,6 +3,7 @@ name: Steven J. Stafstrom
 given_name: Steven
 family_name: Stafstrom
 email: Steven.Stafstrom@cga.ct.gov
+image: http://www2.housedems.ct.gov/Stafstrom/images/Stafstrom_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Stafstrom
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27129%27&dist_name=Stafstrom,%20Steven%20J.
 other_names:
 - name: Stafstrom, Steven J.
 other_identifiers:

--- a/data/ct/legislature/Susan-M-Johnson-454e5979-c5bb-4f4e-9f3d-dc11f5e5b6ca.yml
+++ b/data/ct/legislature/Susan-M-Johnson-454e5979-c5bb-4f4e-9f3d-dc11f5e5b6ca.yml
@@ -3,6 +3,7 @@ name: Susan M. Johnson
 given_name: Susan
 family_name: Johnson
 email: Susan.Johnson@cga.ct.gov
+image: http://www2.housedems.ct.gov/Johnson/images/Johnson_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Johnson
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27049%27&dist_name=Johnson,%20Susan%20M.
 other_names:
 - name: Johnson, Susan M.
 other_identifiers:

--- a/data/ct/legislature/Tami-Zawistowski-b57c3599-c0b0-4fd3-a48c-2bfd32d95071.yml
+++ b/data/ct/legislature/Tami-Zawistowski-b57c3599-c0b0-4fd3-a48c-2bfd32d95071.yml
@@ -3,6 +3,7 @@ name: Tami Zawistowski
 given_name: Tami
 family_name: Zawistowski
 email: Tami.Zawistowski@housegop.ct.gov
+image: https://www.cthousegop.com/zawistowski/wp-content/uploads/sites/71/2016/11/Zawistowski-Bio-Web.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Zawistowski/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27061%27&dist_name=Zawistowski,%20Tami
 other_names:
 - name: Zawistowski, Tami
 other_identifiers:

--- a/data/ct/legislature/Tammy-Nuccio-cbdde335-cd3e-4769-b477-5893c46d96b6.yml
+++ b/data/ct/legislature/Tammy-Nuccio-cbdde335-cd3e-4769-b477-5893c46d96b6.yml
@@ -3,6 +3,7 @@ name: Tammy Nuccio
 given_name: Tammy
 family_name: Nuccio
 email: Tammy.Nuccio@housegop.ct.gov
+image: https://cga.ct.gov/legpics/053.png?ver=
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: https://www.cthousegop.com/Nuccio
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27053%27&dist_name=Nuccio,%20Tammy
 other_names:
 - name: Nuccio, Tammy
 sources:

--- a/data/ct/legislature/Tammy-R-Exum-8872e78b-25b4-406b-84b2-949c700f7b56.yml
+++ b/data/ct/legislature/Tammy-R-Exum-8872e78b-25b4-406b-84b2-949c700f7b56.yml
@@ -3,6 +3,7 @@ name: Tammy R. Exum
 given_name: Tammy
 family_name: Exum
 email: Tammy.Exum@cga.ct.gov
+image: http://www2.housedems.ct.gov/Exum/images/Exum_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -16,6 +17,7 @@ offices:
   voice: 860-240-8585
 links:
 - url: http://www.housedems.ct.gov/exum
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27019%27&dist_name=Exum,%20Tammy%20R.
 other_names:
 - name: Exum, Tammy R.
 sources:

--- a/data/ct/legislature/Terrie-E-Wood-fd57836a-b0bd-4ff9-8490-5ba5903d52a5.yml
+++ b/data/ct/legislature/Terrie-E-Wood-fd57836a-b0bd-4ff9-8490-5ba5903d52a5.yml
@@ -3,6 +3,7 @@ name: Terrie E. Wood
 given_name: Terrie
 family_name: Wood
 email: Terrie.Wood@housegop.ct.gov
+image: https://www.cthousegop.com/wood/wp-content/uploads/sites/69/2016/11/Wood_Bio_Web.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Wood/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27141%27&dist_name=Wood,%20Terrie%20E.
 other_names:
 - name: Wood, Terrie E.
 other_identifiers:

--- a/data/ct/legislature/Tim-Ackert-d458d504-9053-4709-bf43-d955083a18ab.yml
+++ b/data/ct/legislature/Tim-Ackert-d458d504-9053-4709-bf43-d955083a18ab.yml
@@ -3,6 +3,7 @@ name: Tim Ackert
 given_name: Tim
 family_name: Ackert
 email: tim.ackert@housegop.ct.gov
+image: https://cga.ct.gov/legpics/008.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Ackert/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27008%27&dist_name=Ackert,%20Tim
 other_names:
 - name: Ackert, Tim
 other_identifiers:

--- a/data/ct/legislature/Tom-Arnone-ea621753-2aca-412d-a221-d4fc5e48ba80.yml
+++ b/data/ct/legislature/Tom-Arnone-ea621753-2aca-412d-a221-d4fc5e48ba80.yml
@@ -3,6 +3,7 @@ name: Tom Arnone
 given_name: Tom
 family_name: Arnone
 email: Tom.Arnone@cga.ct.gov
+image: https://cga.ct.gov/legpics/058.png?ver=
 party:
 - name: Democratic
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/arnone
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27058%27&dist_name=Arnone,%20Tom
 other_names:
 - name: Arnone, Tom
 sources:

--- a/data/ct/legislature/Tom-Delnicki-8bf7e55e-afc1-4f5c-99c3-9b7a1356fbc3.yml
+++ b/data/ct/legislature/Tom-Delnicki-8bf7e55e-afc1-4f5c-99c3-9b7a1356fbc3.yml
@@ -3,6 +3,7 @@ name: Tom Delnicki
 given_name: Tom
 family_name: Delnicki
 email: Tom.Delnicki@housegop.ct.gov
+image: https://cga.ct.gov/legpics/014.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Delnicki/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27014%27&dist_name=Delnicki,%20Tom
 other_names:
 - name: Delnicki, Tom
 other_identifiers:

--- a/data/ct/legislature/Tom-ODea-03642345-7acb-4294-91b5-84dcc3c18cc7.yml
+++ b/data/ct/legislature/Tom-ODea-03642345-7acb-4294-91b5-84dcc3c18cc7.yml
@@ -3,6 +3,7 @@ name: Tom O'Dea
 given_name: Tom
 family_name: O'Dea
 email: Tom.ODea@housegop.ct.gov
+image: https://www.cthousegop.com/odea/wp-content/uploads/sites/46/2018/05/ODea-Headshot-683x1024.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/ODea/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27125%27&dist_name=O%27Dea,%20Tom
 other_names:
 - name: O'dea, Tom
 other_identifiers:

--- a/data/ct/legislature/Toni-E-Walker-59460c80-5324-423f-a06c-158d69a30b02.yml
+++ b/data/ct/legislature/Toni-E-Walker-59460c80-5324-423f-a06c-158d69a30b02.yml
@@ -3,6 +3,7 @@ name: Toni E. Walker
 given_name: Toni
 family_name: Walker
 email: Toni.Walker@cga.ct.gov
+image: http://www2.housedems.ct.gov/Walker/images/Walker_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.housedems.ct.gov/Walker
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27093%27&dist_name=Walker,%20Toni%20E.
 other_names:
 - name: Walker, Toni E.
 other_identifiers:

--- a/data/ct/legislature/Tony-Hwang-b1ab473b-e7ff-4c53-96af-ee796c89f4dd.yml
+++ b/data/ct/legislature/Tony-Hwang-b1ab473b-e7ff-4c53-96af-ee796c89f4dd.yml
@@ -3,6 +3,7 @@ name: Tony Hwang
 given_name: Tony
 family_name: Hwang
 email: Tony.Hwang@cga.ct.gov
+image: https://ctsenaterepublicans.com/wp-content/uploads/2021/08/Hwang_Headshot2019.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.ctsenaterepublicans.com/home-Hwang
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S28%27&dist_name=Hwang,%20Tony
 other_names:
 - name: Hwang, Tony
 other_identifiers:

--- a/data/ct/legislature/Tony-Scott-bc3200fa-f97b-433f-bb0b-ac15f71b2e92.yml
+++ b/data/ct/legislature/Tony-Scott-bc3200fa-f97b-433f-bb0b-ac15f71b2e92.yml
@@ -3,7 +3,7 @@ name: Tony J. Scott
 given_name: Tony
 family_name: Scott
 email: Tony.Scott@housegop.ct.gov
-image: https://www.cthousegop.com/scott/wp-content/uploads/sites/93/2021/04/web-banner-scott-1-2048x1072.jpg
+image: https://cga.ct.gov/legpics/112.png?ver=
 party:
 - name: Republican
 roles:
@@ -19,6 +19,7 @@ offices:
   address: 97 Benedict Road; Monroe, CT 06468
 links:
 - url: http://www.cthousegop.com/Scott
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27112%27&dist_name=Scott,%20Tony%20J
 other_names:
 - name: Tony Scott
 sources:

--- a/data/ct/legislature/Travis-Simms-9e9d6f02-ee29-4ff3-a6fe-1b8a0cec0612.yml
+++ b/data/ct/legislature/Travis-Simms-9e9d6f02-ee29-4ff3-a6fe-1b8a0cec0612.yml
@@ -3,6 +3,7 @@ name: Travis Simms
 given_name: Travis
 family_name: Simms
 email: Travis.Simms@cga.ct.gov
+image: http://www2.housedems.ct.gov/Simms/images/Simms_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -17,6 +18,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/simms
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27140%27&dist_name=Simms,%20Travis
 other_names:
 - name: Simms, Travis
 sources:

--- a/data/ct/legislature/Trenee-McGee-5a41c633-8d04-43c6-b3c2-64cbbbbefcc4.yml
+++ b/data/ct/legislature/Trenee-McGee-5a41c633-8d04-43c6-b3c2-64cbbbbefcc4.yml
@@ -3,6 +3,7 @@ name: Trenee McGee
 given_name: Trenee
 family_name: McGee
 email: Trenee.McGee@cga.ct.gov
+image: http://www2.housedems.ct.gov/McGeeT/images/McGeeT_HS.jpg
 party:
 - name: Democratic
 roles:
@@ -18,6 +19,7 @@ offices:
   address: Legislative Office Building; Hartford, CT 06106
 links:
 - url: http://www.housedems.ct.gov/McgeeT
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27116%27&dist_name=McGee,%20Trenee
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:

--- a/data/ct/legislature/Vincent-J-Candelora-1d02baaa-ab25-4607-b33f-40948893f928.yml
+++ b/data/ct/legislature/Vincent-J-Candelora-1d02baaa-ab25-4607-b33f-40948893f928.yml
@@ -3,6 +3,7 @@ name: Vincent J. Candelora
 given_name: Vincent
 family_name: Candelora
 email: Vincent.Candelora@housegop.ct.gov
+image: https://www.cthousegop.com/candelora/wp-content/uploads/sites/12/2022/02/Candelora-2022-Bio-Photo-Web.jpg
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Candelora/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27086%27&dist_name=Candelora,%20Vincent%20J.
 other_names:
 - name: Candelora, Vincent J.
 other_identifiers:

--- a/data/ct/legislature/Whit-Betts-ed8c3238-f1f8-451c-8906-8feca116a025.yml
+++ b/data/ct/legislature/Whit-Betts-ed8c3238-f1f8-451c-8906-8feca116a025.yml
@@ -3,6 +3,7 @@ name: Whit Betts
 given_name: Whit
 family_name: Betts
 email: whit.betts@housegop.ct.gov
+image: https://cga.ct.gov/legpics/078.png?ver=
 party:
 - name: Republican
 roles:
@@ -21,6 +22,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Betts/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27078%27&dist_name=Betts,%20Whit
 other_names:
 - name: Betts, Whit
 other_identifiers:

--- a/data/ct/legislature/Will-Haskell-982f8478-39ab-44d8-8322-6807a26e25e4.yml
+++ b/data/ct/legislature/Will-Haskell-982f8478-39ab-44d8-8322-6807a26e25e4.yml
@@ -2,6 +2,7 @@ id: ocd-person/982f8478-39ab-44d8-8322-6807a26e25e4
 name: Will Haskell
 given_name: Will
 family_name: Haskell
+image: http://www.senatedems.ct.gov/templates/Haskell/images/Haskell-hi.jpg
 party:
 - name: Democratic
 roles:
@@ -19,6 +20,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.senatedems.ct.gov/haskell
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27S26%27&dist_name=Haskell,%20Will
 other_names:
 - name: Haskell, Will
 sources:

--- a/data/ct/legislature/William-A-Petit-Jr-MD-3ee72607-8d51-4752-af90-dd669611187b.yml
+++ b/data/ct/legislature/William-A-Petit-Jr-MD-3ee72607-8d51-4752-af90-dd669611187b.yml
@@ -3,6 +3,7 @@ name: William A. Petit Jr., M.D.
 given_name: William
 family_name: Petit
 email: William.Petit@housegop.ct.gov
+image: https://www.cthousegop.com/petit/wp-content/uploads/sites/51/2021/01/Petit__Standard-Photo-2021-709x1024.jpg
 party:
 - name: Republican
 roles:
@@ -20,6 +21,7 @@ offices:
   name: 'District Office #1'
 links:
 - url: http://www.cthousegop.com/Petit/
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27022%27&dist_name=Petit,%20William%20A.
 other_names:
 - name: Petit, William A.
 other_identifiers:

--- a/data/ct/legislature/William-Pizzuto-f7127b57-a72f-4b84-abf6-77b021cddf3f.yml
+++ b/data/ct/legislature/William-Pizzuto-f7127b57-a72f-4b84-abf6-77b021cddf3f.yml
@@ -18,6 +18,10 @@ offices:
   address: 300 Capitol Avenue; Hartford, CT 06109
 links:
 - url: http://cthousegop.com/Pizzuto
+- url: https://cga.ct.gov/asp/CGABillStatus/CGAMemberBills.asp?dist_code=%27071%27&dist_name=Pizzuto,%20William
+other_names:
+- name: Pizzuto, William
+- name: Bill Pizzuto
 sources:
 - url: ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv
 extras:


### PR DESCRIPTION
Added Connecticut image URLs for every current legislator, except for recently elected William Pizzuto.

Legislator image URLs were retrieved from the sites below. When the same legislator had an image on more than 1 site, the higher quality image was chosen:
https://cga.ct.gov
http://www.housedems.ct.gov
https://www.cthousegop.com
http://www.senatedems.ct.gov
https://ctsenaterepublicans.com

Executive image URLs were retrieved from:
https://portal.ct.gov/