### PR TITLE
Add Chicago Mayor

### DIFF
--- a/data/il/municipalities/Brandon-Johnson-53d852f6-5c1f-47d4-861d-1505dae7f07c.yml
+++ b/data/il/municipalities/Brandon-Johnson-53d852f6-5c1f-47d4-861d-1505dae7f07c.yml
@@ -1,0 +1,18 @@
+id: ocd-person/53d852f6-5c1f-47d4-861d-1505dae7f07c
+name: Brandon Johnson
+given_name: Brandon
+family_name: Johnson
+email: letterforthemayor@cityofchicago.org
+roles:
+- start_date: '2023-05-15'
+  end_date: '2027-05-16'
+  type: mayor
+  jurisdiction: ocd-jurisdiction/country:us/state:il/place:chicago/government
+offices:
+- classification: primary
+  address: 121 N LaSalle Street, 4th Floor;Chicago, IL 60602
+  voice: 312-744-9500
+links:
+- url: https://webapps1.chicago.gov/eforms/contactUsForm
+sources:
+- url: https://webapps1.chicago.gov/eforms/contactUsForm


### PR DESCRIPTION
Brandon Johnson was [inaugurated today](https://abc7chicago.com/chicago-mayor-brandon-johnson-inauguration-livestream-credit-union-1-arena-mayoral-2023/13249293/#:~:text=Brandon%20Johnson%20sworn%20in%20as%20Chicago%20mayor%20at%20inauguration%20ceremony&text=CHICAGO%20(WLS)%20%2D%2D%20Brandon%20Johnson,were%20also%20officially%20sworn%20in.)