### PR TITLE
PR: Add missing images and correct 2 names

### DIFF
--- a/data/pr/executive/Francisco-Rosado-Colomer-f21042d2-549c-479e-a685-5e8ba99b8fca.yml
+++ b/data/pr/executive/Francisco-Rosado-Colomer-f21042d2-549c-479e-a685-5e8ba99b8fca.yml
@@ -3,6 +3,7 @@ name: Francisco Rosado Colomer
 given_name: Francisco
 family_name: Rosado Colomer
 email: frosado@cee.pr.gov
+image: https://ww2.ceepur.org/sites/ComisionEE/es-pr/Webmaster/pic/FranciscoJRosado-Presidente-web.jpg
 party:
 - name: Independent
 roles:

--- a/data/pr/executive/Pedro-Pierluisi-d3472067-f01e-4526-88c3-0b502fc68517.yml
+++ b/data/pr/executive/Pedro-Pierluisi-d3472067-f01e-4526-88c3-0b502fc68517.yml
@@ -3,6 +3,7 @@ name: Pedro Pierluisi
 given_name: Pedro
 family_name: Pierluisi
 birth_date: 1959-04-26
+image: https://assets-global.website-files.com/6078c37d5979559c7a2e362b/611fcb094045f45dac81388a_Goibernador-Pedro-Pierluisi.jpg
 party:
 - name: Partido Nuevo Progresista
 roles:

--- a/data/pr/legislature/Ada-Garcia-Montes-e7e195f3-09ac-4958-bb0b-e4e215e4c9fa.yml
+++ b/data/pr/legislature/Ada-Garcia-Montes-e7e195f3-09ac-4958-bb0b-e4e215e4c9fa.yml
@@ -2,6 +2,7 @@ id: ocd-person/e7e195f3-09ac-4958-bb0b-e4e215e4c9fa
 name: "Ada Garc\xEDa Montes"
 given_name: Ada
 family_name: "Garc\xEDa Montes"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/690/Screen%20Shot%202021-08-17%20at%209.37.12%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: IV
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=690
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=690

--- a/data/pr/legislature/Albert-Torres-Berrios-9a94f5b3-93a2-404d-9d3e-036b12d13ef4.yml
+++ b/data/pr/legislature/Albert-Torres-Berrios-9a94f5b3-93a2-404d-9d3e-036b12d13ef4.yml
@@ -2,6 +2,7 @@ id: ocd-person/9a94f5b3-93a2-404d-9d3e-036b12d13ef4
 name: Albert Torres Berrios
 given_name: Albert
 family_name: Torres Berrios
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/695/Screen%20Shot%202021-08-17%20at%209.37.53%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VI
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=695
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=695

--- a/data/pr/legislature/Ana-Irma-Rivera-Lassen-a61f5354-ceaa-4fc0-9dc7-73caf5d83d1f.yml
+++ b/data/pr/legislature/Ana-Irma-Rivera-Lassen-a61f5354-ceaa-4fc0-9dc7-73caf5d83d1f.yml
@@ -2,6 +2,7 @@ id: ocd-person/a61f5354-ceaa-4fc0-9dc7-73caf5d83d1f
 name: "Ana Irma Rivera Lass\xE9n"
 given_name: Ana Irma
 family_name: "Rivera Lass\xE9n"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/707/Screen%20Shot%202021-08-17%20at%209.48.12%20PM.png
 party:
 - name: Movimiento Victoria Ciudadana
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=707
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=707

--- a/data/pr/legislature/Deborah-Soto-Arroyo-7408df66-3e8f-45a1-9844-aa6b1add8c60.yml
+++ b/data/pr/legislature/Deborah-Soto-Arroyo-7408df66-3e8f-45a1-9844-aa6b1add8c60.yml
@@ -2,6 +2,7 @@ id: ocd-person/7408df66-3e8f-45a1-9844-aa6b1add8c60
 name: Deborah Soto Arroyo
 given_name: Deborah
 family_name: Soto Arroyo
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/720/Deborah%20Soto.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '10'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=720
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=720

--- a/data/pr/legislature/Domingo-Torres-Garca-0bb123e5-c41d-4fb4-a6ee-7efb453d245a.yml
+++ b/data/pr/legislature/Domingo-Torres-Garca-0bb123e5-c41d-4fb4-a6ee-7efb453d245a.yml
@@ -2,6 +2,7 @@ id: ocd-person/0bb123e5-c41d-4fb4-a6ee-7efb453d245a
 name: "Domingo Torres Garc\xEDa"
 given_name: Domingo
 family_name: "Torres Garc\xEDa"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/735/Torres%20Garc%c3%ada.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '25'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=735
+other_names:
+- name: "Domingo J. Torres Garc\xEDa"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=735

--- a/data/pr/legislature/Edgardo-Feliciano-43fcbc03-037f-4ecf-916f-6a5925692a79.yml
+++ b/data/pr/legislature/Edgardo-Feliciano-43fcbc03-037f-4ecf-916f-6a5925692a79.yml
@@ -2,6 +2,7 @@ id: ocd-person/43fcbc03-037f-4ecf-916f-6a5925692a79
 name: Edgardo Feliciano
 given_name: Edgardo
 family_name: Feliciano
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/722/Edgardo%20Feliciano.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '12'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=722
+other_names:
+- name: "Edgardo Feliciano S\xE1nchez"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=722

--- a/data/pr/legislature/Eladio-Cardona-48b0040b-5345-4ef0-aa27-e68e38b29131.yml
+++ b/data/pr/legislature/Eladio-Cardona-48b0040b-5345-4ef0-aa27-e68e38b29131.yml
@@ -2,6 +2,7 @@ id: ocd-person/48b0040b-5345-4ef0-aa27-e68e38b29131
 name: Eladio Cardona
 given_name: Eladio
 family_name: Cardona
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/726/Eladio%20Cardona.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '16'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=726
+other_names:
+- name: Eladio J. Cardona Quiles
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=726

--- a/data/pr/legislature/Elizabeth-Rosa-Velez-f6cbbf9c-03d1-4d0e-9acb-58ca7a0a0e18.yml
+++ b/data/pr/legislature/Elizabeth-Rosa-Velez-f6cbbf9c-03d1-4d0e-9acb-58ca7a0a0e18.yml
@@ -2,6 +2,7 @@ id: ocd-person/f6cbbf9c-03d1-4d0e-9acb-58ca7a0a0e18
 name: "Elizabeth Rosa V\xE9lez"
 given_name: Elizabeth
 family_name: "Rosa V\xE9lez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/688/Screen%20Shot%202021-08-17%20at%209.38.51%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: III
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=688
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=688

--- a/data/pr/legislature/Estrella-Martnez-Soto-a5b90d78-5c49-42e3-bc1c-44e6bb6cb85d.yml
+++ b/data/pr/legislature/Estrella-Martnez-Soto-a5b90d78-5c49-42e3-bc1c-44e6bb6cb85d.yml
@@ -2,6 +2,7 @@ id: ocd-person/a5b90d78-5c49-42e3-bc1c-44e6bb6cb85d
 name: "Estrella Mart\xEDnez Soto"
 given_name: Estrella
 family_name: "Mart\xEDnez Soto"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/737/Martinez%20Soto.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '27'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=737
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=737

--- a/data/pr/legislature/Gregorio-Matias-Rosario-beb1660c-fd16-4f3b-851f-1b6f40bdd62d.yml
+++ b/data/pr/legislature/Gregorio-Matias-Rosario-beb1660c-fd16-4f3b-851f-1b6f40bdd62d.yml
@@ -2,6 +2,7 @@ id: ocd-person/beb1660c-fd16-4f3b-851f-1b6f40bdd62d
 name: Gregorio Matias Rosario
 given_name: Gregorio
 family_name: Matias Rosario
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/709/Screen%20Shot%202021-08-17%20at%209.43.14%20PM.png
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=709
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=709

--- a/data/pr/legislature/Gretchen-Hau-76dae9be-424c-4da4-bf9f-9842fd3da06f.yml
+++ b/data/pr/legislature/Gretchen-Hau-76dae9be-424c-4da4-bf9f-9842fd3da06f.yml
@@ -2,6 +2,7 @@ id: ocd-person/76dae9be-424c-4da4-bf9f-9842fd3da06f
 name: Gretchen Hau
 given_name: Gretchen
 family_name: Hau
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/694/Screen%20Shot%202021-08-17%20at%209.27.45%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VI
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=694
+other_names:
+- name: Gretchen M. Hau
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=694

--- a/data/pr/legislature/Hctor-Ferrer-Ros-0c318d9b-2b74-42c7-8ec2-7c89ee41955e.yml
+++ b/data/pr/legislature/Hctor-Ferrer-Ros-0c318d9b-2b74-42c7-8ec2-7c89ee41955e.yml
@@ -2,6 +2,7 @@ id: ocd-person/0c318d9b-2b74-42c7-8ec2-7c89ee41955e
 name: "H\xE9ctor E. Ferrer Santiago"
 given_name: "H\xE9ctor"
 family_name: "Ferrer Santiago"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/751/Ferrer%20Santiago.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:

--- a/data/pr/legislature/Hctor-Ferrer-Ros-0c318d9b-2b74-42c7-8ec2-7c89ee41955e.yml
+++ b/data/pr/legislature/Hctor-Ferrer-Ros-0c318d9b-2b74-42c7-8ec2-7c89ee41955e.yml
@@ -1,7 +1,7 @@
 id: ocd-person/0c318d9b-2b74-42c7-8ec2-7c89ee41955e
-name: "H\xE9ctor Ferrer R\xEDos"
+name: "H\xE9ctor E. Ferrer Santiago"
 given_name: "H\xE9ctor"
-family_name: "Ferrer R\xEDos"
+family_name: "Ferrer Santiago"
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +9,11 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=751
+- url: https://www.camara.pr.gov/team/hector-e-ferrer-santiago/
+other_names:
+- name: "H\xE9ctor Enrique Ferrer Santiago"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=751
+- url: https://www.camara.pr.gov/team/hector-e-ferrer-santiago/

--- a/data/pr/legislature/Javier-Aponte-Dalmau-b96e27b7-42ef-412b-a8a6-41593703754c.yml
+++ b/data/pr/legislature/Javier-Aponte-Dalmau-b96e27b7-42ef-412b-a8a6-41593703754c.yml
@@ -2,6 +2,7 @@ id: ocd-person/b96e27b7-42ef-412b-a8a6-41593703754c
 name: Javier Aponte Dalmau
 given_name: Javier
 family_name: Aponte Dalmau
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/698/Screen%20Shot%202021-08-17%20at%209.29.45%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VIII
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=698
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=698

--- a/data/pr/legislature/Jessie-Corts-Ramos-00a3deb7-1213-488b-a338-7b543c042153.yml
+++ b/data/pr/legislature/Jessie-Corts-Ramos-00a3deb7-1213-488b-a338-7b543c042153.yml
@@ -2,6 +2,7 @@ id: ocd-person/00a3deb7-1213-488b-a338-7b543c042153
 name: "Jessie Cort\xE9s Ramos"
 given_name: Jessie
 family_name: "Cort\xE9s Ramos"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/728/Jessie%20Cortes1.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '18'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=728
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=728

--- a/data/pr/legislature/Joanne-Rodriguez-Veve-a67879ee-0450-4270-a99f-d186bed3f783.yml
+++ b/data/pr/legislature/Joanne-Rodriguez-Veve-a67879ee-0450-4270-a99f-d186bed3f783.yml
@@ -2,6 +2,7 @@ id: ocd-person/a67879ee-0450-4270-a99f-d186bed3f783
 name: "Joanne Rodr\xEDguez Veve"
 given_name: Joanne
 family_name: "Rodr\xEDguez Veve"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/701/Screen%20Shot%202021-08-17%20at%209.50.59%20PM.png
 party:
 - name: Proyecto Dignidad
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=701
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=701

--- a/data/pr/legislature/Jocelyne-Rodrguez-Negrn-e0600ac5-be13-4718-a006-71b87027cd7d.yml
+++ b/data/pr/legislature/Jocelyne-Rodrguez-Negrn-e0600ac5-be13-4718-a006-71b87027cd7d.yml
@@ -2,6 +2,7 @@ id: ocd-person/e0600ac5-be13-4718-a006-71b87027cd7d
 name: "Jocelyne Rodr\xEDguez Negr\xF3n"
 given_name: Jocelyne
 family_name: "Rodr\xEDguez Negr\xF3n"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/729/Jocelyn%20Rodriguez.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '19'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=729
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=729

--- a/data/pr/legislature/Jorge-Alfredo-Rivera-Segarra-a600d7fd-3e2a-4148-aabf-c805b436db43.yml
+++ b/data/pr/legislature/Jorge-Alfredo-Rivera-Segarra-a600d7fd-3e2a-4148-aabf-c805b436db43.yml
@@ -2,6 +2,7 @@ id: ocd-person/a600d7fd-3e2a-4148-aabf-c805b436db43
 name: Jorge Alfredo Rivera Segarra
 given_name: Jorge Alfredo
 family_name: Rivera Segarra
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/732/Jorge%20Rivera.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '22'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=732
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=732

--- a/data/pr/legislature/Jos-Bernardo-Mrquez-51a95b4d-0006-49e8-83ae-6c139a1d5b1b.yml
+++ b/data/pr/legislature/Jos-Bernardo-Mrquez-51a95b4d-0006-49e8-83ae-6c139a1d5b1b.yml
@@ -2,6 +2,7 @@ id: ocd-person/51a95b4d-0006-49e8-83ae-6c139a1d5b1b
 name: "Jos\xE9 Bernardo M\xE1rquez"
 given_name: "Jos\xE9"
 family_name: "Bernardo M\xE1rquez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/758/Marquez%20Reyes.jpg
 party:
 - name: Movimiento Victoria Ciudadana
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=758
+other_names:
+- name: "Jos\xE9 B. M\xE1rquez Reyes"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=758

--- a/data/pr/legislature/Jos-Rivera-Madera-92012861-cfe9-4dfa-9811-6e4302d01435.yml
+++ b/data/pr/legislature/Jos-Rivera-Madera-92012861-cfe9-4dfa-9811-6e4302d01435.yml
@@ -2,6 +2,7 @@ id: ocd-person/92012861-cfe9-4dfa-9811-6e4302d01435
 name: "Jos\xE9 Rivera Madera"
 given_name: "Jos\xE9"
 family_name: Rivera Madera
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/733/Rivera%20Madera.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '23'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=733
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=733

--- a/data/pr/legislature/Juan-Jos-Santiago-Nieves-31630aa4-8a2a-400b-b49f-3ff341e79fc6.yml
+++ b/data/pr/legislature/Juan-Jos-Santiago-Nieves-31630aa4-8a2a-400b-b49f-3ff341e79fc6.yml
@@ -2,6 +2,7 @@ id: ocd-person/31630aa4-8a2a-400b-b49f-3ff341e79fc6
 name: "Juan Jos\xE9 Santiago Nieves"
 given_name: "Juan Jos\xE9"
 family_name: Santiago Nieves
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/738/Santiago%20Nieves.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '28'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=738
+other_names:
+- name: Juan J. Santiago Nieves
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=738

--- a/data/pr/legislature/Juan-Zaragoza-Gmez-968b51ad-f1ad-41d8-84c2-e76a4f450e70.yml
+++ b/data/pr/legislature/Juan-Zaragoza-Gmez-968b51ad-f1ad-41d8-84c2-e76a4f450e70.yml
@@ -2,6 +2,7 @@ id: ocd-person/968b51ad-f1ad-41d8-84c2-e76a4f450e70
 name: "Juan Zaragoza G\xF3mez"
 given_name: Juan
 family_name: "Zaragoza G\xF3mez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/704/Screen%20Shot%202021-08-17%20at%209.39.45%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=704
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=704

--- a/data/pr/legislature/Kebin-Andrs-Maldonado-Martiz-e8e22c30-066d-4105-8ba0-0ff20c286ca9.yml
+++ b/data/pr/legislature/Kebin-Andrs-Maldonado-Martiz-e8e22c30-066d-4105-8ba0-0ff20c286ca9.yml
@@ -2,6 +2,7 @@ id: ocd-person/e8e22c30-066d-4105-8ba0-0ff20c286ca9
 name: "Kebin Andr\xE9s Maldonado Martiz"
 given_name: Kebin
 family_name: "Andr\xE9s Maldonado Martiz"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/730/Kebin%20Maldonado.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '20'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=730
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=730

--- a/data/pr/legislature/Keren-Riquelme-9b6a68d4-b93e-4d8d-be05-c7597e691b65.yml
+++ b/data/pr/legislature/Keren-Riquelme-9b6a68d4-b93e-4d8d-be05-c7597e691b65.yml
@@ -2,6 +2,7 @@ id: ocd-person/9b6a68d4-b93e-4d8d-be05-c7597e691b65
 name: Keren Riquelme
 given_name: Keren
 family_name: Riquelme
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/710/Keren%20Riquelme.jpeg
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=710
+other_names:
+- name: Keren L. Riquelme Cabrera
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=710

--- a/data/pr/legislature/Lislie-Janet-Burgos-Muiz-05dee06f-a941-43cc-a4ce-fef9f3132784.yml
+++ b/data/pr/legislature/Lislie-Janet-Burgos-Muiz-05dee06f-a941-43cc-a4ce-fef9f3132784.yml
@@ -2,6 +2,7 @@ id: ocd-person/05dee06f-a941-43cc-a4ce-fef9f3132784
 name: "Lisie Janet Burgos Mu\xF1iz"
 given_name: Lisie Janet
 family_name: "Burgos Mu\xF1iz"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/754/Burgos%20Muniz.jpg
 party:
 - name: Proyecto Dignidad
 roles:
@@ -12,6 +13,8 @@ roles:
 links:
 - url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=754
 - url: https://www.camara.pr.gov/team/lisie-j-burgos-muniz/
+other_names:
+- name: "Lisie J. Burgos Mu\xF1iz"
 sources:
 - url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=754
 - url: https://www.camara.pr.gov/team/lisie-j-burgos-muniz/

--- a/data/pr/legislature/Lislie-Janet-Burgos-Muiz-05dee06f-a941-43cc-a4ce-fef9f3132784.yml
+++ b/data/pr/legislature/Lislie-Janet-Burgos-Muiz-05dee06f-a941-43cc-a4ce-fef9f3132784.yml
@@ -1,6 +1,6 @@
 id: ocd-person/05dee06f-a941-43cc-a4ce-fef9f3132784
-name: "Lislie Janet Burgos Mu\xF1iz"
-given_name: Lislie Janet
+name: "Lisie Janet Burgos Mu\xF1iz"
+given_name: Lisie Janet
 family_name: "Burgos Mu\xF1iz"
 party:
 - name: Proyecto Dignidad
@@ -9,3 +9,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=754
+- url: https://www.camara.pr.gov/team/lisie-j-burgos-muniz/
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=754
+- url: https://www.camara.pr.gov/team/lisie-j-burgos-muniz/

--- a/data/pr/legislature/Maria-De-Lourdes-Santiago-6954a3cf-d38f-4628-ade1-46a492a774ab.yml
+++ b/data/pr/legislature/Maria-De-Lourdes-Santiago-6954a3cf-d38f-4628-ade1-46a492a774ab.yml
@@ -2,6 +2,7 @@ id: ocd-person/6954a3cf-d38f-4628-ade1-46a492a774ab
 name: "Mar\xEDa De Lourdes Santiago"
 given_name: "Mar\xEDa"
 family_name: De Lourdes Santiago
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/700/Screen%20Shot%202021-08-17%20at%209.50.08%20PM.png
 party:
 - name: "Partido Independentista Puertorrique\xF1o"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=700
+other_names:
+- name: "Mar\xEDa De Lourdes Santiago Negr\xF3n"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=700

--- a/data/pr/legislature/Marially-Gonzalez-dd5cfa44-9cb3-414b-a780-ea182b4fe217.yml
+++ b/data/pr/legislature/Marially-Gonzalez-dd5cfa44-9cb3-414b-a780-ea182b4fe217.yml
@@ -2,6 +2,7 @@ id: ocd-person/dd5cfa44-9cb3-414b-a780-ea182b4fe217
 name: "Marially Gonz\xE1lez"
 given_name: Marially
 family_name: "Gonz\xE1lez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/692/Screen%20Shot%202021-08-17%20at%209.32.12%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: V
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=692
+other_names:
+- name: "Marially Gonz\xE1lez Huertas"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=692

--- a/data/pr/legislature/Mariana-Nogales-Molinelli-13349eb9-b441-419a-8687-671729d39010.yml
+++ b/data/pr/legislature/Mariana-Nogales-Molinelli-13349eb9-b441-419a-8687-671729d39010.yml
@@ -2,6 +2,7 @@ id: ocd-person/13349eb9-b441-419a-8687-671729d39010
 name: Mariana Nogales Molinelli
 given_name: Mariana
 family_name: Nogales Molinelli
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/753/Nogales%20Molinelli.jpg
 party:
 - name: Movimiento Victoria Ciudadana
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=753
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=753

--- a/data/pr/legislature/Marissa-Jimenez-9a9ebf96-43e3-41b9-976c-ffed31f5c0ec.yml
+++ b/data/pr/legislature/Marissa-Jimenez-9a9ebf96-43e3-41b9-976c-ffed31f5c0ec.yml
@@ -2,6 +2,7 @@ id: ocd-person/9a9ebf96-43e3-41b9-976c-ffed31f5c0ec
 name: "Marissa Jim\xE9nez"
 given_name: Marissa
 family_name: "Jim\xE9nez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/699/Screen%20Shot%202021-08-17%20at%209.44.52%20PM.png
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VIII
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=699
+other_names:
+- name: "Marissa Jim\xE9nez Santoni"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=699

--- a/data/pr/legislature/Migdalia-Gonzalez-a5036514-440a-4db9-a089-349caea8ca73.yml
+++ b/data/pr/legislature/Migdalia-Gonzalez-a5036514-440a-4db9-a089-349caea8ca73.yml
@@ -2,6 +2,7 @@ id: ocd-person/a5036514-440a-4db9-a089-349caea8ca73
 name: "Migdalia Gonz\xE1lez"
 given_name: Migdalia
 family_name: "Gonz\xE1lez"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/691/Screen%20Shot%202021-08-17%20at%209.33.31%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: IV
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=691
+other_names:
+- name: "Migdalia Gonz\xE1lez Arroyo"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=691

--- a/data/pr/legislature/Nitza-Mor-02d88e4b-3717-43c5-b7fd-14e6a2224043.yml
+++ b/data/pr/legislature/Nitza-Mor-02d88e4b-3717-43c5-b7fd-14e6a2224043.yml
@@ -2,6 +2,7 @@ id: ocd-person/02d88e4b-3717-43c5-b7fd-14e6a2224043
 name: "Nitza Mor\xE1n"
 given_name: Nitza
 family_name: "Mor\xE1n"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/685/Screen%20Shot%202021-08-17%20at%209.34.32%20PM.png
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: I
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=685
+other_names:
+- name: "Nitza Mor\xE1n Trinidad"
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=685

--- a/data/pr/legislature/Orlando-Aponte-Rosario-451c7127-1448-49a3-a851-6e0922cefb12.yml
+++ b/data/pr/legislature/Orlando-Aponte-Rosario-451c7127-1448-49a3-a851-6e0922cefb12.yml
@@ -2,6 +2,7 @@ id: ocd-person/451c7127-1448-49a3-a851-6e0922cefb12
 name: Orlando Aponte Rosario
 given_name: Orlando
 family_name: Aponte Rosario
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/736/Aponte%20Rosario.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '26'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=736
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=736

--- a/data/pr/legislature/Rafael-Bernabe-27133d78-0b35-4578-b4a5-6c324353000d.yml
+++ b/data/pr/legislature/Rafael-Bernabe-27133d78-0b35-4578-b4a5-6c324353000d.yml
@@ -2,6 +2,7 @@ id: ocd-person/27133d78-0b35-4578-b4a5-6c324353000d
 name: Rafael Bernabe
 given_name: Rafael
 family_name: Bernabe
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/708/Screen%20Shot%202021-08-17%20at%209.49.15%20PM.png
 party:
 - name: Movimiento Victoria Ciudadana
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: At-Large
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=708
+other_names:
+- name: Rafael Bernabe Riefkohl
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=708

--- a/data/pr/legislature/Ramon-Ruiz-Nieves-1c1195f6-af0a-438f-9e00-2b7428e73cd0.yml
+++ b/data/pr/legislature/Ramon-Ruiz-Nieves-1c1195f6-af0a-438f-9e00-2b7428e73cd0.yml
@@ -2,6 +2,7 @@ id: ocd-person/1c1195f6-af0a-438f-9e00-2b7428e73cd0
 name: "Ram\xF3n Ruiz Nieves"
 given_name: "Ram\xF3n"
 family_name: Ruiz Nieves
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/693/Screen%20Shot%202021-08-17%20at%209.41.22%20PM.png
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: V
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=693
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=693

--- a/data/pr/legislature/Rosamar-Trujillo-Plumey-e64987be-382b-4def-bea1-90a84d39360f.yml
+++ b/data/pr/legislature/Rosamar-Trujillo-Plumey-e64987be-382b-4def-bea1-90a84d39360f.yml
@@ -2,6 +2,7 @@ id: ocd-person/e64987be-382b-4def-bea1-90a84d39360f
 name: Rosamar Trujillo Plumey
 given_name: Rosamar
 family_name: Trujillo Plumey
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/696/Rosamar%20Trujillo.jpeg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VII
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=696
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=696

--- a/data/pr/legislature/Ruben-Soto-Rivera-e34ad4c3-324f-48a0-8c7c-9cc3c641d163.yml
+++ b/data/pr/legislature/Ruben-Soto-Rivera-e34ad4c3-324f-48a0-8c7c-9cc3c641d163.yml
@@ -2,6 +2,7 @@ id: ocd-person/e34ad4c3-324f-48a0-8c7c-9cc3c641d163
 name: "Rub\xE9n Soto Rivera"
 given_name: "Rub\xE9n"
 family_name: Soto Rivera
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/689/Ruben%20Soto.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: III
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=689
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=689

--- a/data/pr/legislature/Sol-Higgins-18257138-221f-4901-89d3-948b5c914950.yml
+++ b/data/pr/legislature/Sol-Higgins-18257138-221f-4901-89d3-948b5c914950.yml
@@ -2,6 +2,7 @@ id: ocd-person/18257138-221f-4901-89d3-948b5c914950
 name: Sol Higgins
 given_name: Sol
 family_name: Higgins
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/745/Higgins%20Cuadrado.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,9 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '35'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=745
+other_names:
+- name: Sol Y. Higgins Cuadrado
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=745

--- a/data/pr/legislature/Wanda-Del-Valle-Correa-ebbc5719-4209-4c46-9ae5-19f0753e1259.yml
+++ b/data/pr/legislature/Wanda-Del-Valle-Correa-ebbc5719-4209-4c46-9ae5-19f0753e1259.yml
@@ -2,6 +2,7 @@ id: ocd-person/ebbc5719-4209-4c46-9ae5-19f0753e1259
 name: Wanda Del Valle Correa
 given_name: Wanda
 family_name: Del Valle Correa
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/748/del%20Valle%20Correa.jpg
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '38'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=748
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=748

--- a/data/pr/legislature/Wanda-Soto-7b837260-0288-4b92-823e-1c07dc2f49d3.yml
+++ b/data/pr/legislature/Wanda-Soto-7b837260-0288-4b92-823e-1c07dc2f49d3.yml
@@ -2,6 +2,7 @@ id: ocd-person/7b837260-0288-4b92-823e-1c07dc2f49d3
 name: Wanda Soto
 given_name: Wanda
 family_name: Soto
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/697/Screen%20Shot%202021-08-17%20at%209.35.15%20PM.png
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,9 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: VII
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=697
+other_names:
+- name: Wanda Soto Tolentino
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=697

--- a/data/pr/legislature/William-Villafae-Ramos-115b8adb-d51e-459f-85c1-bc71f0ffa95a.yml
+++ b/data/pr/legislature/William-Villafae-Ramos-115b8adb-d51e-459f-85c1-bc71f0ffa95a.yml
@@ -2,6 +2,7 @@ id: ocd-person/115b8adb-d51e-459f-85c1-bc71f0ffa95a
 name: "William Villafa\xF1e Ramos"
 given_name: William
 family_name: "Villafa\xF1e Ramos"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/703/Screen%20Shot%202021-08-17%20at%209.46.37%20PM.png
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -11,3 +12,7 @@ roles:
   district: At-Large
 other_names:
 - name: "William E. Villafa\xF1e Ramos"
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=703
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=703

--- a/data/pr/legislature/Yazzer-Morales-Daz-42788383-8253-4e73-95da-134b911edc69.yml
+++ b/data/pr/legislature/Yazzer-Morales-Daz-42788383-8253-4e73-95da-134b911edc69.yml
@@ -2,6 +2,7 @@ id: ocd-person/42788383-8253-4e73-95da-134b911edc69
 name: "Yazzer Morales D\xEDaz"
 given_name: Yazzer
 family_name: "Morales D\xEDaz"
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/719/Morales%20Diaz.jpg
 party:
 - name: Partido Nuevo Progresista
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '9'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=719
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=719

--- a/data/pr/legislature/ngel-Fourquet-Cordero-4c98369a-5291-4b17-90da-e967d5d92657.yml
+++ b/data/pr/legislature/ngel-Fourquet-Cordero-4c98369a-5291-4b17-90da-e967d5d92657.yml
@@ -2,6 +2,7 @@ id: ocd-person/4c98369a-5291-4b17-90da-e967d5d92657
 name: "\xC1ngel Fourquet Cordero"
 given_name: "\xC1ngel"
 family_name: Fourquet Cordero
+image: https://sutra.oslpr.org/osl/SUTRA/foto_legislador/2021/734/Fourquet%20Cordero.jpg
 party:
 - name: "Partido Popular Democr\xE1tico"
 roles:
@@ -9,3 +10,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/territory:pr/government
   district: '24'
+links:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=734
+sources:
+- url: https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=734


### PR DESCRIPTION
Added Puerto Rico image URLs to the current legislators that didn't have one.

Additionally, while adding the images I came across 2 legislators with names that needed to be corrected. I applied the corrections, but didn't want to rename the files to match the new names as I wasn't aware of the impact this would have. Please let me know how to handle correcting the filenames and I can make the appropriate changes.

### Name Correction Details

1. Lisie Janet Burgos Muñiz

    - Detail:
Previous name used was misspelled "Lislie".

    - Sources:
https://www.camara.pr.gov/team/lisie-j-burgos-muniz/
https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=754

2. Héctor E. Ferrer Santiago

    - Detail:
Based on my research, this is using the name of the retired legislator "Héctor Ferrer Ríos", who was in the Puerto Rico House of Representatives until 2012. "Héctor E. Ferrer Santiago" has been a member of the Puerto Rico House of Representatives since 2021 and is also the son of "Héctor Ferrer Ríos".

    - Sources:
https://www.elvocero.com/politica/caras-nuevas-en-la-legislatura-h-ctor-ferrer-santiago/article_b50c7f38-6007-11eb-8e8b-8b2754e9b51f.html
https://thehill.com/latino/415128-puerto-rico-opposition-leader-dead-at-48/
https://www.camara.pr.gov/team/hector-e-ferrer-santiago/
https://sutra.oslpr.org/osl/esutra/AdmLegisladorReg.aspx?rid=751

    - Open States person info for the retired "Héctor Ferrer Ríos":
ID: 77773388-f634-4a70-96ed-ea52e2216ccf
URL: https://openstates.org/person/hector-ferrer-rios-3dQYqZ2eLvkPOW22fLb8k3/