### PR TITLE
CA: people data fix

### DIFF
--- a/data/ca/legislature/Al-Muratsuchi-78610d0e-c790-4fc9-ab8e-0887adbbe063.yml
+++ b/data/ca/legislature/Al-Muratsuchi-78610d0e-c790-4fc9-ab8e-0887adbbe063.yml
@@ -20,8 +20,6 @@ offices:
   voice: 310-375-0691
 links:
 - url: https://a66.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD66&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000523

--- a/data/ca/legislature/Alex-Lee-5d0057a2-e04d-44ca-b1d5-fc55e113351a.yml
+++ b/data/ca/legislature/Alex-Lee-5d0057a2-e04d-44ca-b1d5-fc55e113351a.yml
@@ -23,9 +23,6 @@ offices:
   voice: 408-262-2501
 links:
 - url: https://a25.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD25&inframe=N
-- url: https://a24.asmdc.org/
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
+++ b/data/ca/legislature/Anna-M-Caballero-fe462917-df55-4a43-9fd8-970541544ca6.yml
@@ -28,8 +28,6 @@ roles:
   district: '14'
 links:
 - url: https://senate.ca.gov/sd12
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD12&inframe=N
-  note: Contact Form
 other_names:
 - name: Anna Marie Caballero
 other_identifiers:

--- a/data/ca/legislature/Anthony-J-Portantino-84f0dbbd-99dd-4ef2-9772-eb06047d847b.yml
+++ b/data/ca/legislature/Anthony-J-Portantino-84f0dbbd-99dd-4ef2-9772-eb06047d847b.yml
@@ -28,8 +28,6 @@ offices:
   voice: 909-599-7351
 links:
 - url: https://senate.ca.gov/sd25
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD25&inframe=N
-  note: Contact Form
 other_names:
 - name: Anthony Portantino
 other_identifiers:

--- a/data/ca/legislature/Anthony-Rendon-27c957dd-86a1-4bbe-9007-f4ebf931a795.yml
+++ b/data/ca/legislature/Anthony-Rendon-27c957dd-86a1-4bbe-9007-f4ebf931a795.yml
@@ -17,8 +17,6 @@ roles:
   district: '62'
 links:
 - url: https://speaker.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD63&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000403

--- a/data/ca/legislature/Ash-Kalra-820619fd-d053-4915-b099-1d134a880228.yml
+++ b/data/ca/legislature/Ash-Kalra-820619fd-d053-4915-b099-1d134a880228.yml
@@ -23,9 +23,6 @@ offices:
   voice: 408-277-1220
 links:
 - url: https://a27.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD27&inframe=N
-  note: Contact Form
-- url: https://a25.asmdc.org/
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000516

--- a/data/ca/legislature/Benjamin-Allen-e725b91e-1f7f-4510-a9cc-0b9a39d283c3.yml
+++ b/data/ca/legislature/Benjamin-Allen-e725b91e-1f7f-4510-a9cc-0b9a39d283c3.yml
@@ -23,9 +23,6 @@ offices:
   voice: 310-318-6994
 links:
 - url: https://senate.ca.gov/sd26
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD26&inframe=N
-- url: https://senate.ca.gov/sd24
-  note: Contact Form
 other_names:
 - name: Ben Allen
 other_identifiers:

--- a/data/ca/legislature/Bill-Dodd-7ecd4221-a627-42dc-9029-bbc543ef3735.yml
+++ b/data/ca/legislature/Bill-Dodd-7ecd4221-a627-42dc-9029-bbc543ef3735.yml
@@ -33,8 +33,6 @@ offices:
   voice: 707-551-2389
 links:
 - url: https://senate.ca.gov/sd03
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD03&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000514

--- a/data/ca/legislature/Blanca-E-Rubio-82cbb6e9-8486-44ec-8450-86d1e700f828.yml
+++ b/data/ca/legislature/Blanca-E-Rubio-82cbb6e9-8486-44ec-8450-86d1e700f828.yml
@@ -19,8 +19,6 @@ offices:
   voice: 626-960-4457
 links:
 - url: https://a48.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD48&inframe=N
-  note: Contact Form
 other_names:
 - name: Blanca Rubio
 other_identifiers:

--- a/data/ca/legislature/Bob-Archuleta-a76028df-5730-47b0-b617-1565621def41.yml
+++ b/data/ca/legislature/Bob-Archuleta-a76028df-5730-47b0-b617-1565621def41.yml
@@ -25,8 +25,6 @@ offices:
   voice: 562-406-1001
 links:
 - url: https://senate.ca.gov/sd32
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD32&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd30
 sources:
 - url: http://senate.ca.gov/senators

--- a/data/ca/legislature/Brian-Dahle-91915f3b-c93f-4f55-a164-58b8c1587d6d.yml
+++ b/data/ca/legislature/Brian-Dahle-91915f3b-c93f-4f55-a164-58b8c1587d6d.yml
@@ -29,8 +29,6 @@ offices:
   voice: 530-271-1022
 links:
 - url: https://senate.ca.gov/sd01
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD01&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000357

--- a/data/ca/legislature/Brian-Maienschein-4c0ad3f7-b949-4206-a550-99633351236c.yml
+++ b/data/ca/legislature/Brian-Maienschein-4c0ad3f7-b949-4206-a550-99633351236c.yml
@@ -28,8 +28,6 @@ offices:
   voice: 858-675-0760
 links:
 - url: https://a77.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD77&inframe=N
-  note: Contact Form
 - url: https://a76.asmdc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/Brian-W-Jones-ea5c3b3d-bbad-41f6-a912-69f60f1553a4.yml
+++ b/data/ca/legislature/Brian-W-Jones-ea5c3b3d-bbad-41f6-a912-69f60f1553a4.yml
@@ -28,8 +28,6 @@ roles:
   district: '40'
 links:
 - url: https://senate.ca.gov/sd38
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD38&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd40
 other_names:
 - name: Brian Jones

--- a/data/ca/legislature/Buffy-Wicks-8230907e-9ae3-4ae9-b52a-c8464a157f64.yml
+++ b/data/ca/legislature/Buffy-Wicks-8230907e-9ae3-4ae9-b52a-c8464a157f64.yml
@@ -18,8 +18,6 @@ roles:
   district: '14'
 links:
 - url: https://a15.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD15&inframe=N
-  note: Contact Form
 - url: https://a14.asmdc.org
 sources:
 - url: http://assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Carlos-Villapudua-2ebacc3c-fd77-4289-b106-789f4e2c2f87.yml
+++ b/data/ca/legislature/Carlos-Villapudua-2ebacc3c-fd77-4289-b106-789f4e2c2f87.yml
@@ -19,8 +19,6 @@ offices:
   voice: 209-948-7479
 links:
 - url: https://a13.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD13&inframe=N
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Cecilia-M-Aguiar-Curry-434bcfb4-1279-40cc-916b-f89af5805a9c.yml
+++ b/data/ca/legislature/Cecilia-M-Aguiar-Curry-434bcfb4-1279-40cc-916b-f89af5805a9c.yml
@@ -24,8 +24,6 @@ offices:
   address: 885 Lakeport Boulevard, Lakeport, CA 95453
 links:
 - url: https://a04.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD04&inframe=N
-  note: Contact Form
 other_names:
 - name: Cecilia Aguiar-Curry
 other_identifiers:

--- a/data/ca/legislature/Chris-R-Holden-154c4712-4a1f-4a57-bd37-b75ee5bfbab5.yml
+++ b/data/ca/legislature/Chris-R-Holden-154c4712-4a1f-4a57-bd37-b75ee5bfbab5.yml
@@ -22,8 +22,6 @@ offices:
   voice: 909-624-7876
 links:
 - url: https://a41.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD41&inframe=N
-  note: Contact Form
 other_names:
 - name: Chris Holden
 other_identifiers:

--- a/data/ca/legislature/Christopher-M-Ward-71590420-10d6-4deb-8d59-453256d625b6.yml
+++ b/data/ca/legislature/Christopher-M-Ward-71590420-10d6-4deb-8d59-453256d625b6.yml
@@ -19,8 +19,6 @@ offices:
   voice: 619-645-3090
 links:
 - url: https://a78.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD78&inframe=N
-  note: Contact Form
 other_names:
 - name: Christopher Ward
 sources:

--- a/data/ca/legislature/Cottie-Petrie-Norris-c766abf8-06ca-4a98-9665-82b87149ca96.yml
+++ b/data/ca/legislature/Cottie-Petrie-Norris-c766abf8-06ca-4a98-9665-82b87149ca96.yml
@@ -23,9 +23,7 @@ offices:
   voice: 949-251-0074
 links:
 - url: https://a74.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD74&inframe=N
 - url: https://a73.asmdc.org/
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Dave-Cortese-0fa65d2c-6020-4586-a6f1-5dfd41db38ff.yml
+++ b/data/ca/legislature/Dave-Cortese-0fa65d2c-6020-4586-a6f1-5dfd41db38ff.yml
@@ -19,8 +19,6 @@ offices:
   voice: 408-558-1295
 links:
 - url: https://senate.ca.gov/sd15
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD15&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Dave-Min-393d31b9-3336-4e2a-b397-fe12898052c2.yml
+++ b/data/ca/legislature/Dave-Min-393d31b9-3336-4e2a-b397-fe12898052c2.yml
@@ -19,8 +19,6 @@ offices:
   voice: 949-223-5472
 links:
 - url: https://senate.ca.gov/sd37
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD37&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Devon-J-Mathis-3ffead8c-6856-4592-8594-182e295b8e87.yml
+++ b/data/ca/legislature/Devon-J-Mathis-3ffead8c-6856-4592-8594-182e295b8e87.yml
@@ -26,8 +26,6 @@ offices:
   voice: 559-585-7170
 links:
 - url: https://ad26.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD26&inframe=N
-  note: Contact Form
 - url: https://ad33.asmrc.org/
 other_names:
 - name: Devon Mathis

--- a/data/ca/legislature/Dr-Joaquin-Arambula-e2da0f08-1bd8-4ac2-95f1-002870238527.yml
+++ b/data/ca/legislature/Dr-Joaquin-Arambula-e2da0f08-1bd8-4ac2-95f1-002870238527.yml
@@ -20,8 +20,6 @@ offices:
   voice: 559-445-5532
 links:
 - url: https://a31.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD31&inframe=N
-  note: Contact Form
 other_names:
 - name: Joaquin Arambula
 - name: Dr. Joaquin Arambula

--- a/data/ca/legislature/Eduardo-Garcia-c4f4c9c1-1f1b-4cb6-854b-434c53495006.yml
+++ b/data/ca/legislature/Eduardo-Garcia-c4f4c9c1-1f1b-4cb6-854b-434c53495006.yml
@@ -17,8 +17,6 @@ roles:
   district: '36'
 links:
 - url: https://a56.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD56&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000461

--- a/data/ca/legislature/Eloise-Gmez-Reyes-19f694d8-b409-40e5-9f87-d8e3e84afc7f.yml
+++ b/data/ca/legislature/Eloise-Gmez-Reyes-19f694d8-b409-40e5-9f87-d8e3e84afc7f.yml
@@ -23,8 +23,6 @@ offices:
   voice: 909-381-3238
 links:
 - url: https://a47.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD47&inframe=N
-  note: Contact Form
 - url: https://a50.asmdc.org
 other_names:
 - name: Eloise Gomez Reyes

--- a/data/ca/legislature/Evan-Low-b6e6e287-12e9-4067-a607-28bf5c481935.yml
+++ b/data/ca/legislature/Evan-Low-b6e6e287-12e9-4067-a607-28bf5c481935.yml
@@ -17,8 +17,6 @@ roles:
   district: '26'
 links:
 - url: https://a28.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD28&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000456

--- a/data/ca/legislature/Freddie-Rodriguez-b1d10c0c-3d3d-4ae1-8c7e-02227cd18aa0.yml
+++ b/data/ca/legislature/Freddie-Rodriguez-b1d10c0c-3d3d-4ae1-8c7e-02227cd18aa0.yml
@@ -23,7 +23,6 @@ offices:
   voice: 909-902-9606
 links:
 - url: https://a52.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD52&inframe=N
 - url: https://a53.asmdc.org/
   note: Contact Form
 other_identifiers:

--- a/data/ca/legislature/Heath-Flora-c830a90c-8964-4c0f-b31b-729cab1144fd.yml
+++ b/data/ca/legislature/Heath-Flora-c830a90c-8964-4c0f-b31b-729cab1144fd.yml
@@ -17,8 +17,6 @@ roles:
   district: '9'
 links:
 - url: https://ad12.asmrc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD12&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000502

--- a/data/ca/legislature/Henry-I-Stern-66bd4b32-5536-4bae-ab55-08c0b70ca5fd.yml
+++ b/data/ca/legislature/Henry-I-Stern-66bd4b32-5536-4bae-ab55-08c0b70ca5fd.yml
@@ -19,8 +19,6 @@ offices:
   voice: 818-876-3352
 links:
 - url: https://senate.ca.gov/sd27
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD27&inframe=N
-  note: Contact Form
 other_names:
 - name: Henry I Stern
 other_identifiers:

--- a/data/ca/legislature/Jacqui-Irwin-e7ad99fd-fda5-4114-af3e-320f5be9be3c.yml
+++ b/data/ca/legislature/Jacqui-Irwin-e7ad99fd-fda5-4114-af3e-320f5be9be3c.yml
@@ -17,8 +17,6 @@ roles:
   district: '42'
 links:
 - url: https://a44.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD44&inframe=N
-  note: Contact Form
 - url: https://a42.asmdc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/James-C-Ramos-156660b1-4c3f-45e3-8384-53cda60d7ea5.yml
+++ b/data/ca/legislature/James-C-Ramos-156660b1-4c3f-45e3-8384-53cda60d7ea5.yml
@@ -18,8 +18,6 @@ roles:
   district: '45'
 links:
 - url: https://a40.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD40&inframe=N
-  note: Contact Form
 other_names:
 - name: James Ramos
 sources:

--- a/data/ca/legislature/James-Gallagher-5d93a1cb-7a01-43ab-a26c-a2abecdee135.yml
+++ b/data/ca/legislature/James-Gallagher-5d93a1cb-7a01-43ab-a26c-a2abecdee135.yml
@@ -22,8 +22,6 @@ offices:
   voice: 530-671-0303
 links:
 - url: http://ad03.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD03&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000458

--- a/data/ca/legislature/Janet-Nguyen-c6471995-41db-497c-8953-dd3ea5871870.yml
+++ b/data/ca/legislature/Janet-Nguyen-c6471995-41db-497c-8953-dd3ea5871870.yml
@@ -21,8 +21,6 @@ roles:
   district: '36'
 links:
 - url: https://ad72.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD72&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000469

--- a/data/ca/legislature/Jesse-Gabriel-407f6fda-8638-4cca-9704-7aa8df7de26e.yml
+++ b/data/ca/legislature/Jesse-Gabriel-407f6fda-8638-4cca-9704-7aa8df7de26e.yml
@@ -23,8 +23,6 @@ offices:
   voice: 818-346-4521
 links:
 - url: https://a45.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD45&inframe=N
-  note: Contact Form
 - url: https://a46.asmdc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/Jim-Patterson-2cb9d19b-360d-4568-a781-b54a483b081e.yml
+++ b/data/ca/legislature/Jim-Patterson-2cb9d19b-360d-4568-a781-b54a483b081e.yml
@@ -23,8 +23,6 @@ offices:
   voice: 559-446-2029
 links:
 - url: https://ad23.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD23&inframe=N
-  note: Contact Form
 - url: https://ad08.asmrc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/Jim-Wood-798893c7-4969-4b39-b9d3-f920806424f3.yml
+++ b/data/ca/legislature/Jim-Wood-798893c7-4969-4b39-b9d3-f920806424f3.yml
@@ -25,8 +25,6 @@ offices:
   voice: 707-463-5770
 links:
 - url: https://a02.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD02&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000443

--- a/data/ca/legislature/John-Laird-7476789f-49a4-491a-b294-9d1486f24193.yml
+++ b/data/ca/legislature/John-Laird-7476789f-49a4-491a-b294-9d1486f24193.yml
@@ -25,8 +25,6 @@ offices:
   voice: 831-425-0401
 links:
 - url: https://senate.ca.gov/sd17
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD17&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Josh-Becker-c71137b2-3fc3-48bf-b0ad-6c29aff98268.yml
+++ b/data/ca/legislature/Josh-Becker-c71137b2-3fc3-48bf-b0ad-6c29aff98268.yml
@@ -19,8 +19,6 @@ offices:
   voice: 650-212-3313
 links:
 - url: https://senate.ca.gov/sd13
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD13&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Josh-Newman-ed40c798-40c1-4fe6-9fb8-c3fee65b48e0.yml
+++ b/data/ca/legislature/Josh-Newman-ed40c798-40c1-4fe6-9fb8-c3fee65b48e0.yml
@@ -24,8 +24,6 @@ offices:
   voice: 714-525-2342
 links:
 - url: http://senate.ca.gov/sd29
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD29&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000521

--- a/data/ca/legislature/Kelly-Seyarto-d9462f08-2b27-4969-8436-9a1c21534a40.yml
+++ b/data/ca/legislature/Kelly-Seyarto-d9462f08-2b27-4969-8436-9a1c21534a40.yml
@@ -24,8 +24,6 @@ offices:
   voice: 951-894-3530
 links:
 - url: https://ad67.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD67&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd32
 sources:
 - url: http://assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Kevin-McCarty-723bd312-e1c3-490c-9a8c-65388f834092.yml
+++ b/data/ca/legislature/Kevin-McCarty-723bd312-e1c3-490c-9a8c-65388f834092.yml
@@ -17,8 +17,6 @@ roles:
   district: '6'
 links:
 - url: https://a07.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD07&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000483

--- a/data/ca/legislature/Laura-Friedman-e4fdea57-14a2-4fa7-a40c-92cf06c07edd.yml
+++ b/data/ca/legislature/Laura-Friedman-e4fdea57-14a2-4fa7-a40c-92cf06c07edd.yml
@@ -17,8 +17,6 @@ roles:
   district: '44'
 links:
 - url: https://a43.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD43&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000500

--- a/data/ca/legislature/Laurie-Davies-1b3ac39e-7b50-4263-bd1d-add1e91d71b9.yml
+++ b/data/ca/legislature/Laurie-Davies-1b3ac39e-7b50-4263-bd1d-add1e91d71b9.yml
@@ -26,8 +26,6 @@ offices:
   voice: 949-240-7300
 links:
 - url: https://ad73.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD73&inframe=N
-  note: Contact Form
 - url: https://ad74.asmrc.org/
 other_identifiers:
 - scheme: openstates

--- a/data/ca/legislature/Lena-A-Gonzalez-cb6cc457-59f8-4dd8-aeb5-691c3795ffb7.yml
+++ b/data/ca/legislature/Lena-A-Gonzalez-cb6cc457-59f8-4dd8-aeb5-691c3795ffb7.yml
@@ -22,8 +22,6 @@ offices:
   voice: 323-277-4560
 links:
 - url: https://senate.ca.gov/sd33
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD33&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Lisa-Calderon-ed58ae30-ffe5-4395-9353-141e4018cbe3.yml
+++ b/data/ca/legislature/Lisa-Calderon-ed58ae30-ffe5-4395-9353-141e4018cbe3.yml
@@ -22,9 +22,7 @@ offices:
   voice: 562-692-5858
 links:
 - url: https://a57.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD57&inframe=N
 - url: https://a56.asmdc.org/
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Luz-M-Rivas-db75b62c-0713-4075-89cb-1437a9648b00.yml
+++ b/data/ca/legislature/Luz-M-Rivas-db75b62c-0713-4075-89cb-1437a9648b00.yml
@@ -17,8 +17,6 @@ roles:
   district: '43'
 links:
 - url: https://a39.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD39&inframe=N
-  note: Contact Form
 other_names:
 - name: Luz Rivas
 other_identifiers:

--- a/data/ca/legislature/Marc-Berman-24facf9e-7fb1-4475-9120-05cd0145c7c1.yml
+++ b/data/ca/legislature/Marc-Berman-24facf9e-7fb1-4475-9120-05cd0145c7c1.yml
@@ -17,8 +17,7 @@ roles:
   district: '23'
 links:
 - url: https://a24.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD24&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000528

--- a/data/ca/legislature/Maria-Elena-Durazo-b3f55460-f87b-4db4-b6a5-35a735f34076.yml
+++ b/data/ca/legislature/Maria-Elena-Durazo-b3f55460-f87b-4db4-b6a5-35a735f34076.yml
@@ -18,8 +18,6 @@ roles:
   district: '26'
 links:
 - url: https://senate.ca.gov/sd24
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD24&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd26
 other_names:
 - name: Maria Elena Durazo

--- a/data/ca/legislature/Marie-Waldron-9df241a1-0f02-456a-9dbf-8706e0b6c15c.yml
+++ b/data/ca/legislature/Marie-Waldron-9df241a1-0f02-456a-9dbf-8706e0b6c15c.yml
@@ -19,8 +19,6 @@ offices:
   voice: 760-480-7570
 links:
 - url: https://ad75.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD75&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000410

--- a/data/ca/legislature/Megan-Dahle-1509d608-4d2b-4ebc-be73-b4cd6c06b7c6.yml
+++ b/data/ca/legislature/Megan-Dahle-1509d608-4d2b-4ebc-be73-b4cd6c06b7c6.yml
@@ -25,8 +25,6 @@ offices:
   voice: 530-927-5757
 links:
 - url: https://ad01.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD01&inframe=N
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Melissa-Hurtado-ee9910a2-0b27-46e0-be87-43c800596b41.yml
+++ b/data/ca/legislature/Melissa-Hurtado-ee9910a2-0b27-46e0-be87-43c800596b41.yml
@@ -27,8 +27,6 @@ offices:
   voice: 559-585-7161
 links:
 - url: https://senate.ca.gov/sd14
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD14&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd16
 sources:
 - url: http://senate.ca.gov/senators

--- a/data/ca/legislature/Miguel-Santiago-2e27cd32-daea-4a11-987b-bef3c4068e02.yml
+++ b/data/ca/legislature/Miguel-Santiago-2e27cd32-daea-4a11-987b-bef3c4068e02.yml
@@ -17,8 +17,6 @@ roles:
   district: '54'
 links:
 - url: https://a53.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD53&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000454

--- a/data/ca/legislature/Mike-A-Gipson-404dbee4-6b74-4249-ab26-9644cab7c7d5.yml
+++ b/data/ca/legislature/Mike-A-Gipson-404dbee4-6b74-4249-ab26-9644cab7c7d5.yml
@@ -17,8 +17,6 @@ roles:
   district: '65'
 links:
 - url: https://a64.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD64&inframe=N
-  note: Contact Form
 - url: https://a65.asmdc.org/
 other_names:
 - name: Mike Gipson

--- a/data/ca/legislature/Mike-McGuire-a1394aeb-094a-4fc0-b4d5-005104ceddc0.yml
+++ b/data/ca/legislature/Mike-McGuire-a1394aeb-094a-4fc0-b4d5-005104ceddc0.yml
@@ -31,8 +31,6 @@ offices:
   voice: 707-445-6508
 links:
 - url: https://senate.ca.gov/sd02
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD02&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000447

--- a/data/ca/legislature/Monique-Limn-e924a3ec-c7c0-4094-8504-7611bcf8979f.yml
+++ b/data/ca/legislature/Monique-Limn-e924a3ec-c7c0-4094-8504-7611bcf8979f.yml
@@ -27,8 +27,6 @@ offices:
   voice: 805-988-1940
 links:
 - url: https://senate.ca.gov/sd19
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD19&inframe=N
-  note: Contact Form
 other_names:
 - name: "Monique Lim\xF3n"
 - name: "S. Monique Lim\xF3n"

--- a/data/ca/legislature/Nancy-Skinner-da008178-5da9-4adb-a690-1360a9bce2db.yml
+++ b/data/ca/legislature/Nancy-Skinner-da008178-5da9-4adb-a690-1360a9bce2db.yml
@@ -29,8 +29,6 @@ offices:
   voice: 510-286-1333
 links:
 - url: https://senate.ca.gov/sd09
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD09&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000501

--- a/data/ca/legislature/Philip-Y-Ting-bf88659d-b2dd-462e-84b3-82ead47ff360.yml
+++ b/data/ca/legislature/Philip-Y-Ting-bf88659d-b2dd-462e-84b3-82ead47ff360.yml
@@ -19,8 +19,6 @@ offices:
   voice: 415-557-2312
 links:
 - url: https://a19.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD19&inframe=N
-  note: Contact Form
 other_names:
 - name: Phil Ting
 - name: Philip Y. Ting

--- a/data/ca/legislature/Phillip-Chen-6ba768a4-2756-42b5-a5c5-f6b8b5db0491.yml
+++ b/data/ca/legislature/Phillip-Chen-6ba768a4-2756-42b5-a5c5-f6b8b5db0491.yml
@@ -16,9 +16,7 @@ roles:
   district: '59'
 links:
 - url: https://ad55.asmrc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD55&inframe=N
 - url: https://ad59.asmrc.org
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000530

--- a/data/ca/legislature/Rebecca-Bauer-Kahan-2918acca-40a2-4819-a79a-b2873c7895bc.yml
+++ b/data/ca/legislature/Rebecca-Bauer-Kahan-2918acca-40a2-4819-a79a-b2873c7895bc.yml
@@ -20,8 +20,6 @@ offices:
   voice: 925-244-1600
 links:
 - url: https://a16.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD16&inframe=N
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Reginald-Byron-Jones-Sawyer-Sr-9f520ee9-8314-4029-8752-e6107f2e734e.yml
+++ b/data/ca/legislature/Reginald-Byron-Jones-Sawyer-Sr-9f520ee9-8314-4029-8752-e6107f2e734e.yml
@@ -17,8 +17,6 @@ roles:
   district: '57'
 links:
 - url: https://a59.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD59&inframe=N
-  note: Contact Form
 - url: https://a57.asmdc.org/
 other_names:
 - name: Reginald Jones-Sawyer

--- a/data/ca/legislature/Richard-D-Roth-26cbb5a7-e485-41f6-9cb6-be82cbef73db.yml
+++ b/data/ca/legislature/Richard-D-Roth-26cbb5a7-e485-41f6-9cb6-be82cbef73db.yml
@@ -19,8 +19,6 @@ offices:
   voice: 951-680-6750
 links:
 - url: https://senate.ca.gov/sd31
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD31&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000327

--- a/data/ca/legislature/Robert-Rivas-68f5ee30-aa70-489b-84b7-6501e6188751.yml
+++ b/data/ca/legislature/Robert-Rivas-68f5ee30-aa70-489b-84b7-6501e6188751.yml
@@ -18,8 +18,6 @@ roles:
   district: '29'
 links:
 - url: https://a30.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD30&inframe=N
-  note: Contact Form
 - url: https://a29.asmdc.org/
 sources:
 - url: http://assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Rosilicie-Ochoa-Bogh-cb5b9356-6798-44d2-8dc2-caf5651ac4e3.yml
+++ b/data/ca/legislature/Rosilicie-Ochoa-Bogh-cb5b9356-6798-44d2-8dc2-caf5651ac4e3.yml
@@ -19,8 +19,6 @@ offices:
   voice: 909-335-0271
 links:
 - url: http://senate.ca.gov/sd23
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD23&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Sabrina-Cervantes-61cc77e3-551f-40e6-bb6f-16edd89b04db.yml
+++ b/data/ca/legislature/Sabrina-Cervantes-61cc77e3-551f-40e6-bb6f-16edd89b04db.yml
@@ -17,8 +17,6 @@ roles:
   district: '58'
 links:
 - url: https://a60.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD60&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000525

--- a/data/ca/legislature/Scott-D-Wiener-de84277e-1c23-4036-bd64-b27c310a1c0e.yml
+++ b/data/ca/legislature/Scott-D-Wiener-de84277e-1c23-4036-bd64-b27c310a1c0e.yml
@@ -19,8 +19,6 @@ offices:
   voice: 415-557-1300
 links:
 - url: https://senate.ca.gov/sd11
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD11&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000512

--- a/data/ca/legislature/Scott-Wilk-f82658a8-e4e5-4f12-807b-b1eec79782d1.yml
+++ b/data/ca/legislature/Scott-Wilk-f82658a8-e4e5-4f12-807b-b1eec79782d1.yml
@@ -30,8 +30,6 @@ offices:
   voice: 760-843-8414
 links:
 - url: http://senate.ca.gov/sd21
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD21&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000505

--- a/data/ca/legislature/Shannon-Grove-b4b8e8fb-831b-4cae-9081-b8f75477fcd0.yml
+++ b/data/ca/legislature/Shannon-Grove-b4b8e8fb-831b-4cae-9081-b8f75477fcd0.yml
@@ -39,9 +39,7 @@ offices:
   voice: 760-228-3136
 links:
 - url: https://senate.ca.gov/sd16
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD16&inframe=N
 - url: https://senate.ca.gov/sd12
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000140

--- a/data/ca/legislature/Sharon-Quirk-Silva-840aa009-3ae4-4484-b9f0-5c5f5060e7db.yml
+++ b/data/ca/legislature/Sharon-Quirk-Silva-840aa009-3ae4-4484-b9f0-5c5f5060e7db.yml
@@ -30,8 +30,6 @@ offices:
   voice: 714-525-6515
 links:
 - url: https://a65.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD65&inframe=N
-  note: Contact Form
 - url: https://a67.asmdc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/Steve-Bennett-1e0ccfc0-2d57-4e57-8d16-589d07c1bc72.yml
+++ b/data/ca/legislature/Steve-Bennett-1e0ccfc0-2d57-4e57-8d16-589d07c1bc72.yml
@@ -17,8 +17,6 @@ roles:
   district: '38'
 links:
 - url: https://a37.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD37&inframe=N
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/legislature/Steven-Bradford-99fd8cce-55ba-493a-b787-e339a57de7df.yml
+++ b/data/ca/legislature/Steven-Bradford-99fd8cce-55ba-493a-b787-e339a57de7df.yml
@@ -32,8 +32,6 @@ offices:
   voice: 310-514-8573
 links:
 - url: https://senate.ca.gov/sd35
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD35&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000510

--- a/data/ca/legislature/Steven-M-Glazer-9521850c-594d-415b-becf-002add076e86.yml
+++ b/data/ca/legislature/Steven-M-Glazer-9521850c-594d-415b-becf-002add076e86.yml
@@ -22,8 +22,6 @@ offices:
   voice: 925-754-1461
 links:
 - url: https://senate.ca.gov/sd07
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD07&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000495

--- a/data/ca/legislature/Susan-Rubio-cb0f6477-568f-49db-aba3-f88e7bccbefc.yml
+++ b/data/ca/legislature/Susan-Rubio-cb0f6477-568f-49db-aba3-f88e7bccbefc.yml
@@ -23,8 +23,6 @@ offices:
   voice: 909-469-1110
 links:
 - url: https://senate.ca.gov/sd22
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD22&inframe=N
-  note: Contact Form
 other_names:
 - name: Rubio
 sources:

--- a/data/ca/legislature/Susan-Talamantes-Eggman-796593d1-498e-4980-bd5e-2db033754c62.yml
+++ b/data/ca/legislature/Susan-Talamantes-Eggman-796593d1-498e-4980-bd5e-2db033754c62.yml
@@ -24,8 +24,6 @@ offices:
   voice: 209-472-9535
 links:
 - url: https://senate.ca.gov/sd05
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD05&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000361

--- a/data/ca/legislature/Tasha-Boerner-Horvath-9e69729e-4383-410b-840e-ad4ea0f1ab4a.yml
+++ b/data/ca/legislature/Tasha-Boerner-Horvath-9e69729e-4383-410b-840e-ad4ea0f1ab4a.yml
@@ -23,9 +23,8 @@ offices:
   voice: 760-434-7605
 links:
 - url: https://a76.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD76&inframe=N
 - url: https://a77.asmdc.org/
-  note: Contact Form
+
 sources:
 - url: https://www.assembly.ca.gov/assemblymembers
 extras:

--- a/data/ca/legislature/Thomas-J-Umberg-cecabb81-51ab-46f5-9815-cc3486da0632.yml
+++ b/data/ca/legislature/Thomas-J-Umberg-cecabb81-51ab-46f5-9815-cc3486da0632.yml
@@ -20,8 +20,6 @@ offices:
   voice: 714-558-3785
 links:
 - url: https://senate.ca.gov/sd34
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD34&inframe=N
-  note: Contact Form
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/legislature/Timothy-S-Grayson-972cffb0-32a6-4cef-8a0f-a8cd901395b0.yml
+++ b/data/ca/legislature/Timothy-S-Grayson-972cffb0-32a6-4cef-8a0f-a8cd901395b0.yml
@@ -26,9 +26,8 @@ offices:
   voice: 707-642-0314
 links:
 - url: https://a14.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD14&inframe=N
 - url: https://a15.asmdc.org
-  note: Contact Form
+
 other_names:
 - name: Timothy Grayson
 other_identifiers:

--- a/data/ca/legislature/Tom-Lackey-a8879d70-713c-4d0c-b723-77d0e96c18df.yml
+++ b/data/ca/legislature/Tom-Lackey-a8879d70-713c-4d0c-b723-77d0e96c18df.yml
@@ -17,8 +17,6 @@ roles:
   district: '34'
 links:
 - url: https://ad36.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD36&inframe=N
-  note: Contact Form
 - url: https://ad34.asmrc.org/
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/legislature/Toni-G-Atkins-426d94ce-e49c-4d56-a185-9eb9c628c006.yml
+++ b/data/ca/legislature/Toni-G-Atkins-426d94ce-e49c-4d56-a185-9eb9c628c006.yml
@@ -30,8 +30,6 @@ offices:
   voice: 619-688-6700
 links:
 - url: https://senate.ca.gov/sd39
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD39&inframe=N
-  note: Contact Form
 other_names:
 - name: Toni Atkins
 other_identifiers:

--- a/data/ca/legislature/Vince-Fong-3dc86015-2733-405e-ba6b-715006f4ab19.yml
+++ b/data/ca/legislature/Vince-Fong-3dc86015-2733-405e-ba6b-715006f4ab19.yml
@@ -23,9 +23,7 @@ offices:
   voice: 661-395-2995
 links:
 - url: https://ad34.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD34&inframe=N
 - url: https://ad32.asmrc.org/
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000503

--- a/data/ca/legislature/Wendy-Carrillo-70b66c63-35f1-416d-9816-79d5752481a6.yml
+++ b/data/ca/legislature/Wendy-Carrillo-70b66c63-35f1-416d-9816-79d5752481a6.yml
@@ -17,8 +17,6 @@ roles:
   district: '52'
 links:
 - url: https://a51.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD51&inframe=N
-  note: Contact Form
 - url: https://a52.asmdc.org/
 other_names:
 - name: Wendy Carillo

--- a/data/ca/retired/Adam-C-Gray-fd14f876-4b18-4101-8ad4-d45d8586683a.yml
+++ b/data/ca/retired/Adam-C-Gray-fd14f876-4b18-4101-8ad4-d45d8586683a.yml
@@ -14,8 +14,7 @@ roles:
   district: '21'
 links:
 - url: https://a21.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD21&inframe=N
-  note: Contact Form
+
 other_names:
 - name: Adam Gray
 other_identifiers:

--- a/data/ca/retired/Adrin-Nazarian-19c64d24-6578-4a4c-bf71-3f3ea51ce505.yml
+++ b/data/ca/retired/Adrin-Nazarian-19c64d24-6578-4a4c-bf71-3f3ea51ce505.yml
@@ -20,8 +20,7 @@ offices:
   voice: 818-376-4246
 links:
 - url: https://a46.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD46&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000393

--- a/data/ca/retired/Andreas-Borgeas-50ff89eb-0e1c-4ca4-90e5-e21c51cb7d94.yml
+++ b/data/ca/retired/Andreas-Borgeas-50ff89eb-0e1c-4ca4-90e5-e21c51cb7d94.yml
@@ -14,8 +14,7 @@ roles:
   district: '8'
 links:
 - url: https://senate.ca.gov/sd08
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD08&inframe=N
-  note: Contact Form
+
 sources:
 - url: http://senate.ca.gov/senators
 - url: https://www.senate.ca.gov/senators

--- a/data/ca/retired/Autumn-R-Burke-0fec719d-4fca-4119-88c2-02c3b4faed85.yml
+++ b/data/ca/retired/Autumn-R-Burke-0fec719d-4fca-4119-88c2-02c3b4faed85.yml
@@ -14,8 +14,6 @@ roles:
   end_reason: Resigned to spend time with family after pandemic
 links:
 - url: https://a62.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD62&inframe=N
-  note: Contact Form
 other_names:
 - name: Autumn Burke
 other_identifiers:

--- a/data/ca/retired/Ben-Hueso-041e3c31-f9c0-4add-ae2e-f5c0a281fc27.yml
+++ b/data/ca/retired/Ben-Hueso-041e3c31-f9c0-4add-ae2e-f5c0a281fc27.yml
@@ -23,8 +23,6 @@ offices:
   voice: 760-335-3442
 links:
 - url: https://senate.ca.gov/sd40
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD40&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000141

--- a/data/ca/retired/Bill-Quirk-9ef08f26-f81d-433e-b055-841432a7d52c.yml
+++ b/data/ca/retired/Bill-Quirk-9ef08f26-f81d-433e-b055-841432a7d52c.yml
@@ -13,8 +13,7 @@ roles:
   district: '20'
 links:
 - url: https://a20.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD20&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000401

--- a/data/ca/retired/Chad-Mayes-29f9b8cf-ac19-49d8-93c5-299f402532f9.yml
+++ b/data/ca/retired/Chad-Mayes-29f9b8cf-ac19-49d8-93c5-299f402532f9.yml
@@ -25,8 +25,7 @@ offices:
   voice: 760-346-6342
 links:
 - url: https://www.assembly.ca.gov/assemblymemberchadmayes
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD42&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000478

--- a/data/ca/retired/Connie-M-Leyva-c95294d8-1c22-4121-939d-f0f4c7c437f0.yml
+++ b/data/ca/retired/Connie-M-Leyva-c95294d8-1c22-4121-939d-f0f4c7c437f0.yml
@@ -13,8 +13,7 @@ roles:
   district: '20'
 links:
 - url: https://senate.ca.gov/sd20
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD20&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000466

--- a/data/ca/retired/Cristina-Garcia-024ce6f2-cbc1-4331-9466-7b57e52cdb8c.yml
+++ b/data/ca/retired/Cristina-Garcia-024ce6f2-cbc1-4331-9466-7b57e52cdb8c.yml
@@ -13,8 +13,7 @@ roles:
   district: '58'
 links:
 - url: https://a58.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD58&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000366

--- a/data/ca/retired/David-Chiu-322fc0ac-b105-4e36-8fab-cf74b0a4e87e.yml
+++ b/data/ca/retired/David-Chiu-322fc0ac-b105-4e36-8fab-cf74b0a4e87e.yml
@@ -14,8 +14,7 @@ roles:
   end_reason: Appointed as City Attorney of San Francisco
 links:
 - url: https://a17.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD17&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000452

--- a/data/ca/retired/Ed-Chau-7a8deb33-ca1f-4c20-93b5-a16cd9536cc2.yml
+++ b/data/ca/retired/Ed-Chau-7a8deb33-ca1f-4c20-93b5-a16cd9536cc2.yml
@@ -14,8 +14,7 @@ roles:
   end_reason: Appointed as Judge of the Los Angeles County Superior Court
 links:
 - url: https://a49.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD49&inframe=N
-  note: Contact Form
+
 other_names:
 - name: Chau
 other_identifiers:

--- a/data/ca/retired/Jim-Cooper-9629be48-b082-4880-85a8-d2e14a4ad1a8.yml
+++ b/data/ca/retired/Jim-Cooper-9629be48-b082-4880-85a8-d2e14a4ad1a8.yml
@@ -13,8 +13,7 @@ roles:
   district: '9'
 links:
 - url: https://a09.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD09&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000457

--- a/data/ca/retired/Jim-Frazier-193620ba-dd85-48ff-9b0e-4611ef2d9613.yml
+++ b/data/ca/retired/Jim-Frazier-193620ba-dd85-48ff-9b0e-4611ef2d9613.yml
@@ -14,8 +14,7 @@ roles:
   end_reason: To use passion and experience in the transportation sector, explore new career opportunities and spend additional time with friends and family.
 links:
 - url: https://a11.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD11&inframe=N
-  note: Contact Form
+
 other_names:
 - name: Jim Frazier
 other_identifiers:

--- a/data/ca/retired/Jim-Nielsen-de59f459-9b3d-410a-ab49-49bc47efcf1f.yml
+++ b/data/ca/retired/Jim-Nielsen-de59f459-9b3d-410a-ab49-49bc47efcf1f.yml
@@ -13,8 +13,7 @@ roles:
   district: '4'
 links:
 - url: http://senate.ca.gov/sd04
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD04&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000103

--- a/data/ca/retired/Jordan-Cunningham-16d16f4a-1551-4546-bec2-e7f336a3e90f.yml
+++ b/data/ca/retired/Jordan-Cunningham-16d16f4a-1551-4546-bec2-e7f336a3e90f.yml
@@ -13,8 +13,7 @@ roles:
   district: '35'
 links:
 - url: https://ad35.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD35&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000519

--- a/data/ca/retired/Jose-Medina-3b14d4a7-73fa-4c85-b6fd-d84a9dd60a47.yml
+++ b/data/ca/retired/Jose-Medina-3b14d4a7-73fa-4c85-b6fd-d84a9dd60a47.yml
@@ -20,8 +20,7 @@ offices:
   voice: 951-369-6644
 links:
 - url: https://a61.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD61&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000387

--- a/data/ca/retired/Ken-Cooley-96fcafb9-0183-46b0-aaa3-dbb21d8d6135.yml
+++ b/data/ca/retired/Ken-Cooley-96fcafb9-0183-46b0-aaa3-dbb21d8d6135.yml
@@ -20,8 +20,7 @@ offices:
   voice: 916-464-1910
 links:
 - url: https://a08.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD08&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000356

--- a/data/ca/retired/Kevin-Kiley-35eec890-026c-412f-8bcf-27e24206a608.yml
+++ b/data/ca/retired/Kevin-Kiley-35eec890-026c-412f-8bcf-27e24206a608.yml
@@ -13,8 +13,7 @@ roles:
   district: '6'
 links:
 - url: https://ad06.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD06&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000520

--- a/data/ca/retired/Kevin-Mullin-a9171d37-d00b-4d46-98ca-a066bce640e5.yml
+++ b/data/ca/retired/Kevin-Mullin-a9171d37-d00b-4d46-98ca-a066bce640e5.yml
@@ -13,8 +13,7 @@ roles:
   district: '22'
 links:
 - url: https://a22.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD22&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000391

--- a/data/ca/retired/Lorena-Gonzalez-dfe28cb5-1e06-418d-b4dd-8328f43c2783.yml
+++ b/data/ca/retired/Lorena-Gonzalez-dfe28cb5-1e06-418d-b4dd-8328f43c2783.yml
@@ -15,8 +15,7 @@ roles:
   end_reason: Taking job at California Labor Federation
 links:
 - url: https://a80.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD80&inframe=N
-  note: Contact Form
+
 other_names:
 - name: Lorena S. Gonzalez
 other_identifiers:

--- a/data/ca/retired/Melissa-A-Melendez-d7cb8647-1324-42e9-b2a6-a26d05863806.yml
+++ b/data/ca/retired/Melissa-A-Melendez-d7cb8647-1324-42e9-b2a6-a26d05863806.yml
@@ -18,8 +18,7 @@ roles:
   district: '28'
 links:
 - url: https://senate.ca.gov/sd28
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD28&inframe=N
-  note: Contact Form
+
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000388

--- a/data/ca/retired/Patricia-C-Bates-9ed8fe52-b020-47d3-92d5-621e32f42e94.yml
+++ b/data/ca/retired/Patricia-C-Bates-9ed8fe52-b020-47d3-92d5-621e32f42e94.yml
@@ -13,8 +13,6 @@ roles:
   district: '36'
 links:
 - url: http://senate.ca.gov/sd36
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD36&inframe=N
-  note: Contact Form
 - url: https://senate.ca.gov/sd36
 other_identifiers:
 - scheme: legacy_openstates

--- a/data/ca/retired/Patrick-ODonnell-e3c486d0-3173-4d1e-a106-9c28c32e7429.yml
+++ b/data/ca/retired/Patrick-ODonnell-e3c486d0-3173-4d1e-a106-9c28c32e7429.yml
@@ -13,8 +13,6 @@ roles:
   district: '70'
 links:
 - url: https://a70.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD70&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000472

--- a/data/ca/retired/Randy-Voepel-63a9e3aa-9baf-444e-820e-1d1caaf2aa3e.yml
+++ b/data/ca/retired/Randy-Voepel-63a9e3aa-9baf-444e-820e-1d1caaf2aa3e.yml
@@ -13,8 +13,6 @@ roles:
   district: '71'
 links:
 - url: https://ad71.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD71&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000506

--- a/data/ca/retired/Richard-Bloom-550a055e-b1d5-406d-9ecb-0f02818baa74.yml
+++ b/data/ca/retired/Richard-Bloom-550a055e-b1d5-406d-9ecb-0f02818baa74.yml
@@ -20,8 +20,6 @@ offices:
   voice: 310-450-0041
 links:
 - url: https://a50.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD50&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000342

--- a/data/ca/retired/Richard-Pan-96c9e551-f768-41c7-ab17-0f204c6be259.yml
+++ b/data/ca/retired/Richard-Pan-96c9e551-f768-41c7-ab17-0f204c6be259.yml
@@ -13,8 +13,6 @@ roles:
   district: '6'
 links:
 - url: http://senate.ca.gov/sd06
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD06&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000149

--- a/data/ca/retired/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
+++ b/data/ca/retired/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
@@ -13,8 +13,6 @@ roles:
   district: '18'
 links:
 - url: https://a18.asmdc.org
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD18&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000346

--- a/data/ca/retired/Robert-M-Hertzberg-d7e883c1-2011-45a1-b5bd-00e2046fa0fd.yml
+++ b/data/ca/retired/Robert-M-Hertzberg-d7e883c1-2011-45a1-b5bd-00e2046fa0fd.yml
@@ -13,8 +13,6 @@ roles:
   district: '18'
 links:
 - url: https://senate.ca.gov/sd18
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=SD18&inframe=N
-  note: Contact Form
 other_names:
 - name: Bob Hertzberg
 other_identifiers:

--- a/data/ca/retired/Rudy-Salas-Jr-7e9b4527-8dc0-4525-9394-23909909e953.yml
+++ b/data/ca/retired/Rudy-Salas-Jr-7e9b4527-8dc0-4525-9394-23909909e953.yml
@@ -13,8 +13,6 @@ roles:
   district: '32'
 links:
 - url: https://a32.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD32&inframe=N
-  note: Contact Form
 other_names:
 - name: Rudy Salas Jr.
 - name: Rudy Salas

--- a/data/ca/retired/Shirley-N-Weber-71cfb6c2-577a-4813-8bdf-a1083314c491.yml
+++ b/data/ca/retired/Shirley-N-Weber-71cfb6c2-577a-4813-8bdf-a1083314c491.yml
@@ -13,8 +13,6 @@ roles:
   district: '79'
 links:
 - url: https://a79.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD79&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000411

--- a/data/ca/retired/Steven-S-Choi-PhD-8b61aa87-d573-47e2-b17b-bd0edd3c8cf2.yml
+++ b/data/ca/retired/Steven-S-Choi-PhD-8b61aa87-d573-47e2-b17b-bd0edd3c8cf2.yml
@@ -13,8 +13,6 @@ roles:
   district: '68'
 links:
 - url: https://ad68.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD68&inframe=N
-  note: Contact Form
 other_names:
 - name: Steven Choi
 - name: Steven S. Choi, PhD.

--- a/data/ca/retired/Suzette-Martinez-Valladares-fb1c2c06-108c-41bf-9f08-44a9f8e0cb08.yml
+++ b/data/ca/retired/Suzette-Martinez-Valladares-fb1c2c06-108c-41bf-9f08-44a9f8e0cb08.yml
@@ -13,8 +13,6 @@ roles:
   district: '38'
 links:
 - url: https://a38.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD38&inframe=N
-  note: Contact Form
 other_names:
 - name: Suzette Valladares
 sources:

--- a/data/ca/retired/Thurston-Smitty-Smith-0ac8bd1c-0b72-4406-9b13-bb741e42d132.yml
+++ b/data/ca/retired/Thurston-Smitty-Smith-0ac8bd1c-0b72-4406-9b13-bb741e42d132.yml
@@ -19,8 +19,6 @@ offices:
   voice: 760-244-5277
 links:
 - url: https://ad33.asmrc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD33&inframe=N
-  note: Contact Form
 sources:
 - url: http://assembly.ca.gov/assemblymembers
 - url: https://www.assembly.ca.gov/assemblymembers

--- a/data/ca/retired/Tom-Daly-6e15bad0-0813-443e-bc20-83d70860b9b9.yml
+++ b/data/ca/retired/Tom-Daly-6e15bad0-0813-443e-bc20-83d70860b9b9.yml
@@ -13,8 +13,6 @@ roles:
   district: '69'
 links:
 - url: https://a69.asmdc.org/
-- url: https://lcmspubcontact.lc.ca.gov/PublicLCMS/ContactPopup.php?district=AD69&inframe=N
-  note: Contact Form
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000358


### PR DESCRIPTION
Updating people data to remove contact form so that it will not show up under "Website" for legislators. Relates to [DATA-2346](https://civic-eagle.atlassian.net/browse/DATA-2346)