### PR TITLE
don't require specific indentation for multi-line strings

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -33,4 +33,4 @@ rules:
   indentation:
     spaces: consistent
     indent-sequences: whatever
-    check-multi-line-strings: true
+    check-multi-line-strings: false


### PR DESCRIPTION
This should help with the random indentation that many of the scrapers produce.