### PR TITLE
Add start dates for CO senators redistricted into new districts

### DIFF
--- a/data/co/legislature/Cleave-Simpson-715df6f2-cef6-4b88-b745-0207c8ffb4ff.yml
+++ b/data/co/legislature/Cleave-Simpson-715df6f2-cef6-4b88-b745-0207c8ffb4ff.yml
@@ -8,11 +8,12 @@ image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2023a
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-10'
+- end_date: '2023-01-08'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '35'
-- type: upper
+- start_date: '2023-01-09'
+  type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '6'
 offices:

--- a/data/co/legislature/Janet-Buckner-a7d01880-beeb-4183-8dfa-a3300600c062.yml
+++ b/data/co/legislature/Janet-Buckner-a7d01880-beeb-4183-8dfa-a3300600c062.yml
@@ -16,7 +16,8 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '28'
-- type: upper
+- start_date: '2023-01-09'
+  type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '29'
 offices:

--- a/data/co/legislature/Jim-Smallwood-e389192e-edc9-448f-a6ca-6a9eb800ae8e.yml
+++ b/data/co/legislature/Jim-Smallwood-e389192e-edc9-448f-a6ca-6a9eb800ae8e.yml
@@ -12,7 +12,8 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '4'
-- type: upper
+- start_date: '2023-01-09'
+  type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '2'
 offices:

--- a/data/co/legislature/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
+++ b/data/co/legislature/Rhonda-Fields-654b2a04-55a4-4158-b45f-2aefdef39a1c.yml
@@ -13,11 +13,12 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '42'
-- end_date: '2023-01-10'
+- end_date: '2023-01-08'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '29'
-- type: upper
+- start_date: '2023-01-09'
+  type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '28'
 offices:

--- a/data/co/retired/Kerry-Donovan-e88f6ebc-1e9e-4c7c-9045-e6f3c22dc90a.yml
+++ b/data/co/retired/Kerry-Donovan-e88f6ebc-1e9e-4c7c-9045-e6f3c22dc90a.yml
@@ -8,7 +8,7 @@ image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2022a
 party:
 - name: Democratic
 roles:
-- end_date: '2023-01-10'
+- end_date: '2023-01-09'
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:co/government
   district: '5'


### PR DESCRIPTION
In CO several senators were redistricted into new districts. They weren't elected to the new district but are serving out the rest of their original term. In these cases having an explicit start date is helpful because we can't infer otherwise when they entered office based on the last election in the district.