### PR TITLE
Removed End Date for US Legislators

### DIFF
--- a/data/us/legislature/A-Donald-McEachin-7d439728-48e9-5f41-a83d-20575fa0cb17.yml
+++ b/data/us/legislature/A-Donald-McEachin-7d439728-48e9-5f41-a83d-20575fa0cb17.yml
@@ -8,7 +8,6 @@ birth_date: 1961-10-10
 image: https://theunitedstates.io/images/congress/450x550/M001200.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-4

--- a/data/us/legislature/A-Drew-Ferguson-IV-cf441c62-91b4-52f5-b9c7-04a45290e5e4.yml
+++ b/data/us/legislature/A-Drew-Ferguson-IV-cf441c62-91b4-52f5-b9c7-04a45290e5e4.yml
@@ -8,7 +8,6 @@ birth_date: 1966-11-15
 image: https://theunitedstates.io/images/congress/450x550/F000465.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-3

--- a/data/us/legislature/Abigail-Davis-Spanberger-d1b6eea9-e526-593d-b87a-0e926c3f2303.yml
+++ b/data/us/legislature/Abigail-Davis-Spanberger-d1b6eea9-e526-593d-b87a-0e926c3f2303.yml
@@ -8,7 +8,6 @@ birth_date: 1979-08-07
 image: https://theunitedstates.io/images/congress/450x550/S001209.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-7

--- a/data/us/legislature/Adam-B-Schiff-c5a3238c-f36a-5b17-af62-ca6dcce0b91d.yml
+++ b/data/us/legislature/Adam-B-Schiff-c5a3238c-f36a-5b17-af62-ca6dcce0b91d.yml
@@ -8,7 +8,6 @@ birth_date: 1960-06-22
 image: https://theunitedstates.io/images/congress/450x550/S001150.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2001-01-03'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-28
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-28

--- a/data/us/legislature/Adam-Kinzinger-4dc33caf-d49e-5f18-82d8-1aa2ce32d2a1.yml
+++ b/data/us/legislature/Adam-Kinzinger-4dc33caf-d49e-5f18-82d8-1aa2ce32d2a1.yml
@@ -7,7 +7,6 @@ birth_date: 1978-02-27
 image: https://theunitedstates.io/images/congress/450x550/K000378.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-16

--- a/data/us/legislature/Adam-Smith-55a28978-7661-5a33-a2be-a505a07e2a8e.yml
+++ b/data/us/legislature/Adam-Smith-55a28978-7661-5a33-a2be-a505a07e2a8e.yml
@@ -7,7 +7,6 @@ birth_date: 1965-06-15
 image: https://theunitedstates.io/images/congress/450x550/S000510.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -71,7 +70,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-9

--- a/data/us/legislature/Adrian-Smith-39f36070-b860-5345-a3cc-ea7fdbf7dfb3.yml
+++ b/data/us/legislature/Adrian-Smith-39f36070-b860-5345-a3cc-ea7fdbf7dfb3.yml
@@ -7,7 +7,6 @@ birth_date: 1970-12-19
 image: https://theunitedstates.io/images/congress/450x550/S001172.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NE-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NE-3

--- a/data/us/legislature/Adriano-Espaillat-0d73f18d-36c1-526d-9d5c-5a0a63ff60af.yml
+++ b/data/us/legislature/Adriano-Espaillat-0d73f18d-36c1-526d-9d5c-5a0a63ff60af.yml
@@ -7,7 +7,6 @@ birth_date: 1954-09-27
 image: https://theunitedstates.io/images/congress/450x550/E000297.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-13

--- a/data/us/legislature/Al-Green-2ad84a53-f957-5a9c-861b-413aac608201.yml
+++ b/data/us/legislature/Al-Green-2ad84a53-f957-5a9c-861b-413aac608201.yml
@@ -7,7 +7,6 @@ birth_date: 1947-09-01
 image: https://theunitedstates.io/images/congress/450x550/G000553.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-9

--- a/data/us/legislature/Al-Lawson-Jr-7b894262-9952-532d-a34c-01e4af0df778.yml
+++ b/data/us/legislature/Al-Lawson-Jr-7b894262-9952-532d-a34c-01e4af0df778.yml
@@ -7,7 +7,6 @@ birth_date: 1948-09-23
 image: https://theunitedstates.io/images/congress/450x550/L000586.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-5

--- a/data/us/legislature/Alan-S-Lowenthal-b018dc43-fe2b-570b-b595-90814010a3ad.yml
+++ b/data/us/legislature/Alan-S-Lowenthal-b018dc43-fe2b-570b-b595-90814010a3ad.yml
@@ -8,7 +8,6 @@ birth_date: 1941-03-08
 image: https://theunitedstates.io/images/congress/450x550/L000579.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-47
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-47

--- a/data/us/legislature/Albio-Sires-c8aaae06-8aa9-5682-9fa3-6f832891e4a3.yml
+++ b/data/us/legislature/Albio-Sires-c8aaae06-8aa9-5682-9fa3-6f832891e4a3.yml
@@ -7,7 +7,6 @@ birth_date: 1951-01-26
 image: https://theunitedstates.io/images/congress/450x550/S001165.jpg
 party:
 - start_date: '2006-11-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2006-11-13'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-8

--- a/data/us/legislature/Alex-Padilla-fadd82ac-5031-5efd-ae39-1afc3f3cd6fb.yml
+++ b/data/us/legislature/Alex-Padilla-fadd82ac-5031-5efd-ae39-1afc3f3cd6fb.yml
@@ -7,7 +7,6 @@ birth_date: 1973-03-22
 image: https://theunitedstates.io/images/congress/450x550/P000145.jpg
 party:
 - start_date: '2021-01-20'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-20'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: California
 - start_date: '2022-12-22'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: California

--- a/data/us/legislature/Alexander-Mooney-1b959af6-5bbc-5e3b-855f-9a140244c31c.yml
+++ b/data/us/legislature/Alexander-Mooney-1b959af6-5bbc-5e3b-855f-9a140244c31c.yml
@@ -8,7 +8,6 @@ birth_date: 1971-06-05
 image: https://theunitedstates.io/images/congress/450x550/M001195.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-2

--- a/data/us/legislature/Alexandria-Ocasio-Cortez-d2a8d710-a781-5a40-b6f2-e46bffcf40d2.yml
+++ b/data/us/legislature/Alexandria-Ocasio-Cortez-d2a8d710-a781-5a40-b6f2-e46bffcf40d2.yml
@@ -7,7 +7,6 @@ birth_date: 1989-10-13
 image: https://theunitedstates.io/images/congress/450x550/O000172.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-14

--- a/data/us/legislature/Alma-S-Adams-76bfaf2b-8259-5f56-bce9-d1c8cd6c780d.yml
+++ b/data/us/legislature/Alma-S-Adams-76bfaf2b-8259-5f56-bce9-d1c8cd6c780d.yml
@@ -8,7 +8,6 @@ birth_date: 1946-05-27
 image: https://theunitedstates.io/images/congress/450x550/A000370.jpg
 party:
 - start_date: '2014-11-12'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2014-11-12'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-12

--- a/data/us/legislature/Ami-Bera-79c4f42e-4775-5ed0-a7e1-d0c942ce6c34.yml
+++ b/data/us/legislature/Ami-Bera-79c4f42e-4775-5ed0-a7e1-d0c942ce6c34.yml
@@ -7,7 +7,6 @@ birth_date: 1965-03-02
 image: https://theunitedstates.io/images/congress/450x550/B001287.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-7

--- a/data/us/legislature/Andr-Carson-ef4b4ed3-1808-548d-8625-2cea913c2e4a.yml
+++ b/data/us/legislature/Andr-Carson-ef4b4ed3-1808-548d-8625-2cea913c2e4a.yml
@@ -7,7 +7,6 @@ birth_date: 1974-10-16
 image: https://theunitedstates.io/images/congress/450x550/C001072.jpg
 party:
 - start_date: '2008-03-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2008-03-13'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-7

--- a/data/us/legislature/Andrew-R-Garbarino-4ec1dbc4-ea21-5f61-92b1-fa55b47a4c61.yml
+++ b/data/us/legislature/Andrew-R-Garbarino-4ec1dbc4-ea21-5f61-92b1-fa55b47a4c61.yml
@@ -8,11 +8,9 @@ birth_date: 1984-09-27
 image: https://theunitedstates.io/images/congress/450x550/G000597.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-2

--- a/data/us/legislature/Andrew-S-Clyde-0dbe5471-29ea-5c84-8270-f55fee08d118.yml
+++ b/data/us/legislature/Andrew-S-Clyde-0dbe5471-29ea-5c84-8270-f55fee08d118.yml
@@ -8,11 +8,9 @@ birth_date: 1963-11-22
 image: https://theunitedstates.io/images/congress/450x550/C001116.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-9

--- a/data/us/legislature/Andy-Barr-fe2fa2c7-83de-5bf2-b602-6ca9f7fc8a6f.yml
+++ b/data/us/legislature/Andy-Barr-fe2fa2c7-83de-5bf2-b602-6ca9f7fc8a6f.yml
@@ -7,7 +7,6 @@ birth_date: 1973-07-24
 image: https://theunitedstates.io/images/congress/450x550/B001282.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-6

--- a/data/us/legislature/Andy-Biggs-86b4b077-b73b-579b-bb73-bc5a4a73719a.yml
+++ b/data/us/legislature/Andy-Biggs-86b4b077-b73b-579b-bb73-bc5a4a73719a.yml
@@ -7,7 +7,6 @@ birth_date: 1958-11-07
 image: https://theunitedstates.io/images/congress/450x550/B001302.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-5

--- a/data/us/legislature/Andy-Harris-74a68d2f-f563-50d8-80a7-408346b8ba14.yml
+++ b/data/us/legislature/Andy-Harris-74a68d2f-f563-50d8-80a7-408346b8ba14.yml
@@ -7,7 +7,6 @@ birth_date: 1957-01-25
 image: https://theunitedstates.io/images/congress/450x550/H001052.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-1

--- a/data/us/legislature/Andy-Kim-62227c11-1ad4-5395-b233-f1f526efc5b4.yml
+++ b/data/us/legislature/Andy-Kim-62227c11-1ad4-5395-b233-f1f526efc5b4.yml
@@ -7,7 +7,6 @@ birth_date: 1982-07-12
 image: https://theunitedstates.io/images/congress/450x550/K000394.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-3

--- a/data/us/legislature/Andy-Levin-91355191-67a1-518f-b6fd-f5c2542b8de2.yml
+++ b/data/us/legislature/Andy-Levin-91355191-67a1-518f-b6fd-f5c2542b8de2.yml
@@ -7,7 +7,6 @@ birth_date: 1960-08-01
 image: https://theunitedstates.io/images/congress/450x550/L000592.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-9

--- a/data/us/legislature/Angie-Craig-6b47c0e2-77d5-5126-b7a5-82bea8fb9c67.yml
+++ b/data/us/legislature/Angie-Craig-6b47c0e2-77d5-5126-b7a5-82bea8fb9c67.yml
@@ -7,7 +7,6 @@ birth_date: 1972-02-14
 image: https://theunitedstates.io/images/congress/450x550/C001119.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-2

--- a/data/us/legislature/Ann-Kirkpatrick-f24513ac-071e-5d62-b777-402b63a33bec.yml
+++ b/data/us/legislature/Ann-Kirkpatrick-f24513ac-071e-5d62-b777-402b63a33bec.yml
@@ -7,7 +7,6 @@ birth_date: 1950-03-24
 image: https://theunitedstates.io/images/congress/450x550/K000368.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-2

--- a/data/us/legislature/Ann-Kuster-7ed34023-b42f-57bc-af69-b36a680122f2.yml
+++ b/data/us/legislature/Ann-Kuster-7ed34023-b42f-57bc-af69-b36a680122f2.yml
@@ -8,7 +8,6 @@ birth_date: 1956-09-05
 image: https://theunitedstates.io/images/congress/450x550/K000382.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NH-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NH-2

--- a/data/us/legislature/Ann-Wagner-12958b9f-2301-5bdb-bf13-81b3de147574.yml
+++ b/data/us/legislature/Ann-Wagner-12958b9f-2301-5bdb-bf13-81b3de147574.yml
@@ -7,7 +7,6 @@ birth_date: 1962-09-13
 image: https://theunitedstates.io/images/congress/450x550/W000812.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-2

--- a/data/us/legislature/Anna-G-Eshoo-047b7a92-9713-54e5-8429-bcd2214908c7.yml
+++ b/data/us/legislature/Anna-G-Eshoo-047b7a92-9713-54e5-8429-bcd2214908c7.yml
@@ -8,7 +8,6 @@ birth_date: 1942-12-13
 image: https://theunitedstates.io/images/congress/450x550/E000215.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-18

--- a/data/us/legislature/Anthony-G-Brown-fd8be658-4120-5e63-9265-943f0aeef07e.yml
+++ b/data/us/legislature/Anthony-G-Brown-fd8be658-4120-5e63-9265-943f0aeef07e.yml
@@ -8,7 +8,6 @@ birth_date: 1961-11-21
 image: https://theunitedstates.io/images/congress/450x550/B001304.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-4

--- a/data/us/legislature/Anthony-Gonzalez-adc148c9-49bc-572e-a293-6299e5567474.yml
+++ b/data/us/legislature/Anthony-Gonzalez-adc148c9-49bc-572e-a293-6299e5567474.yml
@@ -7,7 +7,6 @@ birth_date: 1984-09-19
 image: https://theunitedstates.io/images/congress/450x550/G000588.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-16

--- a/data/us/legislature/Ashley-Hinson-50705d33-6967-5424-8f57-7df22ecbc6e6.yml
+++ b/data/us/legislature/Ashley-Hinson-50705d33-6967-5424-8f57-7df22ecbc6e6.yml
@@ -7,11 +7,9 @@ birth_date: 1983-06-27
 image: https://theunitedstates.io/images/congress/450x550/H001091.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IA-1

--- a/data/us/legislature/August-Pfluger-2519c079-f97e-532b-b53e-167398fd7398.yml
+++ b/data/us/legislature/August-Pfluger-2519c079-f97e-532b-b53e-167398fd7398.yml
@@ -8,11 +8,9 @@ birth_date: 1978-12-28
 image: https://theunitedstates.io/images/congress/450x550/P000048.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-11

--- a/data/us/legislature/Aumua-Amata-Coleman-Radewagen-eb3fa86b-690c-5cc0-8f5e-54af60f28a06.yml
+++ b/data/us/legislature/Aumua-Amata-Coleman-Radewagen-eb3fa86b-690c-5cc0-8f5e-54af60f28a06.yml
@@ -8,7 +8,6 @@ birth_date: 1947-12-29
 image: https://theunitedstates.io/images/congress/450x550/R000600.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AS-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AS-AL

--- a/data/us/legislature/Austin-Scott-20c33933-79f5-58d1-834c-60779932257e.yml
+++ b/data/us/legislature/Austin-Scott-20c33933-79f5-58d1-834c-60779932257e.yml
@@ -7,7 +7,6 @@ birth_date: 1969-12-10
 image: https://theunitedstates.io/images/congress/450x550/S001189.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-8

--- a/data/us/legislature/Ayanna-Pressley-ab80da0d-902f-5d28-b765-1885853182bd.yml
+++ b/data/us/legislature/Ayanna-Pressley-ab80da0d-902f-5d28-b765-1885853182bd.yml
@@ -7,7 +7,6 @@ birth_date: 1974-02-03
 image: https://theunitedstates.io/images/congress/450x550/P000617.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-7

--- a/data/us/legislature/Barbara-Lee-3cbc3ca2-4447-50e2-abed-ba3fe86569d8.yml
+++ b/data/us/legislature/Barbara-Lee-3cbc3ca2-4447-50e2-abed-ba3fe86569d8.yml
@@ -7,7 +7,6 @@ birth_date: 1946-07-16
 image: https://theunitedstates.io/images/congress/450x550/L000551.jpg
 party:
 - start_date: '1998-04-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1998-04-07'
@@ -71,7 +70,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-13

--- a/data/us/legislature/Barry-Loudermilk-13e07344-3cec-5f29-a27b-2dd6979dbeb5.yml
+++ b/data/us/legislature/Barry-Loudermilk-13e07344-3cec-5f29-a27b-2dd6979dbeb5.yml
@@ -7,7 +7,6 @@ birth_date: 1963-12-22
 image: https://theunitedstates.io/images/congress/450x550/L000583.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-11

--- a/data/us/legislature/Barry-Moore-b242258c-669a-53a7-be30-5f529f03398e.yml
+++ b/data/us/legislature/Barry-Moore-b242258c-669a-53a7-be30-5f529f03398e.yml
@@ -7,11 +7,9 @@ birth_date: 1966-09-26
 image: https://theunitedstates.io/images/congress/450x550/M001212.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-2

--- a/data/us/legislature/Ben-Cline-bb0d60f6-19a4-5229-a67d-a1d428e7c0b2.yml
+++ b/data/us/legislature/Ben-Cline-bb0d60f6-19a4-5229-a67d-a1d428e7c0b2.yml
@@ -7,7 +7,6 @@ birth_date: 1972-02-29
 image: https://theunitedstates.io/images/congress/450x550/C001118.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-6

--- a/data/us/legislature/Bennie-G-Thompson-c171d352-db84-5c96-8260-1fcd7eab2575.yml
+++ b/data/us/legislature/Bennie-G-Thompson-c171d352-db84-5c96-8260-1fcd7eab2575.yml
@@ -8,7 +8,6 @@ birth_date: 1948-01-28
 image: https://theunitedstates.io/images/congress/450x550/T000193.jpg
 party:
 - start_date: '1993-04-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-04-13'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-2

--- a/data/us/legislature/Beth-Van-Duyne-861bd195-d8aa-5e72-9699-4f5ad3d5e499.yml
+++ b/data/us/legislature/Beth-Van-Duyne-861bd195-d8aa-5e72-9699-4f5ad3d5e499.yml
@@ -8,11 +8,9 @@ birth_date: 1970-11-16
 image: https://theunitedstates.io/images/congress/450x550/V000134.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-24

--- a/data/us/legislature/Betty-McCollum-61c4224a-c1d6-5739-bca6-0db7e58d84bd.yml
+++ b/data/us/legislature/Betty-McCollum-61c4224a-c1d6-5739-bca6-0db7e58d84bd.yml
@@ -8,7 +8,6 @@ birth_date: 1954-07-12
 image: https://theunitedstates.io/images/congress/450x550/M001143.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2001-01-03'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-4

--- a/data/us/legislature/Bill-Foster-a512ad2f-4554-5b04-a00b-1de672f9099a.yml
+++ b/data/us/legislature/Bill-Foster-a512ad2f-4554-5b04-a00b-1de672f9099a.yml
@@ -7,7 +7,6 @@ birth_date: 1955-10-07
 image: https://theunitedstates.io/images/congress/450x550/F000454.jpg
 party:
 - start_date: '2008-03-08'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2008-03-08'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-11

--- a/data/us/legislature/Bill-Huizenga-ce06af2e-4591-560d-8f14-8f1817c9ad1f.yml
+++ b/data/us/legislature/Bill-Huizenga-ce06af2e-4591-560d-8f14-8f1817c9ad1f.yml
@@ -7,7 +7,6 @@ birth_date: 1969-01-31
 image: https://theunitedstates.io/images/congress/450x550/H001058.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-2

--- a/data/us/legislature/Bill-Johnson-37280554-1674-5b92-8eb1-1be9fe1e76ae.yml
+++ b/data/us/legislature/Bill-Johnson-37280554-1674-5b92-8eb1-1be9fe1e76ae.yml
@@ -7,7 +7,6 @@ birth_date: 1954-11-10
 image: https://theunitedstates.io/images/congress/450x550/J000292.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-6

--- a/data/us/legislature/Bill-Pascrell-Jr-bff03292-2b2c-55fc-aa20-83dce2fccd77.yml
+++ b/data/us/legislature/Bill-Pascrell-Jr-bff03292-2b2c-55fc-aa20-83dce2fccd77.yml
@@ -8,7 +8,6 @@ birth_date: 1937-01-25
 image: https://theunitedstates.io/images/congress/450x550/P000096.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-9

--- a/data/us/legislature/Bill-Posey-40abdb56-d1b4-54a3-bc53-b586f8c06ac3.yml
+++ b/data/us/legislature/Bill-Posey-40abdb56-d1b4-54a3-bc53-b586f8c06ac3.yml
@@ -7,7 +7,6 @@ birth_date: 1947-12-18
 image: https://theunitedstates.io/images/congress/450x550/P000599.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-8

--- a/data/us/legislature/Billy-Long-7eee4b78-acdf-5932-a01f-bd432694f644.yml
+++ b/data/us/legislature/Billy-Long-7eee4b78-acdf-5932-a01f-bd432694f644.yml
@@ -7,7 +7,6 @@ birth_date: 1955-08-11
 image: https://theunitedstates.io/images/congress/450x550/L000576.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-7

--- a/data/us/legislature/Blaine-Luetkemeyer-686325e7-8dc3-587d-9ee1-e0ad14202350.yml
+++ b/data/us/legislature/Blaine-Luetkemeyer-686325e7-8dc3-587d-9ee1-e0ad14202350.yml
@@ -7,7 +7,6 @@ birth_date: 1952-05-07
 image: https://theunitedstates.io/images/congress/450x550/L000569.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-3

--- a/data/us/legislature/Blake-D-Moore-3854aa11-1cec-58f6-8e90-c721a0db3525.yml
+++ b/data/us/legislature/Blake-D-Moore-3854aa11-1cec-58f6-8e90-c721a0db3525.yml
@@ -8,11 +8,9 @@ birth_date: 1980-06-22
 image: https://theunitedstates.io/images/congress/450x550/M001213.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-1

--- a/data/us/legislature/Bob-Gibbs-45130241-d84a-5d2d-a1a6-9cd4bc07a51f.yml
+++ b/data/us/legislature/Bob-Gibbs-45130241-d84a-5d2d-a1a6-9cd4bc07a51f.yml
@@ -7,7 +7,6 @@ birth_date: 1954-06-14
 image: https://theunitedstates.io/images/congress/450x550/G000563.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-7

--- a/data/us/legislature/Bob-Good-e53e5a13-c82a-5208-96d0-f6769c0d8a67.yml
+++ b/data/us/legislature/Bob-Good-e53e5a13-c82a-5208-96d0-f6769c0d8a67.yml
@@ -8,11 +8,9 @@ birth_date: 1965-09-11
 image: https://theunitedstates.io/images/congress/450x550/G000595.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-5

--- a/data/us/legislature/Bobby-L-Rush-00985f6e-89fd-599f-8b94-4308e35c8170.yml
+++ b/data/us/legislature/Bobby-L-Rush-00985f6e-89fd-599f-8b94-4308e35c8170.yml
@@ -8,7 +8,6 @@ birth_date: 1946-11-23
 image: https://theunitedstates.io/images/congress/450x550/R000515.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-1

--- a/data/us/legislature/Bonnie-Watson-Coleman-ff55ab02-9d61-544c-8f4d-710a09d8f5db.yml
+++ b/data/us/legislature/Bonnie-Watson-Coleman-ff55ab02-9d61-544c-8f4d-710a09d8f5db.yml
@@ -7,7 +7,6 @@ birth_date: 1945-02-06
 image: https://theunitedstates.io/images/congress/450x550/W000822.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-12

--- a/data/us/legislature/Brad-Finstad-bc26b71a-566f-57fd-9d5b-23bc27e4c4a4.yml
+++ b/data/us/legislature/Brad-Finstad-bc26b71a-566f-57fd-9d5b-23bc27e4c4a4.yml
@@ -7,11 +7,9 @@ birth_date: 1976-05-30
 image: https://theunitedstates.io/images/congress/450x550/F000475.jpg
 party:
 - start_date: '2022-08-12'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-08-12'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-1

--- a/data/us/legislature/Brad-R-Wenstrup-717ac307-3248-5726-bdcf-de58d683943f.yml
+++ b/data/us/legislature/Brad-R-Wenstrup-717ac307-3248-5726-bdcf-de58d683943f.yml
@@ -8,7 +8,6 @@ birth_date: 1958-06-17
 image: https://theunitedstates.io/images/congress/450x550/W000815.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-2

--- a/data/us/legislature/Brad-Sherman-4015098b-d823-5776-9b47-ceb09bf523a9.yml
+++ b/data/us/legislature/Brad-Sherman-4015098b-d823-5776-9b47-ceb09bf523a9.yml
@@ -8,7 +8,6 @@ birth_date: 1954-10-24
 image: https://theunitedstates.io/images/congress/450x550/S000344.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-30
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-30

--- a/data/us/legislature/Bradley-Scott-Schneider-a3c68bbd-f241-52c8-a7e9-7f340f316b7a.yml
+++ b/data/us/legislature/Bradley-Scott-Schneider-a3c68bbd-f241-52c8-a7e9-7f340f316b7a.yml
@@ -8,7 +8,6 @@ birth_date: 1961-08-20
 image: https://theunitedstates.io/images/congress/450x550/S001190.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-10

--- a/data/us/legislature/Brenda-L-Lawrence-adffb29a-765e-5429-93b9-d5a06d157621.yml
+++ b/data/us/legislature/Brenda-L-Lawrence-adffb29a-765e-5429-93b9-d5a06d157621.yml
@@ -8,7 +8,6 @@ birth_date: 1954-10-18
 image: https://theunitedstates.io/images/congress/450x550/L000581.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-14

--- a/data/us/legislature/Brendan-F-Boyle-d1509871-89c0-5f39-bc3d-b55e444e3909.yml
+++ b/data/us/legislature/Brendan-F-Boyle-d1509871-89c0-5f39-bc3d-b55e444e3909.yml
@@ -8,7 +8,6 @@ birth_date: 1977-02-06
 image: https://theunitedstates.io/images/congress/450x550/B001296.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-2

--- a/data/us/legislature/Brett-Guthrie-a7ba76d3-828f-52bd-9b30-cdbacf0af2b8.yml
+++ b/data/us/legislature/Brett-Guthrie-a7ba76d3-828f-52bd-9b30-cdbacf0af2b8.yml
@@ -7,7 +7,6 @@ birth_date: 1964-02-18
 image: https://theunitedstates.io/images/congress/450x550/G000558.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-2

--- a/data/us/legislature/Brian-Babin-e1f14f02-810c-52c5-8ad5-b2744b95a069.yml
+++ b/data/us/legislature/Brian-Babin-e1f14f02-810c-52c5-8ad5-b2744b95a069.yml
@@ -7,7 +7,6 @@ birth_date: 1948-03-23
 image: https://theunitedstates.io/images/congress/450x550/B001291.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-36
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-36

--- a/data/us/legislature/Brian-Higgins-1c58a989-8724-597e-8572-658594d14181.yml
+++ b/data/us/legislature/Brian-Higgins-1c58a989-8724-597e-8572-658594d14181.yml
@@ -8,7 +8,6 @@ birth_date: 1959-10-06
 image: https://theunitedstates.io/images/congress/450x550/H001038.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-26
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-26

--- a/data/us/legislature/Brian-J-Mast-e7b50abf-92e8-56f1-a5f7-7db9a63fb43f.yml
+++ b/data/us/legislature/Brian-J-Mast-e7b50abf-92e8-56f1-a5f7-7db9a63fb43f.yml
@@ -8,7 +8,6 @@ birth_date: 1980-07-10
 image: https://theunitedstates.io/images/congress/450x550/M001199.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-18

--- a/data/us/legislature/Brian-K-Fitzpatrick-a6a4c673-58ba-587b-b36b-7a559c379f23.yml
+++ b/data/us/legislature/Brian-K-Fitzpatrick-a6a4c673-58ba-587b-b36b-7a559c379f23.yml
@@ -8,7 +8,6 @@ birth_date: 1973-12-17
 image: https://theunitedstates.io/images/congress/450x550/F000466.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-1

--- a/data/us/legislature/Brian-Schatz-bd24fe60-5756-5d23-bcbf-4734f366c257.yml
+++ b/data/us/legislature/Brian-Schatz-bd24fe60-5756-5d23-bcbf-4734f366c257.yml
@@ -8,7 +8,6 @@ birth_date: 1972-10-20
 image: https://theunitedstates.io/images/congress/450x550/S001194.jpg
 party:
 - start_date: '2012-12-27'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2012-12-27'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Hawaii
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Hawaii

--- a/data/us/legislature/Bruce-Westerman-c46204bc-8484-585e-91de-6053bd3c3cbc.yml
+++ b/data/us/legislature/Bruce-Westerman-c46204bc-8484-585e-91de-6053bd3c3cbc.yml
@@ -7,7 +7,6 @@ birth_date: 1967-11-18
 image: https://theunitedstates.io/images/congress/450x550/W000821.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-4

--- a/data/us/legislature/Bryan-Steil-3203c6f1-12ea-59aa-aeb4-9faa94e04f17.yml
+++ b/data/us/legislature/Bryan-Steil-3203c6f1-12ea-59aa-aeb4-9faa94e04f17.yml
@@ -7,7 +7,6 @@ birth_date: 1981-03-30
 image: https://theunitedstates.io/images/congress/450x550/S001213.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-1

--- a/data/us/legislature/Burgess-Owens-f5c47b2f-8eb9-51f9-b403-d41b5bdcd229.yml
+++ b/data/us/legislature/Burgess-Owens-f5c47b2f-8eb9-51f9-b403-d41b5bdcd229.yml
@@ -7,11 +7,9 @@ birth_date: 1951-08-02
 image: https://theunitedstates.io/images/congress/450x550/O000086.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-4

--- a/data/us/legislature/Byron-Donalds-c281df65-bcd6-5f42-860c-874e38bcd03a.yml
+++ b/data/us/legislature/Byron-Donalds-c281df65-bcd6-5f42-860c-874e38bcd03a.yml
@@ -8,11 +8,9 @@ birth_date: 1978-10-28
 image: https://theunitedstates.io/images/congress/450x550/D000032.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-19

--- a/data/us/legislature/C-A-Dutch-Ruppersberger-6badec3f-9e2b-5f2c-8683-dd8a7ae87d9f.yml
+++ b/data/us/legislature/C-A-Dutch-Ruppersberger-6badec3f-9e2b-5f2c-8683-dd8a7ae87d9f.yml
@@ -8,7 +8,6 @@ birth_date: 1946-01-31
 image: https://theunitedstates.io/images/congress/450x550/R000576.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-2

--- a/data/us/legislature/C-Scott-Franklin-04fde057-6aef-56ae-9baa-b1450d74ab09.yml
+++ b/data/us/legislature/C-Scott-Franklin-04fde057-6aef-56ae-9baa-b1450d74ab09.yml
@@ -8,11 +8,9 @@ birth_date: 1964-08-23
 image: https://theunitedstates.io/images/congress/450x550/F000472.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-15

--- a/data/us/legislature/Carlos-A-Gimenez-9db37a87-2ba9-56a0-9b42-89697222e044.yml
+++ b/data/us/legislature/Carlos-A-Gimenez-9db37a87-2ba9-56a0-9b42-89697222e044.yml
@@ -8,11 +8,9 @@ birth_date: 1954-01-17
 image: https://theunitedstates.io/images/congress/450x550/G000593.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-26

--- a/data/us/legislature/Carol-D-Miller-1ad151d2-5d26-5421-9b6f-a87d4a05396f.yml
+++ b/data/us/legislature/Carol-D-Miller-1ad151d2-5d26-5421-9b6f-a87d4a05396f.yml
@@ -8,7 +8,6 @@ birth_date: 1950-11-04
 image: https://theunitedstates.io/images/congress/450x550/M001205.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-3

--- a/data/us/legislature/Carolyn-B-Maloney-7be08a18-827d-512e-b56b-414bf4531a22.yml
+++ b/data/us/legislature/Carolyn-B-Maloney-7be08a18-827d-512e-b56b-414bf4531a22.yml
@@ -8,7 +8,6 @@ birth_date: 1946-02-19
 image: https://theunitedstates.io/images/congress/450x550/M000087.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-12

--- a/data/us/legislature/Carolyn-Bourdeaux-6a19876c-af4b-58c4-8583-34a32d4e2413.yml
+++ b/data/us/legislature/Carolyn-Bourdeaux-6a19876c-af4b-58c4-8583-34a32d4e2413.yml
@@ -7,11 +7,9 @@ birth_date: 1970-06-03
 image: https://theunitedstates.io/images/congress/450x550/B001312.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-7

--- a/data/us/legislature/Catherine-Cortez-Masto-00bdfb60-1b6f-5a4a-9157-b7cafc399c46.yml
+++ b/data/us/legislature/Catherine-Cortez-Masto-00bdfb60-1b6f-5a4a-9157-b7cafc399c46.yml
@@ -7,11 +7,9 @@ birth_date: 1964-03-29
 image: https://theunitedstates.io/images/congress/450x550/C001113.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Nevada

--- a/data/us/legislature/Cathy-McMorris-Rodgers-b420935f-8662-5012-ab5a-befcdc9e39f2.yml
+++ b/data/us/legislature/Cathy-McMorris-Rodgers-b420935f-8662-5012-ab5a-befcdc9e39f2.yml
@@ -8,7 +8,6 @@ birth_date: 1969-05-22
 image: https://theunitedstates.io/images/congress/450x550/M001159.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2005-01-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-5

--- a/data/us/legislature/Charles-E-Schumer-ced62f94-88a6-5a4b-b470-89cf1ee4bdac.yml
+++ b/data/us/legislature/Charles-E-Schumer-ced62f94-88a6-5a4b-b470-89cf1ee4bdac.yml
@@ -8,7 +8,6 @@ birth_date: 1950-11-23
 image: https://theunitedstates.io/images/congress/450x550/S000148.jpg
 party:
 - start_date: '1981-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1981-01-05'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: New York
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: New York

--- a/data/us/legislature/Charles-J-Chuck-Fleischmann-640abb7e-8890-59bc-b5cb-b21c88288657.yml
+++ b/data/us/legislature/Charles-J-Chuck-Fleischmann-640abb7e-8890-59bc-b5cb-b21c88288657.yml
@@ -8,7 +8,6 @@ birth_date: 1962-10-11
 image: https://theunitedstates.io/images/congress/450x550/F000459.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-3

--- a/data/us/legislature/Charlie-Crist-0d0f3918-9287-5993-bc2d-5fbec60a3a4a.yml
+++ b/data/us/legislature/Charlie-Crist-0d0f3918-9287-5993-bc2d-5fbec60a3a4a.yml
@@ -7,7 +7,6 @@ birth_date: 1956-07-24
 image: https://theunitedstates.io/images/congress/450x550/C001111.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-13

--- a/data/us/legislature/Chellie-Pingree-78a440e5-f314-5f5b-930b-48ab822bb39a.yml
+++ b/data/us/legislature/Chellie-Pingree-78a440e5-f314-5f5b-930b-48ab822bb39a.yml
@@ -7,7 +7,6 @@ birth_date: 1955-04-02
 image: https://theunitedstates.io/images/congress/450x550/P000597.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ME-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ME-1

--- a/data/us/legislature/Cheri-Bustos-0f2a5b9d-88d0-5520-8a12-48a66284de75.yml
+++ b/data/us/legislature/Cheri-Bustos-0f2a5b9d-88d0-5520-8a12-48a66284de75.yml
@@ -7,7 +7,6 @@ birth_date: 1961-10-17
 image: https://theunitedstates.io/images/congress/450x550/B001286.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-17
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-17

--- a/data/us/legislature/Chip-Roy-2398f81d-6371-544d-a7ff-24cf993a716b.yml
+++ b/data/us/legislature/Chip-Roy-2398f81d-6371-544d-a7ff-24cf993a716b.yml
@@ -7,7 +7,6 @@ birth_date: 1972-08-07
 image: https://theunitedstates.io/images/congress/450x550/R000614.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-21
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-21

--- a/data/us/legislature/Chris-Jacobs-f81e3ecb-84b4-56c3-b2a7-4f0837d998ad.yml
+++ b/data/us/legislature/Chris-Jacobs-f81e3ecb-84b4-56c3-b2a7-4f0837d998ad.yml
@@ -7,7 +7,6 @@ birth_date: 1966-11-28
 image: https://theunitedstates.io/images/congress/450x550/J000020.jpg
 party:
 - start_date: '2020-07-21'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2020-07-21'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-27
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-27

--- a/data/us/legislature/Chris-Pappas-22a8725b-acc8-530a-9a57-6b0a7f750fca.yml
+++ b/data/us/legislature/Chris-Pappas-22a8725b-acc8-530a-9a57-6b0a7f750fca.yml
@@ -7,7 +7,6 @@ birth_date: 1980-06-04
 image: https://theunitedstates.io/images/congress/450x550/P000614.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NH-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NH-1

--- a/data/us/legislature/Chris-Stewart-b6e7b90c-6380-561a-8416-ea7aed9fd8c5.yml
+++ b/data/us/legislature/Chris-Stewart-b6e7b90c-6380-561a-8416-ea7aed9fd8c5.yml
@@ -7,7 +7,6 @@ birth_date: 1960-07-15
 image: https://theunitedstates.io/images/congress/450x550/S001192.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-2

--- a/data/us/legislature/Chris-Van-Hollen-6b768c01-2e7d-5316-9ece-d5e215648f85.yml
+++ b/data/us/legislature/Chris-Van-Hollen-6b768c01-2e7d-5316-9ece-d5e215648f85.yml
@@ -7,7 +7,6 @@ birth_date: 1959-01-10
 image: https://theunitedstates.io/images/congress/450x550/V000128.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-8
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Maryland

--- a/data/us/legislature/Chrissy-Houlahan-04b67b59-b46f-5db7-96e3-a78591cf0734.yml
+++ b/data/us/legislature/Chrissy-Houlahan-04b67b59-b46f-5db7-96e3-a78591cf0734.yml
@@ -7,7 +7,6 @@ birth_date: 1967-06-05
 image: https://theunitedstates.io/images/congress/450x550/H001085.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-6

--- a/data/us/legislature/Christopher-H-Smith-84a22f15-cf83-5f0b-a048-a6fc50aa60fe.yml
+++ b/data/us/legislature/Christopher-H-Smith-84a22f15-cf83-5f0b-a048-a6fc50aa60fe.yml
@@ -8,7 +8,6 @@ birth_date: 1953-03-04
 image: https://theunitedstates.io/images/congress/450x550/S000522.jpg
 party:
 - start_date: '1981-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1981-01-05'
@@ -112,7 +111,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-4

--- a/data/us/legislature/Chuck-Grassley-259d896b-e9b5-5237-9243-f5597ae0db7c.yml
+++ b/data/us/legislature/Chuck-Grassley-259d896b-e9b5-5237-9243-f5597ae0db7c.yml
@@ -8,7 +8,6 @@ birth_date: 1933-09-17
 image: https://theunitedstates.io/images/congress/450x550/G000386.jpg
 party:
 - start_date: '1975-01-14'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1975-01-14'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Iowa
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Iowa

--- a/data/us/legislature/Claudia-Tenney-21f20fe0-1075-512d-99a6-cafcebf57d20.yml
+++ b/data/us/legislature/Claudia-Tenney-21f20fe0-1075-512d-99a6-cafcebf57d20.yml
@@ -7,7 +7,6 @@ birth_date: 1961-02-04
 image: https://theunitedstates.io/images/congress/450x550/T000478.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-22
 - start_date: '2021-02-11'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-22

--- a/data/us/legislature/Clay-Higgins-ffc5bfa2-67c8-5743-afa6-3250b0752485.yml
+++ b/data/us/legislature/Clay-Higgins-ffc5bfa2-67c8-5743-afa6-3250b0752485.yml
@@ -7,7 +7,6 @@ birth_date: 1961-08-24
 image: https://theunitedstates.io/images/congress/450x550/H001077.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-3

--- a/data/us/legislature/Cliff-Bentz-dd9d3668-b18a-5102-8628-7f2972350402.yml
+++ b/data/us/legislature/Cliff-Bentz-dd9d3668-b18a-5102-8628-7f2972350402.yml
@@ -8,11 +8,9 @@ birth_date: 1952-01-12
 image: https://theunitedstates.io/images/congress/450x550/B000668.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-2

--- a/data/us/legislature/Colin-Z-Allred-45574c8a-7f88-525b-b5b8-255a8d69f335.yml
+++ b/data/us/legislature/Colin-Z-Allred-45574c8a-7f88-525b-b5b8-255a8d69f335.yml
@@ -8,7 +8,6 @@ birth_date: 1983-04-15
 image: https://theunitedstates.io/images/congress/450x550/A000376.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-32
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-32

--- a/data/us/legislature/Connie-Conway-02333a0f-14ca-555d-9c43-a573e40661dc.yml
+++ b/data/us/legislature/Connie-Conway-02333a0f-14ca-555d-9c43-a573e40661dc.yml
@@ -7,11 +7,9 @@ birth_date: 1950-09-25
 image: https://theunitedstates.io/images/congress/450x550/C001128.jpg
 party:
 - start_date: '2022-06-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-06-07'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-22

--- a/data/us/legislature/Conor-Lamb-efc4890a-e0da-5a47-a44d-39145b7d5903.yml
+++ b/data/us/legislature/Conor-Lamb-efc4890a-e0da-5a47-a44d-39145b7d5903.yml
@@ -7,7 +7,6 @@ birth_date: 1984-06-27
 image: https://theunitedstates.io/images/congress/450x550/L000588.jpg
 party:
 - start_date: '2018-04-12'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2018-04-12'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-17
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-17

--- a/data/us/legislature/Cori-Bush-adba4aa8-0d6a-5a7f-9a71-d1a9f9c5e1a0.yml
+++ b/data/us/legislature/Cori-Bush-adba4aa8-0d6a-5a7f-9a71-d1a9f9c5e1a0.yml
@@ -7,11 +7,9 @@ birth_date: 1976-07-21
 image: https://theunitedstates.io/images/congress/450x550/B001224.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-1

--- a/data/us/legislature/Cynthia-Axne-0101c54f-6aaa-5f63-a627-05f7296a087d.yml
+++ b/data/us/legislature/Cynthia-Axne-0101c54f-6aaa-5f63-a627-05f7296a087d.yml
@@ -7,7 +7,6 @@ birth_date: 1965-04-20
 image: https://theunitedstates.io/images/congress/450x550/A000378.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IA-3

--- a/data/us/legislature/Dan-Bishop-ff2f62f3-ccac-57d0-bcad-47a3bfeacb79.yml
+++ b/data/us/legislature/Dan-Bishop-ff2f62f3-ccac-57d0-bcad-47a3bfeacb79.yml
@@ -7,7 +7,6 @@ birth_date: 1964-07-01
 image: https://theunitedstates.io/images/congress/450x550/B001311.jpg
 party:
 - start_date: '2019-09-17'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-09-17'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-9

--- a/data/us/legislature/Dan-Crenshaw-6e2bcde3-a1f5-5296-9f9f-88c71885f3db.yml
+++ b/data/us/legislature/Dan-Crenshaw-6e2bcde3-a1f5-5296-9f9f-88c71885f3db.yml
@@ -7,7 +7,6 @@ birth_date: 1984-03-14
 image: https://theunitedstates.io/images/congress/450x550/C001120.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-2

--- a/data/us/legislature/Dan-Newhouse-c2de8671-10f6-5eb3-8624-a9fd877464b5.yml
+++ b/data/us/legislature/Dan-Newhouse-c2de8671-10f6-5eb3-8624-a9fd877464b5.yml
@@ -7,7 +7,6 @@ birth_date: 1955-07-10
 image: https://theunitedstates.io/images/congress/450x550/N000189.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-4

--- a/data/us/legislature/Daniel-Meuser-df0edff1-f76c-5916-b28e-f70338b23a7a.yml
+++ b/data/us/legislature/Daniel-Meuser-df0edff1-f76c-5916-b28e-f70338b23a7a.yml
@@ -7,7 +7,6 @@ birth_date: 1964-02-10
 image: https://theunitedstates.io/images/congress/450x550/M001204.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-9

--- a/data/us/legislature/Daniel-T-Kildee-ba55e5b8-ac4e-5ea8-b7a8-d180e10a3562.yml
+++ b/data/us/legislature/Daniel-T-Kildee-ba55e5b8-ac4e-5ea8-b7a8-d180e10a3562.yml
@@ -8,7 +8,6 @@ birth_date: 1958-08-11
 image: https://theunitedstates.io/images/congress/450x550/K000380.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-5

--- a/data/us/legislature/Daniel-Webster-04db1dc5-1903-5913-a439-fed236ff85a3.yml
+++ b/data/us/legislature/Daniel-Webster-04db1dc5-1903-5913-a439-fed236ff85a3.yml
@@ -7,7 +7,6 @@ birth_date: 1949-04-27
 image: https://theunitedstates.io/images/congress/450x550/W000806.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-11

--- a/data/us/legislature/Danny-K-Davis-a494987e-6674-5df8-a8b2-de4b5a99de86.yml
+++ b/data/us/legislature/Danny-K-Davis-a494987e-6674-5df8-a8b2-de4b5a99de86.yml
@@ -8,7 +8,6 @@ birth_date: 1941-09-06
 image: https://theunitedstates.io/images/congress/450x550/D000096.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-7

--- a/data/us/legislature/Darin-LaHood-a7bc3999-648e-58ed-b606-f387e825427c.yml
+++ b/data/us/legislature/Darin-LaHood-a7bc3999-648e-58ed-b606-f387e825427c.yml
@@ -7,7 +7,6 @@ birth_date: 1968-07-05
 image: https://theunitedstates.io/images/congress/450x550/L000585.jpg
 party:
 - start_date: '2015-09-17'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-09-17'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-18

--- a/data/us/legislature/Darrell-Issa-15e5e4c2-568f-55b4-9aa2-54797027c984.yml
+++ b/data/us/legislature/Darrell-Issa-15e5e4c2-568f-55b4-9aa2-54797027c984.yml
@@ -8,7 +8,6 @@ birth_date: 1953-11-01
 image: https://theunitedstates.io/images/congress/450x550/I000056.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2001-01-03'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-49
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-50

--- a/data/us/legislature/Darren-Soto-ef44884b-f8bf-542b-b1ae-f36c7cf8e962.yml
+++ b/data/us/legislature/Darren-Soto-ef44884b-f8bf-542b-b1ae-f36c7cf8e962.yml
@@ -7,7 +7,6 @@ birth_date: 1978-02-25
 image: https://theunitedstates.io/images/congress/450x550/S001200.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-9

--- a/data/us/legislature/David-B-McKinley-211b3ee9-48b9-57c0-8715-12ea047484fc.yml
+++ b/data/us/legislature/David-B-McKinley-211b3ee9-48b9-57c0-8715-12ea047484fc.yml
@@ -8,7 +8,6 @@ birth_date: 1947-03-28
 image: https://theunitedstates.io/images/congress/450x550/M001180.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WV-1

--- a/data/us/legislature/David-E-Price-3da2a16b-4772-5dc1-837a-87f7b3894dec.yml
+++ b/data/us/legislature/David-E-Price-3da2a16b-4772-5dc1-837a-87f7b3894dec.yml
@@ -8,7 +8,6 @@ birth_date: 1940-08-17
 image: https://theunitedstates.io/images/congress/450x550/P000523.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1987-01-06'
@@ -92,7 +91,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-4

--- a/data/us/legislature/David-G-Valadao-cf552a34-e9e1-5de9-9270-b5b441dd89fe.yml
+++ b/data/us/legislature/David-G-Valadao-cf552a34-e9e1-5de9-9270-b5b441dd89fe.yml
@@ -8,7 +8,6 @@ birth_date: 1977-04-14
 image: https://theunitedstates.io/images/congress/450x550/V000129.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-21
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-21

--- a/data/us/legislature/David-J-Trone-e23c900b-5d24-55cb-a1d1-73ac69e597ef.yml
+++ b/data/us/legislature/David-J-Trone-e23c900b-5d24-55cb-a1d1-73ac69e597ef.yml
@@ -8,7 +8,6 @@ birth_date: 1955-09-21
 image: https://theunitedstates.io/images/congress/450x550/T000483.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-6

--- a/data/us/legislature/David-Kustoff-5beaa710-fc70-563c-9842-f885e13d9aea.yml
+++ b/data/us/legislature/David-Kustoff-5beaa710-fc70-563c-9842-f885e13d9aea.yml
@@ -7,7 +7,6 @@ birth_date: 1966-10-08
 image: https://theunitedstates.io/images/congress/450x550/K000392.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-8

--- a/data/us/legislature/David-N-Cicilline-c1210b41-26d8-5768-9321-50a485c83e98.yml
+++ b/data/us/legislature/David-N-Cicilline-c1210b41-26d8-5768-9321-50a485c83e98.yml
@@ -8,7 +8,6 @@ birth_date: 1961-07-15
 image: https://theunitedstates.io/images/congress/450x550/C001084.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: RI-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: RI-1

--- a/data/us/legislature/David-P-Joyce-b7ff0450-1acd-5127-b3f5-7246374119a9.yml
+++ b/data/us/legislature/David-P-Joyce-b7ff0450-1acd-5127-b3f5-7246374119a9.yml
@@ -8,7 +8,6 @@ birth_date: 1957-03-17
 image: https://theunitedstates.io/images/congress/450x550/J000295.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-14

--- a/data/us/legislature/David-Rouzer-5e9726e3-2aae-5708-9227-0e95ac43c203.yml
+++ b/data/us/legislature/David-Rouzer-5e9726e3-2aae-5708-9227-0e95ac43c203.yml
@@ -7,7 +7,6 @@ birth_date: 1972-02-16
 image: https://theunitedstates.io/images/congress/450x550/R000603.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-7

--- a/data/us/legislature/David-Schweikert-100d00e0-275c-5bd0-960e-c24c3b50a8e5.yml
+++ b/data/us/legislature/David-Schweikert-100d00e0-275c-5bd0-960e-c24c3b50a8e5.yml
@@ -7,7 +7,6 @@ birth_date: 1962-03-03
 image: https://theunitedstates.io/images/congress/450x550/S001183.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-6

--- a/data/us/legislature/David-Scott-e6650822-1063-5485-b062-d169ea173ec2.yml
+++ b/data/us/legislature/David-Scott-e6650822-1063-5485-b062-d169ea173ec2.yml
@@ -7,7 +7,6 @@ birth_date: 1945-06-27
 image: https://theunitedstates.io/images/congress/450x550/S001157.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -56,7 +55,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-13

--- a/data/us/legislature/Dean-Phillips-501837d6-d9cc-5b1e-a2e3-e53f047192a5.yml
+++ b/data/us/legislature/Dean-Phillips-501837d6-d9cc-5b1e-a2e3-e53f047192a5.yml
@@ -7,7 +7,6 @@ birth_date: 1969-01-20
 image: https://theunitedstates.io/images/congress/450x550/P000616.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-3

--- a/data/us/legislature/Debbie-Dingell-b48d0289-7d22-5bb4-bd17-b351aa3ec4a2.yml
+++ b/data/us/legislature/Debbie-Dingell-b48d0289-7d22-5bb4-bd17-b351aa3ec4a2.yml
@@ -7,7 +7,6 @@ birth_date: 1953-11-23
 image: https://theunitedstates.io/images/congress/450x550/D000624.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-12

--- a/data/us/legislature/Debbie-Lesko-ce00d736-9c65-52f1-9cdf-aff115c2b7b4.yml
+++ b/data/us/legislature/Debbie-Lesko-ce00d736-9c65-52f1-9cdf-aff115c2b7b4.yml
@@ -7,7 +7,6 @@ birth_date: 1958-11-14
 image: https://theunitedstates.io/images/congress/450x550/L000589.jpg
 party:
 - start_date: '2018-05-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2018-05-07'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-8

--- a/data/us/legislature/Debbie-Wasserman-Schultz-7bacff4a-1d4a-5c4f-a59c-311206c181d2.yml
+++ b/data/us/legislature/Debbie-Wasserman-Schultz-7bacff4a-1d4a-5c4f-a59c-311206c181d2.yml
@@ -7,7 +7,6 @@ birth_date: 1966-09-27
 image: https://theunitedstates.io/images/congress/450x550/W000797.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-23
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-23

--- a/data/us/legislature/Deborah-K-Ross-ea21df34-9ef4-5746-b83a-700bdc2d1918.yml
+++ b/data/us/legislature/Deborah-K-Ross-ea21df34-9ef4-5746-b83a-700bdc2d1918.yml
@@ -8,11 +8,9 @@ birth_date: 1963-06-20
 image: https://theunitedstates.io/images/congress/450x550/R000305.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-2

--- a/data/us/legislature/Derek-Kilmer-0a7f80ad-caf7-5d0b-b50b-441764153649.yml
+++ b/data/us/legislature/Derek-Kilmer-0a7f80ad-caf7-5d0b-b50b-441764153649.yml
@@ -7,7 +7,6 @@ birth_date: 1974-01-01
 image: https://theunitedstates.io/images/congress/450x550/K000381.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-6

--- a/data/us/legislature/Diana-DeGette-241df76f-7089-5821-ab7f-bb54d92ee9d7.yml
+++ b/data/us/legislature/Diana-DeGette-241df76f-7089-5821-ab7f-bb54d92ee9d7.yml
@@ -8,7 +8,6 @@ birth_date: 1957-07-29
 image: https://theunitedstates.io/images/congress/450x550/D000197.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-1

--- a/data/us/legislature/Diana-Harshbarger-b090c59e-4d88-5d35-99ba-ec3798f88978.yml
+++ b/data/us/legislature/Diana-Harshbarger-b090c59e-4d88-5d35-99ba-ec3798f88978.yml
@@ -7,11 +7,9 @@ birth_date: 1960-01-01
 image: https://theunitedstates.io/images/congress/450x550/H001086.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-1

--- a/data/us/legislature/Dina-Titus-51152aac-2c93-5445-99ed-026df5b6ad37.yml
+++ b/data/us/legislature/Dina-Titus-51152aac-2c93-5445-99ed-026df5b6ad37.yml
@@ -7,7 +7,6 @@ birth_date: 1950-05-23
 image: https://theunitedstates.io/images/congress/450x550/T000468.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-1

--- a/data/us/legislature/Don-Bacon-d409840c-63c1-53e4-9ff6-e5677cef9fe6.yml
+++ b/data/us/legislature/Don-Bacon-d409840c-63c1-53e4-9ff6-e5677cef9fe6.yml
@@ -7,7 +7,6 @@ birth_date: 1963-08-16
 image: https://theunitedstates.io/images/congress/450x550/B001298.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NE-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NE-2

--- a/data/us/legislature/Donald-M-Payne-Jr-fa65b2cc-a6a5-56fa-8c78-5bc2ecdd93e6.yml
+++ b/data/us/legislature/Donald-M-Payne-Jr-fa65b2cc-a6a5-56fa-8c78-5bc2ecdd93e6.yml
@@ -8,7 +8,6 @@ birth_date: 1958-12-17
 image: https://theunitedstates.io/images/congress/450x550/P000604.jpg
 party:
 - start_date: '2012-11-15'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2012-11-15'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-10

--- a/data/us/legislature/Donald-Norcross-b0e4bf70-7945-5f39-bb1b-f993a59367b4.yml
+++ b/data/us/legislature/Donald-Norcross-b0e4bf70-7945-5f39-bb1b-f993a59367b4.yml
@@ -8,7 +8,6 @@ birth_date: 1958-12-13
 image: https://theunitedstates.io/images/congress/450x550/N000188.jpg
 party:
 - start_date: '2014-11-12'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2014-11-12'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-1

--- a/data/us/legislature/Donald-S-Beyer-Jr-63d110f3-ccdb-5783-9d6a-4a7103f30c01.yml
+++ b/data/us/legislature/Donald-S-Beyer-Jr-63d110f3-ccdb-5783-9d6a-4a7103f30c01.yml
@@ -8,7 +8,6 @@ birth_date: 1950-06-20
 image: https://theunitedstates.io/images/congress/450x550/B001292.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-8

--- a/data/us/legislature/Doris-O-Matsui-5262c34c-a015-5290-9ca4-3b6ec86f4b1d.yml
+++ b/data/us/legislature/Doris-O-Matsui-5262c34c-a015-5290-9ca4-3b6ec86f4b1d.yml
@@ -8,7 +8,6 @@ birth_date: 1944-09-25
 image: https://theunitedstates.io/images/congress/450x550/M001163.jpg
 party:
 - start_date: '2005-03-10'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-03-10'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-6

--- a/data/us/legislature/Doug-LaMalfa-4e34a7cb-7c10-5e5d-8086-a33ef00207bd.yml
+++ b/data/us/legislature/Doug-LaMalfa-4e34a7cb-7c10-5e5d-8086-a33ef00207bd.yml
@@ -7,7 +7,6 @@ birth_date: 1960-07-02
 image: https://theunitedstates.io/images/congress/450x550/L000578.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-1

--- a/data/us/legislature/Doug-Lamborn-c4154717-8bdf-5a5e-ac05-24c35f195a78.yml
+++ b/data/us/legislature/Doug-Lamborn-c4154717-8bdf-5a5e-ac05-24c35f195a78.yml
@@ -7,7 +7,6 @@ birth_date: 1954-05-24
 image: https://theunitedstates.io/images/congress/450x550/L000564.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-5

--- a/data/us/legislature/Dusty-Johnson-1bc146c5-42d6-5bf7-a862-34747a4b8ed7.yml
+++ b/data/us/legislature/Dusty-Johnson-1bc146c5-42d6-5bf7-a862-34747a4b8ed7.yml
@@ -7,7 +7,6 @@ birth_date: 1976-09-30
 image: https://theunitedstates.io/images/congress/450x550/J000301.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SD-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SD-AL

--- a/data/us/legislature/Dwight-Evans-c9d5abc5-4c4a-5ff5-a132-8885eb020e6e.yml
+++ b/data/us/legislature/Dwight-Evans-c9d5abc5-4c4a-5ff5-a132-8885eb020e6e.yml
@@ -7,7 +7,6 @@ birth_date: 1954-05-16
 image: https://theunitedstates.io/images/congress/450x550/E000296.jpg
 party:
 - start_date: '2016-11-14'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2016-11-14'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-3

--- a/data/us/legislature/Earl-Blumenauer-acd197d4-7996-5b4c-b01d-a61702d99385.yml
+++ b/data/us/legislature/Earl-Blumenauer-acd197d4-7996-5b4c-b01d-a61702d99385.yml
@@ -7,7 +7,6 @@ birth_date: 1948-08-16
 image: https://theunitedstates.io/images/congress/450x550/B000574.jpg
 party:
 - start_date: '1996-05-21'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1996-05-21'
@@ -76,7 +75,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-3

--- a/data/us/legislature/Earl-L-Buddy-Carter-85e43f57-4901-52fd-9fad-57373277f5e1.yml
+++ b/data/us/legislature/Earl-L-Buddy-Carter-85e43f57-4901-52fd-9fad-57373277f5e1.yml
@@ -8,7 +8,6 @@ birth_date: 1957-09-06
 image: https://theunitedstates.io/images/congress/450x550/C001103.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-1

--- a/data/us/legislature/Ed-Case-20f1a4db-1281-5e3f-9d6d-657a3f178b3f.yml
+++ b/data/us/legislature/Ed-Case-20f1a4db-1281-5e3f-9d6d-657a3f178b3f.yml
@@ -7,7 +7,6 @@ birth_date: 1952-09-27
 image: https://theunitedstates.io/images/congress/450x550/C001055.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: HI-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: HI-1

--- a/data/us/legislature/Ed-Perlmutter-fb48fcad-e37c-5764-bde4-a84dad9e5e70.yml
+++ b/data/us/legislature/Ed-Perlmutter-fb48fcad-e37c-5764-bde4-a84dad9e5e70.yml
@@ -7,7 +7,6 @@ birth_date: 1953-05-01
 image: https://theunitedstates.io/images/congress/450x550/P000593.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-7

--- a/data/us/legislature/Eddie-Bernice-Johnson-1b2162ab-267e-513e-9ef0-3c2bf418e9c6.yml
+++ b/data/us/legislature/Eddie-Bernice-Johnson-1b2162ab-267e-513e-9ef0-3c2bf418e9c6.yml
@@ -8,7 +8,6 @@ birth_date: 1935-12-03
 image: https://theunitedstates.io/images/congress/450x550/J000126.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-30
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-30

--- a/data/us/legislature/Elaine-G-Luria-4fa00d56-773e-55d0-84cb-bc59fb5789ce.yml
+++ b/data/us/legislature/Elaine-G-Luria-4fa00d56-773e-55d0-84cb-bc59fb5789ce.yml
@@ -8,7 +8,6 @@ birth_date: 1975-08-15
 image: https://theunitedstates.io/images/congress/450x550/L000591.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-2

--- a/data/us/legislature/Eleanor-Holmes-Norton-709b6b03-c38f-540b-85f2-83c16f62d3bd.yml
+++ b/data/us/legislature/Eleanor-Holmes-Norton-709b6b03-c38f-540b-85f2-83c16f62d3bd.yml
@@ -8,7 +8,6 @@ birth_date: 1937-06-13
 image: https://theunitedstates.io/images/congress/450x550/N000147.jpg
 party:
 - start_date: '1991-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1991-01-03'
@@ -87,7 +86,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: DC-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: DC-AL

--- a/data/us/legislature/Elise-M-Stefanik-febd3b9d-501f-5191-aaff-87666a5af603.yml
+++ b/data/us/legislature/Elise-M-Stefanik-febd3b9d-501f-5191-aaff-87666a5af603.yml
@@ -8,7 +8,6 @@ birth_date: 1984-07-02
 image: https://theunitedstates.io/images/congress/450x550/S001196.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-21
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-21

--- a/data/us/legislature/Elissa-Slotkin-e7ebade8-8c17-50e0-ac00-70e0327b9071.yml
+++ b/data/us/legislature/Elissa-Slotkin-e7ebade8-8c17-50e0-ac00-70e0327b9071.yml
@@ -7,7 +7,6 @@ birth_date: 1976-07-10
 image: https://theunitedstates.io/images/congress/450x550/S001208.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-8

--- a/data/us/legislature/Emanuel-Cleaver-8ea538b9-6af5-5683-8b4b-9061f89691c1.yml
+++ b/data/us/legislature/Emanuel-Cleaver-8ea538b9-6af5-5683-8b4b-9061f89691c1.yml
@@ -7,7 +7,6 @@ birth_date: 1944-10-26
 image: https://theunitedstates.io/images/congress/450x550/C001061.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-5

--- a/data/us/legislature/Eric-A-Rick-Crawford-9a89c225-65e9-5680-a780-9802c17cb7c4.yml
+++ b/data/us/legislature/Eric-A-Rick-Crawford-9a89c225-65e9-5680-a780-9802c17cb7c4.yml
@@ -8,7 +8,6 @@ birth_date: 1966-01-22
 image: https://theunitedstates.io/images/congress/450x550/C001087.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-1

--- a/data/us/legislature/Eric-Swalwell-032302ae-d513-5e31-bafc-8bc3cbb18d7c.yml
+++ b/data/us/legislature/Eric-Swalwell-032302ae-d513-5e31-bafc-8bc3cbb18d7c.yml
@@ -7,7 +7,6 @@ birth_date: 1980-11-16
 image: https://theunitedstates.io/images/congress/450x550/S001193.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-15
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-15

--- a/data/us/legislature/Frank-D-Lucas-90a2bdbf-1b51-5e72-aef9-5a98c305f31d.yml
+++ b/data/us/legislature/Frank-D-Lucas-90a2bdbf-1b51-5e72-aef9-5a98c305f31d.yml
@@ -8,7 +8,6 @@ birth_date: 1960-01-06
 image: https://theunitedstates.io/images/congress/450x550/L000491.jpg
 party:
 - start_date: '1993-05-10'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1993-05-10'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-3

--- a/data/us/legislature/Frank-J-Mrvan-c6c1c65f-7735-5ebb-951c-56d6cacc8ebb.yml
+++ b/data/us/legislature/Frank-J-Mrvan-c6c1c65f-7735-5ebb-951c-56d6cacc8ebb.yml
@@ -8,11 +8,9 @@ birth_date: 1969-04-16
 image: https://theunitedstates.io/images/congress/450x550/M001214.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-1

--- a/data/us/legislature/Frank-Pallone-Jr-dfcc16d4-7116-5a16-bf7f-81c6f10d8276.yml
+++ b/data/us/legislature/Frank-Pallone-Jr-dfcc16d4-7116-5a16-bf7f-81c6f10d8276.yml
@@ -8,7 +8,6 @@ birth_date: 1951-10-30
 image: https://theunitedstates.io/images/congress/450x550/P000034.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1987-01-06'
@@ -97,7 +96,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-6

--- a/data/us/legislature/Fred-Keller-54c60e16-763d-518d-b662-db8c98fa4454.yml
+++ b/data/us/legislature/Fred-Keller-54c60e16-763d-518d-b662-db8c98fa4454.yml
@@ -7,7 +7,6 @@ birth_date: 1965-10-23
 image: https://theunitedstates.io/images/congress/450x550/K000395.jpg
 party:
 - start_date: '2019-06-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-06-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-12

--- a/data/us/legislature/Fred-Upton-b847521c-aa8d-5d95-9cb7-bacb80074871.yml
+++ b/data/us/legislature/Fred-Upton-b847521c-aa8d-5d95-9cb7-bacb80074871.yml
@@ -8,7 +8,6 @@ birth_date: 1953-04-23
 image: https://theunitedstates.io/images/congress/450x550/U000031.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1987-01-06'
@@ -97,7 +96,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-6

--- a/data/us/legislature/Frederica-S-Wilson-bd701bdc-2944-5bb8-b4bf-e2914e6e1241.yml
+++ b/data/us/legislature/Frederica-S-Wilson-bd701bdc-2944-5bb8-b4bf-e2914e6e1241.yml
@@ -8,7 +8,6 @@ birth_date: 1942-11-05
 image: https://theunitedstates.io/images/congress/450x550/W000808.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-24
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-24

--- a/data/us/legislature/G-K-Butterfield-68ce99c6-7680-5ff5-8290-fba46a7af889.yml
+++ b/data/us/legislature/G-K-Butterfield-68ce99c6-7680-5ff5-8290-fba46a7af889.yml
@@ -8,7 +8,6 @@ birth_date: 1947-04-27
 image: https://theunitedstates.io/images/congress/450x550/B001251.jpg
 party:
 - start_date: '2004-07-21'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2004-07-21'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-1

--- a/data/us/legislature/Garret-Graves-6b0fb307-b985-56d0-83d3-c17a01e9b98e.yml
+++ b/data/us/legislature/Garret-Graves-6b0fb307-b985-56d0-83d3-c17a01e9b98e.yml
@@ -7,7 +7,6 @@ birth_date: 1972-01-31
 image: https://theunitedstates.io/images/congress/450x550/G000577.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-6

--- a/data/us/legislature/Gary-J-Palmer-1add3f9c-2946-50ed-92e9-fa54a98fe985.yml
+++ b/data/us/legislature/Gary-J-Palmer-1add3f9c-2946-50ed-92e9-fa54a98fe985.yml
@@ -8,7 +8,6 @@ birth_date: 1954-05-14
 image: https://theunitedstates.io/images/congress/450x550/P000609.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-6

--- a/data/us/legislature/Gerald-E-Connolly-716b011f-3673-558d-b35f-d5a454cafa81.yml
+++ b/data/us/legislature/Gerald-E-Connolly-716b011f-3673-558d-b35f-d5a454cafa81.yml
@@ -8,7 +8,6 @@ birth_date: 1950-03-30
 image: https://theunitedstates.io/images/congress/450x550/C001078.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -42,7 +41,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-11

--- a/data/us/legislature/Glenn-Grothman-57016d46-c931-5a93-aeb5-1ffec71fb87e.yml
+++ b/data/us/legislature/Glenn-Grothman-57016d46-c931-5a93-aeb5-1ffec71fb87e.yml
@@ -7,7 +7,6 @@ birth_date: 1955-07-03
 image: https://theunitedstates.io/images/congress/450x550/G000576.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-6

--- a/data/us/legislature/Glenn-Thompson-2faf9e06-f667-5b60-830f-2161dae9c77a.yml
+++ b/data/us/legislature/Glenn-Thompson-2faf9e06-f667-5b60-830f-2161dae9c77a.yml
@@ -7,7 +7,6 @@ birth_date: 1959-07-27
 image: https://theunitedstates.io/images/congress/450x550/T000467.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-15
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-15

--- a/data/us/legislature/Grace-F-Napolitano-228dc55f-1b76-5458-b344-4df46c4e632a.yml
+++ b/data/us/legislature/Grace-F-Napolitano-228dc55f-1b76-5458-b344-4df46c4e632a.yml
@@ -8,7 +8,6 @@ birth_date: 1936-12-04
 image: https://theunitedstates.io/images/congress/450x550/N000179.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1999-01-06'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-32
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-32

--- a/data/us/legislature/Grace-Meng-ae123357-c70e-5d29-b16f-2d17775ab0f6.yml
+++ b/data/us/legislature/Grace-Meng-ae123357-c70e-5d29-b16f-2d17775ab0f6.yml
@@ -7,7 +7,6 @@ birth_date: 1975-10-01
 image: https://theunitedstates.io/images/congress/450x550/M001188.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-6

--- a/data/us/legislature/Greg-Pence-4c0bab34-0485-54c6-8b00-15042f52fd87.yml
+++ b/data/us/legislature/Greg-Pence-4c0bab34-0485-54c6-8b00-15042f52fd87.yml
@@ -7,7 +7,6 @@ birth_date: 1956-11-14
 image: https://theunitedstates.io/images/congress/450x550/P000615.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-6

--- a/data/us/legislature/Greg-Stanton-3300ee9c-6602-5be9-9bb5-2fb7f65a8d5c.yml
+++ b/data/us/legislature/Greg-Stanton-3300ee9c-6602-5be9-9bb5-2fb7f65a8d5c.yml
@@ -7,7 +7,6 @@ birth_date: 1970-03-08
 image: https://theunitedstates.io/images/congress/450x550/S001211.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-9

--- a/data/us/legislature/Gregorio-Kilili-Camacho-Sablan-3f4f5bab-eae1-594a-a93f-53c463b03d5b.yml
+++ b/data/us/legislature/Gregorio-Kilili-Camacho-Sablan-3f4f5bab-eae1-594a-a93f-53c463b03d5b.yml
@@ -8,7 +8,6 @@ birth_date: 1955-01-19
 image: https://theunitedstates.io/images/congress/450x550/S001177.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 - start_date: '2015-01-06'
   end_date: '2017-01-03'
@@ -45,7 +44,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MP-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MP-AL

--- a/data/us/legislature/Gregory-F-Murphy-b66a5d85-c9cd-5689-a482-d175230ab86d.yml
+++ b/data/us/legislature/Gregory-F-Murphy-b66a5d85-c9cd-5689-a482-d175230ab86d.yml
@@ -8,7 +8,6 @@ birth_date: 1963-03-05
 image: https://theunitedstates.io/images/congress/450x550/M001210.jpg
 party:
 - start_date: '2019-09-17'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-09-17'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-3

--- a/data/us/legislature/Gregory-W-Meeks-372b42da-f525-5938-9a01-e21378fe287c.yml
+++ b/data/us/legislature/Gregory-W-Meeks-372b42da-f525-5938-9a01-e21378fe287c.yml
@@ -8,7 +8,6 @@ birth_date: 1953-09-25
 image: https://theunitedstates.io/images/congress/450x550/M001137.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-5

--- a/data/us/legislature/Gus-M-Bilirakis-cd29931a-8dab-5ad7-8d4e-f0066cce7d4c.yml
+++ b/data/us/legislature/Gus-M-Bilirakis-cd29931a-8dab-5ad7-8d4e-f0066cce7d4c.yml
@@ -8,7 +8,6 @@ birth_date: 1963-02-08
 image: https://theunitedstates.io/images/congress/450x550/B001257.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-12

--- a/data/us/legislature/Guy-Reschenthaler-58bfb394-46c1-51e6-9f85-c3f091ddada7.yml
+++ b/data/us/legislature/Guy-Reschenthaler-58bfb394-46c1-51e6-9f85-c3f091ddada7.yml
@@ -7,7 +7,6 @@ birth_date: 1983-04-17
 image: https://theunitedstates.io/images/congress/450x550/R000610.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-14

--- a/data/us/legislature/Gwen-Moore-0223a517-1c97-5425-8bca-2120c45ce2e5.yml
+++ b/data/us/legislature/Gwen-Moore-0223a517-1c97-5425-8bca-2120c45ce2e5.yml
@@ -7,7 +7,6 @@ birth_date: 1951-04-18
 image: https://theunitedstates.io/images/congress/450x550/M001160.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-4

--- a/data/us/legislature/H-Morgan-Griffith-562f0794-c1fb-50ee-b69c-3a01b25cfc3a.yml
+++ b/data/us/legislature/H-Morgan-Griffith-562f0794-c1fb-50ee-b69c-3a01b25cfc3a.yml
@@ -8,7 +8,6 @@ birth_date: 1958-03-15
 image: https://theunitedstates.io/images/congress/450x550/G000568.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-9

--- a/data/us/legislature/Hakeem-S-Jeffries-f06d8480-e875-5184-8316-4140a912a03d.yml
+++ b/data/us/legislature/Hakeem-S-Jeffries-f06d8480-e875-5184-8316-4140a912a03d.yml
@@ -8,7 +8,6 @@ birth_date: 1970-08-04
 image: https://theunitedstates.io/images/congress/450x550/J000294.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-8

--- a/data/us/legislature/Haley-M-Stevens-62d84fce-0ff4-53df-b7a8-4c02d1dc8654.yml
+++ b/data/us/legislature/Haley-M-Stevens-62d84fce-0ff4-53df-b7a8-4c02d1dc8654.yml
@@ -8,7 +8,6 @@ birth_date: 1983-06-24
 image: https://theunitedstates.io/images/congress/450x550/S001215.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-11

--- a/data/us/legislature/Harold-Rogers-8b8caa4b-52c1-54aa-bb51-bd0bccdc69b9.yml
+++ b/data/us/legislature/Harold-Rogers-8b8caa4b-52c1-54aa-bb51-bd0bccdc69b9.yml
@@ -7,7 +7,6 @@ birth_date: 1937-12-31
 image: https://theunitedstates.io/images/congress/450x550/R000395.jpg
 party:
 - start_date: '1981-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1981-01-05'
@@ -111,7 +110,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-5

--- a/data/us/legislature/Henry-C-Hank-Johnson-Jr-51b7316e-0885-571b-8a2e-daf54dd906bb.yml
+++ b/data/us/legislature/Henry-C-Hank-Johnson-Jr-51b7316e-0885-571b-8a2e-daf54dd906bb.yml
@@ -8,7 +8,6 @@ birth_date: 1954-10-02
 image: https://theunitedstates.io/images/congress/450x550/J000288.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-4

--- a/data/us/legislature/Henry-Cuellar-f67869ed-f124-54ce-b870-600ae4ff20e8.yml
+++ b/data/us/legislature/Henry-Cuellar-f67869ed-f124-54ce-b870-600ae4ff20e8.yml
@@ -7,7 +7,6 @@ birth_date: 1955-09-19
 image: https://theunitedstates.io/images/congress/450x550/C001063.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-28
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-28

--- a/data/us/legislature/Ilhan-Omar-dc1ded48-08a5-5981-be73-53bbbe668782.yml
+++ b/data/us/legislature/Ilhan-Omar-dc1ded48-08a5-5981-be73-53bbbe668782.yml
@@ -7,7 +7,6 @@ birth_date: 1981-10-04
 image: https://theunitedstates.io/images/congress/450x550/O000173.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-5

--- a/data/us/legislature/J-Hill-73ff0305-598d-5558-9b5e-6834be8a503a.yml
+++ b/data/us/legislature/J-Hill-73ff0305-598d-5558-9b5e-6834be8a503a.yml
@@ -8,7 +8,6 @@ birth_date: 1956-12-05
 image: https://theunitedstates.io/images/congress/450x550/H001072.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-2

--- a/data/us/legislature/J-Luis-Correa-86b65fd7-4549-51fa-80e8-eaf3daf3e60e.yml
+++ b/data/us/legislature/J-Luis-Correa-86b65fd7-4549-51fa-80e8-eaf3daf3e60e.yml
@@ -8,7 +8,6 @@ birth_date: 1958-01-24
 image: https://theunitedstates.io/images/congress/450x550/C001110.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-46
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-46

--- a/data/us/legislature/Jack-Bergman-5f3b131a-0f64-5d55-875a-2861e5347727.yml
+++ b/data/us/legislature/Jack-Bergman-5f3b131a-0f64-5d55-875a-2861e5347727.yml
@@ -7,7 +7,6 @@ birth_date: 1947-02-02
 image: https://theunitedstates.io/images/congress/450x550/B001301.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-1

--- a/data/us/legislature/Jackie-Speier-5dbdd577-3409-52d9-af1f-4596256b26b7.yml
+++ b/data/us/legislature/Jackie-Speier-5dbdd577-3409-52d9-af1f-4596256b26b7.yml
@@ -7,7 +7,6 @@ birth_date: 1950-05-14
 image: https://theunitedstates.io/images/congress/450x550/S001175.jpg
 party:
 - start_date: '2008-04-08'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2008-04-08'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-14

--- a/data/us/legislature/Jahana-Hayes-1d87ca8c-1a95-531f-bbdd-34e1679d45d2.yml
+++ b/data/us/legislature/Jahana-Hayes-1d87ca8c-1a95-531f-bbdd-34e1679d45d2.yml
@@ -7,7 +7,6 @@ birth_date: 1973-03-08
 image: https://theunitedstates.io/images/congress/450x550/H001081.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-5

--- a/data/us/legislature/Jaime-Herrera-Beutler-91520670-a965-5cfe-893f-f0edaf5eaa90.yml
+++ b/data/us/legislature/Jaime-Herrera-Beutler-91520670-a965-5cfe-893f-f0edaf5eaa90.yml
@@ -7,7 +7,6 @@ birth_date: 1978-11-03
 image: https://theunitedstates.io/images/congress/450x550/H001056.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-3

--- a/data/us/legislature/Jake-Auchincloss-a68063b7-2ce8-5638-a836-4fa7b22b3432.yml
+++ b/data/us/legislature/Jake-Auchincloss-a68063b7-2ce8-5638-a836-4fa7b22b3432.yml
@@ -8,11 +8,9 @@ birth_date: 1988-01-29
 image: https://theunitedstates.io/images/congress/450x550/A000148.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-4

--- a/data/us/legislature/Jake-Ellzey-7add5a36-095e-5209-b94f-71b436555100.yml
+++ b/data/us/legislature/Jake-Ellzey-7add5a36-095e-5209-b94f-71b436555100.yml
@@ -7,11 +7,9 @@ birth_date: 1970-01-24
 image: https://theunitedstates.io/images/congress/450x550/E000071.jpg
 party:
 - start_date: '2021-07-30'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-07-30'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-6

--- a/data/us/legislature/Jake-LaTurner-b4bfc55d-3cdd-5a6e-accf-912a2b2d28b8.yml
+++ b/data/us/legislature/Jake-LaTurner-b4bfc55d-3cdd-5a6e-accf-912a2b2d28b8.yml
@@ -7,11 +7,9 @@ birth_date: 1988-02-17
 image: https://theunitedstates.io/images/congress/450x550/L000266.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-2

--- a/data/us/legislature/Jamaal-Bowman-e79a7ea4-9fcd-5c43-99b3-68bee77eb928.yml
+++ b/data/us/legislature/Jamaal-Bowman-e79a7ea4-9fcd-5c43-99b3-68bee77eb928.yml
@@ -7,11 +7,9 @@ birth_date: 1976-04-01
 image: https://theunitedstates.io/images/congress/450x550/B001223.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-16

--- a/data/us/legislature/James-A-Himes-e1a8d4da-7cbd-571e-817d-774ff06bb342.yml
+++ b/data/us/legislature/James-A-Himes-e1a8d4da-7cbd-571e-817d-774ff06bb342.yml
@@ -8,7 +8,6 @@ birth_date: 1966-07-05
 image: https://theunitedstates.io/images/congress/450x550/H001047.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -42,7 +41,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-4

--- a/data/us/legislature/James-Comer-57b0c699-cef2-5740-bd15-4ad2562f8975.yml
+++ b/data/us/legislature/James-Comer-57b0c699-cef2-5740-bd15-4ad2562f8975.yml
@@ -7,7 +7,6 @@ birth_date: 1972-08-19
 image: https://theunitedstates.io/images/congress/450x550/C001108.jpg
 party:
 - start_date: '2016-11-14'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2016-11-14'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-1

--- a/data/us/legislature/James-E-Clyburn-e24e02a4-f70c-5b9e-84e2-eda2d153f80f.yml
+++ b/data/us/legislature/James-E-Clyburn-e24e02a4-f70c-5b9e-84e2-eda2d153f80f.yml
@@ -8,7 +8,6 @@ birth_date: 1940-07-21
 image: https://theunitedstates.io/images/congress/450x550/C000537.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-6

--- a/data/us/legislature/James-Lankford-62a44404-9be2-5bbc-b672-0ed5f1aba53d.yml
+++ b/data/us/legislature/James-Lankford-62a44404-9be2-5bbc-b672-0ed5f1aba53d.yml
@@ -7,7 +7,6 @@ birth_date: 1968-03-04
 image: https://theunitedstates.io/images/congress/450x550/L000575.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Oklahoma
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Oklahoma

--- a/data/us/legislature/James-P-McGovern-d44223bc-5f00-56aa-be61-28b5a3b4429d.yml
+++ b/data/us/legislature/James-P-McGovern-d44223bc-5f00-56aa-be61-28b5a3b4429d.yml
@@ -8,7 +8,6 @@ birth_date: 1959-11-20
 image: https://theunitedstates.io/images/congress/450x550/M000312.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-2

--- a/data/us/legislature/James-R-Baird-749232ec-b66c-5bd7-b828-10a466b95f0a.yml
+++ b/data/us/legislature/James-R-Baird-749232ec-b66c-5bd7-b828-10a466b95f0a.yml
@@ -8,7 +8,6 @@ birth_date: 1945-06-04
 image: https://theunitedstates.io/images/congress/450x550/B001307.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-4

--- a/data/us/legislature/James-R-Langevin-61ef9322-82bc-52a1-983e-3026b8834a43.yml
+++ b/data/us/legislature/James-R-Langevin-61ef9322-82bc-52a1-983e-3026b8834a43.yml
@@ -8,7 +8,6 @@ birth_date: 1964-04-22
 image: https://theunitedstates.io/images/congress/450x550/L000559.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2001-01-03'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: RI-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: RI-2

--- a/data/us/legislature/Jamie-Raskin-289b4cb5-a838-5b08-8f74-e06d4d251ae7.yml
+++ b/data/us/legislature/Jamie-Raskin-289b4cb5-a838-5b08-8f74-e06d4d251ae7.yml
@@ -7,7 +7,6 @@ birth_date: 1962-12-13
 image: https://theunitedstates.io/images/congress/450x550/R000606.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-8

--- a/data/us/legislature/Janice-D-Schakowsky-c5e8693c-dca3-5ff7-b456-e71d944e4fb0.yml
+++ b/data/us/legislature/Janice-D-Schakowsky-c5e8693c-dca3-5ff7-b456-e71d944e4fb0.yml
@@ -8,7 +8,6 @@ birth_date: 1944-05-26
 image: https://theunitedstates.io/images/congress/450x550/S001145.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1999-01-06'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-9

--- a/data/us/legislature/Jared-F-Golden-3c47a44a-29b8-5aa1-b61a-9e49ea0caf99.yml
+++ b/data/us/legislature/Jared-F-Golden-3c47a44a-29b8-5aa1-b61a-9e49ea0caf99.yml
@@ -8,7 +8,6 @@ birth_date: 1982-07-25
 image: https://theunitedstates.io/images/congress/450x550/G000592.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ME-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ME-2

--- a/data/us/legislature/Jared-Huffman-c2b08e7d-2372-5af6-b333-7ea2787cb3ca.yml
+++ b/data/us/legislature/Jared-Huffman-c2b08e7d-2372-5af6-b333-7ea2787cb3ca.yml
@@ -7,7 +7,6 @@ birth_date: 1964-02-18
 image: https://theunitedstates.io/images/congress/450x550/H001068.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-2

--- a/data/us/legislature/Jason-Crow-fb2f7d0c-f39b-50a6-8bdc-8bdc181683bc.yml
+++ b/data/us/legislature/Jason-Crow-fb2f7d0c-f39b-50a6-8bdc-8bdc181683bc.yml
@@ -7,7 +7,6 @@ birth_date: 1979-03-15
 image: https://theunitedstates.io/images/congress/450x550/C001121.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-6

--- a/data/us/legislature/Jason-Smith-559a5a0c-4b35-56f0-aa59-76c98e6cfb45.yml
+++ b/data/us/legislature/Jason-Smith-559a5a0c-4b35-56f0-aa59-76c98e6cfb45.yml
@@ -8,7 +8,6 @@ birth_date: 1980-06-16
 image: https://theunitedstates.io/images/congress/450x550/S001195.jpg
 party:
 - start_date: '2013-06-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-06-04'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-8

--- a/data/us/legislature/Jay-Obernolte-d78f994b-01dc-5dfb-a08f-fc2ca2cef7ec.yml
+++ b/data/us/legislature/Jay-Obernolte-d78f994b-01dc-5dfb-a08f-fc2ca2cef7ec.yml
@@ -8,11 +8,9 @@ birth_date: 1970-08-18
 image: https://theunitedstates.io/images/congress/450x550/O000019.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-8

--- a/data/us/legislature/Jeff-Duncan-5c67147e-00d5-5430-b1c1-59a6da4269d6.yml
+++ b/data/us/legislature/Jeff-Duncan-5c67147e-00d5-5430-b1c1-59a6da4269d6.yml
@@ -7,7 +7,6 @@ birth_date: 1966-01-07
 image: https://theunitedstates.io/images/congress/450x550/D000615.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-3

--- a/data/us/legislature/Jefferson-Van-Drew-a7706596-7110-5866-935b-b44668b92af1.yml
+++ b/data/us/legislature/Jefferson-Van-Drew-a7706596-7110-5866-935b-b44668b92af1.yml
@@ -7,7 +7,6 @@ birth_date: 1953-02-23
 image: https://theunitedstates.io/images/congress/450x550/V000133.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-2

--- a/data/us/legislature/Jennifer-Wexton-660e8554-8d00-501a-bd27-e65689d39837.yml
+++ b/data/us/legislature/Jennifer-Wexton-660e8554-8d00-501a-bd27-e65689d39837.yml
@@ -7,7 +7,6 @@ birth_date: 1968-05-27
 image: https://theunitedstates.io/images/congress/450x550/W000825.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-10

--- a/data/us/legislature/Jenniffer-Gonzlez-Coln-3f563cbe-7057-5771-b8d0-6e2e063da96f.yml
+++ b/data/us/legislature/Jenniffer-Gonzlez-Coln-3f563cbe-7057-5771-b8d0-6e2e063da96f.yml
@@ -7,7 +7,6 @@ birth_date: 1976-08-05
 image: https://theunitedstates.io/images/congress/450x550/G000582.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PR-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PR-AL

--- a/data/us/legislature/Jerrold-Nadler-d6cd4f62-7c5f-5595-ac5e-4e40741e5f3b.yml
+++ b/data/us/legislature/Jerrold-Nadler-d6cd4f62-7c5f-5595-ac5e-4e40741e5f3b.yml
@@ -8,7 +8,6 @@ birth_date: 1947-06-13
 image: https://theunitedstates.io/images/congress/450x550/N000002.jpg
 party:
 - start_date: '1992-11-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1992-11-03'
@@ -87,7 +86,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-10

--- a/data/us/legislature/Jerry-L-Carl-6813a4c1-4353-5517-9314-5d36ecebabfd.yml
+++ b/data/us/legislature/Jerry-L-Carl-6813a4c1-4353-5517-9314-5d36ecebabfd.yml
@@ -8,11 +8,9 @@ birth_date: 1958-06-17
 image: https://theunitedstates.io/images/congress/450x550/C001054.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-1

--- a/data/us/legislature/Jerry-McNerney-25067139-8957-50e6-bbe1-63e06a3476f7.yml
+++ b/data/us/legislature/Jerry-McNerney-25067139-8957-50e6-bbe1-63e06a3476f7.yml
@@ -7,7 +7,6 @@ birth_date: 1951-06-18
 image: https://theunitedstates.io/images/congress/450x550/M001166.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-9

--- a/data/us/legislature/Jerry-Moran-00c39487-8eec-5494-af5e-96e9b025a39b.yml
+++ b/data/us/legislature/Jerry-Moran-00c39487-8eec-5494-af5e-96e9b025a39b.yml
@@ -7,7 +7,6 @@ birth_date: 1954-05-29
 image: https://theunitedstates.io/images/congress/450x550/M000934.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Kansas
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Kansas

--- a/data/us/legislature/Jess-G-Chuy-Garca-f89c416f-c08d-5251-9a31-201a5265e283.yml
+++ b/data/us/legislature/Jess-G-Chuy-Garca-f89c416f-c08d-5251-9a31-201a5265e283.yml
@@ -8,7 +8,6 @@ birth_date: 1956-04-12
 image: https://theunitedstates.io/images/congress/450x550/G000586.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-4

--- a/data/us/legislature/Jim-Banks-befb976c-1369-5d86-a53f-4aeebdf486cc.yml
+++ b/data/us/legislature/Jim-Banks-befb976c-1369-5d86-a53f-4aeebdf486cc.yml
@@ -7,7 +7,6 @@ birth_date: 1979-07-16
 image: https://theunitedstates.io/images/congress/450x550/B001299.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-3

--- a/data/us/legislature/Jim-Cooper-0eb890a0-7278-5ec6-ac91-b4675095a38c.yml
+++ b/data/us/legislature/Jim-Cooper-0eb890a0-7278-5ec6-ac91-b4675095a38c.yml
@@ -7,7 +7,6 @@ birth_date: 1954-06-19
 image: https://theunitedstates.io/images/congress/450x550/C000754.jpg
 party:
 - start_date: '1983-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1983-01-03'
@@ -86,7 +85,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-5

--- a/data/us/legislature/Jim-Costa-8d953afe-9b42-5c80-9f43-4ccf8af79513.yml
+++ b/data/us/legislature/Jim-Costa-8d953afe-9b42-5c80-9f43-4ccf8af79513.yml
@@ -7,7 +7,6 @@ birth_date: 1952-04-13
 image: https://theunitedstates.io/images/congress/450x550/C001059.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-16

--- a/data/us/legislature/Jim-Jordan-bc5dadc9-a085-507e-82e1-1622d9a1fc90.yml
+++ b/data/us/legislature/Jim-Jordan-bc5dadc9-a085-507e-82e1-1622d9a1fc90.yml
@@ -7,7 +7,6 @@ birth_date: 1964-02-17
 image: https://theunitedstates.io/images/congress/450x550/J000289.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-4

--- a/data/us/legislature/Jimmy-Gomez-20be777c-8a2b-54c6-9b54-df88ff19b8ae.yml
+++ b/data/us/legislature/Jimmy-Gomez-20be777c-8a2b-54c6-9b54-df88ff19b8ae.yml
@@ -7,7 +7,6 @@ birth_date: 1974-11-25
 image: https://theunitedstates.io/images/congress/450x550/G000585.jpg
 party:
 - start_date: '2017-07-11'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-07-11'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-34
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-34

--- a/data/us/legislature/Jimmy-Panetta-946e688a-6b60-567e-bea7-893eb4364acc.yml
+++ b/data/us/legislature/Jimmy-Panetta-946e688a-6b60-567e-bea7-893eb4364acc.yml
@@ -7,7 +7,6 @@ birth_date: 1969-10-01
 image: https://theunitedstates.io/images/congress/450x550/P000613.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-20
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-20

--- a/data/us/legislature/Joaquin-Castro-d0fe7bc7-b883-5485-814f-f7cee999e409.yml
+++ b/data/us/legislature/Joaquin-Castro-d0fe7bc7-b883-5485-814f-f7cee999e409.yml
@@ -7,7 +7,6 @@ birth_date: 1974-09-16
 image: https://theunitedstates.io/images/congress/450x550/C001091.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-20
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-20

--- a/data/us/legislature/Jodey-C-Arrington-4938e6be-7c14-536d-a559-91c74fcc17db.yml
+++ b/data/us/legislature/Jodey-C-Arrington-4938e6be-7c14-536d-a559-91c74fcc17db.yml
@@ -8,7 +8,6 @@ birth_date: 1972-03-09
 image: https://theunitedstates.io/images/congress/450x550/A000375.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-19
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-19

--- a/data/us/legislature/Jody-B-Hice-a5b50fc1-ef3b-5c6a-83e3-0a59dc2ede9d.yml
+++ b/data/us/legislature/Jody-B-Hice-a5b50fc1-ef3b-5c6a-83e3-0a59dc2ede9d.yml
@@ -8,7 +8,6 @@ birth_date: 1960-04-22
 image: https://theunitedstates.io/images/congress/450x550/H001071.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-10

--- a/data/us/legislature/Joe-Courtney-b34622c6-66c7-5f9a-822f-55e3f9ac3c73.yml
+++ b/data/us/legislature/Joe-Courtney-b34622c6-66c7-5f9a-822f-55e3f9ac3c73.yml
@@ -7,7 +7,6 @@ birth_date: 1953-04-06
 image: https://theunitedstates.io/images/congress/450x550/C001069.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-2

--- a/data/us/legislature/Joe-Neguse-04243e35-118c-5541-a21e-763c594a083a.yml
+++ b/data/us/legislature/Joe-Neguse-04243e35-118c-5541-a21e-763c594a083a.yml
@@ -7,7 +7,6 @@ birth_date: 1984-05-13
 image: https://theunitedstates.io/images/congress/450x550/N000191.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-2

--- a/data/us/legislature/Joe-Wilson-af50abf4-b711-5bbc-a920-465e39c99f42.yml
+++ b/data/us/legislature/Joe-Wilson-af50abf4-b711-5bbc-a920-465e39c99f42.yml
@@ -8,7 +8,6 @@ birth_date: 1947-07-31
 image: https://theunitedstates.io/images/congress/450x550/W000795.jpg
 party:
 - start_date: '2001-12-18'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2001-12-18'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-2

--- a/data/us/legislature/John-A-Yarmuth-1672af60-33f0-5558-bce4-5336dd83c744.yml
+++ b/data/us/legislature/John-A-Yarmuth-1672af60-33f0-5558-bce4-5336dd83c744.yml
@@ -8,7 +8,6 @@ birth_date: 1947-11-04
 image: https://theunitedstates.io/images/congress/450x550/Y000062.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-3

--- a/data/us/legislature/John-B-Larson-4d2b82fc-189e-5007-980f-64a85612afdb.yml
+++ b/data/us/legislature/John-B-Larson-4d2b82fc-189e-5007-980f-64a85612afdb.yml
@@ -8,7 +8,6 @@ birth_date: 1948-07-22
 image: https://theunitedstates.io/images/congress/450x550/L000557.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1999-01-06'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-1

--- a/data/us/legislature/John-Boozman-b352dd8b-dd06-57b0-833a-2b0b3bd33ad6.yml
+++ b/data/us/legislature/John-Boozman-b352dd8b-dd06-57b0-833a-2b0b3bd33ad6.yml
@@ -7,7 +7,6 @@ birth_date: 1950-12-10
 image: https://theunitedstates.io/images/congress/450x550/B001236.jpg
 party:
 - start_date: '2001-11-29'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2001-11-29'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Arkansas
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Arkansas

--- a/data/us/legislature/John-Garamendi-d4381c32-b267-5e35-b118-c0da3a0a80a1.yml
+++ b/data/us/legislature/John-Garamendi-d4381c32-b267-5e35-b118-c0da3a0a80a1.yml
@@ -7,7 +7,6 @@ birth_date: 1945-01-24
 image: https://theunitedstates.io/images/congress/450x550/G000559.jpg
 party:
 - start_date: '2009-11-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-11-03'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-3

--- a/data/us/legislature/John-H-Rutherford-5ab7829c-a819-5616-ac0e-a0aaa359f493.yml
+++ b/data/us/legislature/John-H-Rutherford-5ab7829c-a819-5616-ac0e-a0aaa359f493.yml
@@ -8,7 +8,6 @@ birth_date: 1952-09-02
 image: https://theunitedstates.io/images/congress/450x550/R000609.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-4

--- a/data/us/legislature/John-Hoeven-18c027d3-52ca-5a48-a4d2-73167e382096.yml
+++ b/data/us/legislature/John-Hoeven-18c027d3-52ca-5a48-a4d2-73167e382096.yml
@@ -7,7 +7,6 @@ birth_date: 1957-03-13
 image: https://theunitedstates.io/images/congress/450x550/H001061.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: North Dakota
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: North Dakota

--- a/data/us/legislature/John-Joyce-50b75c29-4e98-5622-b60f-59485dcc1141.yml
+++ b/data/us/legislature/John-Joyce-50b75c29-4e98-5622-b60f-59485dcc1141.yml
@@ -7,7 +7,6 @@ birth_date: 1957-02-08
 image: https://theunitedstates.io/images/congress/450x550/J000302.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-13

--- a/data/us/legislature/John-Katko-3a47778c-03b7-56ab-887a-ba10c2924e77.yml
+++ b/data/us/legislature/John-Katko-3a47778c-03b7-56ab-887a-ba10c2924e77.yml
@@ -7,7 +7,6 @@ birth_date: 1962-11-09
 image: https://theunitedstates.io/images/congress/450x550/K000386.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-24
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-24

--- a/data/us/legislature/John-Kennedy-7a996578-ee76-59c8-856c-4f63861a62da.yml
+++ b/data/us/legislature/John-Kennedy-7a996578-ee76-59c8-856c-4f63861a62da.yml
@@ -8,11 +8,9 @@ birth_date: 1951-11-21
 image: https://theunitedstates.io/images/congress/450x550/K000393.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Louisiana

--- a/data/us/legislature/John-P-Sarbanes-a1232c4d-25eb-555a-85a3-b2e168a086c1.yml
+++ b/data/us/legislature/John-P-Sarbanes-a1232c4d-25eb-555a-85a3-b2e168a086c1.yml
@@ -8,7 +8,6 @@ birth_date: 1962-05-22
 image: https://theunitedstates.io/images/congress/450x550/S001168.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-3

--- a/data/us/legislature/John-R-Carter-7b014168-dc13-5568-96df-8c7cbb335268.yml
+++ b/data/us/legislature/John-R-Carter-7b014168-dc13-5568-96df-8c7cbb335268.yml
@@ -8,7 +8,6 @@ birth_date: 1941-11-06
 image: https://theunitedstates.io/images/congress/450x550/C001051.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-31
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-31

--- a/data/us/legislature/John-R-Curtis-7cc5139d-8e53-560c-9828-926395e1552d.yml
+++ b/data/us/legislature/John-R-Curtis-7cc5139d-8e53-560c-9828-926395e1552d.yml
@@ -8,7 +8,6 @@ birth_date: 1960-05-10
 image: https://theunitedstates.io/images/congress/450x550/C001114.jpg
 party:
 - start_date: '2017-11-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-11-13'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: UT-3

--- a/data/us/legislature/John-R-Moolenaar-cb38b814-2794-505a-9232-f1bd56ca3ca0.yml
+++ b/data/us/legislature/John-R-Moolenaar-cb38b814-2794-505a-9232-f1bd56ca3ca0.yml
@@ -8,7 +8,6 @@ birth_date: 1961-05-08
 image: https://theunitedstates.io/images/congress/450x550/M001194.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-4

--- a/data/us/legislature/John-Rose-a30feb1f-c9fe-5612-808e-8fe5a55b76dc.yml
+++ b/data/us/legislature/John-Rose-a30feb1f-c9fe-5612-808e-8fe5a55b76dc.yml
@@ -8,7 +8,6 @@ birth_date: 1965-02-23
 image: https://theunitedstates.io/images/congress/450x550/R000612.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-6

--- a/data/us/legislature/John-Thune-342214ae-2e66-50a4-9a10-acc467bd5d98.yml
+++ b/data/us/legislature/John-Thune-342214ae-2e66-50a4-9a10-acc467bd5d98.yml
@@ -7,7 +7,6 @@ birth_date: 1961-01-07
 image: https://theunitedstates.io/images/congress/450x550/T000250.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: South Dakota
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: South Dakota

--- a/data/us/legislature/Joseph-D-Morelle-70681900-af7f-5ee5-b826-7ab8c4194a9e.yml
+++ b/data/us/legislature/Joseph-D-Morelle-70681900-af7f-5ee5-b826-7ab8c4194a9e.yml
@@ -8,7 +8,6 @@ birth_date: 1957-04-29
 image: https://theunitedstates.io/images/congress/450x550/M001206.jpg
 party:
 - start_date: '2018-11-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2018-11-13'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-25
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-25

--- a/data/us/legislature/Joseph-Sempolinski-4bfc1a4d-6f3f-57e0-aadd-88671e1d0254.yml
+++ b/data/us/legislature/Joseph-Sempolinski-4bfc1a4d-6f3f-57e0-aadd-88671e1d0254.yml
@@ -7,11 +7,9 @@ birth_date: 1982-02-10
 image: https://theunitedstates.io/images/congress/450x550/S001219.jpg
 party:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-23

--- a/data/us/legislature/Josh-Gottheimer-8ce4e2db-be5a-5493-a399-b2e6061301ba.yml
+++ b/data/us/legislature/Josh-Gottheimer-8ce4e2db-be5a-5493-a399-b2e6061301ba.yml
@@ -7,7 +7,6 @@ birth_date: 1975-03-08
 image: https://theunitedstates.io/images/congress/450x550/G000583.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-5

--- a/data/us/legislature/Josh-Harder-3ed77541-5a79-56b1-94d9-79baa74e938b.yml
+++ b/data/us/legislature/Josh-Harder-3ed77541-5a79-56b1-94d9-79baa74e938b.yml
@@ -7,7 +7,6 @@ birth_date: 1986-08-01
 image: https://theunitedstates.io/images/congress/450x550/H001090.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-10

--- a/data/us/legislature/Joyce-Beatty-47fb8c8b-1c71-5c66-9781-94be94803332.yml
+++ b/data/us/legislature/Joyce-Beatty-47fb8c8b-1c71-5c66-9781-94be94803332.yml
@@ -7,7 +7,6 @@ birth_date: 1950-03-12
 image: https://theunitedstates.io/images/congress/450x550/B001281.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-3

--- a/data/us/legislature/Juan-Vargas-904bef1f-7ef4-51af-aeef-b0ac8e1fbe06.yml
+++ b/data/us/legislature/Juan-Vargas-904bef1f-7ef4-51af-aeef-b0ac8e1fbe06.yml
@@ -7,7 +7,6 @@ birth_date: 1961-03-07
 image: https://theunitedstates.io/images/congress/450x550/V000130.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-51
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-51

--- a/data/us/legislature/Judy-Chu-a06fc4e8-2e1e-52b6-9aef-83d9405fe16b.yml
+++ b/data/us/legislature/Judy-Chu-a06fc4e8-2e1e-52b6-9aef-83d9405fe16b.yml
@@ -8,7 +8,6 @@ birth_date: 1953-07-07
 image: https://theunitedstates.io/images/congress/450x550/C001080.jpg
 party:
 - start_date: '2009-07-16'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-07-16'
@@ -42,7 +41,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-27
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-27

--- a/data/us/legislature/Julia-Brownley-84e51316-26ee-55c7-88e8-ae3bd2b7b3cc.yml
+++ b/data/us/legislature/Julia-Brownley-84e51316-26ee-55c7-88e8-ae3bd2b7b3cc.yml
@@ -7,7 +7,6 @@ birth_date: 1952-08-28
 image: https://theunitedstates.io/images/congress/450x550/B001285.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-26
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-26

--- a/data/us/legislature/Julia-Letlow-2a914bb0-5ddc-52d0-abb0-f0cd7830fc5f.yml
+++ b/data/us/legislature/Julia-Letlow-2a914bb0-5ddc-52d0-abb0-f0cd7830fc5f.yml
@@ -7,11 +7,9 @@ birth_date: 1981-03-16
 image: https://theunitedstates.io/images/congress/450x550/L000595.jpg
 party:
 - start_date: '2021-04-14'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-04-14'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-5

--- a/data/us/legislature/Kaialii-Kahele-8ce5f212-19b5-553a-a295-91c914da86c8.yml
+++ b/data/us/legislature/Kaialii-Kahele-8ce5f212-19b5-553a-a295-91c914da86c8.yml
@@ -7,11 +7,9 @@ birth_date: 1974-03-28
 image: https://theunitedstates.io/images/congress/450x550/K000396.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: HI-2

--- a/data/us/legislature/Karen-Bass-02f50417-c155-5ebd-b059-896e3a64e3ce.yml
+++ b/data/us/legislature/Karen-Bass-02f50417-c155-5ebd-b059-896e3a64e3ce.yml
@@ -7,7 +7,6 @@ birth_date: 1953-10-03
 image: https://theunitedstates.io/images/congress/450x550/B001270.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-37
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-37

--- a/data/us/legislature/Kat-Cammack-0963048e-e973-5563-a888-497a3bd4a492.yml
+++ b/data/us/legislature/Kat-Cammack-0963048e-e973-5563-a888-497a3bd4a492.yml
@@ -7,11 +7,9 @@ birth_date: 1988-02-16
 image: https://theunitedstates.io/images/congress/450x550/C001039.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-3

--- a/data/us/legislature/Katherine-M-Clark-c882e018-77a3-529f-83ca-151e98d04264.yml
+++ b/data/us/legislature/Katherine-M-Clark-c882e018-77a3-529f-83ca-151e98d04264.yml
@@ -8,7 +8,6 @@ birth_date: 1963-07-17
 image: https://theunitedstates.io/images/congress/450x550/C001101.jpg
 party:
 - start_date: '2013-12-12'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-12-12'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-5

--- a/data/us/legislature/Kathleen-M-Rice-b3de5413-0aaf-503f-92c2-6b5b540970d4.yml
+++ b/data/us/legislature/Kathleen-M-Rice-b3de5413-0aaf-503f-92c2-6b5b540970d4.yml
@@ -8,7 +8,6 @@ birth_date: 1965-02-15
 image: https://theunitedstates.io/images/congress/450x550/R000602.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-4

--- a/data/us/legislature/Kathy-Castor-4e9be052-7054-5a13-84af-4e5176dbac41.yml
+++ b/data/us/legislature/Kathy-Castor-4e9be052-7054-5a13-84af-4e5176dbac41.yml
@@ -7,7 +7,6 @@ birth_date: 1966-08-20
 image: https://theunitedstates.io/images/congress/450x550/C001066.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-14

--- a/data/us/legislature/Kathy-E-Manning-1c6b4ab9-cf1b-5dc1-a537-b991aff8fe5b.yml
+++ b/data/us/legislature/Kathy-E-Manning-1c6b4ab9-cf1b-5dc1-a537-b991aff8fe5b.yml
@@ -8,11 +8,9 @@ birth_date: 1956-12-03
 image: https://theunitedstates.io/images/congress/450x550/M001135.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-6

--- a/data/us/legislature/Katie-Porter-8582a25f-087e-5d46-8c12-7dd2e5cf5417.yml
+++ b/data/us/legislature/Katie-Porter-8582a25f-087e-5d46-8c12-7dd2e5cf5417.yml
@@ -7,7 +7,6 @@ birth_date: 1974-01-03
 image: https://theunitedstates.io/images/congress/450x550/P000618.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-45
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-45

--- a/data/us/legislature/Kay-Granger-32f7cd03-4f8d-5354-b6d1-114bdd4f9af1.yml
+++ b/data/us/legislature/Kay-Granger-32f7cd03-4f8d-5354-b6d1-114bdd4f9af1.yml
@@ -7,7 +7,6 @@ birth_date: 1943-01-18
 image: https://theunitedstates.io/images/congress/450x550/G000377.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -71,7 +70,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-12

--- a/data/us/legislature/Kelly-Armstrong-ea4b65ca-7dbf-575b-abdb-1ac17d6ebb13.yml
+++ b/data/us/legislature/Kelly-Armstrong-ea4b65ca-7dbf-575b-abdb-1ac17d6ebb13.yml
@@ -7,7 +7,6 @@ birth_date: 1976-10-08
 image: https://theunitedstates.io/images/congress/450x550/A000377.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ND-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ND-AL

--- a/data/us/legislature/Ken-Buck-ae816838-90af-512b-8a98-9389b05e9b6a.yml
+++ b/data/us/legislature/Ken-Buck-ae816838-90af-512b-8a98-9389b05e9b6a.yml
@@ -7,7 +7,6 @@ birth_date: 1959-02-16
 image: https://theunitedstates.io/images/congress/450x550/B001297.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-4

--- a/data/us/legislature/Ken-Calvert-3ca12a7a-5192-58bf-ba92-c219af17d74c.yml
+++ b/data/us/legislature/Ken-Calvert-3ca12a7a-5192-58bf-ba92-c219af17d74c.yml
@@ -8,7 +8,6 @@ birth_date: 1953-06-08
 image: https://theunitedstates.io/images/congress/450x550/C000059.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-42
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-42

--- a/data/us/legislature/Kevin-Brady-724efb82-0dc0-54d1-a56a-5f3af0ea7371.yml
+++ b/data/us/legislature/Kevin-Brady-724efb82-0dc0-54d1-a56a-5f3af0ea7371.yml
@@ -8,7 +8,6 @@ birth_date: 1955-04-11
 image: https://theunitedstates.io/images/congress/450x550/B000755.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-8

--- a/data/us/legislature/Kevin-Hern-139e15e1-4a50-5126-ad7a-b462c44f00e0.yml
+++ b/data/us/legislature/Kevin-Hern-139e15e1-4a50-5126-ad7a-b462c44f00e0.yml
@@ -8,7 +8,6 @@ birth_date: 1961-12-04
 image: https://theunitedstates.io/images/congress/450x550/H001082.jpg
 party:
 - start_date: '2018-11-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2018-11-13'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-1

--- a/data/us/legislature/Kevin-McCarthy-d62b2724-dfc4-58c1-abd2-2a6ac89ec3bf.yml
+++ b/data/us/legislature/Kevin-McCarthy-d62b2724-dfc4-58c1-abd2-2a6ac89ec3bf.yml
@@ -7,7 +7,6 @@ birth_date: 1965-01-26
 image: https://theunitedstates.io/images/congress/450x550/M001165.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-23
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-23

--- a/data/us/legislature/Kim-Schrier-eb152f16-def8-5b51-9379-e7e463628ad6.yml
+++ b/data/us/legislature/Kim-Schrier-eb152f16-def8-5b51-9379-e7e463628ad6.yml
@@ -7,7 +7,6 @@ birth_date: 1968-08-23
 image: https://theunitedstates.io/images/congress/450x550/S001216.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-8

--- a/data/us/legislature/Kurt-Schrader-292dc6b5-550c-596b-876a-bf4c7843b3f8.yml
+++ b/data/us/legislature/Kurt-Schrader-292dc6b5-550c-596b-876a-bf4c7843b3f8.yml
@@ -7,7 +7,6 @@ birth_date: 1951-10-19
 image: https://theunitedstates.io/images/congress/450x550/S001180.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-5

--- a/data/us/legislature/Kweisi-Mfume-79575558-ef44-5bb5-9c64-3d3fe3fb4427.yml
+++ b/data/us/legislature/Kweisi-Mfume-79575558-ef44-5bb5-9c64-3d3fe3fb4427.yml
@@ -7,7 +7,6 @@ birth_date: 1948-10-24
 image: https://theunitedstates.io/images/congress/450x550/M000687.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1987-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-7

--- a/data/us/legislature/Lance-Gooden-8d52be7e-dba0-5b01-bb9a-c0cfb72fa609.yml
+++ b/data/us/legislature/Lance-Gooden-8d52be7e-dba0-5b01-bb9a-c0cfb72fa609.yml
@@ -7,7 +7,6 @@ birth_date: 1982-12-01
 image: https://theunitedstates.io/images/congress/450x550/G000589.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-5

--- a/data/us/legislature/Larry-Bucshon-9b31b2fc-8303-5ad0-85d3-1051a49aedb2.yml
+++ b/data/us/legislature/Larry-Bucshon-9b31b2fc-8303-5ad0-85d3-1051a49aedb2.yml
@@ -7,7 +7,6 @@ birth_date: 1962-05-31
 image: https://theunitedstates.io/images/congress/450x550/B001275.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-8

--- a/data/us/legislature/Lauren-Boebert-bbaa33e5-6ab2-5fba-bb46-35e44f89e553.yml
+++ b/data/us/legislature/Lauren-Boebert-bbaa33e5-6ab2-5fba-bb46-35e44f89e553.yml
@@ -8,11 +8,9 @@ birth_date: 1986-12-15
 image: https://theunitedstates.io/images/congress/450x550/B000825.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CO-3

--- a/data/us/legislature/Lauren-Underwood-9415f4f1-c2b8-5543-b695-d8cace3373f2.yml
+++ b/data/us/legislature/Lauren-Underwood-9415f4f1-c2b8-5543-b695-d8cace3373f2.yml
@@ -7,7 +7,6 @@ birth_date: 1986-10-04
 image: https://theunitedstates.io/images/congress/450x550/U000040.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-14

--- a/data/us/legislature/Lee-M-Zeldin-9820ff72-a39e-5f36-a698-baa4720708bb.yml
+++ b/data/us/legislature/Lee-M-Zeldin-9820ff72-a39e-5f36-a698-baa4720708bb.yml
@@ -8,7 +8,6 @@ birth_date: 1980-01-30
 image: https://theunitedstates.io/images/congress/450x550/Z000017.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-1

--- a/data/us/legislature/Linda-T-Snchez-b01048a9-27a5-5fed-b5ef-7bf3b3be6d04.yml
+++ b/data/us/legislature/Linda-T-Snchez-b01048a9-27a5-5fed-b5ef-7bf3b3be6d04.yml
@@ -8,7 +8,6 @@ birth_date: 1969-01-28
 image: https://theunitedstates.io/images/congress/450x550/S001156.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-38
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-38

--- a/data/us/legislature/Lisa-Blunt-Rochester-0b32bee9-863e-522f-99b8-9ad8e5d8f42e.yml
+++ b/data/us/legislature/Lisa-Blunt-Rochester-0b32bee9-863e-522f-99b8-9ad8e5d8f42e.yml
@@ -7,7 +7,6 @@ birth_date: 1962-02-10
 image: https://theunitedstates.io/images/congress/450x550/B001303.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: DE-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: DE-AL

--- a/data/us/legislature/Lisa-C-McClain-f8a1c19c-3aa4-5c20-a8a4-211a40b2c540.yml
+++ b/data/us/legislature/Lisa-C-McClain-f8a1c19c-3aa4-5c20-a8a4-211a40b2c540.yml
@@ -8,11 +8,9 @@ birth_date: 1966-04-07
 image: https://theunitedstates.io/images/congress/450x550/M001136.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-10

--- a/data/us/legislature/Lisa-Murkowski-cd76253c-a786-586d-aaac-bd14db985c3b.yml
+++ b/data/us/legislature/Lisa-Murkowski-cd76253c-a786-586d-aaac-bd14db985c3b.yml
@@ -8,7 +8,6 @@ birth_date: 1957-05-22
 image: https://theunitedstates.io/images/congress/450x550/M001153.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Alaska
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Alaska

--- a/data/us/legislature/Liz-Cheney-601f7bba-aac4-5010-9553-d6a214d03abb.yml
+++ b/data/us/legislature/Liz-Cheney-601f7bba-aac4-5010-9553-d6a214d03abb.yml
@@ -7,7 +7,6 @@ birth_date: 1966-07-28
 image: https://theunitedstates.io/images/congress/450x550/C001109.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WY-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WY-AL

--- a/data/us/legislature/Lizzie-Fletcher-b2b37c5e-17c0-5833-b5e0-fe4f93834761.yml
+++ b/data/us/legislature/Lizzie-Fletcher-b2b37c5e-17c0-5833-b5e0-fe4f93834761.yml
@@ -7,7 +7,6 @@ birth_date: 1975-02-13
 image: https://theunitedstates.io/images/congress/450x550/F000468.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-7

--- a/data/us/legislature/Lloyd-Doggett-09fc76c2-eb6b-52c2-bc3d-de183e362df0.yml
+++ b/data/us/legislature/Lloyd-Doggett-09fc76c2-eb6b-52c2-bc3d-de183e362df0.yml
@@ -8,7 +8,6 @@ birth_date: 1946-10-06
 image: https://theunitedstates.io/images/congress/450x550/D000399.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1995-01-04'
@@ -77,7 +76,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-35
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-35

--- a/data/us/legislature/Lloyd-Smucker-0f2326f2-b5dc-5428-bcaa-9a1078d0750c.yml
+++ b/data/us/legislature/Lloyd-Smucker-0f2326f2-b5dc-5428-bcaa-9a1078d0750c.yml
@@ -7,7 +7,6 @@ birth_date: 1964-01-23
 image: https://theunitedstates.io/images/congress/450x550/S001199.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-11

--- a/data/us/legislature/Lois-Frankel-6dca533f-6c45-5308-9d6c-b579d4baf301.yml
+++ b/data/us/legislature/Lois-Frankel-6dca533f-6c45-5308-9d6c-b579d4baf301.yml
@@ -7,7 +7,6 @@ birth_date: 1948-05-16
 image: https://theunitedstates.io/images/congress/450x550/F000462.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-21
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-21

--- a/data/us/legislature/Lori-Trahan-f8d561c8-c0f2-5251-9d52-53289b82c7d9.yml
+++ b/data/us/legislature/Lori-Trahan-f8d561c8-c0f2-5251-9d52-53289b82c7d9.yml
@@ -7,7 +7,6 @@ birth_date: 1973-10-27
 image: https://theunitedstates.io/images/congress/450x550/T000482.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-3

--- a/data/us/legislature/Louie-Gohmert-52faca59-597a-542b-aa80-94aa0bbe46f4.yml
+++ b/data/us/legislature/Louie-Gohmert-52faca59-597a-542b-aa80-94aa0bbe46f4.yml
@@ -8,7 +8,6 @@ birth_date: 1953-08-18
 image: https://theunitedstates.io/images/congress/450x550/G000552.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2005-01-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-1

--- a/data/us/legislature/Lucille-Roybal-Allard-c718d211-6200-5336-9c19-67a80575d5e9.yml
+++ b/data/us/legislature/Lucille-Roybal-Allard-c718d211-6200-5336-9c19-67a80575d5e9.yml
@@ -7,7 +7,6 @@ birth_date: 1941-06-12
 image: https://theunitedstates.io/images/congress/450x550/R000486.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -81,7 +80,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-40
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-40

--- a/data/us/legislature/Lucy-McBath-b5d26a8a-2954-574c-abf8-1c232e928c9c.yml
+++ b/data/us/legislature/Lucy-McBath-b5d26a8a-2954-574c-abf8-1c232e928c9c.yml
@@ -7,7 +7,6 @@ birth_date: 1960-06-01
 image: https://theunitedstates.io/images/congress/450x550/M001208.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-6

--- a/data/us/legislature/Madeleine-Dean-1daf07ea-2575-511e-a5a8-47f0662cf209.yml
+++ b/data/us/legislature/Madeleine-Dean-1daf07ea-2575-511e-a5a8-47f0662cf209.yml
@@ -7,7 +7,6 @@ birth_date: 1959-06-06
 image: https://theunitedstates.io/images/congress/450x550/D000631.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-4

--- a/data/us/legislature/Madison-Cawthorn-16ed6edb-3c78-5a35-8303-b0618531093b.yml
+++ b/data/us/legislature/Madison-Cawthorn-16ed6edb-3c78-5a35-8303-b0618531093b.yml
@@ -7,11 +7,9 @@ birth_date: 1995-08-01
 image: https://theunitedstates.io/images/congress/450x550/C001104.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-11

--- a/data/us/legislature/Marc-A-Veasey-fe3cbb3c-90cd-5661-8f02-2e7da15459b8.yml
+++ b/data/us/legislature/Marc-A-Veasey-fe3cbb3c-90cd-5661-8f02-2e7da15459b8.yml
@@ -8,7 +8,6 @@ birth_date: 1971-01-03
 image: https://theunitedstates.io/images/congress/450x550/V000131.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-33
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-33

--- a/data/us/legislature/Marco-Rubio-014b069e-c444-50fe-99ef-bf72ae5aecd5.yml
+++ b/data/us/legislature/Marco-Rubio-014b069e-c444-50fe-99ef-bf72ae5aecd5.yml
@@ -7,7 +7,6 @@ birth_date: 1971-05-28
 image: https://theunitedstates.io/images/congress/450x550/R000595.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Florida
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Florida

--- a/data/us/legislature/Marcy-Kaptur-b6f3dafd-0c6e-5694-ac20-59a88e891f62.yml
+++ b/data/us/legislature/Marcy-Kaptur-b6f3dafd-0c6e-5694-ac20-59a88e891f62.yml
@@ -7,7 +7,6 @@ birth_date: 1946-06-17
 image: https://theunitedstates.io/images/congress/450x550/K000009.jpg
 party:
 - start_date: '1983-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1983-01-03'
@@ -106,7 +105,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-9

--- a/data/us/legislature/Margaret-Wood-Hassan-c59c2d02-3a1e-55a7-b1eb-638a902899d5.yml
+++ b/data/us/legislature/Margaret-Wood-Hassan-c59c2d02-3a1e-55a7-b1eb-638a902899d5.yml
@@ -8,11 +8,9 @@ birth_date: 1958-02-27
 image: https://theunitedstates.io/images/congress/450x550/H001076.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: New Hampshire

--- a/data/us/legislature/Maria-Elvira-Salazar-23524e03-1206-50cb-844d-ddea47f258da.yml
+++ b/data/us/legislature/Maria-Elvira-Salazar-23524e03-1206-50cb-844d-ddea47f258da.yml
@@ -8,11 +8,9 @@ birth_date: 1961-11-01
 image: https://theunitedstates.io/images/congress/450x550/S000168.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-27

--- a/data/us/legislature/Mariannette-Miller-Meeks-fc8623ea-be1e-518f-aa76-3598910fa676.yml
+++ b/data/us/legislature/Mariannette-Miller-Meeks-fc8623ea-be1e-518f-aa76-3598910fa676.yml
@@ -8,11 +8,9 @@ birth_date: 1955-09-06
 image: https://theunitedstates.io/images/congress/450x550/M001215.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IA-2

--- a/data/us/legislature/Marie-Newman-a8ad82c4-eabb-5a71-b538-40bc116a11ad.yml
+++ b/data/us/legislature/Marie-Newman-a8ad82c4-eabb-5a71-b538-40bc116a11ad.yml
@@ -7,11 +7,9 @@ birth_date: 1964-04-13
 image: https://theunitedstates.io/images/congress/450x550/N000192.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-3

--- a/data/us/legislature/Marilyn-Strickland-f0914f67-02b0-5f3c-8f03-949f79c30f62.yml
+++ b/data/us/legislature/Marilyn-Strickland-f0914f67-02b0-5f3c-8f03-949f79c30f62.yml
@@ -7,11 +7,9 @@ birth_date: 1962-09-25
 image: https://theunitedstates.io/images/congress/450x550/S001159.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-10

--- a/data/us/legislature/Mario-Diaz-Balart-7e5729d1-198d-5389-be51-d1e05969729c.yml
+++ b/data/us/legislature/Mario-Diaz-Balart-7e5729d1-198d-5389-be51-d1e05969729c.yml
@@ -7,7 +7,6 @@ birth_date: 1961-09-25
 image: https://theunitedstates.io/images/congress/450x550/D000600.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -56,7 +55,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-25
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-25

--- a/data/us/legislature/Marjorie-Taylor-Greene-8c511e48-a002-5f1c-a4b9-1cd18b7f7a6e.yml
+++ b/data/us/legislature/Marjorie-Taylor-Greene-8c511e48-a002-5f1c-a4b9-1cd18b7f7a6e.yml
@@ -8,11 +8,9 @@ birth_date: 1974-05-27
 image: https://theunitedstates.io/images/congress/450x550/G000596.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-14

--- a/data/us/legislature/Mark-DeSaulnier-a1d66d4f-5f94-5605-9e25-96c8f5b4e2df.yml
+++ b/data/us/legislature/Mark-DeSaulnier-a1d66d4f-5f94-5605-9e25-96c8f5b4e2df.yml
@@ -7,7 +7,6 @@ birth_date: 1952-03-31
 image: https://theunitedstates.io/images/congress/450x550/D000623.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-11

--- a/data/us/legislature/Mark-E-Amodei-e58ac762-d546-52f3-8efd-8a2c8f12f731.yml
+++ b/data/us/legislature/Mark-E-Amodei-e58ac762-d546-52f3-8efd-8a2c8f12f731.yml
@@ -8,7 +8,6 @@ birth_date: 1958-06-12
 image: https://theunitedstates.io/images/congress/450x550/A000369.jpg
 party:
 - start_date: '2011-09-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-09-13'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-2

--- a/data/us/legislature/Mark-E-Green-92fdf72b-20aa-5d08-83b8-833c4714b0ac.yml
+++ b/data/us/legislature/Mark-E-Green-92fdf72b-20aa-5d08-83b8-833c4714b0ac.yml
@@ -8,7 +8,6 @@ birth_date: 1964-11-08
 image: https://theunitedstates.io/images/congress/450x550/G000590.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-7

--- a/data/us/legislature/Mark-Kelly-30665d55-5695-5ede-930d-c92e63e4ee65.yml
+++ b/data/us/legislature/Mark-Kelly-30665d55-5695-5ede-930d-c92e63e4ee65.yml
@@ -7,11 +7,9 @@ birth_date: 1964-02-21
 image: https://theunitedstates.io/images/congress/450x550/K000377.jpg
 party:
 - start_date: '2020-12-02'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2020-12-02'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Arizona

--- a/data/us/legislature/Mark-Pocan-50093b91-c03b-5dbf-acb8-e5881dd576e4.yml
+++ b/data/us/legislature/Mark-Pocan-50093b91-c03b-5dbf-acb8-e5881dd576e4.yml
@@ -7,7 +7,6 @@ birth_date: 1964-08-14
 image: https://theunitedstates.io/images/congress/450x550/P000607.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-2

--- a/data/us/legislature/Mark-Takano-d01bffb6-a515-5ca5-8203-3a9b8d5da15e.yml
+++ b/data/us/legislature/Mark-Takano-d01bffb6-a515-5ca5-8203-3a9b8d5da15e.yml
@@ -7,7 +7,6 @@ birth_date: 1960-12-10
 image: https://theunitedstates.io/images/congress/450x550/T000472.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-41
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-41

--- a/data/us/legislature/Markwayne-Mullin-c1fcdb86-e58e-59ed-94f2-40e481824423.yml
+++ b/data/us/legislature/Markwayne-Mullin-c1fcdb86-e58e-59ed-94f2-40e481824423.yml
@@ -7,7 +7,6 @@ birth_date: 1977-07-26
 image: https://theunitedstates.io/images/congress/450x550/M001190.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-2

--- a/data/us/legislature/Mary-E-Miller-b98a30a0-ae7f-5910-9883-3132a7164446.yml
+++ b/data/us/legislature/Mary-E-Miller-b98a30a0-ae7f-5910-9883-3132a7164446.yml
@@ -8,11 +8,9 @@ birth_date: 1959-08-27
 image: https://theunitedstates.io/images/congress/450x550/M001211.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-15

--- a/data/us/legislature/Mary-Gay-Scanlon-4dc45e4a-78e1-545f-94c1-10c1d9a12f15.yml
+++ b/data/us/legislature/Mary-Gay-Scanlon-4dc45e4a-78e1-545f-94c1-10c1d9a12f15.yml
@@ -8,7 +8,6 @@ birth_date: 1959-08-30
 image: https://theunitedstates.io/images/congress/450x550/S001205.jpg
 party:
 - start_date: '2018-11-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2018-11-13'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-5

--- a/data/us/legislature/Mary-Sattler-Peltola-be59b2eb-82fa-5b34-af53-30a9aa8b1123.yml
+++ b/data/us/legislature/Mary-Sattler-Peltola-be59b2eb-82fa-5b34-af53-30a9aa8b1123.yml
@@ -8,11 +8,9 @@ birth_date: 1973-08-31
 image: https://theunitedstates.io/images/congress/450x550/P000619.jpg
 party:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AK-AL

--- a/data/us/legislature/Matt-Cartwright-1f22bb4c-3315-53ae-848a-e30bb8fec18e.yml
+++ b/data/us/legislature/Matt-Cartwright-1f22bb4c-3315-53ae-848a-e30bb8fec18e.yml
@@ -8,7 +8,6 @@ birth_date: 1961-05-01
 image: https://theunitedstates.io/images/congress/450x550/C001090.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-8

--- a/data/us/legislature/Matt-Gaetz-89e031c0-3988-5b08-b7a3-7d4e63eb0579.yml
+++ b/data/us/legislature/Matt-Gaetz-89e031c0-3988-5b08-b7a3-7d4e63eb0579.yml
@@ -7,7 +7,6 @@ birth_date: 1982-05-07
 image: https://theunitedstates.io/images/congress/450x550/G000578.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-1

--- a/data/us/legislature/Matthew-M-Rosendale-Sr-5b030c5d-0d50-5452-b2f8-95f8659056fb.yml
+++ b/data/us/legislature/Matthew-M-Rosendale-Sr-5b030c5d-0d50-5452-b2f8-95f8659056fb.yml
@@ -8,11 +8,9 @@ birth_date: 1960-07-07
 image: https://theunitedstates.io/images/congress/450x550/R000103.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MT-AL

--- a/data/us/legislature/Maxine-Waters-fc7a4a9e-9274-546f-ae5c-bcf46f3fe0f2.yml
+++ b/data/us/legislature/Maxine-Waters-fc7a4a9e-9274-546f-ae5c-bcf46f3fe0f2.yml
@@ -7,7 +7,6 @@ birth_date: 1938-08-15
 image: https://theunitedstates.io/images/congress/450x550/W000187.jpg
 party:
 - start_date: '1991-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1991-01-03'
@@ -86,7 +85,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-43
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-43

--- a/data/us/legislature/Mayra-Flores-ef8da5df-fffc-5baf-807c-044b70be6231.yml
+++ b/data/us/legislature/Mayra-Flores-ef8da5df-fffc-5baf-807c-044b70be6231.yml
@@ -7,11 +7,9 @@ birth_date: 1986-01-01
 image: https://theunitedstates.io/images/congress/450x550/F000473.jpg
 party:
 - start_date: '2022-06-21'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-06-21'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-34

--- a/data/us/legislature/Melanie-A-Stansbury-e3c837d0-9b42-53c9-a131-896bb28aa319.yml
+++ b/data/us/legislature/Melanie-A-Stansbury-e3c837d0-9b42-53c9-a131-896bb28aa319.yml
@@ -8,11 +8,9 @@ birth_date: 1979-01-31
 image: https://theunitedstates.io/images/congress/450x550/S001218.jpg
 party:
 - start_date: '2021-06-14'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-06-14'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NM-1

--- a/data/us/legislature/Michael-C-Burgess-e40d8398-4cca-57bb-a8cc-8376230801d4.yml
+++ b/data/us/legislature/Michael-C-Burgess-e40d8398-4cca-57bb-a8cc-8376230801d4.yml
@@ -8,7 +8,6 @@ birth_date: 1950-12-23
 image: https://theunitedstates.io/images/congress/450x550/B001248.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-26
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-26

--- a/data/us/legislature/Michael-Cloud-da5e831e-227c-58a1-bf1a-86782158fb57.yml
+++ b/data/us/legislature/Michael-Cloud-da5e831e-227c-58a1-bf1a-86782158fb57.yml
@@ -7,7 +7,6 @@ birth_date: 1975-05-13
 image: https://theunitedstates.io/images/congress/450x550/C001115.jpg
 party:
 - start_date: '2018-07-10'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2018-07-10'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-27
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-27

--- a/data/us/legislature/Michael-F-Bennet-16a0a125-6ebe-58b3-810f-df10c0e7df1f.yml
+++ b/data/us/legislature/Michael-F-Bennet-16a0a125-6ebe-58b3-810f-df10c0e7df1f.yml
@@ -8,7 +8,6 @@ birth_date: 1964-11-28
 image: https://theunitedstates.io/images/congress/450x550/B001267.jpg
 party:
 - start_date: '2009-01-22'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-22'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Colorado
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Colorado

--- a/data/us/legislature/Michael-F-Doyle-52d09f45-3b79-5dba-9eb0-e14dcbd8d564.yml
+++ b/data/us/legislature/Michael-F-Doyle-52d09f45-3b79-5dba-9eb0-e14dcbd8d564.yml
@@ -8,7 +8,6 @@ birth_date: 1953-08-05
 image: https://theunitedstates.io/images/congress/450x550/D000482.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1995-01-04'
@@ -77,7 +76,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-18

--- a/data/us/legislature/Michael-F-Q-San-Nicolas-20e8925f-21af-5e60-a892-f80f4da20037.yml
+++ b/data/us/legislature/Michael-F-Q-San-Nicolas-20e8925f-21af-5e60-a892-f80f4da20037.yml
@@ -8,7 +8,6 @@ birth_date: 1981-01-30
 image: https://theunitedstates.io/images/congress/450x550/S001204.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GU-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GU-AL

--- a/data/us/legislature/Michael-Guest-6b015607-c3dd-5867-a1bb-733bf84fe091.yml
+++ b/data/us/legislature/Michael-Guest-6b015607-c3dd-5867-a1bb-733bf84fe091.yml
@@ -7,7 +7,6 @@ birth_date: 1970-02-04
 image: https://theunitedstates.io/images/congress/450x550/G000591.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-3

--- a/data/us/legislature/Michael-K-Simpson-ba023811-213b-5bb1-a0dc-11a9458364f1.yml
+++ b/data/us/legislature/Michael-K-Simpson-ba023811-213b-5bb1-a0dc-11a9458364f1.yml
@@ -8,7 +8,6 @@ birth_date: 1950-09-08
 image: https://theunitedstates.io/images/congress/450x550/S001148.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1999-01-06'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ID-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ID-2

--- a/data/us/legislature/Michael-R-Turner-bac6c65d-846b-5e60-9532-fa216c99ccf6.yml
+++ b/data/us/legislature/Michael-R-Turner-bac6c65d-846b-5e60-9532-fa216c99ccf6.yml
@@ -8,7 +8,6 @@ birth_date: 1960-01-11
 image: https://theunitedstates.io/images/congress/450x550/T000463.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-10

--- a/data/us/legislature/Michael-T-McCaul-15d37180-ddd2-5bb6-8dd4-cdd2690eca86.yml
+++ b/data/us/legislature/Michael-T-McCaul-15d37180-ddd2-5bb6-8dd4-cdd2690eca86.yml
@@ -8,7 +8,6 @@ birth_date: 1962-01-14
 image: https://theunitedstates.io/images/congress/450x550/M001157.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2005-01-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-10

--- a/data/us/legislature/Michael-Waltz-f335088b-3b7b-5009-9dd9-f389ffe59cdb.yml
+++ b/data/us/legislature/Michael-Waltz-f335088b-3b7b-5009-9dd9-f389ffe59cdb.yml
@@ -7,7 +7,6 @@ birth_date: 1974-01-31
 image: https://theunitedstates.io/images/congress/450x550/W000823.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-6

--- a/data/us/legislature/Michelle-Fischbach-66724fb4-e553-59cb-b8ba-314e3bf9f1ea.yml
+++ b/data/us/legislature/Michelle-Fischbach-66724fb4-e553-59cb-b8ba-314e3bf9f1ea.yml
@@ -8,11 +8,9 @@ birth_date: 1965-11-03
 image: https://theunitedstates.io/images/congress/450x550/F000470.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-7

--- a/data/us/legislature/Michelle-Steel-b95a5cd3-53ca-5f03-8b14-703add32cf84.yml
+++ b/data/us/legislature/Michelle-Steel-b95a5cd3-53ca-5f03-8b14-703add32cf84.yml
@@ -8,11 +8,9 @@ birth_date: 1955-06-21
 image: https://theunitedstates.io/images/congress/450x550/S001135.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-48

--- a/data/us/legislature/Mike-Bost-f49d7d57-812e-584d-85f7-0c3b547bfca4.yml
+++ b/data/us/legislature/Mike-Bost-f49d7d57-812e-584d-85f7-0c3b547bfca4.yml
@@ -7,7 +7,6 @@ birth_date: 1960-12-30
 image: https://theunitedstates.io/images/congress/450x550/B001295.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-12

--- a/data/us/legislature/Mike-Carey-e2402add-94f2-53fa-9f40-69ba590c744f.yml
+++ b/data/us/legislature/Mike-Carey-e2402add-94f2-53fa-9f40-69ba590c744f.yml
@@ -7,11 +7,9 @@ birth_date: 1971-03-13
 image: https://theunitedstates.io/images/congress/450x550/C001126.jpg
 party:
 - start_date: '2021-11-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-11-04'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-15

--- a/data/us/legislature/Mike-Crapo-9243a3a9-4e91-5fc8-9643-ae46455b688b.yml
+++ b/data/us/legislature/Mike-Crapo-9243a3a9-4e91-5fc8-9643-ae46455b688b.yml
@@ -8,7 +8,6 @@ birth_date: 1951-05-20
 image: https://theunitedstates.io/images/congress/450x550/C000880.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1993-01-05'
@@ -42,7 +41,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Idaho
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Idaho

--- a/data/us/legislature/Mike-Flood-51e14e3d-a2c7-5d16-81d5-6608049b5d7e.yml
+++ b/data/us/legislature/Mike-Flood-51e14e3d-a2c7-5d16-81d5-6608049b5d7e.yml
@@ -7,11 +7,9 @@ birth_date: 1975-02-23
 image: https://theunitedstates.io/images/congress/450x550/F000474.jpg
 party:
 - start_date: '2022-07-12'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-07-12'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NE-1

--- a/data/us/legislature/Mike-Gallagher-0f9b050b-b8cf-56d9-bc31-edfcdd3c2fe5.yml
+++ b/data/us/legislature/Mike-Gallagher-0f9b050b-b8cf-56d9-bc31-edfcdd3c2fe5.yml
@@ -7,7 +7,6 @@ birth_date: 1984-03-03
 image: https://theunitedstates.io/images/congress/450x550/G000579.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-8

--- a/data/us/legislature/Mike-Garcia-db31d257-8b81-52c8-a2e1-d26c6ee4a8be.yml
+++ b/data/us/legislature/Mike-Garcia-db31d257-8b81-52c8-a2e1-d26c6ee4a8be.yml
@@ -7,7 +7,6 @@ birth_date: 1976-04-24
 image: https://theunitedstates.io/images/congress/450x550/G000061.jpg
 party:
 - start_date: '2020-05-19'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2020-05-19'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-25
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-25

--- a/data/us/legislature/Mike-Johnson-ef2a1e73-edb7-5f53-9f61-da2020fc417d.yml
+++ b/data/us/legislature/Mike-Johnson-ef2a1e73-edb7-5f53-9f61-da2020fc417d.yml
@@ -7,7 +7,6 @@ birth_date: 1972-01-30
 image: https://theunitedstates.io/images/congress/450x550/J000299.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-4

--- a/data/us/legislature/Mike-Kelly-72511635-46e3-536d-8880-b32c7cf3e470.yml
+++ b/data/us/legislature/Mike-Kelly-72511635-46e3-536d-8880-b32c7cf3e470.yml
@@ -7,7 +7,6 @@ birth_date: 1948-05-10
 image: https://theunitedstates.io/images/congress/450x550/K000376.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-16

--- a/data/us/legislature/Mike-Lee-461257ff-088f-5edd-b342-4652ce1c111f.yml
+++ b/data/us/legislature/Mike-Lee-461257ff-088f-5edd-b342-4652ce1c111f.yml
@@ -7,7 +7,6 @@ birth_date: 1971-06-04
 image: https://theunitedstates.io/images/congress/450x550/L000577.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Utah
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Utah

--- a/data/us/legislature/Mike-Levin-ac0c3c4b-14c8-5bc1-bb8b-001af291ee3d.yml
+++ b/data/us/legislature/Mike-Levin-ac0c3c4b-14c8-5bc1-bb8b-001af291ee3d.yml
@@ -7,7 +7,6 @@ birth_date: 1978-10-28
 image: https://theunitedstates.io/images/congress/450x550/L000593.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-49
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-49

--- a/data/us/legislature/Mike-Quigley-b8578429-a84d-5542-a903-02feaee3a7d4.yml
+++ b/data/us/legislature/Mike-Quigley-b8578429-a84d-5542-a903-02feaee3a7d4.yml
@@ -7,7 +7,6 @@ birth_date: 1958-10-17
 image: https://theunitedstates.io/images/congress/450x550/Q000023.jpg
 party:
 - start_date: '2009-04-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-04-07'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-5

--- a/data/us/legislature/Mike-Rogers-612162b9-752c-50f4-b2e5-de10dae5c160.yml
+++ b/data/us/legislature/Mike-Rogers-612162b9-752c-50f4-b2e5-de10dae5c160.yml
@@ -7,7 +7,6 @@ birth_date: 1958-07-16
 image: https://theunitedstates.io/images/congress/450x550/R000575.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -56,7 +55,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-3

--- a/data/us/legislature/Mike-Thompson-237700e9-fd25-5daa-a301-2fde714f5923.yml
+++ b/data/us/legislature/Mike-Thompson-237700e9-fd25-5daa-a301-2fde714f5923.yml
@@ -8,7 +8,6 @@ birth_date: 1951-01-24
 image: https://theunitedstates.io/images/congress/450x550/T000460.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1999-01-06'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-5

--- a/data/us/legislature/Mikie-Sherrill-bbe70084-5f54-5897-8518-a9467558a4b1.yml
+++ b/data/us/legislature/Mikie-Sherrill-bbe70084-5f54-5897-8518-a9467558a4b1.yml
@@ -7,7 +7,6 @@ birth_date: 1972-01-19
 image: https://theunitedstates.io/images/congress/450x550/S001207.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-11
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-11

--- a/data/us/legislature/Mo-Brooks-fec25df5-e17b-549c-a5e8-35680a4f901f.yml
+++ b/data/us/legislature/Mo-Brooks-fec25df5-e17b-549c-a5e8-35680a4f901f.yml
@@ -7,7 +7,6 @@ birth_date: 1954-04-29
 image: https://theunitedstates.io/images/congress/450x550/B001274.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-5

--- a/data/us/legislature/Mondaire-Jones-814517a8-5c6d-59fa-9748-0f190b00c475.yml
+++ b/data/us/legislature/Mondaire-Jones-814517a8-5c6d-59fa-9748-0f190b00c475.yml
@@ -7,11 +7,9 @@ birth_date: 1987-05-18
 image: https://theunitedstates.io/images/congress/450x550/J000306.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-17

--- a/data/us/legislature/Nancy-Mace-c50627f5-6447-55e3-9ca9-183daf188b58.yml
+++ b/data/us/legislature/Nancy-Mace-c50627f5-6447-55e3-9ca9-183daf188b58.yml
@@ -8,11 +8,9 @@ birth_date: 1977-12-04
 image: https://theunitedstates.io/images/congress/450x550/M000194.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-1

--- a/data/us/legislature/Nancy-Pelosi-8056c810-7170-5009-88c3-a670ab30164b.yml
+++ b/data/us/legislature/Nancy-Pelosi-8056c810-7170-5009-88c3-a670ab30164b.yml
@@ -7,7 +7,6 @@ birth_date: 1940-03-26
 image: https://theunitedstates.io/images/congress/450x550/P000197.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1987-01-06'
@@ -96,7 +95,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-12

--- a/data/us/legislature/Nanette-Diaz-Barragn-5ec7a759-2c3a-5270-8328-13c7ac611580.yml
+++ b/data/us/legislature/Nanette-Diaz-Barragn-5ec7a759-2c3a-5270-8328-13c7ac611580.yml
@@ -8,7 +8,6 @@ birth_date: 1976-09-15
 image: https://theunitedstates.io/images/congress/450x550/B001300.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-44
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-44

--- a/data/us/legislature/Neal-P-Dunn-cebc95c4-7c20-58c5-829c-c3391f0761fa.yml
+++ b/data/us/legislature/Neal-P-Dunn-cebc95c4-7c20-58c5-829c-c3391f0761fa.yml
@@ -8,7 +8,6 @@ birth_date: 1953-02-16
 image: https://theunitedstates.io/images/congress/450x550/D000628.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-2

--- a/data/us/legislature/Nicole-Malliotakis-d47735a4-c407-5389-bfd2-f638ffccdd06.yml
+++ b/data/us/legislature/Nicole-Malliotakis-d47735a4-c407-5389-bfd2-f638ffccdd06.yml
@@ -7,11 +7,9 @@ birth_date: 1980-11-11
 image: https://theunitedstates.io/images/congress/450x550/M000317.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-11

--- a/data/us/legislature/Nikema-Williams-132a1bba-204a-5d4f-a406-40b4342bad1b.yml
+++ b/data/us/legislature/Nikema-Williams-132a1bba-204a-5d4f-a406-40b4342bad1b.yml
@@ -8,11 +8,9 @@ birth_date: 1978-07-30
 image: https://theunitedstates.io/images/congress/450x550/W000788.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-5

--- a/data/us/legislature/Norma-J-Torres-32caaab6-5712-57c2-83c6-7b226b2c1056.yml
+++ b/data/us/legislature/Norma-J-Torres-32caaab6-5712-57c2-83c6-7b226b2c1056.yml
@@ -8,7 +8,6 @@ birth_date: 1965-04-04
 image: https://theunitedstates.io/images/congress/450x550/T000474.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-35
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-35

--- a/data/us/legislature/Nydia-M-Velzquez-bc18d350-32b2-5e37-8b43-6f85ae9b5b09.yml
+++ b/data/us/legislature/Nydia-M-Velzquez-bc18d350-32b2-5e37-8b43-6f85ae9b5b09.yml
@@ -8,7 +8,6 @@ birth_date: 1953-03-28
 image: https://theunitedstates.io/images/congress/450x550/V000081.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-7

--- a/data/us/legislature/Pat-Fallon-425d847d-6fbf-55a7-a117-76bca5e3f299.yml
+++ b/data/us/legislature/Pat-Fallon-425d847d-6fbf-55a7-a117-76bca5e3f299.yml
@@ -8,11 +8,9 @@ birth_date: 1967-12-19
 image: https://theunitedstates.io/images/congress/450x550/F000246.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-4

--- a/data/us/legislature/Patrick-J-Leahy-fedd20de-dee5-55b2-9beb-792404ba1480.yml
+++ b/data/us/legislature/Patrick-J-Leahy-fedd20de-dee5-55b2-9beb-792404ba1480.yml
@@ -8,7 +8,6 @@ birth_date: 1940-03-31
 image: https://theunitedstates.io/images/congress/450x550/L000174.jpg
 party:
 - start_date: '1975-01-14'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1975-01-14'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Vermont
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Vermont

--- a/data/us/legislature/Patrick-J-Toomey-213ace63-6074-501b-930d-ccdf3e4128ac.yml
+++ b/data/us/legislature/Patrick-J-Toomey-213ace63-6074-501b-930d-ccdf3e4128ac.yml
@@ -8,7 +8,6 @@ birth_date: 1961-11-17
 image: https://theunitedstates.io/images/congress/450x550/T000461.jpg
 party:
 - start_date: '1999-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1999-01-06'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Pennsylvania
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Pennsylvania

--- a/data/us/legislature/Patrick-Ryan-10de7024-4b40-57b0-ae78-101372fd4a02.yml
+++ b/data/us/legislature/Patrick-Ryan-10de7024-4b40-57b0-ae78-101372fd4a02.yml
@@ -7,11 +7,9 @@ birth_date: 1982-03-28
 image: https://theunitedstates.io/images/congress/450x550/R000579.jpg
 party:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2022-09-13'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-19

--- a/data/us/legislature/Patrick-T-McHenry-3ae689a1-81a2-5c40-b26e-ee49648945d6.yml
+++ b/data/us/legislature/Patrick-T-McHenry-3ae689a1-81a2-5c40-b26e-ee49648945d6.yml
@@ -8,7 +8,6 @@ birth_date: 1975-10-22
 image: https://theunitedstates.io/images/congress/450x550/M001156.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2005-01-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-10

--- a/data/us/legislature/Patty-Murray-eb3ab543-13a1-53db-a8a1-459e8e91b701.yml
+++ b/data/us/legislature/Patty-Murray-eb3ab543-13a1-53db-a8a1-459e8e91b701.yml
@@ -7,7 +7,6 @@ birth_date: 1950-10-11
 image: https://theunitedstates.io/images/congress/450x550/M001111.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Washington
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Washington

--- a/data/us/legislature/Paul-A-Gosar-5eae38e3-8420-5c09-831a-db73d9cba978.yml
+++ b/data/us/legislature/Paul-A-Gosar-5eae38e3-8420-5c09-831a-db73d9cba978.yml
@@ -8,7 +8,6 @@ birth_date: 1958-11-22
 image: https://theunitedstates.io/images/congress/450x550/G000565.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-4

--- a/data/us/legislature/Paul-Tonko-19360ce3-5ad4-5b67-b253-0239a5360fbb.yml
+++ b/data/us/legislature/Paul-Tonko-19360ce3-5ad4-5b67-b253-0239a5360fbb.yml
@@ -7,7 +7,6 @@ birth_date: 1949-06-18
 image: https://theunitedstates.io/images/congress/450x550/T000469.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-20
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-20

--- a/data/us/legislature/Pete-Aguilar-705749f4-c12c-5090-88fa-012d36611500.yml
+++ b/data/us/legislature/Pete-Aguilar-705749f4-c12c-5090-88fa-012d36611500.yml
@@ -7,7 +7,6 @@ birth_date: 1979-06-19
 image: https://theunitedstates.io/images/congress/450x550/A000371.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-31
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-31

--- a/data/us/legislature/Pete-Sessions-4325bd84-1297-5481-a6b7-80534123c81f.yml
+++ b/data/us/legislature/Pete-Sessions-4325bd84-1297-5481-a6b7-80534123c81f.yml
@@ -8,7 +8,6 @@ birth_date: 1955-03-22
 image: https://theunitedstates.io/images/congress/450x550/S000250.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -67,7 +66,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-32
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-17

--- a/data/us/legislature/Pete-Stauber-54c25fbc-b91d-5d2b-8403-9b8fb1fb6792.yml
+++ b/data/us/legislature/Pete-Stauber-54c25fbc-b91d-5d2b-8403-9b8fb1fb6792.yml
@@ -7,7 +7,6 @@ birth_date: 1966-05-10
 image: https://theunitedstates.io/images/congress/450x550/S001212.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-8

--- a/data/us/legislature/Peter-A-DeFazio-74d33ca5-ced7-58fb-afdb-c19b27a51784.yml
+++ b/data/us/legislature/Peter-A-DeFazio-74d33ca5-ced7-58fb-afdb-c19b27a51784.yml
@@ -8,7 +8,6 @@ birth_date: 1947-05-27
 image: https://theunitedstates.io/images/congress/450x550/D000191.jpg
 party:
 - start_date: '1987-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1987-01-06'
@@ -97,7 +96,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-4

--- a/data/us/legislature/Peter-Meijer-3a71af21-4beb-5302-b9a9-758e9342cbef.yml
+++ b/data/us/legislature/Peter-Meijer-3a71af21-4beb-5302-b9a9-758e9342cbef.yml
@@ -8,11 +8,9 @@ birth_date: 1988-01-10
 image: https://theunitedstates.io/images/congress/450x550/M001186.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-3

--- a/data/us/legislature/Peter-Welch-8addb5a8-a569-54b2-811b-b5d091350411.yml
+++ b/data/us/legislature/Peter-Welch-8addb5a8-a569-54b2-811b-b5d091350411.yml
@@ -7,7 +7,6 @@ birth_date: 1947-05-02
 image: https://theunitedstates.io/images/congress/450x550/W000800.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VT-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VT-AL

--- a/data/us/legislature/Pramila-Jayapal-7849cc06-924b-5f36-a446-1f97d9fbdc63.yml
+++ b/data/us/legislature/Pramila-Jayapal-7849cc06-924b-5f36-a446-1f97d9fbdc63.yml
@@ -7,7 +7,6 @@ birth_date: 1965-09-21
 image: https://theunitedstates.io/images/congress/450x550/J000298.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-7

--- a/data/us/legislature/Raja-Krishnamoorthi-b13e8680-abc9-51dc-a6b6-bed78927bfff.yml
+++ b/data/us/legislature/Raja-Krishnamoorthi-b13e8680-abc9-51dc-a6b6-bed78927bfff.yml
@@ -7,7 +7,6 @@ birth_date: 1973-07-19
 image: https://theunitedstates.io/images/congress/450x550/K000391.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-8

--- a/data/us/legislature/Ral-M-Grijalva-06cee575-8fbe-5552-9f2b-9fe5aa2a3725.yml
+++ b/data/us/legislature/Ral-M-Grijalva-06cee575-8fbe-5552-9f2b-9fe5aa2a3725.yml
@@ -8,7 +8,6 @@ birth_date: 1948-02-19
 image: https://theunitedstates.io/images/congress/450x550/G000551.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-3

--- a/data/us/legislature/Ralph-Norman-9b2b75b5-2641-51be-91c3-9d14d40e4d1a.yml
+++ b/data/us/legislature/Ralph-Norman-9b2b75b5-2641-51be-91c3-9d14d40e4d1a.yml
@@ -7,7 +7,6 @@ birth_date: 1953-06-20
 image: https://theunitedstates.io/images/congress/450x550/N000190.jpg
 party:
 - start_date: '2017-06-26'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-06-26'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-5

--- a/data/us/legislature/Rand-Paul-7a1c13f9-1aac-5461-aa2a-11642749828d.yml
+++ b/data/us/legislature/Rand-Paul-7a1c13f9-1aac-5461-aa2a-11642749828d.yml
@@ -7,7 +7,6 @@ birth_date: 1963-01-07
 image: https://theunitedstates.io/images/congress/450x550/P000603.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Kentucky
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Kentucky

--- a/data/us/legislature/Randy-Feenstra-31a92a8a-f498-5ca5-a37b-fd92b162c913.yml
+++ b/data/us/legislature/Randy-Feenstra-31a92a8a-f498-5ca5-a37b-fd92b162c913.yml
@@ -8,11 +8,9 @@ birth_date: 1969-01-14
 image: https://theunitedstates.io/images/congress/450x550/F000446.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IA-4

--- a/data/us/legislature/Randy-K-Weber-Sr-4662eadc-a9a7-500c-b9c2-521a013d3729.yml
+++ b/data/us/legislature/Randy-K-Weber-Sr-4662eadc-a9a7-500c-b9c2-521a013d3729.yml
@@ -8,7 +8,6 @@ birth_date: 1953-07-02
 image: https://theunitedstates.io/images/congress/450x550/W000814.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-14
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-14

--- a/data/us/legislature/Raphael-G-Warnock-37f5a4b9-98b2-5c3d-857b-6e02f5123345.yml
+++ b/data/us/legislature/Raphael-G-Warnock-37f5a4b9-98b2-5c3d-857b-6e02f5123345.yml
@@ -8,11 +8,9 @@ birth_date: 1969-07-23
 image: https://theunitedstates.io/images/congress/450x550/W000790.jpg
 party:
 - start_date: '2021-01-20'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-20'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Georgia

--- a/data/us/legislature/Rashida-Tlaib-e7497932-512f-5b6f-8830-aa4b6737cd2e.yml
+++ b/data/us/legislature/Rashida-Tlaib-e7497932-512f-5b6f-8830-aa4b6737cd2e.yml
@@ -7,7 +7,6 @@ birth_date: 1976-07-24
 image: https://theunitedstates.io/images/congress/450x550/T000481.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-13

--- a/data/us/legislature/Raul-Ruiz-4db06595-7db2-51a8-8574-703e9af111b9.yml
+++ b/data/us/legislature/Raul-Ruiz-4db06595-7db2-51a8-8574-703e9af111b9.yml
@@ -7,7 +7,6 @@ birth_date: 1972-08-25
 image: https://theunitedstates.io/images/congress/450x550/R000599.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-36
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-36

--- a/data/us/legislature/Richard-Blumenthal-62fd9e8b-80ea-5484-b1f1-3f3b4c350cc3.yml
+++ b/data/us/legislature/Richard-Blumenthal-62fd9e8b-80ea-5484-b1f1-3f3b4c350cc3.yml
@@ -7,7 +7,6 @@ birth_date: 1946-02-13
 image: https://theunitedstates.io/images/congress/450x550/B001277.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Connecticut
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Connecticut

--- a/data/us/legislature/Richard-Burr-39df75fd-67d3-5a8f-b00b-64bd3a4124f2.yml
+++ b/data/us/legislature/Richard-Burr-39df75fd-67d3-5a8f-b00b-64bd3a4124f2.yml
@@ -8,7 +8,6 @@ birth_date: 1955-11-30
 image: https://theunitedstates.io/images/congress/450x550/B001135.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1995-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: North Carolina
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: North Carolina

--- a/data/us/legislature/Richard-C-Shelby-40f5a007-0911-5636-839c-cfda5fd3e3ca.yml
+++ b/data/us/legislature/Richard-C-Shelby-40f5a007-0911-5636-839c-cfda5fd3e3ca.yml
@@ -11,7 +11,6 @@ party:
   end_date: '1993-01-03'
   name: Democratic
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1979-01-15'
@@ -60,7 +59,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Alabama
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Alabama

--- a/data/us/legislature/Richard-E-Neal-882d0f96-61bb-57b0-9683-c72425d337e9.yml
+++ b/data/us/legislature/Richard-E-Neal-882d0f96-61bb-57b0-9683-c72425d337e9.yml
@@ -8,7 +8,6 @@ birth_date: 1949-02-14
 image: https://theunitedstates.io/images/congress/450x550/N000015.jpg
 party:
 - start_date: '1989-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1989-01-03'
@@ -92,7 +91,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-1

--- a/data/us/legislature/Richard-Hudson-18943ddd-9052-5b22-905b-65ff2ac3abf7.yml
+++ b/data/us/legislature/Richard-Hudson-18943ddd-9052-5b22-905b-65ff2ac3abf7.yml
@@ -7,7 +7,6 @@ birth_date: 1971-11-04
 image: https://theunitedstates.io/images/congress/450x550/H001067.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-8

--- a/data/us/legislature/Rick-Larsen-9f1d5b03-66ab-5d94-9b92-aed4e8168c4d.yml
+++ b/data/us/legislature/Rick-Larsen-9f1d5b03-66ab-5d94-9b92-aed4e8168c4d.yml
@@ -7,7 +7,6 @@ birth_date: 1965-06-15
 image: https://theunitedstates.io/images/congress/450x550/L000560.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2001-01-03'
@@ -61,7 +60,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-2

--- a/data/us/legislature/Rick-W-Allen-4cdf55a7-a62e-5b3d-a07f-305f4e9dc5c1.yml
+++ b/data/us/legislature/Rick-W-Allen-4cdf55a7-a62e-5b3d-a07f-305f4e9dc5c1.yml
@@ -8,7 +8,6 @@ birth_date: 1951-11-07
 image: https://theunitedstates.io/images/congress/450x550/A000372.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-12

--- a/data/us/legislature/Ritchie-Torres-3a4aef6c-28c5-5cb7-a664-0e8c9d0c4fd2.yml
+++ b/data/us/legislature/Ritchie-Torres-3a4aef6c-28c5-5cb7-a664-0e8c9d0c4fd2.yml
@@ -8,11 +8,9 @@ birth_date: 1988-03-12
 image: https://theunitedstates.io/images/congress/450x550/T000486.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-15

--- a/data/us/legislature/Ro-Khanna-1256e24c-ef63-5a90-9cf6-1da0dcd63ce8.yml
+++ b/data/us/legislature/Ro-Khanna-1256e24c-ef63-5a90-9cf6-1da0dcd63ce8.yml
@@ -7,7 +7,6 @@ birth_date: 1976-09-13
 image: https://theunitedstates.io/images/congress/450x550/K000389.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-17
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-17

--- a/data/us/legislature/Rob-Portman-68b92607-9467-5706-a019-640dd3cf8901.yml
+++ b/data/us/legislature/Rob-Portman-68b92607-9467-5706-a019-640dd3cf8901.yml
@@ -8,7 +8,6 @@ birth_date: 1955-12-19
 image: https://theunitedstates.io/images/congress/450x550/P000449.jpg
 party:
 - start_date: '1993-05-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1993-05-04'
@@ -52,7 +51,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Ohio
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Ohio

--- a/data/us/legislature/Robert-B-Aderholt-1a69c825-1015-5d72-a8d8-a720d586c3b4.yml
+++ b/data/us/legislature/Robert-B-Aderholt-1a69c825-1015-5d72-a8d8-a720d586c3b4.yml
@@ -8,7 +8,6 @@ birth_date: 1965-07-22
 image: https://theunitedstates.io/images/congress/450x550/A000055.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-4

--- a/data/us/legislature/Robert-C-Bobby-Scott-b20b2d62-fa4a-5014-baac-2f86e1c691eb.yml
+++ b/data/us/legislature/Robert-C-Bobby-Scott-b20b2d62-fa4a-5014-baac-2f86e1c691eb.yml
@@ -8,7 +8,6 @@ birth_date: 1947-04-30
 image: https://theunitedstates.io/images/congress/450x550/S000185.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-3

--- a/data/us/legislature/Robert-E-Latta-2158a719-5cfa-5c41-92f7-4f0853782d2b.yml
+++ b/data/us/legislature/Robert-E-Latta-2158a719-5cfa-5c41-92f7-4f0853782d2b.yml
@@ -8,7 +8,6 @@ birth_date: 1956-04-18
 image: https://theunitedstates.io/images/congress/450x550/L000566.jpg
 party:
 - start_date: '2007-12-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-12-13'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-5

--- a/data/us/legislature/Robert-J-Wittman-0adba0f5-0723-584b-8071-3e442a01f2d2.yml
+++ b/data/us/legislature/Robert-J-Wittman-0adba0f5-0723-584b-8071-3e442a01f2d2.yml
@@ -8,7 +8,6 @@ birth_date: 1959-02-03
 image: https://theunitedstates.io/images/congress/450x550/W000804.jpg
 party:
 - start_date: '2007-12-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-12-13'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VA-1

--- a/data/us/legislature/Robin-L-Kelly-ced9bf2d-1308-5316-94c0-c1410716021a.yml
+++ b/data/us/legislature/Robin-L-Kelly-ced9bf2d-1308-5316-94c0-c1410716021a.yml
@@ -8,7 +8,6 @@ birth_date: 1956-04-30
 image: https://theunitedstates.io/images/congress/450x550/K000385.jpg
 party:
 - start_date: '2013-04-09'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-04-09'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-2

--- a/data/us/legislature/Rodney-Davis-f438a328-f213-5940-b79e-d782562acf73.yml
+++ b/data/us/legislature/Rodney-Davis-f438a328-f213-5940-b79e-d782562acf73.yml
@@ -7,7 +7,6 @@ birth_date: 1970-01-05
 image: https://theunitedstates.io/images/congress/450x550/D000619.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-13

--- a/data/us/legislature/Roger-Williams-e77e9595-b0fb-5923-a051-9f3221d8d6a9.yml
+++ b/data/us/legislature/Roger-Williams-e77e9595-b0fb-5923-a051-9f3221d8d6a9.yml
@@ -7,7 +7,6 @@ birth_date: 1949-09-13
 image: https://theunitedstates.io/images/congress/450x550/W000816.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-25
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-25

--- a/data/us/legislature/Ron-Estes-09eb0ce6-8616-5896-b1d2-d90f494eb4d9.yml
+++ b/data/us/legislature/Ron-Estes-09eb0ce6-8616-5896-b1d2-d90f494eb4d9.yml
@@ -7,7 +7,6 @@ birth_date: 1956-07-19
 image: https://theunitedstates.io/images/congress/450x550/E000298.jpg
 party:
 - start_date: '2017-04-25'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-04-25'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-4

--- a/data/us/legislature/Ron-Johnson-67d8f8b5-1fad-5132-9da8-3210783163a8.yml
+++ b/data/us/legislature/Ron-Johnson-67d8f8b5-1fad-5132-9da8-3210783163a8.yml
@@ -7,7 +7,6 @@ birth_date: 1955-04-08
 image: https://theunitedstates.io/images/congress/450x550/J000293.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Wisconsin
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Wisconsin

--- a/data/us/legislature/Ron-Kind-d897105b-30a7-5d70-aa1a-1a0eb95f0d37.yml
+++ b/data/us/legislature/Ron-Kind-d897105b-30a7-5d70-aa1a-1a0eb95f0d37.yml
@@ -8,7 +8,6 @@ birth_date: 1963-03-16
 image: https://theunitedstates.io/images/congress/450x550/K000188.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1997-01-07'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-3

--- a/data/us/legislature/Ron-Wyden-7b0a82d1-eb2f-53a3-8352-de8b64d41060.yml
+++ b/data/us/legislature/Ron-Wyden-7b0a82d1-eb2f-53a3-8352-de8b64d41060.yml
@@ -7,7 +7,6 @@ birth_date: 1949-05-03
 image: https://theunitedstates.io/images/congress/450x550/W000779.jpg
 party:
 - start_date: '1981-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1981-01-05'
@@ -71,7 +70,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Oregon
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Oregon

--- a/data/us/legislature/Ronny-Jackson-417128fd-ee37-5676-988d-263b908aa027.yml
+++ b/data/us/legislature/Ronny-Jackson-417128fd-ee37-5676-988d-263b908aa027.yml
@@ -8,11 +8,9 @@ birth_date: 1967-05-04
 image: https://theunitedstates.io/images/congress/450x550/J000304.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-13

--- a/data/us/legislature/Rosa-L-DeLauro-30e732cb-6e0a-5920-bd7e-8d62ca9b2f7c.yml
+++ b/data/us/legislature/Rosa-L-DeLauro-30e732cb-6e0a-5920-bd7e-8d62ca9b2f7c.yml
@@ -8,7 +8,6 @@ birth_date: 1943-03-02
 image: https://theunitedstates.io/images/congress/450x550/D000216.jpg
 party:
 - start_date: '1991-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1991-01-03'
@@ -87,7 +86,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CT-3

--- a/data/us/legislature/Roy-Blunt-7d0222ad-aa5d-5856-98c8-a7d35995b945.yml
+++ b/data/us/legislature/Roy-Blunt-7d0222ad-aa5d-5856-98c8-a7d35995b945.yml
@@ -7,7 +7,6 @@ birth_date: 1950-01-10
 image: https://theunitedstates.io/images/congress/450x550/B000575.jpg
 party:
 - start_date: '1997-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1997-01-07'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Missouri
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Missouri

--- a/data/us/legislature/Ruben-Gallego-256da84c-1b8a-5d48-99ba-9c9f7dd2d310.yml
+++ b/data/us/legislature/Ruben-Gallego-256da84c-1b8a-5d48-99ba-9c9f7dd2d310.yml
@@ -7,7 +7,6 @@ birth_date: 1979-11-20
 image: https://theunitedstates.io/images/congress/450x550/G000574.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-7

--- a/data/us/legislature/Rudy-Yakym-III-bf37099b-56fe-54fe-acc1-a6d79a0107d1.yml
+++ b/data/us/legislature/Rudy-Yakym-III-bf37099b-56fe-54fe-acc1-a6d79a0107d1.yml
@@ -7,11 +7,9 @@ birth_date: 1984-02-24
 image: https://theunitedstates.io/images/congress/450x550/Y000067.jpg
 party:
 - start_date: '2022-11-14'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2022-11-14'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-2

--- a/data/us/legislature/Russ-Fulcher-59f2dee7-1c9f-588e-a8ca-158e054f7fca.yml
+++ b/data/us/legislature/Russ-Fulcher-59f2dee7-1c9f-588e-a8ca-158e054f7fca.yml
@@ -7,7 +7,6 @@ birth_date: 1973-07-19
 image: https://theunitedstates.io/images/congress/450x550/F000469.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ID-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: ID-1

--- a/data/us/legislature/Salud-O-Carbajal-a106e70c-7857-5d7c-8252-5f4768818ef2.yml
+++ b/data/us/legislature/Salud-O-Carbajal-a106e70c-7857-5d7c-8252-5f4768818ef2.yml
@@ -8,7 +8,6 @@ birth_date: 1964-11-18
 image: https://theunitedstates.io/images/congress/450x550/C001112.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-24
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-24

--- a/data/us/legislature/Sam-Graves-82ed7662-b9c2-53f7-bab6-c2d59732128b.yml
+++ b/data/us/legislature/Sam-Graves-82ed7662-b9c2-53f7-bab6-c2d59732128b.yml
@@ -8,7 +8,6 @@ birth_date: 1963-11-07
 image: https://theunitedstates.io/images/congress/450x550/G000546.jpg
 party:
 - start_date: '2001-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2001-01-03'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-6

--- a/data/us/legislature/Sanford-D-Bishop-Jr-bbc6615a-22ca-51f6-b674-8c7753e93333.yml
+++ b/data/us/legislature/Sanford-D-Bishop-Jr-bbc6615a-22ca-51f6-b674-8c7753e93333.yml
@@ -8,7 +8,6 @@ birth_date: 1947-02-04
 image: https://theunitedstates.io/images/congress/450x550/B000490.jpg
 party:
 - start_date: '1993-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1993-01-05'
@@ -82,7 +81,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: GA-2

--- a/data/us/legislature/Sara-Jacobs-7c181af1-a048-53f0-a16c-833ffd27aef4.yml
+++ b/data/us/legislature/Sara-Jacobs-7c181af1-a048-53f0-a16c-833ffd27aef4.yml
@@ -7,11 +7,9 @@ birth_date: 1989-02-01
 image: https://theunitedstates.io/images/congress/450x550/J000305.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-53

--- a/data/us/legislature/Scott-DesJarlais-e34e7060-b2be-56c9-a20f-42de3d875b88.yml
+++ b/data/us/legislature/Scott-DesJarlais-e34e7060-b2be-56c9-a20f-42de3d875b88.yml
@@ -7,7 +7,6 @@ birth_date: 1964-02-21
 image: https://theunitedstates.io/images/congress/450x550/D000616.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-4

--- a/data/us/legislature/Scott-Fitzgerald-ad74f627-3223-5505-811c-599046becb2e.yml
+++ b/data/us/legislature/Scott-Fitzgerald-ad74f627-3223-5505-811c-599046becb2e.yml
@@ -8,11 +8,9 @@ birth_date: 1963-11-16
 image: https://theunitedstates.io/images/congress/450x550/F000471.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-5

--- a/data/us/legislature/Scott-H-Peters-379b2f6a-82e3-572b-a471-75020486662e.yml
+++ b/data/us/legislature/Scott-H-Peters-379b2f6a-82e3-572b-a471-75020486662e.yml
@@ -8,7 +8,6 @@ birth_date: 1958-06-17
 image: https://theunitedstates.io/images/congress/450x550/P000608.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-52
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-52

--- a/data/us/legislature/Scott-Perry-2ac15c4d-4052-5a49-9b5c-70b93a4e325e.yml
+++ b/data/us/legislature/Scott-Perry-2ac15c4d-4052-5a49-9b5c-70b93a4e325e.yml
@@ -7,7 +7,6 @@ birth_date: 1962-05-27
 image: https://theunitedstates.io/images/congress/450x550/P000605.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-10

--- a/data/us/legislature/Sean-Casten-89f8b007-1bf3-589a-bffe-92acf526f448.yml
+++ b/data/us/legislature/Sean-Casten-89f8b007-1bf3-589a-bffe-92acf526f448.yml
@@ -7,7 +7,6 @@ birth_date: 1971-11-23
 image: https://theunitedstates.io/images/congress/450x550/C001117.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-6

--- a/data/us/legislature/Sean-Patrick-Maloney-32229bfa-ffd2-5d51-86c4-b35c5b20e53a.yml
+++ b/data/us/legislature/Sean-Patrick-Maloney-32229bfa-ffd2-5d51-86c4-b35c5b20e53a.yml
@@ -8,7 +8,6 @@ birth_date: 1966-07-30
 image: https://theunitedstates.io/images/congress/450x550/M001185.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -32,7 +31,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-18

--- a/data/us/legislature/Seth-Moulton-7cdb552c-a069-5bae-8c32-c42a2f6c04f6.yml
+++ b/data/us/legislature/Seth-Moulton-7cdb552c-a069-5bae-8c32-c42a2f6c04f6.yml
@@ -7,7 +7,6 @@ birth_date: 1978-10-24
 image: https://theunitedstates.io/images/congress/450x550/M001196.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-6

--- a/data/us/legislature/Sharice-Davids-70056f40-1938-557d-be5d-ddb841c9f19a.yml
+++ b/data/us/legislature/Sharice-Davids-70056f40-1938-557d-be5d-ddb841c9f19a.yml
@@ -7,7 +7,6 @@ birth_date: 1980-05-22
 image: https://theunitedstates.io/images/congress/450x550/D000629.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-3

--- a/data/us/legislature/Sheila-Cherfilus-McCormick-89e894b3-e6a6-5c7c-bc77-dd60cc826b0d.yml
+++ b/data/us/legislature/Sheila-Cherfilus-McCormick-89e894b3-e6a6-5c7c-bc77-dd60cc826b0d.yml
@@ -7,11 +7,9 @@ birth_date: 1979-01-25
 image: https://theunitedstates.io/images/congress/450x550/C001127.jpg
 party:
 - start_date: '2022-01-18'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2022-01-18'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-20

--- a/data/us/legislature/Sheila-Jackson-Lee-99710435-8a59-5f14-9acd-da267980551c.yml
+++ b/data/us/legislature/Sheila-Jackson-Lee-99710435-8a59-5f14-9acd-da267980551c.yml
@@ -7,7 +7,6 @@ birth_date: 1950-01-12
 image: https://theunitedstates.io/images/congress/450x550/J000032.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1995-01-04'
@@ -76,7 +75,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-18
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-18

--- a/data/us/legislature/Shontel-M-Brown-f2916088-1774-50ba-8023-34f7fe686e49.yml
+++ b/data/us/legislature/Shontel-M-Brown-f2916088-1774-50ba-8023-34f7fe686e49.yml
@@ -8,11 +8,9 @@ birth_date: 1975-06-24
 image: https://theunitedstates.io/images/congress/450x550/B001313.jpg
 party:
 - start_date: '2021-11-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-11-04'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-11

--- a/data/us/legislature/Stacey-E-Plaskett-8b830e4d-1e2b-5b7b-9f71-6152222a342f.yml
+++ b/data/us/legislature/Stacey-E-Plaskett-8b830e4d-1e2b-5b7b-9f71-6152222a342f.yml
@@ -8,7 +8,6 @@ birth_date: 1966-05-13
 image: https://theunitedstates.io/images/congress/450x550/P000610.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VI-AL
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: VI-AL

--- a/data/us/legislature/Steny-H-Hoyer-5554fdf4-9035-5d23-aeb0-fee7d786fa81.yml
+++ b/data/us/legislature/Steny-H-Hoyer-5554fdf4-9035-5d23-aeb0-fee7d786fa81.yml
@@ -8,7 +8,6 @@ birth_date: 1939-06-14
 image: https://theunitedstates.io/images/congress/450x550/H000874.jpg
 party:
 - start_date: '1981-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1981-01-05'
@@ -112,7 +111,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MD-5

--- a/data/us/legislature/Stephanie-I-Bice-2add0122-3206-5502-985b-18808db8f685.yml
+++ b/data/us/legislature/Stephanie-I-Bice-2add0122-3206-5502-985b-18808db8f685.yml
@@ -8,11 +8,9 @@ birth_date: 1973-11-11
 image: https://theunitedstates.io/images/congress/450x550/B000740.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-5

--- a/data/us/legislature/Stephanie-N-Murphy-942a1fb7-4ada-53c3-98b7-dc3177419219.yml
+++ b/data/us/legislature/Stephanie-N-Murphy-942a1fb7-4ada-53c3-98b7-dc3177419219.yml
@@ -8,7 +8,6 @@ birth_date: 1978-09-16
 image: https://theunitedstates.io/images/congress/450x550/M001202.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-7

--- a/data/us/legislature/Stephen-F-Lynch-cc7120d8-f57d-5841-9526-3429e9f0f2c2.yml
+++ b/data/us/legislature/Stephen-F-Lynch-cc7120d8-f57d-5841-9526-3429e9f0f2c2.yml
@@ -8,7 +8,6 @@ birth_date: 1955-03-31
 image: https://theunitedstates.io/images/congress/450x550/L000562.jpg
 party:
 - start_date: '2001-10-23'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2001-10-23'
@@ -62,7 +61,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-8

--- a/data/us/legislature/Steve-Chabot-8a8e41b2-91f1-5ed5-a02d-1ba66677e0e4.yml
+++ b/data/us/legislature/Steve-Chabot-8a8e41b2-91f1-5ed5-a02d-1ba66677e0e4.yml
@@ -8,7 +8,6 @@ birth_date: 1953-01-22
 image: https://theunitedstates.io/images/congress/450x550/C000266.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '1995-01-04'
@@ -72,7 +71,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-1

--- a/data/us/legislature/Steve-Cohen-e56dabed-c7b4-51c2-a29b-c9850bc9feff.yml
+++ b/data/us/legislature/Steve-Cohen-e56dabed-c7b4-51c2-a29b-c9850bc9feff.yml
@@ -7,7 +7,6 @@ birth_date: 1949-05-24
 image: https://theunitedstates.io/images/congress/450x550/C001068.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-9

--- a/data/us/legislature/Steve-Scalise-b86826b1-800d-5976-98fa-617ccb74ce88.yml
+++ b/data/us/legislature/Steve-Scalise-b86826b1-800d-5976-98fa-617ccb74ce88.yml
@@ -8,7 +8,6 @@ birth_date: 1965-10-06
 image: https://theunitedstates.io/images/congress/450x550/S001176.jpg
 party:
 - start_date: '2008-05-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2008-05-07'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-1

--- a/data/us/legislature/Steve-Womack-b3fc0e27-b0a3-5106-ae4f-65d6cc93c031.yml
+++ b/data/us/legislature/Steve-Womack-b3fc0e27-b0a3-5106-ae4f-65d6cc93c031.yml
@@ -7,7 +7,6 @@ birth_date: 1957-02-18
 image: https://theunitedstates.io/images/congress/450x550/W000809.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AR-3

--- a/data/us/legislature/Steven-Horsford-980a78cc-847f-50be-8967-6c8895ad337e.yml
+++ b/data/us/legislature/Steven-Horsford-980a78cc-847f-50be-8967-6c8895ad337e.yml
@@ -8,7 +8,6 @@ birth_date: 1973-04-29
 image: https://theunitedstates.io/images/congress/450x550/H001066.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-4

--- a/data/us/legislature/Steven-M-Palazzo-78695a02-f1c0-5b1b-ba66-0098da8cb083.yml
+++ b/data/us/legislature/Steven-M-Palazzo-78695a02-f1c0-5b1b-ba66-0098da8cb083.yml
@@ -8,7 +8,6 @@ birth_date: 1970-02-21
 image: https://theunitedstates.io/images/congress/450x550/P000601.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-4

--- a/data/us/legislature/Susan-Wild-b5356530-dd09-5b14-98f2-365d70bf4e5c.yml
+++ b/data/us/legislature/Susan-Wild-b5356530-dd09-5b14-98f2-365d70bf4e5c.yml
@@ -8,7 +8,6 @@ birth_date: 1957-06-07
 image: https://theunitedstates.io/images/congress/450x550/W000826.jpg
 party:
 - start_date: '2018-11-27'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2018-11-27'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: PA-7

--- a/data/us/legislature/Susie-Lee-4333db3d-a55e-5d8e-b2ec-1041414ba2e6.yml
+++ b/data/us/legislature/Susie-Lee-4333db3d-a55e-5d8e-b2ec-1041414ba2e6.yml
@@ -7,7 +7,6 @@ birth_date: 1966-11-07
 image: https://theunitedstates.io/images/congress/450x550/L000590.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NV-3

--- a/data/us/legislature/Suzan-K-DelBene-799d9723-1f90-5558-b8c6-6f293c7eaddd.yml
+++ b/data/us/legislature/Suzan-K-DelBene-799d9723-1f90-5558-b8c6-6f293c7eaddd.yml
@@ -8,7 +8,6 @@ birth_date: 1962-02-17
 image: https://theunitedstates.io/images/congress/450x550/D000617.jpg
 party:
 - start_date: '2012-11-13'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2012-11-13'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WA-1

--- a/data/us/legislature/Suzanne-Bonamici-90d40f72-ffae-544d-86bb-b41605730fee.yml
+++ b/data/us/legislature/Suzanne-Bonamici-90d40f72-ffae-544d-86bb-b41605730fee.yml
@@ -7,7 +7,6 @@ birth_date: 1954-10-14
 image: https://theunitedstates.io/images/congress/450x550/B001278.jpg
 party:
 - start_date: '2012-02-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2012-02-07'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OR-1

--- a/data/us/legislature/Sylvia-R-Garcia-168e0e9e-0d4c-57d2-99a6-8fc99be594be.yml
+++ b/data/us/legislature/Sylvia-R-Garcia-168e0e9e-0d4c-57d2-99a6-8fc99be594be.yml
@@ -8,7 +8,6 @@ birth_date: 1950-09-06
 image: https://theunitedstates.io/images/congress/450x550/G000587.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-29
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-29

--- a/data/us/legislature/Tammy-Duckworth-c02182c1-3275-5f3e-9c66-2f0873cc72c7.yml
+++ b/data/us/legislature/Tammy-Duckworth-c02182c1-3275-5f3e-9c66-2f0873cc72c7.yml
@@ -7,7 +7,6 @@ birth_date: 1968-03-12
 image: https://theunitedstates.io/images/congress/450x550/D000622.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IL-8
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Illinois

--- a/data/us/legislature/Ted-Budd-67c3f0bb-7182-51b8-98d0-253144992bfe.yml
+++ b/data/us/legislature/Ted-Budd-67c3f0bb-7182-51b8-98d0-253144992bfe.yml
@@ -7,7 +7,6 @@ birth_date: 1971-10-21
 image: https://theunitedstates.io/images/congress/450x550/B001305.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-13

--- a/data/us/legislature/Ted-Lieu-b472f29c-b960-5cea-b5fb-0e9d4d6d10a4.yml
+++ b/data/us/legislature/Ted-Lieu-b472f29c-b960-5cea-b5fb-0e9d4d6d10a4.yml
@@ -7,7 +7,6 @@ birth_date: 1969-03-29
 image: https://theunitedstates.io/images/congress/450x550/L000582.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-33
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-33

--- a/data/us/legislature/Teresa-Leger-Fernandez-1548bb05-ef78-5582-9058-fd92d3c9c61c.yml
+++ b/data/us/legislature/Teresa-Leger-Fernandez-1548bb05-ef78-5582-9058-fd92d3c9c61c.yml
@@ -7,11 +7,9 @@ birth_date: 1959-07-01
 image: https://theunitedstates.io/images/congress/450x550/L000273.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NM-3

--- a/data/us/legislature/Terri-Sewell-f747c3f1-7247-5c91-9870-901ec617e884.yml
+++ b/data/us/legislature/Terri-Sewell-f747c3f1-7247-5c91-9870-901ec617e884.yml
@@ -8,7 +8,6 @@ birth_date: 1965-01-01
 image: https://theunitedstates.io/images/congress/450x550/S001185.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AL-7

--- a/data/us/legislature/Thomas-Massie-7d1234be-d22a-5374-8022-59a795f0f3f4.yml
+++ b/data/us/legislature/Thomas-Massie-7d1234be-d22a-5374-8022-59a795f0f3f4.yml
@@ -7,7 +7,6 @@ birth_date: 1971-01-13
 image: https://theunitedstates.io/images/congress/450x550/M001184.jpg
 party:
 - start_date: '2012-11-13'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2012-11-13'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KY-4

--- a/data/us/legislature/Thomas-P-Tiffany-5048bd11-acf0-5775-a75f-5f085fc8bc11.yml
+++ b/data/us/legislature/Thomas-P-Tiffany-5048bd11-acf0-5775-a75f-5f085fc8bc11.yml
@@ -8,7 +8,6 @@ birth_date: 1957-12-30
 image: https://theunitedstates.io/images/congress/450x550/T000165.jpg
 party:
 - start_date: '2020-05-19'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2020-05-19'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: WI-7

--- a/data/us/legislature/Thomas-R-Suozzi-4182b897-5c2e-5dff-a87c-aa7911e81a3d.yml
+++ b/data/us/legislature/Thomas-R-Suozzi-4182b897-5c2e-5dff-a87c-aa7911e81a3d.yml
@@ -8,7 +8,6 @@ birth_date: 1962-08-31
 image: https://theunitedstates.io/images/congress/450x550/S001201.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-3

--- a/data/us/legislature/Tim-Burchett-06b83e26-fe35-526d-86fb-7a6d80b20d1a.yml
+++ b/data/us/legislature/Tim-Burchett-06b83e26-fe35-526d-86fb-7a6d80b20d1a.yml
@@ -7,7 +7,6 @@ birth_date: 1964-08-25
 image: https://theunitedstates.io/images/congress/450x550/B001309.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-2
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TN-2

--- a/data/us/legislature/Tim-Ryan-ae4f98ba-689e-55b5-8624-673808efb95c.yml
+++ b/data/us/legislature/Tim-Ryan-ae4f98ba-689e-55b5-8624-673808efb95c.yml
@@ -8,7 +8,6 @@ birth_date: 1973-07-16
 image: https://theunitedstates.io/images/congress/450x550/R000577.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2003-01-07'
@@ -57,7 +56,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-13
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-13

--- a/data/us/legislature/Tim-Scott-3bb4a99e-9448-5b35-86cd-114bd035535e.yml
+++ b/data/us/legislature/Tim-Scott-3bb4a99e-9448-5b35-86cd-114bd035535e.yml
@@ -7,7 +7,6 @@ birth_date: 1965-09-19
 image: https://theunitedstates.io/images/congress/450x550/S001184.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: South Carolina
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: South Carolina

--- a/data/us/legislature/Tim-Walberg-9e622be4-95d2-5bf7-a99f-543d45400e82.yml
+++ b/data/us/legislature/Tim-Walberg-9e622be4-95d2-5bf7-a99f-543d45400e82.yml
@@ -7,7 +7,6 @@ birth_date: 1951-04-12
 image: https://theunitedstates.io/images/congress/450x550/W000798.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MI-7

--- a/data/us/legislature/Todd-Young-7ec39cbb-df0e-5970-aba1-5722964f55bb.yml
+++ b/data/us/legislature/Todd-Young-7ec39cbb-df0e-5970-aba1-5722964f55bb.yml
@@ -8,7 +8,6 @@ birth_date: 1972-08-24
 image: https://theunitedstates.io/images/congress/450x550/Y000064.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -27,7 +26,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-9
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/government
   district: Indiana

--- a/data/us/legislature/Tom-Cole-34706e89-9ed8-5078-b825-f310caf5a8f6.yml
+++ b/data/us/legislature/Tom-Cole-34706e89-9ed8-5078-b825-f310caf5a8f6.yml
@@ -7,7 +7,6 @@ birth_date: 1949-04-28
 image: https://theunitedstates.io/images/congress/450x550/C001053.jpg
 party:
 - start_date: '2003-01-07'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2003-01-07'
@@ -56,7 +55,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OK-4

--- a/data/us/legislature/Tom-Emmer-08e42c4f-2c5e-5fe0-87cf-0e8de2bdb52d.yml
+++ b/data/us/legislature/Tom-Emmer-08e42c4f-2c5e-5fe0-87cf-0e8de2bdb52d.yml
@@ -7,7 +7,6 @@ birth_date: 1961-03-03
 image: https://theunitedstates.io/images/congress/450x550/E000294.jpg
 party:
 - start_date: '2015-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-01-06'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-6
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MN-6

--- a/data/us/legislature/Tom-Malinowski-e566ad21-535a-51fa-8ee3-1037f77ef7db.yml
+++ b/data/us/legislature/Tom-Malinowski-e566ad21-535a-51fa-8ee3-1037f77ef7db.yml
@@ -7,7 +7,6 @@ birth_date: 1965-09-23
 image: https://theunitedstates.io/images/congress/450x550/M001203.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NJ-7

--- a/data/us/legislature/Tom-McClintock-173a4f3f-e38f-569e-97b2-e0424195f16c.yml
+++ b/data/us/legislature/Tom-McClintock-173a4f3f-e38f-569e-97b2-e0424195f16c.yml
@@ -7,7 +7,6 @@ birth_date: 1956-07-10
 image: https://theunitedstates.io/images/congress/450x550/M001177.jpg
 party:
 - start_date: '2009-01-06'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2009-01-06'
@@ -41,7 +40,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-4

--- a/data/us/legislature/Tom-OHalleran-79ce72c3-9051-5cf3-8b01-d69a479e270c.yml
+++ b/data/us/legislature/Tom-OHalleran-79ce72c3-9051-5cf3-8b01-d69a479e270c.yml
@@ -7,7 +7,6 @@ birth_date: 1946-01-24
 image: https://theunitedstates.io/images/congress/450x550/O000171.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: AZ-1

--- a/data/us/legislature/Tom-Rice-930c3a9a-6bd3-540a-b2a4-3a7b268ebd17.yml
+++ b/data/us/legislature/Tom-Rice-930c3a9a-6bd3-540a-b2a4-3a7b268ebd17.yml
@@ -7,7 +7,6 @@ birth_date: 1957-08-04
 image: https://theunitedstates.io/images/congress/450x550/R000597.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-7
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-7

--- a/data/us/legislature/Tony-Crdenas-147fa8d0-050e-585a-b299-b82e84db0845.yml
+++ b/data/us/legislature/Tony-Crdenas-147fa8d0-050e-585a-b299-b82e84db0845.yml
@@ -7,7 +7,6 @@ birth_date: 1963-03-31
 image: https://theunitedstates.io/images/congress/450x550/C001097.jpg
 party:
 - start_date: '2013-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2013-01-03'
@@ -31,7 +30,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-29
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-29

--- a/data/us/legislature/Tony-Gonzales-7e086fc4-85ff-58af-a436-5f6fa7bfa527.yml
+++ b/data/us/legislature/Tony-Gonzales-7e086fc4-85ff-58af-a436-5f6fa7bfa527.yml
@@ -8,11 +8,9 @@ birth_date: 1980-10-10
 image: https://theunitedstates.io/images/congress/450x550/G000594.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-23

--- a/data/us/legislature/Tracey-Mann-675e8a3b-ea68-55f8-aeb8-be287fe621bd.yml
+++ b/data/us/legislature/Tracey-Mann-675e8a3b-ea68-55f8-aeb8-be287fe621bd.yml
@@ -8,11 +8,9 @@ birth_date: 1976-12-17
 image: https://theunitedstates.io/images/congress/450x550/M000871.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: KS-1

--- a/data/us/legislature/Trent-Kelly-c495bde9-29b3-5e71-ab0e-dedff0de9a84.yml
+++ b/data/us/legislature/Trent-Kelly-c495bde9-29b3-5e71-ab0e-dedff0de9a84.yml
@@ -7,7 +7,6 @@ birth_date: 1966-03-01
 image: https://theunitedstates.io/images/congress/450x550/K000388.jpg
 party:
 - start_date: '2015-06-09'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2015-06-09'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-1
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MS-1

--- a/data/us/legislature/Trey-Hollingsworth-71a0ace4-60a3-58af-a88f-4ac9f19992e5.yml
+++ b/data/us/legislature/Trey-Hollingsworth-71a0ace4-60a3-58af-a88f-4ac9f19992e5.yml
@@ -7,7 +7,6 @@ birth_date: 1983-09-12
 image: https://theunitedstates.io/images/congress/450x550/H001074.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-9

--- a/data/us/legislature/Troy-A-Carter-5e3dc0b5-2afe-5b83-ab42-9352225b2235.yml
+++ b/data/us/legislature/Troy-A-Carter-5e3dc0b5-2afe-5b83-ab42-9352225b2235.yml
@@ -8,11 +8,9 @@ birth_date: 1963-10-26
 image: https://theunitedstates.io/images/congress/450x550/C001125.jpg
 party:
 - start_date: '2021-05-11'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2021-05-11'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: LA-2

--- a/data/us/legislature/Troy-Balderson-7ba189b5-1c2a-5acd-8118-446326a8e02b.yml
+++ b/data/us/legislature/Troy-Balderson-7ba189b5-1c2a-5acd-8118-446326a8e02b.yml
@@ -7,7 +7,6 @@ birth_date: 1962-01-16
 image: https://theunitedstates.io/images/congress/450x550/B001306.jpg
 party:
 - start_date: '2018-09-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2018-09-05'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-12
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-12

--- a/data/us/legislature/Troy-E-Nehls-ec5c60e6-2666-535c-a95a-ec6ab9e02e3f.yml
+++ b/data/us/legislature/Troy-E-Nehls-ec5c60e6-2666-535c-a95a-ec6ab9e02e3f.yml
@@ -8,11 +8,9 @@ birth_date: 1968-04-07
 image: https://theunitedstates.io/images/congress/450x550/N000026.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-22

--- a/data/us/legislature/Val-Butler-Demings-95f0001d-7720-5911-9fde-b4f462d4a202.yml
+++ b/data/us/legislature/Val-Butler-Demings-95f0001d-7720-5911-9fde-b4f462d4a202.yml
@@ -8,7 +8,6 @@ birth_date: 1957-03-12
 image: https://theunitedstates.io/images/congress/450x550/D000627.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -22,7 +21,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-10
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-10

--- a/data/us/legislature/Van-Taylor-d949e19e-28b1-5a2e-9e93-1b8e3db44cbb.yml
+++ b/data/us/legislature/Van-Taylor-d949e19e-28b1-5a2e-9e93-1b8e3db44cbb.yml
@@ -7,7 +7,6 @@ birth_date: 1972-08-01
 image: https://theunitedstates.io/images/congress/450x550/T000479.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-3
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-3

--- a/data/us/legislature/Vern-Buchanan-1e646f7b-600b-503f-9524-3ae95d00cd2d.yml
+++ b/data/us/legislature/Vern-Buchanan-1e646f7b-600b-503f-9524-3ae95d00cd2d.yml
@@ -7,7 +7,6 @@ birth_date: 1951-05-08
 image: https://theunitedstates.io/images/congress/450x550/B001260.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2007-01-04'
@@ -46,7 +45,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-16

--- a/data/us/legislature/Veronica-Escobar-a656d2f5-2e90-535c-91d9-d27ad1150c03.yml
+++ b/data/us/legislature/Veronica-Escobar-a656d2f5-2e90-535c-91d9-d27ad1150c03.yml
@@ -7,7 +7,6 @@ birth_date: 1969-09-15
 image: https://theunitedstates.io/images/congress/450x550/E000299.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2019-01-03'
@@ -16,7 +15,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-16
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-16

--- a/data/us/legislature/Vicente-Gonzalez-8b1ad439-078b-5e79-a845-64236b87f11f.yml
+++ b/data/us/legislature/Vicente-Gonzalez-8b1ad439-078b-5e79-a845-64236b87f11f.yml
@@ -7,7 +7,6 @@ birth_date: 1967-09-04
 image: https://theunitedstates.io/images/congress/450x550/G000581.jpg
 party:
 - start_date: '2017-01-03'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2017-01-03'
@@ -21,7 +20,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-15
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: TX-15

--- a/data/us/legislature/Vicky-Hartzler-f6c3671b-0865-5482-9766-6be4dc0b2266.yml
+++ b/data/us/legislature/Vicky-Hartzler-f6c3671b-0865-5482-9766-6be4dc0b2266.yml
@@ -7,7 +7,6 @@ birth_date: 1960-10-13
 image: https://theunitedstates.io/images/congress/450x550/H001053.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2011-01-05'
@@ -36,7 +35,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MO-4

--- a/data/us/legislature/Victoria-Spartz-bdb81964-c3cc-5f48-8854-7b9c88c23755.yml
+++ b/data/us/legislature/Victoria-Spartz-bdb81964-c3cc-5f48-8854-7b9c88c23755.yml
@@ -7,11 +7,9 @@ birth_date: 1978-10-06
 image: https://theunitedstates.io/images/congress/450x550/S000929.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: IN-5

--- a/data/us/legislature/Virginia-Foxx-b77761e4-93cb-5fbb-972e-5d591198df8f.yml
+++ b/data/us/legislature/Virginia-Foxx-b77761e4-93cb-5fbb-972e-5d591198df8f.yml
@@ -7,7 +7,6 @@ birth_date: 1943-06-29
 image: https://theunitedstates.io/images/congress/450x550/F000450.jpg
 party:
 - start_date: '2005-01-04'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2005-01-04'
@@ -51,7 +50,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-5
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NC-5

--- a/data/us/legislature/W-Gregory-Steube-5fdae4c2-ba21-56a4-ae8c-5e95a175a90a.yml
+++ b/data/us/legislature/W-Gregory-Steube-5fdae4c2-ba21-56a4-ae8c-5e95a175a90a.yml
@@ -8,7 +8,6 @@ birth_date: 1978-05-19
 image: https://theunitedstates.io/images/congress/450x550/S001214.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-17
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: FL-17

--- a/data/us/legislature/Warren-Davidson-1eaeee77-2e74-51b9-a70f-30e16378f080.yml
+++ b/data/us/legislature/Warren-Davidson-1eaeee77-2e74-51b9-a70f-30e16378f080.yml
@@ -7,7 +7,6 @@ birth_date: 1970-03-01
 image: https://theunitedstates.io/images/congress/450x550/D000626.jpg
 party:
 - start_date: '2016-06-09'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2016-06-09'
@@ -26,7 +25,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-8
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: OH-8

--- a/data/us/legislature/William-R-Keating-ec0f62a4-5b85-5df2-888a-200166766b17.yml
+++ b/data/us/legislature/William-R-Keating-ec0f62a4-5b85-5df2-888a-200166766b17.yml
@@ -8,7 +8,6 @@ birth_date: 1952-09-06
 image: https://theunitedstates.io/images/congress/450x550/K000375.jpg
 party:
 - start_date: '2011-01-05'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2011-01-05'
@@ -37,7 +36,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: MA-9

--- a/data/us/legislature/William-R-Timmons-IV-678a7e1c-3834-5536-937f-fdb30edca68e.yml
+++ b/data/us/legislature/William-R-Timmons-IV-678a7e1c-3834-5536-937f-fdb30edca68e.yml
@@ -8,7 +8,6 @@ birth_date: 1984-04-30
 image: https://theunitedstates.io/images/congress/450x550/T000480.jpg
 party:
 - start_date: '2019-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2019-01-03'
@@ -17,7 +16,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-4
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: SC-4

--- a/data/us/legislature/Young-Kim-34a22a9d-abf9-5e79-91f5-e4e08be6d2c9.yml
+++ b/data/us/legislature/Young-Kim-34a22a9d-abf9-5e79-91f5-e4e08be6d2c9.yml
@@ -8,11 +8,9 @@ birth_date: 1962-10-18
 image: https://theunitedstates.io/images/congress/450x550/K000397.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-39

--- a/data/us/legislature/Yvette-D-Clarke-969d3e67-5686-5b4c-a8fe-5ec702a7343d.yml
+++ b/data/us/legislature/Yvette-D-Clarke-969d3e67-5686-5b4c-a8fe-5ec702a7343d.yml
@@ -8,7 +8,6 @@ birth_date: 1964-11-21
 image: https://theunitedstates.io/images/congress/450x550/C001067.jpg
 party:
 - start_date: '2007-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '2007-01-04'
@@ -47,7 +46,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-9
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NY-9

--- a/data/us/legislature/Yvette-Herrell-70b410f7-7253-5091-b26f-f9e8e961d3e8.yml
+++ b/data/us/legislature/Yvette-Herrell-70b410f7-7253-5091-b26f-f9e8e961d3e8.yml
@@ -7,11 +7,9 @@ birth_date: 1964-03-16
 image: https://theunitedstates.io/images/congress/450x550/H001084.jpg
 party:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: NM-2

--- a/data/us/legislature/Zoe-Lofgren-80764021-2b87-5b48-8999-98943700dea8.yml
+++ b/data/us/legislature/Zoe-Lofgren-80764021-2b87-5b48-8999-98943700dea8.yml
@@ -7,7 +7,6 @@ birth_date: 1947-12-21
 image: https://theunitedstates.io/images/congress/450x550/L000397.jpg
 party:
 - start_date: '1995-01-04'
-  end_date: '2023-01-03'
   name: Democratic
 roles:
 - start_date: '1995-01-04'
@@ -76,7 +75,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-19
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
   district: CA-19


### PR DESCRIPTION
I have temporarily removed the End Date for legislators ending their term on 1/03/2023. This will be added back once we have updated US Legislator data.