### PR TITLE
LA people: vacancies filled, all comm members

### DIFF
--- a/data/la/committees/lower-Administration-of-Criminal-Justice-54190716-6dee-47f6-89aa-296421967d21.yml
+++ b/data/la/committees/lower-Administration-of-Criminal-Justice-54190716-6dee-47f6-89aa-296421967d21.yml
@@ -23,6 +23,7 @@ members:
   person_id: ocd-person/b3de3921-3132-43e4-b22b-5b907a21108e
 - name: Jonathan Goudeau, I
   role: Member
+  person_id: ocd-person/8b72535d-0380-4e39-a168-dcd1c742f47c
 - name: Valarie Hodges
   role: Member
   person_id: ocd-person/33e76c3a-a834-444c-9872-fc2af5c83837
@@ -47,3 +48,24 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Joseph A. Marino, III
+  role: Chairman
+  person_id: ocd-person/f0b68891-c893-47e8-b2cc-5ed83c16151d
+- name: Marcus Anthony Bryant
+  role: Member
+  person_id: ocd-person/4d1c2a6e-0339-4b7a-ac52-dfd9064bfbbf
+- name: Kathy Edmonston
+  role: Member
+  person_id: ocd-person/92f7834e-8ce3-437f-bdbf-8dad3528ae3b
+- name: Dodie Horton
+  role: Member
+  person_id: ocd-person/4661fe94-874c-4884-99a2-c60516c811ff
+- name: Alonzo L. Knox
+  role: Member
+  person_id: ocd-person/967fa557-fcdc-4a75-a13e-dabf05b85905
+- name: Vanessa Caston LaFleur
+  role: Member
+  person_id: ocd-person/9510158f-4e63-4b68-ad44-daef2987b780
+- name: C. Denise Marcelle
+  role: Member
+  person_id: ocd-person/20def39d-ba5c-45d7-ba6c-5cf43590d4b0

--- a/data/la/committees/lower-Agriculture-Forestry-Aquaculture-and-Rural-Development-801965d6-c6c2-4ee7-ad69-86df1d1315df.yml
+++ b/data/la/committees/lower-Agriculture-Forestry-Aquaculture-and-Rural-Development-801965d6-c6c2-4ee7-ad69-86df1d1315df.yml
@@ -38,6 +38,7 @@ members:
   person_id: ocd-person/87828aa1-a979-419e-aac6-c808c00896e7
 - name: Vincent "Vinney" St. Blanc, III
   role: Member
+  person_id: ocd-person/c75a9e00-6017-4e74-95fd-70fbfa803c58
 - name: Christopher Turner
   role: Member
   person_id: ocd-person/a07b757e-a57b-4dda-aa6a-7bf5e6b3561d
@@ -53,3 +54,24 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Dustin Miller
+  role: Vice Chair
+  person_id: ocd-person/dcf2c7e1-e124-424c-ac0c-8d1e6600e970
+- name: Ken Brass
+  role: Member
+  person_id: ocd-person/43a80737-e614-475d-aace-2d1324cb516a
+- name: Marcus Anthony Bryant
+  role: Member
+  person_id: ocd-person/4d1c2a6e-0339-4b7a-ac52-dfd9064bfbbf
+- name: Adrian Fisher
+  role: Member
+  person_id: ocd-person/5d1fade2-4678-406c-b4ed-657baed1db2b
+- name: C. Travis Johnson
+  role: Member
+  person_id: ocd-person/871d5c01-9710-46f4-aeba-b321bdf11e30
+- name: Larry Selders
+  role: Member
+  person_id: ocd-person/52035a94-6995-4ea4-b463-1109d683048b
+- name: Francis C. Thompson
+  role: Member
+  person_id: ocd-person/7796b73e-f06a-4d0b-8a85-cfde955a4cd1

--- a/data/la/committees/lower-Appropriations-8a769fd3-4564-4a87-9b39-612e28ea940b.yml
+++ b/data/la/committees/lower-Appropriations-8a769fd3-4564-4a87-9b39-612e28ea940b.yml
@@ -66,3 +66,27 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Francis C. Thompson
+  role: Vice Chair
+  person_id: ocd-person/7796b73e-f06a-4d0b-8a85-cfde955a4cd1
+- name: Roy Daryl Adams
+  role: Member
+  person_id: ocd-person/0353532c-93a0-41cb-9621-278c8ef19178
+- name: Barbara Carpenter
+  role: Member
+  person_id: ocd-person/ad514eed-2832-4ae3-a0c5-62d8f2721297
+- name: Aimee Adatto Freeman
+  role: Member
+  person_id: ocd-person/3937cef1-8c62-428c-8837-aa6a6a8b60e7
+- name: Jason Hughes
+  role: Member
+  person_id: ocd-person/9c15d56b-627b-4fbe-8e23-2ac8385c2224
+- name: Rodney Lyons
+  role: Member
+  person_id: ocd-person/71696836-b261-4646-8127-407c40e2c35b
+- name: C. Denise Marcelle
+  role: Member
+  person_id: ocd-person/20def39d-ba5c-45d7-ba6c-5cf43590d4b0
+- name: Dustin Miller
+  role: Member
+  person_id: ocd-person/dcf2c7e1-e124-424c-ac0c-8d1e6600e970

--- a/data/la/committees/lower-Civil-Law-and-Procedure-f1e7a027-9d8a-41f9-8a91-41f98d6f30da.yml
+++ b/data/la/committees/lower-Civil-Law-and-Procedure-f1e7a027-9d8a-41f9-8a91-41f98d6f30da.yml
@@ -54,3 +54,21 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Delisha Boyd
+  role: Member
+  person_id: ocd-person/d107ae2b-6cb6-4545-a185-d63408f46033
+- name: Robby Carter
+  role: Member
+  person_id: ocd-person/a24e242f-3fd9-479c-8423-cf0c6e2c6273
+- name: Wilford Carter, Sr.
+  role: Member
+  person_id: ocd-person/3ced6b49-7f72-41d0-a84c-0e7cff17e88b
+- name: Patrick O. Jefferson
+  role: Member
+  person_id: ocd-person/cbdfdaef-57ee-44d0-aa40-6058561c572c
+- name: Sam Jenkins
+  role: Member
+  person_id: ocd-person/79bdb4d1-c272-4f9e-9cb6-d327bd3a51af
+- name: Alonzo L. Knox
+  role: Member
+  person_id: ocd-person/967fa557-fcdc-4a75-a13e-dabf05b85905

--- a/data/la/committees/lower-Commerce-e51de66c-c310-4fa6-be71-6bf08a6e24ca.yml
+++ b/data/la/committees/lower-Commerce-e51de66c-c310-4fa6-be71-6bf08a6e24ca.yml
@@ -23,6 +23,7 @@ members:
   person_id: ocd-person/90b6f6c3-9620-4fbb-8c23-f8ab7b163de7
 - name: Jonathan Goudeau, I
   role: Member
+  person_id: ocd-person/8b72535d-0380-4e39-a168-dcd1c742f47c
 - name: Paul Hollis
   role: Member
   person_id: ocd-person/a78e621d-059e-4359-8de6-add1ea897274
@@ -34,6 +35,7 @@ members:
   person_id: ocd-person/e6a15fa6-85e2-4e5b-b267-202a5cc1f01a
 - name: Vincent "Vinney" St. Blanc, III
   role: Member
+  person_id: ocd-person/c75a9e00-6017-4e74-95fd-70fbfa803c58
 - name: Phillip Eric Tarver
   role: Member
   person_id: ocd-person/04a524b7-1f7a-4d01-8491-c52df47e20cc
@@ -52,3 +54,24 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Chad Brown
+  role: Member
+  person_id: ocd-person/6c1520bb-eebb-41ec-8d67-4f6e936f60b9
+- name: Kenny R. Cox
+  role: Member
+  person_id: ocd-person/334e5810-37cf-427c-9d26-5b26880caf33
+- name: Adrian Fisher
+  role: Member
+  person_id: ocd-person/5d1fade2-4678-406c-b4ed-657baed1db2b
+- name: Kyle M. Green, Jr.
+  role: Member
+  person_id: ocd-person/8ffaa2bd-ff67-464a-b639-19a6069e28a2
+- name: Edmond Jordan
+  role: Member
+  person_id: ocd-person/efdf7ee4-4d37-4e57-8f0c-e0db52ee7f70
+- name: Vanessa Caston LaFleur
+  role: Member
+  person_id: ocd-person/9510158f-4e63-4b68-ad44-daef2987b780
+- name: Candace N. Newell
+  role: Member
+  person_id: ocd-person/85a96a1b-a8a0-4ddd-acd7-9452b48f5ace

--- a/data/la/committees/lower-Education-f46b1765-c3a2-4c16-9fb6-c916b0855ff2.yml
+++ b/data/la/committees/lower-Education-f46b1765-c3a2-4c16-9fb6-c916b0855ff2.yml
@@ -32,6 +32,7 @@ members:
   person_id: ocd-person/2a4d4c31-ee06-4f32-a67b-c55db60502e4
 - name: Vincent "Vinney" St. Blanc, III
   role: Member
+  person_id: ocd-person/c75a9e00-6017-4e74-95fd-70fbfa803c58
 - name: Phillip Eric Tarver
   role: Member
   person_id: ocd-person/04a524b7-1f7a-4d01-8491-c52df47e20cc
@@ -41,3 +42,18 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Patrick O. Jefferson
+  role: Vice Chair
+  person_id: ocd-person/cbdfdaef-57ee-44d0-aa40-6058561c572c
+- name: Ken Brass
+  role: Member
+  person_id: ocd-person/43a80737-e614-475d-aace-2d1324cb516a
+- name: Aimee Adatto Freeman
+  role: Member
+  person_id: ocd-person/3937cef1-8c62-428c-8837-aa6a6a8b60e7
+- name: Brett F. Geymann
+  role: Member
+  person_id: ocd-person/9ffd05e6-a127-4896-b60e-fc2722fa8779
+- name: Tammy T. Phelps
+  role: Member
+  person_id: ocd-person/a838e3b6-52ea-4ad0-a308-2337762a492b

--- a/data/la/committees/lower-Health-and-Welfare-fa593757-8414-4bc1-95b4-c7a3f81392b0.yml
+++ b/data/la/committees/lower-Health-and-Welfare-fa593757-8414-4bc1-95b4-c7a3f81392b0.yml
@@ -45,3 +45,30 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Roy Daryl Adams
+  role: Member
+  person_id: ocd-person/0353532c-93a0-41cb-9621-278c8ef19178
+- name: Robby Carter
+  role: Member
+  person_id: ocd-person/a24e242f-3fd9-479c-8423-cf0c6e2c6273
+- name: Kenny R. Cox
+  role: Member
+  person_id: ocd-person/334e5810-37cf-427c-9d26-5b26880caf33
+- name: Jason Hughes
+  role: Member
+  person_id: ocd-person/9c15d56b-627b-4fbe-8e23-2ac8385c2224
+- name: C. Travis Johnson
+  role: Member
+  person_id: ocd-person/871d5c01-9710-46f4-aeba-b321bdf11e30
+- name: Ed Larvadain, III
+  role: Member
+  person_id: ocd-person/9a91a848-9d01-46b6-84f1-cc868681e912
+- name: Dustin Miller
+  role: Member
+  person_id: ocd-person/dcf2c7e1-e124-424c-ac0c-8d1e6600e970
+- name: Pat Moore
+  role: Member
+  person_id: ocd-person/88548c7a-b637-4821-b336-c99cfa475e22
+- name: Larry Selders
+  role: Member
+  person_id: ocd-person/52035a94-6995-4ea4-b463-1109d683048b

--- a/data/la/committees/lower-House-and-Governmental-Affairs-6cea15ef-dd81-461c-b0cb-3420ff81da48.yml
+++ b/data/la/committees/lower-House-and-Governmental-Affairs-6cea15ef-dd81-461c-b0cb-3420ff81da48.yml
@@ -48,3 +48,21 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Rodney Lyons
+  role: Vice Chair
+  person_id: ocd-person/71696836-b261-4646-8127-407c40e2c35b
+- name: Wilford Carter, Sr.
+  role: Member
+  person_id: ocd-person/3ced6b49-7f72-41d0-a84c-0e7cff17e88b
+- name: Sam Jenkins
+  role: Member
+  person_id: ocd-person/79bdb4d1-c272-4f9e-9cb6-d327bd3a51af
+- name: Jeremy LaCombe
+  role: Member
+  person_id: ocd-person/9ae6b490-4fe0-435c-93fd-ad316e474204
+- name: Richard Nelson
+  role: Member
+  person_id: ocd-person/db83720b-c2bf-4f1d-b98f-3250cc48c113
+- name: Candace N. Newell
+  role: Member
+  person_id: ocd-person/85a96a1b-a8a0-4ddd-acd7-9452b48f5ace

--- a/data/la/committees/lower-Insurance-7a9eef64-2cfa-4898-92db-887f6a394f93.yml
+++ b/data/la/committees/lower-Insurance-7a9eef64-2cfa-4898-92db-887f6a394f93.yml
@@ -42,3 +42,24 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Edmond Jordan
+  role: Vice Chair
+  person_id: ocd-person/efdf7ee4-4d37-4e57-8f0c-e0db52ee7f70
+- name: Delisha Boyd
+  role: Member
+  person_id: ocd-person/d107ae2b-6cb6-4545-a185-d63408f46033
+- name: Chad Brown
+  role: Member
+  person_id: ocd-person/6c1520bb-eebb-41ec-8d67-4f6e936f60b9
+- name: Cedric Glover
+  role: Member
+  person_id: ocd-person/9b53270a-813b-476c-b1b3-331ecedcca60
+- name: Kyle M. Green, Jr.
+  role: Member
+  person_id: ocd-person/8ffaa2bd-ff67-464a-b639-19a6069e28a2
+- name: Danny McCormick
+  role: Member
+  person_id: ocd-person/dc59ede6-164c-4fd4-adc1-7e080309776b
+- name: Matthew Willard
+  role: Member
+  person_id: ocd-person/834e887f-c79d-44ed-be47-74571a792249

--- a/data/la/committees/lower-Judiciary-d91fd9e3-293e-4c40-a397-df97cc6ce96b.yml
+++ b/data/la/committees/lower-Judiciary-d91fd9e3-293e-4c40-a397-df97cc6ce96b.yml
@@ -42,3 +42,15 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Randal L. Gaines
+  role: Chairman
+  person_id: ocd-person/c8fa77d4-2453-4953-b87a-1c58d841ce97
+- name: Jason Hughes
+  role: Member
+  person_id: ocd-person/9c15d56b-627b-4fbe-8e23-2ac8385c2224
+- name: Edmond Jordan
+  role: Member
+  person_id: ocd-person/efdf7ee4-4d37-4e57-8f0c-e0db52ee7f70
+- name: Mandie Landry
+  role: Member
+  person_id: ocd-person/6e106343-c9e7-4993-aca8-201210f61d64

--- a/data/la/committees/lower-Labor-and-Industrial-Relations-60a7cd2a-d777-4132-a1a2-388a6a816645.yml
+++ b/data/la/committees/lower-Labor-and-Industrial-Relations-60a7cd2a-d777-4132-a1a2-388a6a816645.yml
@@ -45,3 +45,18 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Barbara Carpenter
+  role: Chairman
+  person_id: ocd-person/ad514eed-2832-4ae3-a0c5-62d8f2721297
+- name: Mack Cormier
+  role: Member
+  person_id: ocd-person/8d31e132-1a5d-4340-bcb1-0f8e093b004d
+- name: Kenny R. Cox
+  role: Member
+  person_id: ocd-person/334e5810-37cf-427c-9d26-5b26880caf33
+- name: Ed Larvadain, III
+  role: Member
+  person_id: ocd-person/9a91a848-9d01-46b6-84f1-cc868681e912
+- name: Tammy T. Phelps
+  role: Member
+  person_id: ocd-person/a838e3b6-52ea-4ad0-a308-2337762a492b

--- a/data/la/committees/lower-Municipal-Parochial-and-Cultural-Affairs-67fc7df3-2a9e-44d5-aedb-bcbfc83d9597.yml
+++ b/data/la/committees/lower-Municipal-Parochial-and-Cultural-Affairs-67fc7df3-2a9e-44d5-aedb-bcbfc83d9597.yml
@@ -48,3 +48,21 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Cedric Glover
+  role: Member
+  person_id: ocd-person/9b53270a-813b-476c-b1b3-331ecedcca60
+- name: Kyle M. Green, Jr.
+  role: Member
+  person_id: ocd-person/8ffaa2bd-ff67-464a-b639-19a6069e28a2
+- name: Rodney Lyons
+  role: Member
+  person_id: ocd-person/71696836-b261-4646-8127-407c40e2c35b
+- name: C. Denise Marcelle
+  role: Member
+  person_id: ocd-person/20def39d-ba5c-45d7-ba6c-5cf43590d4b0
+- name: Candace N. Newell
+  role: Member
+  person_id: ocd-person/85a96a1b-a8a0-4ddd-acd7-9452b48f5ace
+- name: Matthew Willard
+  role: Member
+  person_id: ocd-person/834e887f-c79d-44ed-be47-74571a792249

--- a/data/la/committees/lower-Natural-Resources-and-Environment-74f27a52-beee-4d02-a2b0-76f3df5b10e8.yml
+++ b/data/la/committees/lower-Natural-Resources-and-Environment-74f27a52-beee-4d02-a2b0-76f3df5b10e8.yml
@@ -57,3 +57,15 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Mack Cormier
+  role: Member
+  person_id: ocd-person/8d31e132-1a5d-4340-bcb1-0f8e093b004d
+- name: Adrian Fisher
+  role: Member
+  person_id: ocd-person/5d1fade2-4678-406c-b4ed-657baed1db2b
+- name: Stephanie Hilferty
+  role: Member
+  person_id: ocd-person/de7591e7-6ae0-47c3-b1ea-12073106498c
+- name: Mandie Landry
+  role: Member
+  person_id: ocd-person/6e106343-c9e7-4993-aca8-201210f61d64

--- a/data/la/committees/lower-Retirement-fef54557-88f4-47d3-a9e8-d063df8ee7ac.yml
+++ b/data/la/committees/lower-Retirement-fef54557-88f4-47d3-a9e8-d063df8ee7ac.yml
@@ -45,3 +45,21 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Roy Daryl Adams
+  role: Member
+  person_id: ocd-person/0353532c-93a0-41cb-9621-278c8ef19178
+- name: Delisha Boyd
+  role: Member
+  person_id: ocd-person/d107ae2b-6cb6-4545-a185-d63408f46033
+- name: Aimee Adatto Freeman
+  role: Member
+  person_id: ocd-person/3937cef1-8c62-428c-8837-aa6a6a8b60e7
+- name: Patrick O. Jefferson
+  role: Member
+  person_id: ocd-person/cbdfdaef-57ee-44d0-aa40-6058561c572c
+- name: Alonzo L. Knox
+  role: Member
+  person_id: ocd-person/967fa557-fcdc-4a75-a13e-dabf05b85905
+- name: Vanessa Caston LaFleur
+  role: Member
+  person_id: ocd-person/9510158f-4e63-4b68-ad44-daef2987b780

--- a/data/la/committees/lower-Transportation-Highways-and-Public-Works-f14025dc-36ef-435c-9392-46f176538176.yml
+++ b/data/la/committees/lower-Transportation-Highways-and-Public-Works-f14025dc-36ef-435c-9392-46f176538176.yml
@@ -45,3 +45,24 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Ken Brass
+  role: Vice Chair
+  person_id: ocd-person/43a80737-e614-475d-aace-2d1324cb516a
+- name: Mack Cormier
+  role: Member
+  person_id: ocd-person/8d31e132-1a5d-4340-bcb1-0f8e093b004d
+- name: Cedric Glover
+  role: Member
+  person_id: ocd-person/9b53270a-813b-476c-b1b3-331ecedcca60
+- name: Ed Larvadain, III
+  role: Member
+  person_id: ocd-person/9a91a848-9d01-46b6-84f1-cc868681e912
+- name: Pat Moore
+  role: Member
+  person_id: ocd-person/88548c7a-b637-4821-b336-c99cfa475e22
+- name: Vincent J. Pierre
+  role: Member
+  person_id: ocd-person/79b96fce-bf08-48e4-bd5d-b5fea3a34723
+- name: Larry Selders
+  role: Member
+  person_id: ocd-person/52035a94-6995-4ea4-b463-1109d683048b

--- a/data/la/committees/lower-Ways-and-Means-bf20c2cd-04ae-43eb-87ce-00b9773b9ca2.yml
+++ b/data/la/committees/lower-Ways-and-Means-bf20c2cd-04ae-43eb-87ce-00b9773b9ca2.yml
@@ -54,3 +54,18 @@ members:
 - name: Clay Schexnayder
   role: Ex Officio
   person_id: ocd-person/69eb0893-93d4-4155-91e8-cc991956b80c
+- name: Marcus Anthony Bryant
+  role: Member
+  person_id: ocd-person/4d1c2a6e-0339-4b7a-ac52-dfd9064bfbbf
+- name: Jeremy LaCombe
+  role: Member
+  person_id: ocd-person/9ae6b490-4fe0-435c-93fd-ad316e474204
+- name: Mandie Landry
+  role: Member
+  person_id: ocd-person/6e106343-c9e7-4993-aca8-201210f61d64
+- name: Tammy T. Phelps
+  role: Member
+  person_id: ocd-person/a838e3b6-52ea-4ad0-a308-2337762a492b
+- name: Matthew Willard
+  role: Member
+  person_id: ocd-person/834e887f-c79d-44ed-be47-74571a792249

--- a/data/la/committees/upper-Agriculture-Forestry-Aquaculture-and-Rural-Development-5103f915-a594-4fcb-994a-e30e76d49d2b.yml
+++ b/data/la/committees/upper-Agriculture-Forestry-Aquaculture-and-Rural-Development-5103f915-a594-4fcb-994a-e30e76d49d2b.yml
@@ -12,8 +12,6 @@ links:
 - url: https://senate.la.gov/Sen_Committees/AgricultureForestry
   note: homepage
 members:
-- name: Stewart Jr. Cathey
-  role: Chairman
 - name: Glen Womack
   role: Vice Chair
   person_id: ocd-person/25923053-3679-443e-bbb1-e2f63a50585c
@@ -32,3 +30,9 @@ members:
 - name: Eddie J. Lambert
   role: Ex Officio
   person_id: ocd-person/c89a156e-8426-4001-8364-94a179482d76
+- name: Katrina R. Jackson
+  role: Member
+  person_id: ocd-person/acdaa5e6-3b22-44b9-8b47-480b801483dd
+- name: Stewart Cathey, Jr.
+  role: Chairman
+  person_id: ocd-person/dd47283c-c202-461f-b56a-8cc2c0b14f15

--- a/data/la/committees/upper-Commerce-Consumer-Protection-and-International-Affairs-60e1a45c-037b-4e14-8c45-34e1eb18f6d7.yml
+++ b/data/la/committees/upper-Commerce-Consumer-Protection-and-International-Affairs-60e1a45c-037b-4e14-8c45-34e1eb18f6d7.yml
@@ -21,8 +21,6 @@ members:
 - name: Mark Abraham
   role: Member
   person_id: ocd-person/addae848-cfaf-4637-a23e-595e45c6e14f
-- name: Stewart Jr. Cathey
-  role: Member
 - name: Patrick Connick
   role: Member
   person_id: ocd-person/a5240587-95aa-4135-befc-de2ea2aa1d51
@@ -35,3 +33,12 @@ members:
 - name: Kirk Talbot
   role: Ex Officio
   person_id: ocd-person/f6f401f7-7fb4-40df-84a0-b5a3f0fe9ec2
+- name: Cleo Fields
+  role: Member
+  person_id: ocd-person/b2eca8f2-6db8-4263-92a4-050e3819de53
+- name: Jimmy Harris
+  role: Member
+  person_id: ocd-person/ce11601e-9a67-48a1-9408-b80943312303
+- name: Stewart Cathey, Jr.
+  role: Member
+  person_id: ocd-person/dd47283c-c202-461f-b56a-8cc2c0b14f15

--- a/data/la/committees/upper-Education-e8e616cf-a500-44b8-9c0f-c5f17c7076d3.yml
+++ b/data/la/committees/upper-Education-e8e616cf-a500-44b8-9c0f-c5f17c7076d3.yml
@@ -27,3 +27,9 @@ members:
 - name: Mack "Bodi" White
   role: Member
   person_id: ocd-person/34227712-b998-4aca-a215-5b2985c91df3
+- name: Cleo Fields
+  role: Chairman
+  person_id: ocd-person/b2eca8f2-6db8-4263-92a4-050e3819de53
+- name: Katrina R. Jackson
+  role: Vice Chair
+  person_id: ocd-person/acdaa5e6-3b22-44b9-8b47-480b801483dd

--- a/data/la/committees/upper-Environmental-Quality-d9075629-aa66-46a3-b757-65bb7ce78893.yml
+++ b/data/la/committees/upper-Environmental-Quality-d9075629-aa66-46a3-b757-65bb7ce78893.yml
@@ -27,5 +27,12 @@ members:
 - name: Sharon Hewitt
   role: Member
   person_id: ocd-person/33f8b98a-fb55-4b02-bf90-7254466f969f
-- name: Stewart Jr. Cathey
+- name: Royce Duplessis
+  role: Member
+  person_id: ocd-person/7d852e7a-ae99-4f89-b4c0-4d7cb7e816db
+- name: Edward J. Price
+  role: Member
+  person_id: ocd-person/1899dc2e-bac6-4951-b3fc-87ea5e2d4969
+- name: Stewart Cathey, Jr.
   role: Ex Officio
+  person_id: ocd-person/dd47283c-c202-461f-b56a-8cc2c0b14f15

--- a/data/la/committees/upper-Finance-38312d03-e5e2-499b-a224-0fd453200120.yml
+++ b/data/la/committees/upper-Finance-38312d03-e5e2-499b-a224-0fd453200120.yml
@@ -36,8 +36,24 @@ members:
 - name: Sharon Hewitt
   role: Interim Member
   person_id: ocd-person/33f8b98a-fb55-4b02-bf90-7254466f969f
-- name: Fred H. Jr. Mills
-  role: Interim Member
 - name: R. L. Bret Allain
   role: Ex Officio
   person_id: ocd-person/655ddc35-ecd0-4db2-a3fe-cd86f1cb7d61
+- name: Regina Barrow
+  role: Member
+  person_id: ocd-person/8710f3da-9aea-41a9-acd2-181377cc6ae7
+- name: Gerald Boudreaux
+  role: Member
+  person_id: ocd-person/379e9992-463c-4188-9702-668457a75c3d
+- name: Jimmy Harris
+  role: Member
+  person_id: ocd-person/ce11601e-9a67-48a1-9408-b80943312303
+- name: Gregory Tarver
+  role: Member
+  person_id: ocd-person/05ace530-e22c-436d-bf1a-562e3a923bef
+- name: Katrina R. Jackson
+  role: Interim Member
+  person_id: ocd-person/acdaa5e6-3b22-44b9-8b47-480b801483dd
+- name: Fred H. Mills, Jr.
+  role: Interim Member
+  person_id: ocd-person/cb6fae11-a6e0-4328-8679-f159bab5aeec

--- a/data/la/committees/upper-Health-and-Welfare-e9b6b7a5-8124-469b-acaf-cfa3783f99c5.yml
+++ b/data/la/committees/upper-Health-and-Welfare-e9b6b7a5-8124-469b-acaf-cfa3783f99c5.yml
@@ -12,8 +12,6 @@ links:
 - url: https://senate.la.gov/Sen_Committees/HealthWelfare
   note: homepage
 members:
-- name: Fred H. Jr. Mills
-  role: Chairman
 - name: Bob Hensgens
   role: Member
   person_id: ocd-person/7dac3861-2ffb-45ba-b690-a8e199eb2acd
@@ -26,3 +24,18 @@ members:
 - name: J. Rogers Pope
   role: Member
   person_id: ocd-person/76de3a6a-09e0-4925-b46e-77b3ff275ef2
+- name: Regina Barrow
+  role: Vice Chair
+  person_id: ocd-person/8710f3da-9aea-41a9-acd2-181377cc6ae7
+- name: Gerald Boudreaux
+  role: Member
+  person_id: ocd-person/379e9992-463c-4188-9702-668457a75c3d
+- name: Gary Carter
+  role: Member
+  person_id: ocd-person/60ffe8d0-0469-4eca-a69a-deec93c203b3
+- name: Jay Luneau
+  role: Member
+  person_id: ocd-person/b4a4657a-e588-4036-9a0f-48847e22a140
+- name: Fred H. Mills, Jr.
+  role: Chairman
+  person_id: ocd-person/cb6fae11-a6e0-4328-8679-f159bab5aeec

--- a/data/la/committees/upper-Insurance-09202202-3bab-4631-a587-7f20b4d0bb82.yml
+++ b/data/la/committees/upper-Insurance-09202202-3bab-4631-a587-7f20b4d0bb82.yml
@@ -33,3 +33,15 @@ members:
 - name: Mike Reese
   role: Ex Officio
   person_id: ocd-person/723f3444-f927-44b0-8659-7ac00370aa92
+- name: Royce Duplessis
+  role: Member
+  person_id: ocd-person/7d852e7a-ae99-4f89-b4c0-4d7cb7e816db
+- name: Katrina R. Jackson
+  role: Member
+  person_id: ocd-person/acdaa5e6-3b22-44b9-8b47-480b801483dd
+- name: Joseph Bouie
+  role: Interim Member
+  person_id: ocd-person/26ccd002-0b4d-4845-8a86-cae06a62be70
+- name: Gary L. Smith, Jr
+  role: Member
+  person_id: ocd-person/62bfd6fe-1be8-4288-876b-d56aa4b2bbc3

--- a/data/la/committees/upper-Judiciary-A-288210e9-ca21-4f68-af17-4d33e84fa8f6.yml
+++ b/data/la/committees/upper-Judiciary-A-288210e9-ca21-4f68-af17-4d33e84fa8f6.yml
@@ -24,3 +24,12 @@ members:
 - name: Jeremy Stine
   role: Member
   person_id: ocd-person/e8c847e2-5ee6-4f9c-a4e4-d7d8daa8464c
+- name: Jimmy Harris
+  role: Vice Chair
+  person_id: ocd-person/ce11601e-9a67-48a1-9408-b80943312303
+- name: Cleo Fields
+  role: Member
+  person_id: ocd-person/b2eca8f2-6db8-4263-92a4-050e3819de53
+- name: Jay Luneau
+  role: Member
+  person_id: ocd-person/b4a4657a-e588-4036-9a0f-48847e22a140

--- a/data/la/committees/upper-Judiciary-B-f6a4720d-69f5-4851-92cf-a0eb8b8742f0.yml
+++ b/data/la/committees/upper-Judiciary-B-f6a4720d-69f5-4851-92cf-a0eb8b8742f0.yml
@@ -24,3 +24,12 @@ members:
 - name: Kirk Talbot
   role: Member
   person_id: ocd-person/f6f401f7-7fb4-40df-84a0-b5a3f0fe9ec2
+- name: Gregory Tarver
+  role: Vice Chair
+  person_id: ocd-person/05ace530-e22c-436d-bf1a-562e3a923bef
+- name: Joseph Bouie
+  role: Member
+  person_id: ocd-person/26ccd002-0b4d-4845-8a86-cae06a62be70
+- name: Gary L. Smith, Jr
+  role: Chairman
+  person_id: ocd-person/62bfd6fe-1be8-4288-876b-d56aa4b2bbc3

--- a/data/la/committees/upper-Judiciary-C-aa5da0b1-aafe-4063-9253-97f82336bbd3.yml
+++ b/data/la/committees/upper-Judiciary-C-aa5da0b1-aafe-4063-9253-97f82336bbd3.yml
@@ -27,3 +27,9 @@ members:
 - name: Mack "Bodi" White
   role: Member
   person_id: ocd-person/34227712-b998-4aca-a215-5b2985c91df3
+- name: Regina Barrow
+  role: Member
+  person_id: ocd-person/8710f3da-9aea-41a9-acd2-181377cc6ae7
+- name: Gary Carter
+  role: Member
+  person_id: ocd-person/60ffe8d0-0469-4eca-a69a-deec93c203b3

--- a/data/la/committees/upper-Labor-and-Industrial-Relations-1e0aea3c-7169-4d61-a883-2ca135447f3c.yml
+++ b/data/la/committees/upper-Labor-and-Industrial-Relations-1e0aea3c-7169-4d61-a883-2ca135447f3c.yml
@@ -15,11 +15,21 @@ members:
 - name: John C. "Jay" Morris
   role: Vice Chair
   person_id: ocd-person/9d6aa1d9-76b2-41ad-a3e0-4fa86da08645
-- name: Stewart Jr. Cathey
-  role: Member
 - name: Jeremy Stine
   role: Member
   person_id: ocd-person/e8c847e2-5ee6-4f9c-a4e4-d7d8daa8464c
 - name: Glen Womack
   role: Member
   person_id: ocd-person/25923053-3679-443e-bbb1-e2f63a50585c
+- name: Jay Luneau
+  role: Chairman
+  person_id: ocd-person/b4a4657a-e588-4036-9a0f-48847e22a140
+- name: Regina Barrow
+  role: Member
+  person_id: ocd-person/8710f3da-9aea-41a9-acd2-181377cc6ae7
+- name: Royce Duplessis
+  role: Member
+  person_id: ocd-person/7d852e7a-ae99-4f89-b4c0-4d7cb7e816db
+- name: Stewart Cathey, Jr.
+  role: Member
+  person_id: ocd-person/dd47283c-c202-461f-b56a-8cc2c0b14f15

--- a/data/la/committees/upper-Local-and-Municipal-Affairs-d9ad42f0-e9fb-4506-bdc7-3c5eae9156c5.yml
+++ b/data/la/committees/upper-Local-and-Municipal-Affairs-d9ad42f0-e9fb-4506-bdc7-3c5eae9156c5.yml
@@ -24,3 +24,12 @@ members:
 - name: Barry Milligan
   role: Member
   person_id: ocd-person/ff5a7b0c-351d-48bd-b448-b3cf24eaa750
+- name: Joseph Bouie
+  role: Chairman
+  person_id: ocd-person/26ccd002-0b4d-4845-8a86-cae06a62be70
+- name: Gerald Boudreaux
+  role: Vice Chair
+  person_id: ocd-person/379e9992-463c-4188-9702-668457a75c3d
+- name: Gregory Tarver
+  role: Member
+  person_id: ocd-person/05ace530-e22c-436d-bf1a-562e3a923bef

--- a/data/la/committees/upper-Retirement-3fbee492-32e0-41bd-9b24-4df807bd9e36.yml
+++ b/data/la/committees/upper-Retirement-3fbee492-32e0-41bd-9b24-4df807bd9e36.yml
@@ -27,3 +27,9 @@ members:
 - name: Kirk Talbot
   role: Member
   person_id: ocd-person/f6f401f7-7fb4-40df-84a0-b5a3f0fe9ec2
+- name: Edward J. Price
+  role: Chairman
+  person_id: ocd-person/1899dc2e-bac6-4951-b3fc-87ea5e2d4969
+- name: Cleo Fields
+  role: Member
+  person_id: ocd-person/b2eca8f2-6db8-4263-92a4-050e3819de53

--- a/data/la/committees/upper-Revenue-and-Fiscal-Affairs-3bde3e53-d508-49f0-a51e-ce27cbaf98b5.yml
+++ b/data/la/committees/upper-Revenue-and-Fiscal-Affairs-3bde3e53-d508-49f0-a51e-ce27cbaf98b5.yml
@@ -24,8 +24,6 @@ members:
 - name: Patrick McMath
   role: Member
   person_id: ocd-person/d4a6db65-2f6f-464f-ae26-58176f2b68e6
-- name: Fred H. Jr. Mills
-  role: Member
 - name: John C. "Jay" Morris
   role: Member
   person_id: ocd-person/9d6aa1d9-76b2-41ad-a3e0-4fa86da08645
@@ -38,11 +36,24 @@ members:
 - name: Louie Bernard
   role: Interim Member
   person_id: ocd-person/49e45511-c6c2-4b3d-b2c1-e4925ecb65be
-- name: Stewart Jr. Cathey
-  role: Interim Member
 - name: Jeremy Stine
   role: Interim Member
   person_id: ocd-person/e8c847e2-5ee6-4f9c-a4e4-d7d8daa8464c
 - name: Mack "Bodi" White
   role: Ex Officio
   person_id: ocd-person/34227712-b998-4aca-a215-5b2985c91df3
+- name: Joseph Bouie
+  role: Member
+  person_id: ocd-person/26ccd002-0b4d-4845-8a86-cae06a62be70
+- name: Jay Luneau
+  role: Member
+  person_id: ocd-person/b4a4657a-e588-4036-9a0f-48847e22a140
+- name: Fred H. Mills, Jr.
+  role: Member
+  person_id: ocd-person/cb6fae11-a6e0-4328-8679-f159bab5aeec
+- name: Gary L. Smith, Jr
+  role: Member
+  person_id: ocd-person/62bfd6fe-1be8-4288-876b-d56aa4b2bbc3
+- name: Stewart Cathey, Jr.
+  role: Interim Member
+  person_id: ocd-person/dd47283c-c202-461f-b56a-8cc2c0b14f15

--- a/data/la/committees/upper-Senate-and-Governmental-Affairs-7febbc0d-0eaf-4ea2-8c0c-60900066418e.yml
+++ b/data/la/committees/upper-Senate-and-Governmental-Affairs-7febbc0d-0eaf-4ea2-8c0c-60900066418e.yml
@@ -30,3 +30,12 @@ members:
 - name: Glen Womack
   role: Member
   person_id: ocd-person/25923053-3679-443e-bbb1-e2f63a50585c
+- name: Joseph Bouie
+  role: Member
+  person_id: ocd-person/26ccd002-0b4d-4845-8a86-cae06a62be70
+- name: Edward J. Price
+  role: Member
+  person_id: ocd-person/1899dc2e-bac6-4951-b3fc-87ea5e2d4969
+- name: Gregory Tarver
+  role: Member
+  person_id: ocd-person/05ace530-e22c-436d-bf1a-562e3a923bef

--- a/data/la/committees/upper-Transportation-Highways-and-Public-Works-d77a2d37-af20-4282-9f45-53636ed9dacb.yml
+++ b/data/la/committees/upper-Transportation-Highways-and-Public-Works-d77a2d37-af20-4282-9f45-53636ed9dacb.yml
@@ -27,3 +27,12 @@ members:
 - name: Bob Hensgens
   role: Ex Officio
   person_id: ocd-person/7dac3861-2ffb-45ba-b690-a8e199eb2acd
+- name: Gary Carter
+  role: Vice Chair
+  person_id: ocd-person/60ffe8d0-0469-4eca-a69a-deec93c203b3
+- name: Edward J. Price
+  role: Member
+  person_id: ocd-person/1899dc2e-bac6-4951-b3fc-87ea5e2d4969
+- name: Gary L. Smith, Jr
+  role: Member
+  person_id: ocd-person/62bfd6fe-1be8-4288-876b-d56aa4b2bbc3

--- a/data/la/legislature/Alan-Seabaugh-5032448a-7275-4a02-8dc1-d251cdde8ad9.yml
+++ b/data/la/legislature/Alan-Seabaugh-5032448a-7275-4a02-8dc1-d251cdde8ad9.yml
@@ -12,7 +12,7 @@ roles:
   district: '5'
 offices:
 - classification: district
-  address: 401 Market Street Suite 1150 Shreveport, LA 71101
+  address: 401 Market Street, Suite 1150 Shreveport, LA 71101
   voice: 318-676-7990
   fax: 318-676-7992
 links:
@@ -36,4 +36,5 @@ extras:
   legislative assistant: Emily Mott and Megan McCreary
   representing parishes:
   - Caddo
-  education: Louisiana State University, B.A., 1990; Louisiana State University Law School, J.D., 1993
+  education: Louisiana State University, B.A., 1990; Louisiana State University Law
+    School, J.D., 1993

--- a/data/la/legislature/Alan-Seabaugh-5032448a-7275-4a02-8dc1-d251cdde8ad9.yml
+++ b/data/la/legislature/Alan-Seabaugh-5032448a-7275-4a02-8dc1-d251cdde8ad9.yml
@@ -37,4 +37,4 @@ extras:
   representing parishes:
   - Caddo
   education: Louisiana State University, B.A., 1990; Louisiana State University Law
-    School, J.D., 1993
+             School, J.D., 1993

--- a/data/la/legislature/Alonzo-L-Knox-967fa557-fcdc-4a75-a13e-dabf05b85905.yml
+++ b/data/la/legislature/Alonzo-L-Knox-967fa557-fcdc-4a75-a13e-dabf05b85905.yml
@@ -1,0 +1,25 @@
+id: ocd-person/967fa557-fcdc-4a75-a13e-dabf05b85905
+name: Alonzo L. Knox
+email: hse093@legis.la.gov
+image: https://house.louisiana.gov/H_Reps/RepPics20/rep93.jpg
+party:
+- name: Democratic
+roles:
+- type: lower
+  jurisdiction: ocd-jurisdiction/country:us/state:la/government
+  district: '93'
+offices:
+- classification: district
+  address: 1239 Baronne Street New Orleans, LA 70113
+links:
+- url: https://house.louisiana.gov/H_Reps/members.aspx?ID=93
+  note: homepage
+sources:
+- url: https://house.louisiana.gov/H_Reps/H_Reps_FullInfo
+- url: https://house.louisiana.gov/H_Reps/members.aspx?ID=93
+extras:
+  legislative assistant: Chantrisse Burnett
+  representing parishes:
+  - Orleans
+  education: "MBA, Trinity University, \r\nBA, Political Science, Southern University\
+    \ at B.R. and \r\nAA, Law Enforcement, Southern University at B.R."

--- a/data/la/legislature/Alonzo-L-Knox-967fa557-fcdc-4a75-a13e-dabf05b85905.yml
+++ b/data/la/legislature/Alonzo-L-Knox-967fa557-fcdc-4a75-a13e-dabf05b85905.yml
@@ -21,5 +21,5 @@ extras:
   legislative assistant: Chantrisse Burnett
   representing parishes:
   - Orleans
-  education: "MBA, Trinity University, \r\nBA, Political Science, Southern University\
-    \ at B.R. and \r\nAA, Law Enforcement, Southern University at B.R."
+  education: "MBA, Trinity University; BA, Political Science, Southern University
+              at B.R.; AA, Law Enforcement, Southern University at B.R."

--- a/data/la/legislature/Barbara-Reich-Freiberg-bd179bf7-f90d-4e3a-baea-a590c3002586.yml
+++ b/data/la/legislature/Barbara-Reich-Freiberg-bd179bf7-f90d-4e3a-baea-a590c3002586.yml
@@ -24,4 +24,4 @@ extras:
   representing parishes:
   - East Baton Rouge
   education: Lee High School; Louisiana Tech University, B.A.; University of North
-    Carolina at Chapel Hill, M.A.
+             Carolina at Chapel Hill, M.A.

--- a/data/la/legislature/Barbara-Reich-Freiberg-bd179bf7-f90d-4e3a-baea-a590c3002586.yml
+++ b/data/la/legislature/Barbara-Reich-Freiberg-bd179bf7-f90d-4e3a-baea-a590c3002586.yml
@@ -10,7 +10,7 @@ roles:
   district: '70'
 offices:
 - classification: district
-  address: 5800 One Perkins Place Suite 7A Baton Rouge, LA 70808
+  address: 5800 One Perkins Place, Suite 7A Baton Rouge, LA 70808
   voice: 225-763-3500
   fax: 225-763-3506
 links:
@@ -23,4 +23,5 @@ extras:
   legislative assistant: Brandi Chambless
   representing parishes:
   - East Baton Rouge
-  education: Lee High School; Louisiana Tech University, B.A.; University of North Carolina at Chapel Hill, M.A.
+  education: Lee High School; Louisiana Tech University, B.A.; University of North
+    Carolina at Chapel Hill, M.A.

--- a/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
+++ b/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
@@ -34,4 +34,4 @@ extras:
   - Bossier
   - Caddo
   education: "Master of Business Administration, LSU Baton Rouge; B.A. Degree,
-             Business Administration, Southern Methodist University"
+              Business Administration, Southern Methodist University"

--- a/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
+++ b/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
@@ -33,4 +33,5 @@ extras:
   representing parishes:
   - Bossier
   - Caddo
-  education: "Master of Business Administration, LSU Baton Rouge;\r\nB.A. Degree,Business Administration, Southern Methodist University"
+  education: "Master of Business Administration, LSU Baton Rouge;\r\nB.A. Degree,\
+    \ Business Administration, Southern Methodist University"

--- a/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
+++ b/data/la/legislature/Barrow-Peacock-2d304e88-d8e7-4c99-9725-cb1c75844a35.yml
@@ -33,5 +33,5 @@ extras:
   representing parishes:
   - Bossier
   - Caddo
-  education: "Master of Business Administration, LSU Baton Rouge;\r\nB.A. Degree,\
-    \ Business Administration, Southern Methodist University"
+  education: "Master of Business Administration, LSU Baton Rouge; B.A. Degree,
+             Business Administration, Southern Methodist University"

--- a/data/la/legislature/Blake-Miguez-8574f94d-93ed-49b0-a5f6-aa1832b5542a.yml
+++ b/data/la/legislature/Blake-Miguez-8574f94d-93ed-49b0-a5f6-aa1832b5542a.yml
@@ -31,4 +31,4 @@ extras:
   representing parishes:
   - Iberia and Vermilion
   education: Catholic High School New Iberia, 1999; Louisiana State University, Political
-    Science, 2004; Southern University Law Center, 2008
+             Science, 2004; Southern University Law Center, 2008

--- a/data/la/legislature/Blake-Miguez-8574f94d-93ed-49b0-a5f6-aa1832b5542a.yml
+++ b/data/la/legislature/Blake-Miguez-8574f94d-93ed-49b0-a5f6-aa1832b5542a.yml
@@ -12,9 +12,9 @@ roles:
   district: '49'
 offices:
 - classification: district
-  address: 1101 E Admiral Doyle Drive Suite 301-8 New Iberia, LA 70560
-  voice: 337-937-8827
-  fax: 337-937-8829
+  address: 1101 E. Admiral Doyle Drive, Suite 301-8 New Iberia, LA 70560
+  voice: 337-373-9400
+  fax: 337-373-9402
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=49
   note: homepage
@@ -30,4 +30,5 @@ extras:
   legislative assistant: Kirsten D. Bourque
   representing parishes:
   - Iberia and Vermilion
-  education: Catholic High School New Iberia, 1999; Louisiana State University, Political Science, 2004; Southern University Law Center, 2008
+  education: Catholic High School New Iberia, 1999; Louisiana State University, Political
+    Science, 2004; Southern University Law Center, 2008

--- a/data/la/legislature/Bryan-Fontenot-90b6f6c3-9620-4fbb-8c23-f8ab7b163de7.yml
+++ b/data/la/legislature/Bryan-Fontenot-90b6f6c3-9620-4fbb-8c23-f8ab7b163de7.yml
@@ -25,4 +25,4 @@ extras:
   representing parishes:
   - Lafourche
   education: 'Thibodaux High School, 1996; Present: Fletcher Technical Community College,
-    Criminal Justice'
+              Criminal Justice'

--- a/data/la/legislature/Bryan-Fontenot-90b6f6c3-9620-4fbb-8c23-f8ab7b163de7.yml
+++ b/data/la/legislature/Bryan-Fontenot-90b6f6c3-9620-4fbb-8c23-f8ab7b163de7.yml
@@ -12,7 +12,7 @@ roles:
   district: '55'
 offices:
 - classification: district
-  address: 406 W 3rd Street Suite 107 Thibodaux, LA 70301-3014
+  address: 406 W 3rd Street, Suite 107 Thibodaux, LA 70301-3014
   voice: 985-447-0999
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=55
@@ -24,4 +24,5 @@ extras:
   legislative assistant: Heather Babin
   representing parishes:
   - Lafourche
-  education: 'Thibodaux High School, 1996; Present: Fletcher Technical Community College, Criminal Justice'
+  education: 'Thibodaux High School, 1996; Present: Fletcher Technical Community College,
+    Criminal Justice'

--- a/data/la/legislature/Buddy-Mincey-Jr-22fece93-3e18-47b9-9cdf-6e5151f9e1de.yml
+++ b/data/la/legislature/Buddy-Mincey-Jr-22fece93-3e18-47b9-9cdf-6e5151f9e1de.yml
@@ -27,4 +27,4 @@ extras:
   representing parishes:
   - Livingston
   education: Denham Springs High School, 1987; Southeastern Louisiana University,
-    B.S., Industrial Technology Supervision Speciality, 1993
+             B.S., Industrial Technology Supervision Speciality, 1993

--- a/data/la/legislature/Buddy-Mincey-Jr-22fece93-3e18-47b9-9cdf-6e5151f9e1de.yml
+++ b/data/la/legislature/Buddy-Mincey-Jr-22fece93-3e18-47b9-9cdf-6e5151f9e1de.yml
@@ -10,7 +10,7 @@ roles:
   district: '71'
 offices:
 - classification: district
-  address: 1810 Florida Ave, SW Suite B Denham Springs, LA 70726
+  address: 1810 Florida Ave, SW, Suite B Denham Springs, LA 70726
   voice: 225-667-6088
   fax: 225-667-6090
 links:
@@ -26,4 +26,5 @@ extras:
   legislative assistant: Teresa Clement
   representing parishes:
   - Livingston
-  education: Denham Springs High School, 1987; Southeastern Louisiana University, B.S., Industrial Technology Supervision Speciality, 1993
+  education: Denham Springs High School, 1987; Southeastern Louisiana University,
+    B.S., Industrial Technology Supervision Speciality, 1993

--- a/data/la/legislature/C-Travis-Johnson-871d5c01-9710-46f4-aeba-b321bdf11e30.yml
+++ b/data/la/legislature/C-Travis-Johnson-871d5c01-9710-46f4-aeba-b321bdf11e30.yml
@@ -28,4 +28,4 @@ extras:
   - Madison
   - and Tensas
   education: Louisiana Tech University, B.S., Political Science Economics; Belhaven
-    University, Masters, Public Administration
+             University, Masters, Public Administration

--- a/data/la/legislature/C-Travis-Johnson-871d5c01-9710-46f4-aeba-b321bdf11e30.yml
+++ b/data/la/legislature/C-Travis-Johnson-871d5c01-9710-46f4-aeba-b321bdf11e30.yml
@@ -10,7 +10,7 @@ roles:
   district: '21'
 offices:
 - classification: district
-  address: 200 Advocate Row Suite D Vidalia, LA 71373
+  address: 200 Advocate Row, Suite D Vidalia, LA 71373
   voice: 225-308-4269
   fax: 318-336-9268
 links:
@@ -27,4 +27,5 @@ extras:
   - East Carroll
   - Madison
   - and Tensas
-  education: Louisiana Tech University, B.S., Political Science Economics; Belhaven University, Masters, Public Administration
+  education: Louisiana Tech University, B.S., Political Science Economics; Belhaven
+    University, Masters, Public Administration

--- a/data/la/legislature/Candace-N-Newell-85a96a1b-a8a0-4ddd-acd7-9452b48f5ace.yml
+++ b/data/la/legislature/Candace-N-Newell-85a96a1b-a8a0-4ddd-acd7-9452b48f5ace.yml
@@ -11,7 +11,7 @@ roles:
 offices:
 - classification: district
   address: New Orleans Lake Front Airport Terminal Building, Suite 149 6001 Stars
-    and Stripes New Orleans, LA 70126
+           and Stripes New Orleans, LA 70126
   voice: 504-240-3435
   fax: 504-240-3437
 links:

--- a/data/la/legislature/Candace-N-Newell-85a96a1b-a8a0-4ddd-acd7-9452b48f5ace.yml
+++ b/data/la/legislature/Candace-N-Newell-85a96a1b-a8a0-4ddd-acd7-9452b48f5ace.yml
@@ -10,7 +10,8 @@ roles:
   district: '99'
 offices:
 - classification: district
-  address: New Orleans Lake Front Airport Terminal Building Suite 149 6001 Stars and Stripes New Orleans, LA 70126
+  address: New Orleans Lake Front Airport Terminal Building, Suite 149 6001 Stars
+    and Stripes New Orleans, LA 70126
   voice: 504-240-3435
   fax: 504-240-3437
 links:

--- a/data/la/legislature/Charles-Anthony-Owen-2a4d4c31-ee06-4f32-a67b-c55db60502e4.yml
+++ b/data/la/legislature/Charles-Anthony-Owen-2a4d4c31-ee06-4f32-a67b-c55db60502e4.yml
@@ -15,8 +15,6 @@ offices:
   address: 6673 Evans Street Rosepine, LA 70659
   voice: 337-460-8726
   fax: 337-460-8727
-- classification: district
-  address: 'Mailing Address: P. O. Box 55 Rosepine, LA 70659'
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=30
   note: homepage

--- a/data/la/legislature/Christopher-Turner-a07b757e-a57b-4dda-aa6a-7bf5e6b3561d.yml
+++ b/data/la/legislature/Christopher-Turner-a07b757e-a57b-4dda-aa6a-7bf5e6b3561d.yml
@@ -12,7 +12,7 @@ roles:
   district: '12'
 offices:
 - classification: district
-  address: 111 N. Trenton Street Suite A Ruston, LA 71270-4321
+  address: 111 N. Trenton Street, Suite A Ruston, LA 71270-4321
   voice: 318-251-5038
   fax: 318-251-5091
 links:
@@ -22,7 +22,7 @@ sources:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=12
 - url: https://house.louisiana.gov/H_Reps/H_Reps_FullInfo
 extras:
-  legislative assistant: Rebecca Daughtry
+  legislative assistant: Mary Anne Hill
   representing parishes:
   - Lincoln and Union
   education: "Oak Grove High School\r\nLouisiana Tech"

--- a/data/la/legislature/Clay-Schexnayder-69eb0893-93d4-4155-91e8-cc991956b80c.yml
+++ b/data/la/legislature/Clay-Schexnayder-69eb0893-93d4-4155-91e8-cc991956b80c.yml
@@ -12,7 +12,7 @@ roles:
   district: '81'
 offices:
 - classification: district
-  address: 6473 Highway 44 Suite 205 Gonzales, LA 70737
+  address: 6473 Highway 44, Suite 205 Gonzales, LA 70737
   voice: 225-473-6016
   fax: 225-473-6018
 links:

--- a/data/la/legislature/Debbie-Villio-aefc2237-5913-4b96-9354-18fb7e58884c.yml
+++ b/data/la/legislature/Debbie-Villio-aefc2237-5913-4b96-9354-18fb7e58884c.yml
@@ -12,7 +12,7 @@ roles:
   district: '79'
 offices:
 - classification: district
-  address: 4203 Williams Blvd. Suite 200 Kenner, LA 70065
+  address: 4203 Williams Blvd., Suite 200 Kenner, LA 70065
   voice: 504-468-8603
   fax: 504-468-8605
 links:

--- a/data/la/legislature/Dodie-Horton-4661fe94-874c-4884-99a2-c60516c811ff.yml
+++ b/data/la/legislature/Dodie-Horton-4661fe94-874c-4884-99a2-c60516c811ff.yml
@@ -12,7 +12,7 @@ roles:
   district: '9'
 offices:
 - classification: district
-  address: 954 Hwy. 80 Suite 400 Haughton, LA 71037
+  address: 954 Hwy. 80, Suite 400 Haughton, LA 71037
   voice: 318-949-2463
   fax: 318-949-5019
 links:

--- a/data/la/legislature/Dustin-Miller-dcf2c7e1-e124-424c-ac0c-8d1e6600e970.yml
+++ b/data/la/legislature/Dustin-Miller-dcf2c7e1-e124-424c-ac0c-8d1e6600e970.yml
@@ -12,7 +12,7 @@ roles:
   district: '40'
 offices:
 - classification: district
-  address: 1310 South Union Street Suite 2 Opelousas, LA 70570
+  address: 1310 South Union Street, Suite 2 Opelousas, LA 70570
   voice: 337-943-2900
   fax: 337-943-2902
 links:
@@ -30,4 +30,5 @@ extras:
   legislative assistant: Kristina Martel
   representing parishes:
   - St. Landry
-  education: Opelousas Catholic High School; University of Louisiana at Lafayette, B.S.N.; Southern University, M.S.N., Family Nursing
+  education: Opelousas Catholic High School; University of Louisiana at Lafayette,
+    B.S.N.; Southern University, M.S.N., Family Nursing

--- a/data/la/legislature/Dustin-Miller-dcf2c7e1-e124-424c-ac0c-8d1e6600e970.yml
+++ b/data/la/legislature/Dustin-Miller-dcf2c7e1-e124-424c-ac0c-8d1e6600e970.yml
@@ -31,4 +31,4 @@ extras:
   representing parishes:
   - St. Landry
   education: Opelousas Catholic High School; University of Louisiana at Lafayette,
-    B.S.N.; Southern University, M.S.N., Family Nursing
+             B.S.N.; Southern University, M.S.N., Family Nursing

--- a/data/la/legislature/Ed-Larvadain-III-9a91a848-9d01-46b6-84f1-cc868681e912.yml
+++ b/data/la/legislature/Ed-Larvadain-III-9a91a848-9d01-46b6-84f1-cc868681e912.yml
@@ -28,4 +28,5 @@ extras:
   legislative assistant: LeCrete Robinson
   representing parishes:
   - Rapides
-  education: "Southern University, Baton Rouge, LA - B.A. Political Science (1987) Southern University Law Center - J.D. (1992)"
+  education: "Southern University, Baton Rouge, LA - B.A. Political Science (1987)\r\
+    \nSouthern University Law Center - J.D. (1992)"

--- a/data/la/legislature/Ed-Larvadain-III-9a91a848-9d01-46b6-84f1-cc868681e912.yml
+++ b/data/la/legislature/Ed-Larvadain-III-9a91a848-9d01-46b6-84f1-cc868681e912.yml
@@ -28,5 +28,5 @@ extras:
   legislative assistant: LeCrete Robinson
   representing parishes:
   - Rapides
-  education: "Southern University, Baton Rouge, LA - B.A. Political Science (1987)\r\
-    \nSouthern University Law Center - J.D. (1992)"
+  education: "Southern University, Baton Rouge, LA - B.A. Political Science (1987)
+              Southern University Law Center - J.D. (1992)"

--- a/data/la/legislature/Foy-Bryan-Gadberry-040e17ea-a4d0-47ce-8f45-527a6bdc83a7.yml
+++ b/data/la/legislature/Foy-Bryan-Gadberry-040e17ea-a4d0-47ce-8f45-527a6bdc83a7.yml
@@ -10,7 +10,7 @@ roles:
   district: '15'
 offices:
 - classification: district
-  address: 4920 Cypress Street Suite 3C West Monroe, LA 71291
+  address: 4920 Cypress Street, Suite 3C West Monroe, LA 71291
   voice: 318-396-8080
   fax: 318-396-8086
 links:

--- a/data/la/legislature/Francis-C-Thompson-7796b73e-f06a-4d0b-8a85-cfde955a4cd1.yml
+++ b/data/la/legislature/Francis-C-Thompson-7796b73e-f06a-4d0b-8a85-cfde955a4cd1.yml
@@ -44,4 +44,4 @@ extras:
   - Richland
   - and West Carroll
   education: Louisiana Technical University, B.S.; Northeast Louisiana University,
-    EdD; Northeast Louisiana University, Med; Louisiana Technical University, MS
+             EdD; Northeast Louisiana University, Med; Louisiana Technical University, MS

--- a/data/la/legislature/Francis-C-Thompson-7796b73e-f06a-4d0b-8a85-cfde955a4cd1.yml
+++ b/data/la/legislature/Francis-C-Thompson-7796b73e-f06a-4d0b-8a85-cfde955a4cd1.yml
@@ -5,7 +5,9 @@ family_name: Thompson
 email: thompsof@legis.la.gov
 image: https://house.louisiana.gov/H_Reps/RepPics20/rep19.jpg
 party:
-- name: Democratic
+- end_date: '2023-04-18'
+  name: Democratic
+- name: Republican
 roles:
 - type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:la/government
@@ -41,4 +43,5 @@ extras:
   - Ouachita
   - Richland
   - and West Carroll
-  education: Louisiana Technical University, B.S.; Northeast Louisiana University, EdD; Northeast Louisiana University, Med; Louisiana Technical University, MS
+  education: Louisiana Technical University, B.S.; Northeast Louisiana University,
+    EdD; Northeast Louisiana University, Med; Louisiana Technical University, MS

--- a/data/la/legislature/Gerald-Beau-Alphonse-Beaullieu-IV-c5ea395a-7594-4585-b193-000e05f08005.yml
+++ b/data/la/legislature/Gerald-Beau-Alphonse-Beaullieu-IV-c5ea395a-7594-4585-b193-000e05f08005.yml
@@ -30,4 +30,4 @@ extras:
   - Lafayette
   - and St. Martin
   education: Louisiana State University, Finance Degree; University of Lafayette,
-    MBA; Certified 401(K) Professional; Accredited Investment Fiduciary
+             MBA; Certified 401(K) Professional; Accredited Investment Fiduciary

--- a/data/la/legislature/Gerald-Beau-Alphonse-Beaullieu-IV-c5ea395a-7594-4585-b193-000e05f08005.yml
+++ b/data/la/legislature/Gerald-Beau-Alphonse-Beaullieu-IV-c5ea395a-7594-4585-b193-000e05f08005.yml
@@ -10,7 +10,7 @@ roles:
   district: '48'
 offices:
 - classification: district
-  address: 209 West Main Street 4th Floor Suite 403 New Iberia, LA 70560
+  address: 209 West Main Street, 4th Floor, Suite 403 New Iberia, LA 70560
   voice: 337-373-4051
   fax: 337-373-4053
 links:
@@ -29,4 +29,5 @@ extras:
   - Iberia
   - Lafayette
   - and St. Martin
-  education: Louisiana State University, Finance Degree; University of Lafayette, MBA; Certified 401(K) Professional; Accredited Investment Fiduciary
+  education: Louisiana State University, Finance Degree; University of Lafayette,
+    MBA; Certified 401(K) Professional; Accredited Investment Fiduciary

--- a/data/la/legislature/Glen-Womack-25923053-3679-443e-bbb1-e2f63a50585c.yml
+++ b/data/la/legislature/Glen-Womack-25923053-3679-443e-bbb1-e2f63a50585c.yml
@@ -15,8 +15,6 @@ offices:
   address: P.O. Box 660 Harrisonburg, LA 71340
   voice: 318-744-0005
   fax: 318-744-0007
-- classification: district
-  address: 119 Pine Street Suite B Harrisonburg, LA 71340
 links:
 - url: https://senate.la.gov/smembers.aspx?ID=32
   note: homepage

--- a/data/la/legislature/Heather-Miley-Cloud-aa2da413-7e13-4c2b-93e8-784edc0a495e.yml
+++ b/data/la/legislature/Heather-Miley-Cloud-aa2da413-7e13-4c2b-93e8-784edc0a495e.yml
@@ -14,8 +14,6 @@ offices:
 - classification: district
   address: P.O Box 269 Turkey Creek, LA 70585
   voice: 337-461-2595
-- classification: district
-  address: 7674 US Hwy 167 Ville Platte, La 70586
 links:
 - url: https://senate.la.gov/smembers.aspx?ID=28
   note: homepage

--- a/data/la/legislature/Jeremy-S-LaCombe-9ae6b490-4fe0-435c-93fd-ad316e474204.yml
+++ b/data/la/legislature/Jeremy-S-LaCombe-9ae6b490-4fe0-435c-93fd-ad316e474204.yml
@@ -5,7 +5,9 @@ family_name: LaCombe
 email: hse018@legis.la.gov
 image: https://house.louisiana.gov/H_Reps/RepPics20/rep18.jpg
 party:
-- name: Democratic
+- end_date: '2023-04-18'
+  name: Democratic
+- name: Republican
 roles:
 - type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:la/government
@@ -31,4 +33,5 @@ extras:
   - Pointe Coupee
   - West Baton Rouge
   - and West Feliciana
-  education: "Northwestern State University - B.A.\r\nLouisiana State University Law School - J.D."
+  education: "Northwestern State University - B.A.\r\nLouisiana State University Law\
+    \ School - J.D."

--- a/data/la/legislature/Jeremy-S-LaCombe-9ae6b490-4fe0-435c-93fd-ad316e474204.yml
+++ b/data/la/legislature/Jeremy-S-LaCombe-9ae6b490-4fe0-435c-93fd-ad316e474204.yml
@@ -33,5 +33,5 @@ extras:
   - Pointe Coupee
   - West Baton Rouge
   - and West Feliciana
-  education: "Northwestern State University - B.A.\r\nLouisiana State University Law\
-    \ School - J.D."
+  education: "Northwestern State University - B.A; Louisiana State University Law
+              School - J.D."

--- a/data/la/legislature/John-R-Illg-Jr-3c0eeaa2-cf62-4b17-9b62-2531c078dd42.yml
+++ b/data/la/legislature/John-R-Illg-Jr-3c0eeaa2-cf62-4b17-9b62-2531c078dd42.yml
@@ -10,7 +10,7 @@ roles:
   district: '78'
 offices:
 - classification: district
-  address: 9523 Jefferson Hwy. Suite A River Ridge, LA 70123
+  address: 9523 Jefferson Hwy., Suite A River Ridge, LA 70123
   voice: 504-736-7030
   fax: 504-736-7032
 links:

--- a/data/la/legislature/Jonathan-Goudeau-I-8b72535d-0380-4e39-a168-dcd1c742f47c.yml
+++ b/data/la/legislature/Jonathan-Goudeau-I-8b72535d-0380-4e39-a168-dcd1c742f47c.yml
@@ -12,7 +12,7 @@ roles:
   district: '31'
 offices:
 - classification: district
-  address: 3639 Ambassador Caffery Pkwy. Suite 214 Lafayette, LA 70503
+  address: 3639 Ambassador Caffery Pkwy., Suite 214 Lafayette, LA 70503
   voice: 337-347-7077
   fax: 337-347-7073
 links:

--- a/data/la/legislature/Joseph-A-Marino-III-f0b68891-c893-47e8-b2cc-5ed83c16151d.yml
+++ b/data/la/legislature/Joseph-A-Marino-III-f0b68891-c893-47e8-b2cc-5ed83c16151d.yml
@@ -13,7 +13,7 @@ roles:
 offices:
 - classification: district
   address: General Government Building, Suite 4300 200 Derbigny Street Gretna, LA
-    70053
+           70053
   voice: 504-361-6013
   fax: 504-361-6687
 links:
@@ -35,4 +35,4 @@ extras:
   representing parishes:
   - Jefferson (Gretna and Terrytown)
   education: Holy Cross High School; Louisiana State University; University of South
-    Carolina School of Law
+             Carolina School of Law

--- a/data/la/legislature/Joseph-A-Marino-III-f0b68891-c893-47e8-b2cc-5ed83c16151d.yml
+++ b/data/la/legislature/Joseph-A-Marino-III-f0b68891-c893-47e8-b2cc-5ed83c16151d.yml
@@ -12,7 +12,8 @@ roles:
   district: '85'
 offices:
 - classification: district
-  address: General Government Building Suite 4300 200 Derbigny Street Gretna, LA 70053
+  address: General Government Building, Suite 4300 200 Derbigny Street Gretna, LA
+    70053
   voice: 504-361-6013
   fax: 504-361-6687
 links:
@@ -33,4 +34,5 @@ extras:
   legislative assistant: Julie Montagino
   representing parishes:
   - Jefferson (Gretna and Terrytown)
-  education: Holy Cross High School; Louisiana State University; University of South Carolina School of Law
+  education: Holy Cross High School; Louisiana State University; University of South
+    Carolina School of Law

--- a/data/la/legislature/Joseph-Orgeron-9002c3a7-c0d9-4112-ad34-e0c6fa909ce1.yml
+++ b/data/la/legislature/Joseph-Orgeron-9002c3a7-c0d9-4112-ad34-e0c6fa909ce1.yml
@@ -28,5 +28,5 @@ extras:
   representing parishes:
   - Jefferson and Lafourche
   education: South Lafourche High School (1984); Nicholls State University, B.S. in
-    Physics (1988); University of Texas M.S. in Physics (1990); University of Texas,
-    PhD in Physics (1993)
+             Physics (1988); University of Texas M.S. in Physics (1990);
+             University of Texas, PhD in Physics (1993)

--- a/data/la/legislature/Joseph-Orgeron-9002c3a7-c0d9-4112-ad34-e0c6fa909ce1.yml
+++ b/data/la/legislature/Joseph-Orgeron-9002c3a7-c0d9-4112-ad34-e0c6fa909ce1.yml
@@ -27,4 +27,6 @@ extras:
   legislative assistant: Denna Guidry
   representing parishes:
   - Jefferson and Lafourche
-  education: South Lafourche High School (1984); Nicholls State University, B.S. in Physics (1988); University of Texas M.S. in Physics (1990); University of Texas,PhD in Physics (1993)
+  education: South Lafourche High School (1984); Nicholls State University, B.S. in
+    Physics (1988); University of Texas M.S. in Physics (1990); University of Texas,
+    PhD in Physics (1993)

--- a/data/la/legislature/Kathy-Edmonston-92f7834e-8ce3-437f-bdbf-8dad3528ae3b.yml
+++ b/data/la/legislature/Kathy-Edmonston-92f7834e-8ce3-437f-bdbf-8dad3528ae3b.yml
@@ -12,7 +12,7 @@ roles:
   district: '88'
 offices:
 - classification: district
-  address: 2115 S. Burnside Suite C Gonzales, LA 70737
+  address: 2115 S. Burnside, Suite C Gonzales, LA 70737
   voice: 225-647-5646
   fax: 225-644-7207
 links:
@@ -22,7 +22,7 @@ sources:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=88
 - url: https://house.louisiana.gov/H_Reps/H_Reps_FullInfo
 extras:
-  legislative assistant: ''
+  legislative assistant: Leslie McDaniel
   representing parishes:
   - Ascension
   education: Louisiana State University, English, B.A.

--- a/data/la/legislature/Ken-Brass-43a80737-e614-475d-aace-2d1324cb516a.yml
+++ b/data/la/legislature/Ken-Brass-43a80737-e614-475d-aace-2d1324cb516a.yml
@@ -12,7 +12,7 @@ roles:
   district: '58'
 offices:
 - classification: district
-  address: 22140 Highway 20 Suite C Vacherie, LA 70090
+  address: 22140 Highway 20, Suite C Vacherie, LA 70090
   voice: 225-265-9005
   fax: 225-265-9006
 links:
@@ -33,4 +33,5 @@ extras:
   - Ascension
   - Iberville
   - and St. James
-  education: Lutcher High School; Southern University A & M College, B.S., Electrical Engineering, 1999
+  education: Lutcher High School; Southern University A & M College, B.S., Electrical
+    Engineering, 1999

--- a/data/la/legislature/Ken-Brass-43a80737-e614-475d-aace-2d1324cb516a.yml
+++ b/data/la/legislature/Ken-Brass-43a80737-e614-475d-aace-2d1324cb516a.yml
@@ -34,4 +34,4 @@ extras:
   - Iberville
   - and St. James
   education: Lutcher High School; Southern University A & M College, B.S., Electrical
-    Engineering, 1999
+             Engineering, 1999

--- a/data/la/legislature/Kyle-M-Green-Jr-8ffaa2bd-ff67-464a-b639-19a6069e28a2.yml
+++ b/data/la/legislature/Kyle-M-Green-Jr-8ffaa2bd-ff67-464a-b639-19a6069e28a2.yml
@@ -10,7 +10,7 @@ roles:
   district: '83'
 offices:
 - classification: district
-  address: 6641 Westbank Expwy. Suite D Marrero, LA 70072
+  address: 6641 Westbank Expwy., Suite D Marrero, LA 70072
   voice: 504-349-8788
   fax: 504-349-8790
 links:
@@ -26,4 +26,5 @@ extras:
   legislative assistant: Sandra Muller
   representing parishes:
   - Jefferson
-  education: Archbishop Shaw High School, 2005; Southern University, B.A., Political Science 2009; Southern University Law Center, J.D., 2015
+  education: Archbishop Shaw High School, 2005; Southern University, B.A., Political
+    Science 2009; Southern University Law Center, J.D., 2015

--- a/data/la/legislature/Kyle-M-Green-Jr-8ffaa2bd-ff67-464a-b639-19a6069e28a2.yml
+++ b/data/la/legislature/Kyle-M-Green-Jr-8ffaa2bd-ff67-464a-b639-19a6069e28a2.yml
@@ -27,4 +27,4 @@ extras:
   representing parishes:
   - Jefferson
   education: Archbishop Shaw High School, 2005; Southern University, B.A., Political
-    Science 2009; Southern University Law Center, J.D., 2015
+             Science 2009; Southern University Law Center, J.D., 2015

--- a/data/la/legislature/Larry-Selders-52035a94-6995-4ea4-b463-1109d683048b.yml
+++ b/data/la/legislature/Larry-Selders-52035a94-6995-4ea4-b463-1109d683048b.yml
@@ -12,7 +12,7 @@ roles:
   district: '67'
 offices:
 - classification: district
-  address: 251 Florida Street Suite 300 Baton Rouge, LA 70801
+  address: 251 Florida Street, Suite 300 Baton Rouge, LA 70801
   voice: 225-342-7106
   fax: 225-342-7117
 links:

--- a/data/la/legislature/Laurie-Schlegel-1dbd875c-89b6-4ea1-a73b-7c8efdb203a3.yml
+++ b/data/la/legislature/Laurie-Schlegel-1dbd875c-89b6-4ea1-a73b-7c8efdb203a3.yml
@@ -24,5 +24,4 @@ extras:
   legislative assistant: Jean-Pierre Risey
   representing parishes:
   - Jefferson
-  education: "Master of Arts-Marriage and Family Counseling\r\nBachelor of Science-\
-    \ Psychology"
+  education: "Master of Arts-Marriage and Family Counseling; Bachelor of Science-Psychology"

--- a/data/la/legislature/Laurie-Schlegel-1dbd875c-89b6-4ea1-a73b-7c8efdb203a3.yml
+++ b/data/la/legislature/Laurie-Schlegel-1dbd875c-89b6-4ea1-a73b-7c8efdb203a3.yml
@@ -12,7 +12,7 @@ roles:
   district: '82'
 offices:
 - classification: district
-  address: 3238 Metairie Road Suite B Metairie, LA 70001
+  address: 3238 Metairie Road, Suite B Metairie, LA 70001
   voice: 504-655-6887
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=82
@@ -24,4 +24,5 @@ extras:
   legislative assistant: Jean-Pierre Risey
   representing parishes:
   - Jefferson
-  education: "Master of Arts-Marriage and Family Counseling\r\nBachelor of Science-Psychology"
+  education: "Master of Arts-Marriage and Family Counseling\r\nBachelor of Science-\
+    \ Psychology"

--- a/data/la/legislature/Lawrence-A-Larry-Bagley-d6e47850-c123-4060-8309-74192011981b.yml
+++ b/data/la/legislature/Lawrence-A-Larry-Bagley-d6e47850-c123-4060-8309-74192011981b.yml
@@ -12,7 +12,7 @@ roles:
   district: '7'
 offices:
 - classification: district
-  address: 671 Hwy. 171 Suite E Stonewall, LA 71078
+  address: 671 Hwy. 171, Suite E Stonewall, LA 71078
   voice: 318-925-9588
   fax: 318-925-9590
 links:
@@ -35,4 +35,5 @@ extras:
   - Caddo
   - DeSoto
   - and Sabine
-  education: Baptist Christian College, B.A.; Stephen F. Austin State University, Master's Degree; Northwestern State University, Plus 30
+  education: Baptist Christian College, B.A.; Stephen F. Austin State University,
+    Master's Degree; Northwestern State University, Plus 30

--- a/data/la/legislature/Lawrence-A-Larry-Bagley-d6e47850-c123-4060-8309-74192011981b.yml
+++ b/data/la/legislature/Lawrence-A-Larry-Bagley-d6e47850-c123-4060-8309-74192011981b.yml
@@ -36,4 +36,4 @@ extras:
   - DeSoto
   - and Sabine
   education: Baptist Christian College, B.A.; Stephen F. Austin State University,
-    Master's Degree; Northwestern State University, Plus 30
+             Master's Degree; Northwestern State University, Plus 30

--- a/data/la/legislature/Mack-Marcel-Cormier-8d31e132-1a5d-4340-bcb1-0f8e093b004d.yml
+++ b/data/la/legislature/Mack-Marcel-Cormier-8d31e132-1a5d-4340-bcb1-0f8e093b004d.yml
@@ -12,10 +12,8 @@ roles:
   district: '105'
 offices:
 - classification: district
-  address: 8857 Highway 23 Belle Chasse, LA 70037
+  address: 'Physical Address: 8857 Highway 23 Belle Chasse, LA 70037'
   voice: 504-356-3013
-- classification: district
-  address: P.O. Box 518 Belle Chasse, LA 70037
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=105
   note: homepage

--- a/data/la/legislature/Malinda-B-White-1537769d-0c74-4c69-91ab-fa35e50c813e.yml
+++ b/data/la/legislature/Malinda-B-White-1537769d-0c74-4c69-91ab-fa35e50c813e.yml
@@ -17,7 +17,7 @@ roles:
   district: '75'
 offices:
 - classification: district
-  address: 116 Georgia Ave. Suite B Bogalusa, LA 70427
+  address: 116 Georgia Ave., Suite B Bogalusa, LA 70427
   voice: 985-730-2147
   fax: 985-730-2149
 links:

--- a/data/la/legislature/Mandie-Landry-6e106343-c9e7-4993-aca8-201210f61d64.yml
+++ b/data/la/legislature/Mandie-Landry-6e106343-c9e7-4993-aca8-201210f61d64.yml
@@ -24,5 +24,5 @@ extras:
   legislative assistant: Nicole Hershey
   representing parishes:
   - Orleans
-  education: "University of Notre Dame, B.A., 2000; \r\nGeorgetown University Law\
-    \ Center, JD, 2005"
+  education: "University of Notre Dame, B.A., 2000; Georgetown University Law
+              Center, JD, 2005"

--- a/data/la/legislature/Mandie-Landry-6e106343-c9e7-4993-aca8-201210f61d64.yml
+++ b/data/la/legislature/Mandie-Landry-6e106343-c9e7-4993-aca8-201210f61d64.yml
@@ -12,7 +12,7 @@ roles:
   district: '91'
 offices:
 - classification: district
-  address: 3915 Baronne Street Unit 1 New Orleans, LA 70115
+  address: 3915 Baronne Street, Unit 1 New Orleans, LA 70115
   voice: 504-895-2526
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=91
@@ -24,4 +24,5 @@ extras:
   legislative assistant: Nicole Hershey
   representing parishes:
   - Orleans
-  education: "University of Notre Dame, B.A., 2000; \r\nGeorgetown University Law Center, JD, 2005"
+  education: "University of Notre Dame, B.A., 2000; \r\nGeorgetown University Law\
+    \ Center, JD, 2005"

--- a/data/la/legislature/Marcus-Anthony-Bryant-4d1c2a6e-0339-4b7a-ac52-dfd9064bfbbf.yml
+++ b/data/la/legislature/Marcus-Anthony-Bryant-4d1c2a6e-0339-4b7a-ac52-dfd9064bfbbf.yml
@@ -10,7 +10,7 @@ roles:
   district: '96'
 offices:
 - classification: district
-  address: 209 West Main Street Suite 405 New Iberia, LA 70560
+  address: 209 West Main Street, Suite 405 New Iberia, LA 70560
   voice: 337-373-9380
   fax: 337-373-9382
 links:

--- a/data/la/legislature/Mark-Wright-d3ecec03-0408-46f0-8c82-b775f787e6e1.yml
+++ b/data/la/legislature/Mark-Wright-d3ecec03-0408-46f0-8c82-b775f787e6e1.yml
@@ -12,7 +12,7 @@ roles:
   district: '77'
 offices:
 - classification: district
-  address: 312 South Jefferson Street Suite A & B Covington, LA 70433
+  address: 312 South Jefferson Street , Suite A & B Covington, LA 70433
   voice: 985-893-6262
   fax: 985-893-6261
 links:

--- a/data/la/legislature/Matthew-Willard-834e887f-c79d-44ed-be47-74571a792249.yml
+++ b/data/la/legislature/Matthew-Willard-834e887f-c79d-44ed-be47-74571a792249.yml
@@ -12,7 +12,7 @@ roles:
   district: '97'
 offices:
 - classification: district
-  address: 2021 Lakeshore Drive Suite 140 New Orleans, LA 70122
+  address: 2021 Lakeshore Drive, Suite 140 New Orleans, LA 70122
   voice: 504-283-4261
   fax: 504-283-4263
 links:

--- a/data/la/legislature/Michael-Charles-Echols-22590bd7-29fe-454d-b61d-2c54c4562274.yml
+++ b/data/la/legislature/Michael-Charles-Echols-22590bd7-29fe-454d-b61d-2c54c4562274.yml
@@ -10,7 +10,7 @@ roles:
   district: '14'
 offices:
 - classification: district
-  address: 8823 Highway 165 N. Suite 1 Monroe, LA 71203
+  address: 8823 Highway 165 N., Suite 1 Monroe, LA 71203
   voice: 318-598-4010
   fax: 318-598-4019
 links:
@@ -25,4 +25,5 @@ extras:
   legislative assistant: Jennifer Lord
   representing parishes:
   - Morehouse and Ouachita
-  education: University of Louisiana Monroe, B.S., Accounting; University Louisiana Monroe, MBA, Business
+  education: University of Louisiana Monroe, B.S., Accounting; University Louisiana
+    Monroe, MBA, Business

--- a/data/la/legislature/Michael-Charles-Echols-22590bd7-29fe-454d-b61d-2c54c4562274.yml
+++ b/data/la/legislature/Michael-Charles-Echols-22590bd7-29fe-454d-b61d-2c54c4562274.yml
@@ -26,4 +26,4 @@ extras:
   representing parishes:
   - Morehouse and Ouachita
   education: University of Louisiana Monroe, B.S., Accounting; University Louisiana
-    Monroe, MBA, Business
+             Monroe, MBA, Business

--- a/data/la/legislature/Michael-Gabe-Firment-50b42a20-9d29-4388-b06f-b4511eda2131.yml
+++ b/data/la/legislature/Michael-Gabe-Firment-50b42a20-9d29-4388-b06f-b4511eda2131.yml
@@ -15,8 +15,6 @@ offices:
   address: 'Physical Address: 181 Barron Road Pollock, LA 71467-3643'
   voice: 318-765-9606
   fax: 318-765-9607
-- classification: district
-  address: 'Mailing: P. O. Box 640 Pollock, LA 71467'
 links:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=22
   note: homepage

--- a/data/la/legislature/Mike-Reese-723f3444-f927-44b0-8659-7ac00370aa92.yml
+++ b/data/la/legislature/Mike-Reese-723f3444-f927-44b0-8659-7ac00370aa92.yml
@@ -14,10 +14,6 @@ offices:
 - classification: district
   address: 1111 South 5th Street Suite E Leesville, LA 71446
   voice: 337-238-6435
-- classification: district
-  address: 218 West 4th Street DeQuincy, LA 70633
-- classification: district
-  address: 401 West 1st Street DeRidder, LA 70634
 links:
 - url: https://senate.la.gov/smembers.aspx?ID=30
   note: homepage

--- a/data/la/legislature/Patricia-Moore-88548c7a-b637-4821-b336-c99cfa475e22.yml
+++ b/data/la/legislature/Patricia-Moore-88548c7a-b637-4821-b336-c99cfa475e22.yml
@@ -29,5 +29,4 @@ extras:
   legislative assistant: Shontae Johnson
   representing parishes:
   - Ouachita
-  education: "Wossman High School;\r\nNortheast Louisiana University/ ULM- College\
-    \ of Business"
+  education: "Wossman High School; Northeast Louisiana University, ULM College of Business"

--- a/data/la/legislature/Patricia-Moore-88548c7a-b637-4821-b336-c99cfa475e22.yml
+++ b/data/la/legislature/Patricia-Moore-88548c7a-b637-4821-b336-c99cfa475e22.yml
@@ -12,7 +12,7 @@ roles:
   district: '17'
 offices:
 - classification: district
-  address: 300 Washington Street Suite 308 Monroe, LA 71201
+  address: 300 Washington Street, Suite 308 Monroe, LA 71201
   voice: 318-362-3014
   fax: 318-362-3019
 links:
@@ -29,4 +29,5 @@ extras:
   legislative assistant: Shontae Johnson
   representing parishes:
   - Ouachita
-  education: "Wossman High School;\r\nNortheast Louisiana University/ ULM- College of Business"
+  education: "Wossman High School;\r\nNortheast Louisiana University/ ULM- College\
+    \ of Business"

--- a/data/la/legislature/Paul-Hollis-a78e621d-059e-4359-8de6-add1ea897274.yml
+++ b/data/la/legislature/Paul-Hollis-a78e621d-059e-4359-8de6-add1ea897274.yml
@@ -12,7 +12,7 @@ roles:
   district: '104'
 offices:
 - classification: district
-  address: 600 N. Highway 190 Suite 202A Covington, LA 70433-5083
+  address: 600 N. Highway 190, Suite 202A Covington, LA 70433-5083
   voice: 985-871-4680
   fax: 985-871-4682
 links:

--- a/data/la/legislature/Paula-P-Davis-386a6e17-a7e7-4715-8420-5e10bf52dcc1.yml
+++ b/data/la/legislature/Paula-P-Davis-386a6e17-a7e7-4715-8420-5e10bf52dcc1.yml
@@ -12,7 +12,7 @@ roles:
   district: '69'
 offices:
 - classification: district
-  address: 7902 Wrenwood Blvd. Suite D Baton Rouge, LA 70809
+  address: 7902 Wrenwood Blvd., Suite D Baton Rouge, LA 70809
   voice: 225-362-5301
   fax: 225-362-5303
 links:
@@ -33,4 +33,5 @@ extras:
   legislative assistant: Bonnie Kolb
   representing parishes:
   - East Baton Rouge
-  education: Breaux Bridge High School; Louisiana State University, B.A., Political Science; LSU School of Government, Fellow
+  education: Breaux Bridge High School; Louisiana State University, B.A., Political
+    Science; LSU School of Government, Fellow

--- a/data/la/legislature/Paula-P-Davis-386a6e17-a7e7-4715-8420-5e10bf52dcc1.yml
+++ b/data/la/legislature/Paula-P-Davis-386a6e17-a7e7-4715-8420-5e10bf52dcc1.yml
@@ -34,4 +34,4 @@ extras:
   representing parishes:
   - East Baton Rouge
   education: Breaux Bridge High School; Louisiana State University, B.A., Political
-    Science; LSU School of Government, Fellow
+             Science; LSU School of Government, Fellow

--- a/data/la/legislature/Polly-Thomas-d95410b8-a66c-4662-bcc6-1884252e061b.yml
+++ b/data/la/legislature/Polly-Thomas-d95410b8-a66c-4662-bcc6-1884252e061b.yml
@@ -30,4 +30,6 @@ extras:
   legislative assistant: Jill Scudari
   representing parishes:
   - Jefferson
-  education: University of Southwestern Louisiana, B.A., Speech Pathology and Audiology, 1969; Texas A&M University, M.S., Educational Psychology, 1974; Texas A&M University,Ph.D., Educational Psychology, 1977
+  education: University of Southwestern Louisiana, B.A., Speech Pathology and Audiology,
+    1969; Texas A&M University, M.S., Educational Psychology, 1974; Texas A&M University,
+    Ph.D., Educational Psychology, 1977

--- a/data/la/legislature/Polly-Thomas-d95410b8-a66c-4662-bcc6-1884252e061b.yml
+++ b/data/la/legislature/Polly-Thomas-d95410b8-a66c-4662-bcc6-1884252e061b.yml
@@ -31,5 +31,5 @@ extras:
   representing parishes:
   - Jefferson
   education: University of Southwestern Louisiana, B.A., Speech Pathology and Audiology,
-    1969; Texas A&M University, M.S., Educational Psychology, 1974; Texas A&M University,
-    Ph.D., Educational Psychology, 1977
+             1969; Texas A&M University, M.S., Educational Psychology, 1974;
+             Texas A&M University, Ph.D., Educational Psychology, 1977

--- a/data/la/legislature/Randal-L-Gaines-c8fa77d4-2453-4953-b87a-1c58d841ce97.yml
+++ b/data/la/legislature/Randal-L-Gaines-c8fa77d4-2453-4953-b87a-1c58d841ce97.yml
@@ -12,7 +12,7 @@ roles:
   district: '57'
 offices:
 - classification: district
-  address: 425 W. Airline Hwy. Suite K LaPlace, LA 70068-3818
+  address: 425 W. Airline Hwy., Suite K LaPlace, LA 70068-3818
   voice: 985-652-1228
   fax: 985-652-1229
 links:

--- a/data/la/legislature/Raymond-J-Crews-126879ce-50c0-4741-a7e7-fb23fecb9d29.yml
+++ b/data/la/legislature/Raymond-J-Crews-126879ce-50c0-4741-a7e7-fb23fecb9d29.yml
@@ -12,7 +12,7 @@ roles:
   district: '8'
 offices:
 - classification: district
-  address: 4921 Shed Road Suite 200 Bossier City, LA 71111-5477
+  address: 4921 Shed Road, Suite 200 Bossier City, LA 71111-5477
   voice: 318-716-7532
   fax: 318-239-1677
 links:

--- a/data/la/legislature/Rick-Edmonds-e49647e3-b5c3-4329-9472-27048115441c.yml
+++ b/data/la/legislature/Rick-Edmonds-e49647e3-b5c3-4329-9472-27048115441c.yml
@@ -12,7 +12,7 @@ roles:
   district: '66'
 offices:
 - classification: district
-  address: 3931 S. Sherwood Forest Blvd. Suite 200 Baton Rouge, LA 70816
+  address: 3931 S. Sherwood Forest Blvd., Suite 200 Baton Rouge, LA 70816
   voice: 225-295-9240
   fax: 225-295-9242
 links:
@@ -27,7 +27,8 @@ sources:
 - url: https://house.louisiana.gov/H_Reps/members.aspx?ID=66
 - url: https://house.louisiana.gov/H_Reps/H_Reps_FullInfo
 extras:
-  legislative assistant: Dera "Fay" Ayers
+  legislative assistant: Zoe McRaney and Dera "Fay" Ayers
   representing parishes:
   - East Baton Rouge
-  education: Fair Park High School; East Texas Baptist University, B.A.; New Orleans Baptist Theological Seminary, M.Div., Doctoral Studies
+  education: Fair Park High School; East Texas Baptist University, B.A.; New Orleans
+    Baptist Theological Seminary, M.Div., Doctoral Studies

--- a/data/la/legislature/Rick-Edmonds-e49647e3-b5c3-4329-9472-27048115441c.yml
+++ b/data/la/legislature/Rick-Edmonds-e49647e3-b5c3-4329-9472-27048115441c.yml
@@ -31,4 +31,4 @@ extras:
   representing parishes:
   - East Baton Rouge
   education: Fair Park High School; East Texas Baptist University, B.A.; New Orleans
-    Baptist Theological Seminary, M.Div., Doctoral Studies
+             Baptist Theological Seminary, M.Div., Doctoral Studies

--- a/data/la/legislature/Robert-Bob-Stanford-Owen-a4aea235-ac61-4183-9ec9-f0e475e2cb5e.yml
+++ b/data/la/legislature/Robert-Bob-Stanford-Owen-a4aea235-ac61-4183-9ec9-f0e475e2cb5e.yml
@@ -10,7 +10,7 @@ roles:
   district: '76'
 offices:
 - classification: district
-  address: 1925 Corporate Square Blvd. Suite C Slidell, LA 70458
+  address: 1925 Corporate Square Blvd., Suite C Slidell, LA 70458
   voice: 985-639-0400
   fax: 985-639-0402
 links:

--- a/data/la/legislature/Rodney-Lyons-71696836-b261-4646-8127-407c40e2c35b.yml
+++ b/data/la/legislature/Rodney-Lyons-71696836-b261-4646-8127-407c40e2c35b.yml
@@ -12,7 +12,7 @@ roles:
   district: '87'
 offices:
 - classification: district
-  address: 5201 Westbank Expressway Suite 114 Marrero, LA 70072
+  address: 5201 Westbank Expressway, Suite 114 Marrero, LA 70072
   voice: 504-510-5417
   fax: 504-349-8704
 links:

--- a/data/la/legislature/Royce-Duplessis-7d852e7a-ae99-4f89-b4c0-4d7cb7e816db.yml
+++ b/data/la/legislature/Royce-Duplessis-7d852e7a-ae99-4f89-b4c0-4d7cb7e816db.yml
@@ -11,7 +11,8 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:la/government
   district: '93'
-- type: upper
+- start_date: '2022-12-06'
+  type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:la/government
   district: '5'
 offices:

--- a/data/la/legislature/Ryan-Joseph-Bourriaque-85ef927c-d038-4534-a8ff-b99ad6656bda.yml
+++ b/data/la/legislature/Ryan-Joseph-Bourriaque-85ef927c-d038-4534-a8ff-b99ad6656bda.yml
@@ -29,6 +29,6 @@ extras:
   - Calcasieu
   - Cameron
   - and Vermilion
-  education: "Bachelors Degree in Psychology  (Louisiana State University)\r\nMasters\
-    \ in Agricultural Economics with a concentration in Natural Resource Economics\
-    \ and Environmental Policy, (Louisiana State University)"
+  education: "Bachelors Degree in Psychology  (Louisiana State University; Masters
+              in Agricultural Economics with a concentration in Natural Resource
+              Economics and Environmental Policy, (Louisiana State University)"

--- a/data/la/legislature/Ryan-Joseph-Bourriaque-85ef927c-d038-4534-a8ff-b99ad6656bda.yml
+++ b/data/la/legislature/Ryan-Joseph-Bourriaque-85ef927c-d038-4534-a8ff-b99ad6656bda.yml
@@ -12,7 +12,7 @@ roles:
   district: '47'
 offices:
 - classification: district
-  address: 122 North State Street Suite 100 Abbeville, LA 70510
+  address: 122 North State Street, Suite 100 Abbeville, LA 70510
   voice: 337-893-5035
   fax: 337-740-5035
 links:
@@ -29,4 +29,6 @@ extras:
   - Calcasieu
   - Cameron
   - and Vermilion
-  education: "Bachelors Degree in Psychology  (Louisiana State University)\r\nMasters in Agricultural Economics with a concentration in Natural Resource Economics and Environmental Policy, (Louisiana State University)"
+  education: "Bachelors Degree in Psychology  (Louisiana State University)\r\nMasters\
+    \ in Agricultural Economics with a concentration in Natural Resource Economics\
+    \ and Environmental Policy, (Louisiana State University)"

--- a/data/la/legislature/Sharon-Hewitt-33f8b98a-fb55-4b02-bf90-7254466f969f.yml
+++ b/data/la/legislature/Sharon-Hewitt-33f8b98a-fb55-4b02-bf90-7254466f969f.yml
@@ -15,8 +15,6 @@ offices:
   address: 250 Bouscaren Street Suite 201 Slidell, LA 70458
   voice: 985-646-6490
   fax: 985-646-6497
-- classification: district
-  address: 100 Port Boulevard Suite 20 Chalmette, LA 70043
 links:
 - url: https://senate.la.gov/smembers.aspx?ID=1
   note: homepage

--- a/data/la/legislature/Stephanie-Hilferty-de7591e7-6ae0-47c3-b1ea-12073106498c.yml
+++ b/data/la/legislature/Stephanie-Hilferty-de7591e7-6ae0-47c3-b1ea-12073106498c.yml
@@ -12,7 +12,7 @@ roles:
   district: '94'
 offices:
 - classification: district
-  address: 3331 Severn Ave. Suite 206 Metairie, LA 70002
+  address: 3331 Severn Ave., Suite 206 Metairie, LA 70002
   voice: 504-885-4154
   fax: 504-885-4156
 links:

--- a/data/la/legislature/Tammy-T-Phelps-a838e3b6-52ea-4ad0-a308-2337762a492b.yml
+++ b/data/la/legislature/Tammy-T-Phelps-a838e3b6-52ea-4ad0-a308-2337762a492b.yml
@@ -10,7 +10,7 @@ roles:
   district: '3'
 offices:
 - classification: district
-  address: 810 E. 70th Street Suite A Shreveport, LA 71106
+  address: 810 E. 70th Street, Suite A Shreveport, LA 71106
   voice: 318-862-3080
   fax: 318-862-3088
 links:
@@ -25,4 +25,5 @@ extras:
   legislative assistant: Belinda Rose
   representing parishes:
   - Caddo
-  education: Captain Shreve High School; Amberton University, Strategic Leadership M.B.A.; Louisiana Tech. University, Business Administration, B.S.
+  education: Captain Shreve High School; Amberton University, Strategic Leadership
+    M.B.A.; Louisiana Tech. University, Business Administration, B.S.

--- a/data/la/legislature/Tammy-T-Phelps-a838e3b6-52ea-4ad0-a308-2337762a492b.yml
+++ b/data/la/legislature/Tammy-T-Phelps-a838e3b6-52ea-4ad0-a308-2337762a492b.yml
@@ -26,4 +26,4 @@ extras:
   representing parishes:
   - Caddo
   education: Captain Shreve High School; Amberton University, Strategic Leadership
-    M.B.A.; Louisiana Tech. University, Business Administration, B.S.
+             M.B.A.; Louisiana Tech. University, Business Administration, B.S.

--- a/data/la/legislature/Thomas-Alexander-Pressly-IV-e6a15fa6-85e2-4e5b-b267-202a5cc1f01a.yml
+++ b/data/la/legislature/Thomas-Alexander-Pressly-IV-e6a15fa6-85e2-4e5b-b267-202a5cc1f01a.yml
@@ -10,7 +10,7 @@ roles:
   district: '6'
 offices:
 - classification: district
-  address: 900 Pierremont Road Suite 119 Shreveport, LA 71106
+  address: 900 Pierremont Road, Suite 119 Shreveport, LA 71106
   voice: 318-862-9920
   fax: 318-862-9922
 links:
@@ -26,4 +26,5 @@ extras:
   legislative assistant: Laurie Kerr
   representing parishes:
   - Bossier and Caddo
-  education: C. E. Byrd High School, 2005; Texas Christian University, B.S., 2009; Loyola University New Orleans College of Law, JD, 2013
+  education: C. E. Byrd High School, 2005; Texas Christian University, B.S., 2009;
+    Loyola University New Orleans College of Law, JD, 2013

--- a/data/la/legislature/Thomas-Alexander-Pressly-IV-e6a15fa6-85e2-4e5b-b267-202a5cc1f01a.yml
+++ b/data/la/legislature/Thomas-Alexander-Pressly-IV-e6a15fa6-85e2-4e5b-b267-202a5cc1f01a.yml
@@ -27,4 +27,4 @@ extras:
   representing parishes:
   - Bossier and Caddo
   education: C. E. Byrd High School, 2005; Texas Christian University, B.S., 2009;
-    Loyola University New Orleans College of Law, JD, 2013
+             Loyola University New Orleans College of Law, JD, 2013

--- a/data/la/legislature/Tony-Bacala-9fde5725-d1b2-4afc-9897-2706dda502c8.yml
+++ b/data/la/legislature/Tony-Bacala-9fde5725-d1b2-4afc-9897-2706dda502c8.yml
@@ -12,7 +12,7 @@ roles:
   district: '59'
 offices:
 - classification: district
-  address: 15482 Airline Hwy. Suite A Prairieville, LA 70769
+  address: 15482 Airline Hwy., Suite A Prairieville, LA 70769
   voice: 225-677-8020
   fax: 225-677-8022
 links:
@@ -30,4 +30,5 @@ extras:
   legislative assistant: Donna Hebert
   representing parishes:
   - Ascension
-  education: Louisiana State University, Bachelor's Degree, 1982; FBI National Academy, 2004
+  education: Louisiana State University, Bachelor's Degree, 1982; FBI National Academy,
+    2004

--- a/data/la/legislature/Tony-Bacala-9fde5725-d1b2-4afc-9897-2706dda502c8.yml
+++ b/data/la/legislature/Tony-Bacala-9fde5725-d1b2-4afc-9897-2706dda502c8.yml
@@ -31,4 +31,4 @@ extras:
   representing parishes:
   - Ascension
   education: Louisiana State University, Bachelor's Degree, 1982; FBI National Academy,
-    2004
+             2004

--- a/data/la/legislature/Valarie-Hodges-33e76c3a-a834-444c-9872-fc2af5c83837.yml
+++ b/data/la/legislature/Valarie-Hodges-33e76c3a-a834-444c-9872-fc2af5c83837.yml
@@ -35,4 +35,4 @@ extras:
   representing parishes:
   - East Baton Rouge and Livingston
   education: Glen Oaks High School, Baton Rouge; Bob Brooks School of Real Estate,
-    Baton Rouge; Light University course work; Louisiana State University
+             Baton Rouge; Light University course work; Louisiana State University

--- a/data/la/legislature/Valarie-Hodges-33e76c3a-a834-444c-9872-fc2af5c83837.yml
+++ b/data/la/legislature/Valarie-Hodges-33e76c3a-a834-444c-9872-fc2af5c83837.yml
@@ -12,7 +12,7 @@ roles:
   district: '64'
 offices:
 - classification: district
-  address: 35055 La. Hwy. 16 Suite 2A Denham Springs, LA 70706
+  address: 35055 La. Hwy. 16, Suite 2A Denham Springs, LA 70706
   voice: 225-791-2199
   fax: 225-791-9203
 links:
@@ -34,4 +34,5 @@ extras:
   legislative assistant: Victoria L. Hymel
   representing parishes:
   - East Baton Rouge and Livingston
-  education: Glen Oaks High School, Baton Rouge; Bob Brooks School of Real Estate, Baton Rouge; Light University course work; Louisiana State University
+  education: Glen Oaks High School, Baton Rouge; Bob Brooks School of Real Estate,
+    Baton Rouge; Light University course work; Louisiana State University

--- a/data/la/legislature/Vanessa-Caston-LaFleur-9510158f-4e63-4b68-ad44-daef2987b780.yml
+++ b/data/la/legislature/Vanessa-Caston-LaFleur-9510158f-4e63-4b68-ad44-daef2987b780.yml
@@ -26,5 +26,5 @@ extras:
   legislative assistant: Phyllis P. Moncriffe, JD
   representing parishes:
   - East Baton Rouge
-  education: "Baton Rouge Magnet High School,\r\nSouthern University and A&M College\
-    \ and\r\nSouthern University Law Center"
+  education: "Baton Rouge Magnet High School,\r\nSouthern University and A&M College
+              and Southern University Law Center"

--- a/data/la/legislature/Vanessa-Caston-LaFleur-9510158f-4e63-4b68-ad44-daef2987b780.yml
+++ b/data/la/legislature/Vanessa-Caston-LaFleur-9510158f-4e63-4b68-ad44-daef2987b780.yml
@@ -26,4 +26,5 @@ extras:
   legislative assistant: Phyllis P. Moncriffe, JD
   representing parishes:
   - East Baton Rouge
-  education: "Baton Rouge Magnet High School,\r\nSouthern University A&M College and Southern University Law Center"
+  education: "Baton Rouge Magnet High School,\r\nSouthern University and A&M College\
+    \ and\r\nSouthern University Law Center"

--- a/settings.yml
+++ b/settings.yml
@@ -24,11 +24,6 @@ ky:
   - chamber: upper
     district: '28'
     vacant_until: 2023-05-16
-la:
-  vacancies:
-  - chamber: lower
-    district: '93'
-    vacant_until: 2023-04-09
 md:
   vacancies:
   - chamber: upper


### PR DESCRIPTION
This PR makes three categories of changes.

1. Updates committee data to include all members (based on a fix to the committees scraper)
2. Updates people data to include a filled vacancy, and remove extra district offices
3. Removes `vacancies` for LA from `settings.yml` because all vacancies have been filled for the jurisdiction at this time