### PR TITLE
PA comms: joint comms add

### DIFF
--- a/data/pa/committees/legislature-Applications-and-Information-Technology-c15c7ae9-33ac-49ed-afc4-7ce952c8209d.yml
+++ b/data/pa/committees/legislature-Applications-and-Information-Technology-c15c7ae9-33ac-49ed-afc4-7ce952c8209d.yml
@@ -1,0 +1,22 @@
+id: ocd-organization/c15c7ae9-33ac-49ed-afc4-7ce952c8209d
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Applications and Information Technology
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Sharif Street
+  role: Chair
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: Craig Dally
+  role: Public Member
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Applications-and-Information-Technology-c79c70b8-56f0-455c-991f-b25ed162e767.yml
+++ b/data/pa/committees/legislature-Applications-and-Information-Technology-c79c70b8-56f0-455c-991f-b25ed162e767.yml
@@ -1,0 +1,22 @@
+id: ocd-organization/c79c70b8-56f0-455c-991f-b25ed162e767
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Applications and Information Technology
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Sharif Street
+  role: Chair
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: Craig Dally
+  role: Public Member
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Capitol-Preservation-4d582918-e794-4bef-88e7-5855218adfc1.yml
+++ b/data/pa/committees/legislature-Capitol-Preservation-4d582918-e794-4bef-88e7-5855218adfc1.yml
@@ -1,0 +1,45 @@
+id: ocd-organization/4d582918-e794-4bef-88e7-5855218adfc1
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Capitol Preservation
+chamber: legislature
+sources:
+- url: http://cpc.state.pa.us/about/capitol-preservation-committee-members.cfm
+  note: Member list page
+links:
+- url: http://cpc.state.pa.us/
+  note: homepage
+members:
+- name: John R. Bowie
+  role: Vice Chairman, Governor's Appointee
+- name: Thomas B. Darr
+  role: Secretary, Supreme Court Appointee
+- name: Patty Kim
+  role: Treasurer
+  person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
+- name: Carolyn T. Comitta
+  role: Member
+  person_id: ocd-person/91c58c1d-de9d-471b-8178-f6ef89c1286b
+- name: John DiSanto
+  role: Member
+  person_id: ocd-person/01ce8a7c-29e4-4439-be3a-b919797dc912
+- name: Frank E. Dittenhafer, II
+  role: FAIA, LEED AP, Governor's Appointee
+- name: Timothy P. Kearney
+  role: Member
+  person_id: ocd-person/f9f2479f-0c37-47d1-a4eb-666146e2856f
+- name: Dawn W. Keefer
+  role: Member
+  person_id: ocd-person/2a13f9df-b7e6-4281-82e4-f7263b6fa12e
+- name: Ruthann Hubbert-Kemper
+  role: Emeritus Member
+- name: Andrea Bakewell Lowery
+  role: Executive Director, Historical & Museum Commission
+- name: Kyle Mullins
+  role: Member
+  person_id: ocd-person/625784c9-4cd0-417c-9c44-1acd53b34307
+- name: Reggie McNeil
+  role: Acting Secretary, Department of General Services
+- name: Parke Wentling
+  role: Member
+  person_id: ocd-person/8f7a2783-e165-4bf2-aead-113d98dd7dd2

--- a/data/pa/committees/legislature-Capitol-Preservation-cfbca86b-e9da-4a30-9dfa-06ce72f5bb4e.yml
+++ b/data/pa/committees/legislature-Capitol-Preservation-cfbca86b-e9da-4a30-9dfa-06ce72f5bb4e.yml
@@ -1,0 +1,44 @@
+id: ocd-organization/cfbca86b-e9da-4a30-9dfa-06ce72f5bb4e
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Capitol Preservation
+chamber: legislature
+sources:
+- url: http://cpc.state.pa.us/about/capitol-preservation-committee-members.cfm
+  note: Member list page
+links:
+- url: http://cpc.state.pa.us/
+  note: homepage
+members:
+- name: John R. Bowie
+  role: Vice Chairman, Governor's Appointee
+- name: Thomas B. Darr
+  role: Secretary, Supreme Court Appointee
+- name: Patty Kim
+  role: Treasurer
+  person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
+- name: Carolyn T. Comitta
+  role: Member
+  person_id: ocd-person/91c58c1d-de9d-471b-8178-f6ef89c1286b
+- name: John DiSanto
+  role: Member
+  person_id: ocd-person/01ce8a7c-29e4-4439-be3a-b919797dc912
+- name: Frank E. Dittenhafer, II
+  role: FAIA, LEED AP, Governor's Appointee
+- name: Timothy P. Kearney
+  role: Member
+  person_id: ocd-person/f9f2479f-0c37-47d1-a4eb-666146e2856f
+- name: Dawn W. Keefer
+  role: Member
+  person_id: ocd-person/2a13f9df-b7e6-4281-82e4-f7263b6fa12e
+- name: Ruthann Hubbert-Kemper
+  role: Emeritus Member
+- name: Andrea Bakewell Lowery
+  role: Executive Director, Historical & Museum Commission
+- name: Kyle Mullins
+  role: Member
+- name: Reggie McNeil
+  role: Acting Secretary, Department of General Services
+- name: Parke Wentling
+  role: Member
+  person_id: ocd-person/8f7a2783-e165-4bf2-aead-113d98dd7dd2

--- a/data/pa/committees/legislature-Education-and-Outreach-099f14dd-dcaa-40d2-bc32-03e26ad68d49.yml
+++ b/data/pa/committees/legislature-Education-and-Outreach-099f14dd-dcaa-40d2-bc32-03e26ad68d49.yml
@@ -1,0 +1,22 @@
+id: ocd-organization/099f14dd-dcaa-40d2-bc32-03e26ad68d49
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Education and Outreach
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Edward M. Marsico, Jr.
+  role: Chair
+- name: Rick Krajewski
+  role: Member
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Douglas K. Marsico
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Education-and-Outreach-76007bee-6a7e-41b0-8797-2c7ebbcde8b9.yml
+++ b/data/pa/committees/legislature-Education-and-Outreach-76007bee-6a7e-41b0-8797-2c7ebbcde8b9.yml
@@ -1,0 +1,22 @@
+id: ocd-organization/76007bee-6a7e-41b0-8797-2c7ebbcde8b9
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Education and Outreach
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Edward M. Marsico, Jr.
+  role: Chair
+- name: Rick Krajewski
+  role: Member
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Douglas K. Marsico
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Executive-and-Administrative-7d87ec12-a972-46fb-804b-018c1b24104c.yml
+++ b/data/pa/committees/legislature-Executive-and-Administrative-7d87ec12-a972-46fb-804b-018c1b24104c.yml
@@ -1,0 +1,24 @@
+id: ocd-organization/7d87ec12-a972-46fb-804b-018c1b24104c
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Executive and Administrative
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Tamara Bernstein
+  role: Chair
+- name: Rick Krajewski
+  role: Member
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a

--- a/data/pa/committees/legislature-Executive-and-Administrative-c88366af-fe55-453d-b084-cad0e4caa447.yml
+++ b/data/pa/committees/legislature-Executive-and-Administrative-c88366af-fe55-453d-b084-cad0e4caa447.yml
@@ -1,0 +1,24 @@
+id: ocd-organization/c88366af-fe55-453d-b084-cad0e4caa447
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Executive and Administrative
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Tamara Bernstein
+  role: Chair
+- name: Rick Krajewski
+  role: Member
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a

--- a/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-00fe5896-1421-43ec-8daf-d2cf96c3a5bc.yml
+++ b/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-00fe5896-1421-43ec-8daf-d2cf96c3a5bc.yml
@@ -1,0 +1,32 @@
+id: ocd-organization/00fe5896-1421-43ec-8daf-d2cf96c3a5bc
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Audit Advisory Commission
+chamber: legislature
+sources:
+- url: https://www.legis.state.pa.us/cfdocs/cteeInfo/laac.cfm
+  note: Committee member list
+links:
+- url: https://www.legis.state.pa.us/cfdocs/cteeInfo/laac.cfm
+  note: homepage
+members:
+- name: Patrick J. Harkins
+  role: Chair
+  person_id: ocd-person/c4a1a8f4-cb29-4700-8235-b103fcb40279
+- name: George Dunbar
+  role: Member
+  person_id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00
+- name: Chris Gebhard
+  role: Member
+  person_id: ocd-person/965b26f8-5a4a-4458-a327-a25d89605e65
+- name: Maria Collett
+  role: Member
+  person_id: ocd-person/323c52e8-f841-4a0b-a49e-91103949fbc8
+- name: Peter Barsz
+  role: Public Member
+- name: Gregory Jordan
+  role: Public Member
+- name: Ira Weiss
+  role: Public Member
+- name: Phil Rudy
+  role: Public Member

--- a/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-86cd0018-81a3-4c78-8a53-b4b8b4f140c9.yml
+++ b/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-86cd0018-81a3-4c78-8a53-b4b8b4f140c9.yml
@@ -1,0 +1,32 @@
+id: ocd-organization/86cd0018-81a3-4c78-8a53-b4b8b4f140c9
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Audit Advisory Commission
+chamber: legislature
+sources:
+- url: https://www.legis.state.pa.us/cfdocs/cteeInfo/laac.cfm
+  note: Committee member list
+links:
+- url: https://www.legis.state.pa.us/cfdocs/cteeInfo/laac.cfm
+  note: homepage
+members:
+- name: Patrick J. Harkins
+  role: Chair
+  person_id: ocd-person/c4a1a8f4-cb29-4700-8235-b103fcb40279
+- name: George Dunbar
+  role: Member
+  person_id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00
+- name: Chris Gebhard
+  role: Member
+  person_id: ocd-person/965b26f8-5a4a-4458-a327-a25d89605e65
+- name: Maria Collett
+  role: Member
+  person_id: ocd-person/323c52e8-f841-4a0b-a49e-91103949fbc8
+- name: Peter Barsz
+  role: Public Member
+- name: Gregory Jordan
+  role: Public Member
+- name: Ira Weiss
+  role: Public Member
+- name: Phil Rudy
+  role: Public Member

--- a/data/pa/committees/legislature-Legislative-Budget-and-Finance-24032128-6e56-44d0-8ed1-c0d62e0b04ce.yml
+++ b/data/pa/committees/legislature-Legislative-Budget-and-Finance-24032128-6e56-44d0-8ed1-c0d62e0b04ce.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/24032128-6e56-44d0-8ed1-c0d62e0b04ce
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Budget and Finance
+chamber: legislature
+sources:
+- url: http://lbfc.legis.state.pa.us/Committee-Members.cfm
+  note: Committee member list
+links:
+- url: http://lbfc.legis.state.pa.us/
+  note: homepage
+members:
+- name: James R. Brewster
+  role: Vice Chairman
+  person_id: ocd-person/cac6095b-9793-4edb-835a-70bc551dfd84
+- name: Cris Dush
+  role: Member
+  person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
+- name: Art Haywood
+  role: Member
+  person_id: ocd-person/ea712eba-1da5-45e2-8d9f-022e8307a614
+- name: Kristin Phillips-Hill
+  role: Member
+  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
+- name: Christine M. Tartaglione
+  role: Member
+  person_id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
+- name: Danilo Burgos
+  role: Member
+  person_id: ocd-person/a2579707-5a31-4f4b-a9ed-49847d35eae6
+- name: Scott Conklin
+  role: Treasurer
+  person_id: ocd-person/97b012cd-5cd7-4039-a9ae-fed936aabe37
+- name: Torren C. Ecker
+  role: Member
+  person_id: ocd-person/6f375652-451b-4c39-9b29-6ba5a07073c6
+- name: Patty Kim
+  role: Member
+  person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
+- name: Tim Twardzik
+  role: Member
+  person_id: ocd-person/686cdc9c-8133-4c1b-a7f0-34b420884559

--- a/data/pa/committees/legislature-Legislative-Budget-and-Finance-f5d762b9-fb9e-4406-acd9-b4e50d1e69b2.yml
+++ b/data/pa/committees/legislature-Legislative-Budget-and-Finance-f5d762b9-fb9e-4406-acd9-b4e50d1e69b2.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/f5d762b9-fb9e-4406-acd9-b4e50d1e69b2
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Budget and Finance
+chamber: legislature
+sources:
+- url: http://lbfc.legis.state.pa.us/Committee-Members.cfm
+  note: Committee member list
+links:
+- url: http://lbfc.legis.state.pa.us/
+  note: homepage
+members:
+- name: James R. Brewster
+  role: Vice Chairman
+  person_id: ocd-person/cac6095b-9793-4edb-835a-70bc551dfd84
+- name: Cris Dush
+  role: Member
+  person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
+- name: Art Haywood
+  role: Member
+  person_id: ocd-person/ea712eba-1da5-45e2-8d9f-022e8307a614
+- name: Kristin Phillips-Hill
+  role: Member
+  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
+- name: Christine M. Tartaglione
+  role: Member
+  person_id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
+- name: Danilo Burgos
+  role: Member
+  person_id: ocd-person/a2579707-5a31-4f4b-a9ed-49847d35eae6
+- name: Scott Conklin
+  role: Treasurer
+  person_id: ocd-person/97b012cd-5cd7-4039-a9ae-fed936aabe37
+- name: Torren C. Ecker
+  role: Member
+  person_id: ocd-person/6f375652-451b-4c39-9b29-6ba5a07073c6
+- name: Patty Kim
+  role: Member
+  person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
+- name: Tim Twardzik
+  role: Member
+  person_id: ocd-person/686cdc9c-8133-4c1b-a7f0-34b420884559

--- a/data/pa/committees/legislature-Legislative-Reapportionment-Commission-8266f5d4-5bde-413b-ba4c-fd38c16eeeef.yml
+++ b/data/pa/committees/legislature-Legislative-Reapportionment-Commission-8266f5d4-5bde-413b-ba4c-fd38c16eeeef.yml
@@ -1,0 +1,26 @@
+id: ocd-organization/8266f5d4-5bde-413b-ba4c-fd38c16eeeef
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Reapportionment Commission
+chamber: legislature
+sources:
+- url: https://www.redistricting.state.pa.us/commission/
+  note: Committee member list
+links:
+- url: https://www.redistricting.state.pa.us/
+  note: homepage
+members:
+- name: Mark A. Nordenberg
+  role: Chair
+- name: Kim L. Ward
+  role: Member
+  person_id: ocd-person/c48a0179-5770-410d-ba97-bdbc05d20786
+- name: Jay Costa
+  role: Member
+  person_id: ocd-person/ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0
+- name: Kerry A. Benninghoff
+  role: Member
+  person_id: ocd-person/5a5a7a42-bc5e-4a07-aee1-d1a01e810385
+- name: Joanna E. McClinton
+  role: Member
+  person_id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5

--- a/data/pa/committees/legislature-Legislative-Reapportionment-Commission-f9dba631-2009-43cc-b94d-d4546a537ac8.yml
+++ b/data/pa/committees/legislature-Legislative-Reapportionment-Commission-f9dba631-2009-43cc-b94d-d4546a537ac8.yml
@@ -1,0 +1,26 @@
+id: ocd-organization/f9dba631-2009-43cc-b94d-d4546a537ac8
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Legislative Reapportionment Commission
+chamber: legislature
+sources:
+- url: https://www.redistricting.state.pa.us/commission/
+  note: Committee member list
+links:
+- url: https://www.redistricting.state.pa.us/
+  note: homepage
+members:
+- name: Mark A. Nordenberg
+  role: Chair
+- name: Kim L. Ward
+  role: Member
+  person_id: ocd-person/c48a0179-5770-410d-ba97-bdbc05d20786
+- name: Jay Costa
+  role: Member
+  person_id: ocd-person/ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0
+- name: Kerry A. Benninghoff
+  role: Member
+  person_id: ocd-person/5a5a7a42-bc5e-4a07-aee1-d1a01e810385
+- name: Joanna E. McClinton
+  role: Member
+  person_id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5

--- a/data/pa/committees/legislature-Local-Government-Commission-68a8947b-2c0c-4a8c-a2c7-c867f161f702.yml
+++ b/data/pa/committees/legislature-Local-Government-Commission-68a8947b-2c0c-4a8c-a2c7-c867f161f702.yml
@@ -1,0 +1,40 @@
+id: ocd-organization/68a8947b-2c0c-4a8c-a2c7-c867f161f702
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Local Government Commission
+chamber: legislature
+sources:
+- url: http://www.lgc.state.pa.us/
+  note: Committee member list
+links:
+- url: http://www.lgc.state.pa.us/
+  note: homepage
+members:
+- name: Scott E. Hutchinson
+  role: Chair
+  person_id: ocd-person/5d3e2203-b11c-4471-8f35-5106c30263ec
+- name: Judy Ward
+  role: Member
+  person_id: ocd-person/b6ed7151-9ea4-4828-b639-785f9e358eb1
+- name: Cris Dush
+  role: Member
+  person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
+- name: Judith L. Schwank
+  role: Member
+  person_id: ocd-person/35362d6e-d00a-4cf1-806d-b4f2f2a55f72
+- name: Timothy P. Kearney
+  role: Member
+  person_id: ocd-person/f9f2479f-0c37-47d1-a4eb-666146e2856f
+- name: R. Lee James
+  role: Member
+  person_id: ocd-person/b29f8685-d054-4c6c-a8ad-d64f80bd840f
+- name: Dan Moul
+  role: Member
+  person_id: ocd-person/f4071288-fa18-48bb-99f1-41abd60d215e
+- name: Jerry Knowles
+  role: Member
+- name: Robert L. Freeman
+  role: Member
+- name: Christina D. Sappey
+  role: Member
+  person_id: ocd-person/43d9c3c2-aeec-416c-859d-ad90600bbe0e

--- a/data/pa/committees/legislature-Local-Government-Commission-ce0227c4-399d-4438-adcd-d8be230720c0.yml
+++ b/data/pa/committees/legislature-Local-Government-Commission-ce0227c4-399d-4438-adcd-d8be230720c0.yml
@@ -1,0 +1,41 @@
+id: ocd-organization/ce0227c4-399d-4438-adcd-d8be230720c0
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Local Government Commission
+chamber: legislature
+sources:
+- url: http://www.lgc.state.pa.us/
+  note: Committee member list
+links:
+- url: http://www.lgc.state.pa.us/
+  note: homepage
+members:
+- name: Scott E. Hutchinson
+  role: Chair
+  person_id: ocd-person/5d3e2203-b11c-4471-8f35-5106c30263ec
+- name: Judy Ward
+  role: Member
+  person_id: ocd-person/b6ed7151-9ea4-4828-b639-785f9e358eb1
+- name: Cris Dush
+  role: Member
+  person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
+- name: Judith L. Schwank
+  role: Member
+  person_id: ocd-person/35362d6e-d00a-4cf1-806d-b4f2f2a55f72
+- name: Timothy P. Kearney
+  role: Member
+  person_id: ocd-person/f9f2479f-0c37-47d1-a4eb-666146e2856f
+- name: R. Lee James
+  role: Member
+  person_id: ocd-person/b29f8685-d054-4c6c-a8ad-d64f80bd840f
+- name: Dan Moul
+  role: Member
+  person_id: ocd-person/f4071288-fa18-48bb-99f1-41abd60d215e
+- name: Jerry Knowles
+  role: Member
+- name: Robert L. Freeman
+  role: Member
+  person_id: ocd-person/13bfe11c-06e2-4a1d-844d-d195ef18dc06
+- name: Christina D. Sappey
+  role: Member
+  person_id: ocd-person/43d9c3c2-aeec-416c-859d-ad90600bbe0e

--- a/data/pa/committees/legislature-Policy-7946261a-db12-4ee3-a08b-66e997132634.yml
+++ b/data/pa/committees/legislature-Policy-7946261a-db12-4ee3-a08b-66e997132634.yml
@@ -1,0 +1,41 @@
+id: ocd-organization/7946261a-db12-4ee3-a08b-66e997132634
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Policy
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Rick Krajewski
+  role: Chair
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Timothy R. Bonner
+  role: Member
+  person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
+- name: Craig A. Dally
+  role: Public Member
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Douglas Marsico
+  role: Public Member
+- name: Edward M. Marsico, Jr.
+  role: Public Member
+- name: Barbara McDermott
+  role: Public Member
+- name: John T. Rago
+  role: Public Member
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Laurel R. Harry
+  role: Ex-officio
+- name: Theodore W. Johnson
+  role: Ex-officio

--- a/data/pa/committees/legislature-Policy-c5cf445a-9a89-4b33-893b-d7618de6363e.yml
+++ b/data/pa/committees/legislature-Policy-c5cf445a-9a89-4b33-893b-d7618de6363e.yml
@@ -1,0 +1,41 @@
+id: ocd-organization/c5cf445a-9a89-4b33-893b-d7618de6363e
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Policy
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Rick Krajewski
+  role: Chair
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Timothy R. Bonner
+  role: Member
+  person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
+- name: Craig A. Dally
+  role: Public Member
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Douglas Marsico
+  role: Public Member
+- name: Edward M. Marsico, Jr.
+  role: Public Member
+- name: Barbara McDermott
+  role: Public Member
+- name: John T. Rago
+  role: Public Member
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Laurel R. Harry
+  role: Ex-officio
+- name: Theodore W. Johnson
+  role: Ex-officio

--- a/data/pa/committees/legislature-Research-and-Data-Analysis-5f5ac597-4b69-42b4-8c2d-49d560a6dfe3.yml
+++ b/data/pa/committees/legislature-Research-and-Data-Analysis-5f5ac597-4b69-42b4-8c2d-49d560a6dfe3.yml
@@ -1,0 +1,20 @@
+id: ocd-organization/5f5ac597-4b69-42b4-8c2d-49d560a6dfe3
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Research and Data Analysis
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Wayne Langerholc, Jr.
+  role: Chair
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Professor John T. Rago
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Research-and-Data-Analysis-ba5ee09f-9b85-4b58-96e4-c3398c76514f.yml
+++ b/data/pa/committees/legislature-Research-and-Data-Analysis-ba5ee09f-9b85-4b58-96e4-c3398c76514f.yml
@@ -1,0 +1,20 @@
+id: ocd-organization/ba5ee09f-9b85-4b58-96e4-c3398c76514f
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: subcommittee
+name: Research and Data Analysis
+chamber: legislature
+parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Wayne Langerholc, Jr.
+  role: Chair
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Professor John T. Rago
+  role: Public Member
+- name: Tamara Bernstein
+  role: Public Member

--- a/data/pa/committees/legislature-Sentencing-3638daed-4e52-4f6b-84ab-ebb94c1b6e6e.yml
+++ b/data/pa/committees/legislature-Sentencing-3638daed-4e52-4f6b-84ab-ebb94c1b6e6e.yml
@@ -1,0 +1,42 @@
+id: ocd-organization/3638daed-4e52-4f6b-84ab-ebb94c1b6e6e
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Sentencing
+chamber: legislature
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/members/current-commission-members/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Tamara R. Bernstein
+  role: Chair
+- name: Rick C. Krajewski
+  role: Vice Chair
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
+- name: Timothy R. Bonner
+  role: Member
+  person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
+- name: Craig A. Dally
+  role: Public Member
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Douglas Marsico
+  role: Public Member
+- name: Edward M. Marsico, Jr.
+  role: Public Member
+- name: Barbara McDermott
+  role: Public Member
+- name: John T. Rago
+  role: Public Member
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Laurel R. Harry
+  role: Ex-officio
+- name: Theodore W. Johnson
+  role: Ex-officio

--- a/data/pa/committees/legislature-Sentencing-475d6591-8e69-44bf-a429-f585a16a802c.yml
+++ b/data/pa/committees/legislature-Sentencing-475d6591-8e69-44bf-a429-f585a16a802c.yml
@@ -1,0 +1,41 @@
+id: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: Sentencing
+chamber: legislature
+sources:
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/members/current-commission-members/
+  note: Member list page
+links:
+- url: https://pcs.la.psu.edu/
+  note: homepage
+members:
+- name: Tamara R. Bernstein
+  role: Chair
+- name: Rick C. Krajewski
+  role: Vice Chair
+- name: Timothy R. Bonner
+  role: Member
+  person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
+- name: Craig A. Dally
+  role: Public Member
+- name: Wayne Langerholc, Jr.
+  role: Member
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Douglas Marsico
+  role: Public Member
+- name: Edward M. Marsico, Jr.
+  role: Public Member
+- name: Barbara McDermott
+  role: Public Member
+- name: John T. Rago
+  role: Public Member
+- name: Sharif Street
+  role: Member
+  person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: David W. Sunday, Jr.
+  role: Public Member
+- name: Laurel R. Harry
+  role: Ex-officio
+- name: Theodore W. Johnson
+  role: Ex-officio

--- a/data/pa/committees/legislature-State-Government-Commission-16769289-34d5-4ee0-b27a-263dd9da9c5b.yml
+++ b/data/pa/committees/legislature-State-Government-Commission-16769289-34d5-4ee0-b27a-263dd9da9c5b.yml
@@ -1,0 +1,54 @@
+id: ocd-organization/16769289-34d5-4ee0-b27a-263dd9da9c5b
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: State Government Commission
+chamber: legislature
+sources:
+- url: http://jsg.legis.state.pa.us/about-us.cfm
+  note: Committee member list
+links:
+- url: http://jsg.legis.state.pa.us/
+  note: homepage
+members:
+- name: Kim L. Ward
+  role: Member
+  person_id: ocd-person/c48a0179-5770-410d-ba97-bdbc05d20786
+- name: Joanna E. McClinton
+  role: Member
+  person_id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5
+- name: Joe Pittman
+  role: Member
+  person_id: ocd-person/722f324f-db47-4ce2-9cbc-93f29ae38158
+- name: Bryan Cutler
+  role: Member
+  person_id: ocd-person/fd5d0580-766c-482c-a12f-e4689e0bcf30
+- name: Jay Costa
+  role: Member
+  person_id: ocd-person/ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0
+- name: Matthew D. Bradford
+  role: Member
+  person_id: ocd-person/a15da78b-2475-4606-854f-7477dfc4233d
+- name: Ryan P. Aument
+  role: Member
+  person_id: ocd-person/84be9cf4-8e9f-4e9c-91f0-f371efba7895
+- name: Timothy J. O'Neal
+  role: Member
+  person_id: ocd-person/2c5551d6-71a8-4099-b1a4-a30721320869
+- name: Christine M. Tartaglione
+  role: Member
+  person_id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
+- name: Dan L. Miller
+  role: Member
+  person_id: ocd-person/cf94e0e7-498b-419b-9d3a-36c31d1eaf46
+- name: Kristin Philips-Hill
+  role: Member
+  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
+- name: George Dunbar
+  role: Member
+  person_id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00
+- name: Wayne D. Fontana
+  role: Member
+  person_id: ocd-person/b93e4f38-764f-4e95-bd51-4d40dba0aaa4
+- name: Michael H. Schlossberg
+  role: Member
+  person_id: ocd-person/fc1f0752-9166-4d7f-987a-ec15b8bf4048

--- a/data/pa/committees/legislature-State-Government-Commission-98fd59d7-2a29-4891-8d5d-60cfee592ba8.yml
+++ b/data/pa/committees/legislature-State-Government-Commission-98fd59d7-2a29-4891-8d5d-60cfee592ba8.yml
@@ -1,0 +1,53 @@
+id: ocd-organization/98fd59d7-2a29-4891-8d5d-60cfee592ba8
+jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+classification: committee
+name: State Government Commission
+chamber: legislature
+sources:
+- url: http://jsg.legis.state.pa.us/about-us.cfm
+  note: Committee member list
+links:
+- url: http://jsg.legis.state.pa.us/
+  note: homepage
+members:
+- name: Kim L. Ward
+  role: Member
+  person_id: ocd-person/c48a0179-5770-410d-ba97-bdbc05d20786
+- name: Joanna E. McClinton
+  role: Member
+  person_id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5
+- name: Joe Pittman
+  role: Member
+  person_id: ocd-person/722f324f-db47-4ce2-9cbc-93f29ae38158
+- name: Bryan Cutler
+  role: Member
+  person_id: ocd-person/fd5d0580-766c-482c-a12f-e4689e0bcf30
+- name: Jay Costa
+  role: Member
+  person_id: ocd-person/ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0
+- name: Matthew D. Bradford
+  role: Member
+  person_id: ocd-person/a15da78b-2475-4606-854f-7477dfc4233d
+- name: Ryan P. Aument
+  role: Member
+  person_id: ocd-person/84be9cf4-8e9f-4e9c-91f0-f371efba7895
+- name: Timothy J. O'Neal
+  role: Member
+  person_id: ocd-person/2c5551d6-71a8-4099-b1a4-a30721320869
+- name: Christine M. Tartaglione
+  role: Member
+  person_id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
+- name: Dan L. Miller
+  role: Member
+  person_id: ocd-person/cf94e0e7-498b-419b-9d3a-36c31d1eaf46
+- name: Kristin Philips-Hill
+  role: Member
+- name: George Dunbar
+  role: Member
+  person_id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00
+- name: Wayne D. Fontana
+  role: Member
+  person_id: ocd-person/b93e4f38-764f-4e95-bd51-4d40dba0aaa4
+- name: Michael H. Schlossberg
+  role: Member
+  person_id: ocd-person/fc1f0752-9166-4d7f-987a-ec15b8bf4048

--- a/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
+++ b/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
@@ -30,6 +30,7 @@ links:
   note: homepage
 other_names:
 - name: Kristin Hill
+- name: Kristin Philips-Hill
 ids:
   twitter: SenatorKristin
   youtube: UCCVUqHEfIFP1Ex1x0t9mELg

--- a/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
+++ b/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
@@ -24,6 +24,8 @@ links:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: https://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1844
   note: homepage
+other_names:
+- name: Kyle Mullins
 ids:
   twitter: RepKyleMullins
   youtube: playlist?list=PLjtqNtfs0bgVkHvgNtVPLCpQ6a-Sqde6E

--- a/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
+++ b/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
@@ -21,6 +21,8 @@ links:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: https://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1918
   note: homepage
+other_names:
+- name: Rick C. Krajewski
 ids:
   twitter: RepKrajewski
   facebook: RepKrajewski

--- a/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
+++ b/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
@@ -24,6 +24,8 @@ links:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: https://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=136
   note: homepage
+other_names:
+- name: Robert L. Freeman
 ids:
   youtube: playlist?list=PLD91FC5F7839C0E52
 other_identifiers:


### PR DESCRIPTION
Adds data for joint (`chamber="legislature"`) committees from Pennsylvania.

Note: Includes many public and non-legislative members on these committees and commissions.