### PR TITLE
PA: update Sen Rothman & remove from lower committees

### DIFF
--- a/data/pa/committees/lower-Appropriations-e50fbc1f-5bbb-4fac-8e13-81944b24cab3.yml
+++ b/data/pa/committees/lower-Appropriations-e50fbc1f-5bbb-4fac-8e13-81944b24cab3.yml
@@ -63,9 +63,6 @@ members:
 - name: Christopher B. Quinn
   role: member
   person_id: ocd-person/d6358ed3-bd9b-4299-ba0a-e5449b38ecd4
-- name: Greg Rothman
-  role: member
-  person_id: ocd-person/3e99b4f3-2efa-4330-b0b9-fb273b1322ea
 - name: Louis C. Schmitt, Jr.
   role: member
   person_id: ocd-person/e19d3bae-7d48-4e27-af66-e9453633edca

--- a/data/pa/committees/lower-Insurance-1720a030-ad6f-4f43-bf17-d53c15bbbece.yml
+++ b/data/pa/committees/lower-Insurance-1720a030-ad6f-4f43-bf17-d53c15bbbece.yml
@@ -48,9 +48,6 @@ members:
 - name: Christopher B. Quinn
   role: member
   person_id: ocd-person/d6358ed3-bd9b-4299-ba0a-e5449b38ecd4
-- name: Greg Rothman
-  role: member
-  person_id: ocd-person/3e99b4f3-2efa-4330-b0b9-fb273b1322ea
 - name: Louis C. Schmitt, Jr.
   role: member
   person_id: ocd-person/e19d3bae-7d48-4e27-af66-e9453633edca

--- a/data/pa/committees/lower-Liquor-Control-60fbf516-a187-4d9a-bcde-dea8ed90ce28.yml
+++ b/data/pa/committees/lower-Liquor-Control-60fbf516-a187-4d9a-bcde-dea8ed90ce28.yml
@@ -51,9 +51,6 @@ members:
 - name: Jim Rigby
   role: Member
   person_id: ocd-person/343e541b-fbd3-4622-bf42-7843494b1714
-- name: Greg Rothman
-  role: member
-  person_id: ocd-person/3e99b4f3-2efa-4330-b0b9-fb273b1322ea
 - name: Brian Smith
   role: Member
   person_id: ocd-person/ac7d02d3-9bb7-4cc1-8cee-4283094fe604

--- a/data/pa/committees/lower-Transportation-71f8f6b1-77e9-44bb-a73a-7f868c8ad11c.yml
+++ b/data/pa/committees/lower-Transportation-71f8f6b1-77e9-44bb-a73a-7f868c8ad11c.yml
@@ -30,9 +30,6 @@ members:
 - name: Mindy Fee
   role: Subcommittee Chair on Transportation Safety
   person_id: ocd-person/f5b2ec4d-1d69-483a-a6ec-143d50ad395b
-- name: Greg Rothman
-  role: Subcommittee Chair on Aviation
-  person_id: ocd-person/3e99b4f3-2efa-4330-b0b9-fb273b1322ea
 - name: Louis C. Schmitt, Jr.
   role: Subcommittee Chair on Railroads
   person_id: ocd-person/e19d3bae-7d48-4e27-af66-e9453633edca

--- a/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
+++ b/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
@@ -36,6 +36,8 @@ ids:
 other_identifiers:
 - scheme: legacy_openstates
   identifier: PAL000529
+- scheme: openstates
+  identifier: ocd-person/561016b3-8903-4b9a-abf3-46e36771b1fe
 sources:
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/representatives_alpha.cfm
 - url: http://www.legis.state.pa.us/cfdocs/legis/home/member_information/House_bio.cfm?id=1733

--- a/settings.yml
+++ b/settings.yml
@@ -38,4 +38,4 @@ wi:
   vacancies:
   - chamber: upper
     district: '8'
-    vacant_until: 2023-04-19
+    vacant_until: 2023-05-19


### PR DESCRIPTION
He has 2 ocd ids now, one for when he was a Representative & now senator. Adds his senatorial id to the `other_identifiers` & removes him from House committees that he's no longer a member of.