### PR TITLE
Correct MI 2023 term end date

### DIFF
--- a/data/mi/legislature/Amos-ONeal-5f160dff-1ce1-4606-a469-fdd08125beb4.yml
+++ b/data/mi/legislature/Amos-ONeal-5f160dff-1ce1-4606-a469-fdd08125beb4.yml
@@ -7,7 +7,7 @@ email: AmosOneal@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '95'

--- a/data/mi/legislature/Andrew-Beeler-77456985-a7be-4384-9dfe-70373b8031f6.yml
+++ b/data/mi/legislature/Andrew-Beeler-77456985-a7be-4384-9dfe-70373b8031f6.yml
@@ -7,7 +7,7 @@ email: AndrewBeeler@house.mi.gov
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '83'

--- a/data/mi/legislature/Brad-Paquette-04a88313-6387-44ab-972c-b000b3c316f4.yml
+++ b/data/mi/legislature/Brad-Paquette-04a88313-6387-44ab-972c-b000b3c316f4.yml
@@ -8,7 +8,7 @@ image: https://dtj5wlj7ond0z.cloudfront.net/uploads/2020/07/HS_PAQUETTE_0119.jpg
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '78'

--- a/data/mi/legislature/Curt-VanderWall-b0804883-3f8c-4341-bbc1-26a0346b37c4.yml
+++ b/data/mi/legislature/Curt-VanderWall-b0804883-3f8c-4341-bbc1-26a0346b37c4.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '101'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '35'

--- a/data/mi/legislature/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
+++ b/data/mi/legislature/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
@@ -13,7 +13,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '56'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '17'

--- a/data/mi/legislature/Darrin-Camilleri-5d2fbcb4-0e27-4cb5-99bf-f94693b3aa12.yml
+++ b/data/mi/legislature/Darrin-Camilleri-5d2fbcb4-0e27-4cb5-99bf-f94693b3aa12.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/camilleri/wp-content/uploads/sites/10/2022/12/Port
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '23'

--- a/data/mi/legislature/David-Martin-95434509-a8fd-4e25-9f04-a952416d6da3.yml
+++ b/data/mi/legislature/David-Martin-95434509-a8fd-4e25-9f04-a952416d6da3.yml
@@ -7,7 +7,7 @@ email: davidmartin@house.mi.gov
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '48'

--- a/data/mi/legislature/Erika-Geiss-ebc9981a-cbe1-4d37-99b0-89d3c350fd3f.yml
+++ b/data/mi/legislature/Erika-Geiss-ebc9981a-cbe1-4d37-99b0-89d3c350fd3f.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '12'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '6'

--- a/data/mi/legislature/Felicia-Brabec-ccfacab2-ec54-40f8-add5-2dfe02908055.yml
+++ b/data/mi/legislature/Felicia-Brabec-ccfacab2-ec54-40f8-add5-2dfe02908055.yml
@@ -7,7 +7,7 @@ email: FeliciaBrabec@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '55'

--- a/data/mi/legislature/Jeff-Irwin-a1c1163d-af8d-4b88-9365-07717d4a45c3.yml
+++ b/data/mi/legislature/Jeff-Irwin-a1c1163d-af8d-4b88-9365-07717d4a45c3.yml
@@ -13,7 +13,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '53'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '18'

--- a/data/mi/legislature/John-Cherry-de1a4de4-aa34-4487-98f8-27b140fed784.yml
+++ b/data/mi/legislature/John-Cherry-de1a4de4-aa34-4487-98f8-27b140fed784.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/cherry/wp-content/uploads/sites/22/2022/12/Portrai
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '49'

--- a/data/mi/legislature/John-Damoose-071e391f-da3d-4e66-ae78-61a63bc23729.yml
+++ b/data/mi/legislature/John-Damoose-071e391f-da3d-4e66-ae78-61a63bc23729.yml
@@ -8,7 +8,7 @@ image: https://www.misenategop.com/wp-content/uploads/2023/01/Damoose-580x770.jp
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '107'

--- a/data/mi/legislature/Jon-Bumstead-5a58fa81-639b-4304-87ca-7471ba9ade96.yml
+++ b/data/mi/legislature/Jon-Bumstead-5a58fa81-639b-4304-87ca-7471ba9ade96.yml
@@ -13,7 +13,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '100'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '34'

--- a/data/mi/legislature/Julie-Rogers-5154033e-e367-449c-a719-9437a309e269.yml
+++ b/data/mi/legislature/Julie-Rogers-5154033e-e367-449c-a719-9437a309e269.yml
@@ -7,7 +7,7 @@ email: JulieRogers@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '60'

--- a/data/mi/legislature/Kara-Hope-f5c9b37d-39a5-4c63-a526-6f35f45cf5cf.yml
+++ b/data/mi/legislature/Kara-Hope-f5c9b37d-39a5-4c63-a526-6f35f45cf5cf.yml
@@ -8,7 +8,7 @@ image: https://housedems.com/sites/default/files/Images/Representative_Images/D0
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '67'

--- a/data/mi/legislature/Kelly-Breen-6f366c7a-8dab-4d39-90b0-3a25760d2234.yml
+++ b/data/mi/legislature/Kelly-Breen-6f366c7a-8dab-4d39-90b0-3a25760d2234.yml
@@ -7,7 +7,7 @@ email: kellybreen@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '38'

--- a/data/mi/legislature/Kevin-Hertel-cbfd5eae-d312-4498-a988-bcb52883f637.yml
+++ b/data/mi/legislature/Kevin-Hertel-cbfd5eae-d312-4498-a988-bcb52883f637.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/hertel/wp-content/uploads/sites/16/2022/12/Hertel_
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '18'

--- a/data/mi/legislature/Laurie-Pohutsky-64f12acb-0356-4726-ab8e-0c9c1945d5b0.yml
+++ b/data/mi/legislature/Laurie-Pohutsky-64f12acb-0356-4726-ab8e-0c9c1945d5b0.yml
@@ -8,7 +8,7 @@ image: https://housedems.com/sites/default/files/Images/Representative_Images/D0
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '19'

--- a/data/mi/legislature/Lori-Stone-9b708d84-ceeb-4611-863c-9220dcc92b76.yml
+++ b/data/mi/legislature/Lori-Stone-9b708d84-ceeb-4611-863c-9220dcc92b76.yml
@@ -8,7 +8,7 @@ image: https://housedems.com/sites/default/files/Images/Representative_Images/D0
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '28'

--- a/data/mi/legislature/Mallory-McMorrow-dc6ff9c0-f2b1-433d-a96b-292cf05bcb50.yml
+++ b/data/mi/legislature/Mallory-McMorrow-dc6ff9c0-f2b1-433d-a96b-292cf05bcb50.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/mcmorrow/wp-content/uploads/sites/14/2023/02/MDS_M
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '13'

--- a/data/mi/legislature/Mark-Huizenga-8564d477-bb39-47a4-87e1-3ceacd7d3abe.yml
+++ b/data/mi/legislature/Mark-Huizenga-8564d477-bb39-47a4-87e1-3ceacd7d3abe.yml
@@ -14,7 +14,7 @@ roles:
   district: '74'
   end_reason: Elected to Michigan Senate
 - start_date: 2021-11-10
-  end_date: '2023-01-11'
+  end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '28'

--- a/data/mi/legislature/Mary-Cavanagh-a9e6b2e4-016d-481e-9f34-1f1b33d857ca.yml
+++ b/data/mi/legislature/Mary-Cavanagh-a9e6b2e4-016d-481e-9f34-1f1b33d857ca.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/cavanagh/wp-content/uploads/sites/12/2022/12/Cavan
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '10'

--- a/data/mi/legislature/Matt-Hall-dc7344e8-b8bf-4f0d-924d-4f4b5ea40554.yml
+++ b/data/mi/legislature/Matt-Hall-dc7344e8-b8bf-4f0d-924d-4f4b5ea40554.yml
@@ -8,7 +8,7 @@ image: https://dtj5wlj7ond0z.cloudfront.net/uploads/2023/01/Leader-Matt-Hall-hea
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '63'

--- a/data/mi/legislature/Matt-Koleszar-42a456fa-8979-468f-b2a6-30f81ff20299.yml
+++ b/data/mi/legislature/Matt-Koleszar-42a456fa-8979-468f-b2a6-30f81ff20299.yml
@@ -8,7 +8,7 @@ image: https://housedems.com/sites/default/files/Images/Representative_Images/D0
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '20'

--- a/data/mi/legislature/Paul-Wojno-1d71200f-5f95-46e8-ac9b-a35c6c0178d8.yml
+++ b/data/mi/legislature/Paul-Wojno-1d71200f-5f95-46e8-ac9b-a35c6c0178d8.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/wojno/wp-content/uploads/sites/3/2023/01/MDS_Wojno
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '9'

--- a/data/mi/legislature/Ranjeev-Puri-1a16bef8-b655-46da-a5c5-07a8c5569eed.yml
+++ b/data/mi/legislature/Ranjeev-Puri-1a16bef8-b655-46da-a5c5-07a8c5569eed.yml
@@ -7,7 +7,7 @@ email: ranjeevpuri@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '21'

--- a/data/mi/legislature/Regina-Weiss-ae5a3a48-9948-4c6c-95c2-c2d0915fd866.yml
+++ b/data/mi/legislature/Regina-Weiss-ae5a3a48-9948-4c6c-95c2-c2d0915fd866.yml
@@ -7,7 +7,7 @@ email: reginaweiss@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '27'

--- a/data/mi/legislature/Robert-Bezotte-f5b2c77c-88b8-4ea7-854a-789b660e5a91.yml
+++ b/data/mi/legislature/Robert-Bezotte-f5b2c77c-88b8-4ea7-854a-789b660e5a91.yml
@@ -7,7 +7,7 @@ email: robertbezotte@house.mi.gov
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '47'

--- a/data/mi/legislature/Roger-Hauck-b6d8b86d-2975-4d07-83fe-a1841f39806b.yml
+++ b/data/mi/legislature/Roger-Hauck-b6d8b86d-2975-4d07-83fe-a1841f39806b.yml
@@ -8,7 +8,7 @@ image: https://www.misenategop.com/wp-content/uploads/2023/01/Hauck-580x770.jpg
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '99'

--- a/data/mi/legislature/Roger-Victory-cd36ab04-a62b-41fa-8b91-d6c792f6719e.yml
+++ b/data/mi/legislature/Roger-Victory-cd36ab04-a62b-41fa-8b91-d6c792f6719e.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '88'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '30'

--- a/data/mi/legislature/Rosemary-Bayer-3e24c95f-2ed8-442a-a41f-1a3a9a0b95ed.yml
+++ b/data/mi/legislature/Rosemary-Bayer-3e24c95f-2ed8-442a-a41f-1a3a9a0b95ed.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/bayer/wp-content/uploads/sites/17/2022/12/Bayer-Of
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '12'

--- a/data/mi/legislature/Ruth-Johnson-8d0d58dd-a718-4f8f-bb7f-c530e039c0c5.yml
+++ b/data/mi/legislature/Ruth-Johnson-8d0d58dd-a718-4f8f-bb7f-c530e039c0c5.yml
@@ -8,7 +8,7 @@ image: https://www.misenategop.com/wp-content/uploads/2023/01/Johnson-580x770.jp
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '14'

--- a/data/mi/legislature/Sarah-Anthony-08eac592-a25a-444f-aea7-db0cdfa79e7b.yml
+++ b/data/mi/legislature/Sarah-Anthony-08eac592-a25a-444f-aea7-db0cdfa79e7b.yml
@@ -8,7 +8,7 @@ image: https://senatedems.com/anthony/wp-content/uploads/sites/21/2022/12/MDS_An
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '68'

--- a/data/mi/legislature/Sean-McCann-c15f272e-73f2-410c-8afe-1cc91ad3603a.yml
+++ b/data/mi/legislature/Sean-McCann-c15f272e-73f2-410c-8afe-1cc91ad3603a.yml
@@ -13,7 +13,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '60'
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '20'

--- a/data/mi/legislature/Stephanie-Young-ea254169-e403-4e29-ab06-8f40fb869ac2.yml
+++ b/data/mi/legislature/Stephanie-Young-ea254169-e403-4e29-ab06-8f40fb869ac2.yml
@@ -7,7 +7,7 @@ email: stephanieyoung@house.mi.gov
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '8'

--- a/data/mi/legislature/Thomas-Albert-c96aa62f-6a2c-4d37-9074-2c25875c639b.yml
+++ b/data/mi/legislature/Thomas-Albert-c96aa62f-6a2c-4d37-9074-2c25875c639b.yml
@@ -8,7 +8,7 @@ image: https://www.misenategop.com/wp-content/uploads/2023/01/Albert-580x770.jpg
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-11'
+- end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '86'


### PR DESCRIPTION
36 legislators had their end date set to Jan 11th but the official term end date is Jan 1st.