### PR TITLE
PA: refresh joint committees

### DIFF
--- a/data/pa/committees/legislature-Applications-and-Information-Technology-f9931cb5-2756-4cf1-b638-0335244221a9.yml
+++ b/data/pa/committees/legislature-Applications-and-Information-Technology-f9931cb5-2756-4cf1-b638-0335244221a9.yml
@@ -1,9 +1,9 @@
-id: ocd-organization/c15c7ae9-33ac-49ed-afc4-7ce952c8209d
+id: ocd-organization/f9931cb5-2756-4cf1-b638-0335244221a9
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: subcommittee
 name: Applications and Information Technology
 chamber: legislature
-parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+parent: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 sources:
 - url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
   note: Member list page

--- a/data/pa/committees/legislature-Capitol-Preservation-f550ecf4-1f73-11ee-be56-0242ac120002.yml
+++ b/data/pa/committees/legislature-Capitol-Preservation-f550ecf4-1f73-11ee-be56-0242ac120002.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/4d582918-e794-4bef-88e7-5855218adfc1
+id: ocd-organization/f550ecf4-1f73-11ee-be56-0242ac120002
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: Capitol Preservation
@@ -15,7 +15,7 @@ members:
 - name: Thomas B. Darr
   role: Secretary, Supreme Court Appointee
 - name: Patty Kim
-  role: Treasurer
+  role: Chair
   person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
 - name: Carolyn T. Comitta
   role: Member
@@ -36,7 +36,7 @@ members:
 - name: Andrea Bakewell Lowery
   role: Executive Director, Historical & Museum Commission
 - name: Kyle Mullins
-  role: Member
+  role: Treasurer
   person_id: ocd-person/625784c9-4cd0-417c-9c44-1acd53b34307
 - name: Reggie McNeil
   role: Acting Secretary, Department of General Services

--- a/data/pa/committees/legislature-Education-and-Outreach-a945c9cd-e707-444c-919e-7a22dddd2487.yml
+++ b/data/pa/committees/legislature-Education-and-Outreach-a945c9cd-e707-444c-919e-7a22dddd2487.yml
@@ -1,9 +1,9 @@
-id: ocd-organization/5f5ac597-4b69-42b4-8c2d-49d560a6dfe3
+id: ocd-organization/a945c9cd-e707-444c-919e-7a22dddd2487
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: subcommittee
-name: Research and Data Analysis
+name: Education and Outreach
 chamber: legislature
-parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+parent: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 sources:
 - url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
   note: Member list page
@@ -11,10 +11,7 @@ links:
 - url: https://pcs.la.psu.edu/
   note: homepage
 members:
-- name: Wayne Langerholc, Jr.
+- name: Edward M. Marsico, Jr.
   role: Chair
-  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
-- name: Professor John T. Rago
-  role: Public Member
 - name: Tamara Bernstein
   role: Public Member

--- a/data/pa/committees/legislature-Executive-and-Administrative-75f9b0f4-5992-4553-aa04-5590775c946f.yml
+++ b/data/pa/committees/legislature-Executive-and-Administrative-75f9b0f4-5992-4553-aa04-5590775c946f.yml
@@ -1,9 +1,9 @@
-id: ocd-organization/7d87ec12-a972-46fb-804b-018c1b24104c
+id: ocd-organization/75f9b0f4-5992-4553-aa04-5590775c946f
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: subcommittee
 name: Executive and Administrative
 chamber: legislature
-parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+parent: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 sources:
 - url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
   note: Member list page
@@ -22,3 +22,6 @@ members:
 - name: Sharif Street
   role: Member
   person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
+- name: Timothy R. Bonner
+  role: Member
+  person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29

--- a/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-904c87ec-9e68-46c1-bdbd-722ec65d84ad.yml
+++ b/data/pa/committees/legislature-Legislative-Audit-Advisory-Commission-904c87ec-9e68-46c1-bdbd-722ec65d84ad.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/00fe5896-1421-43ec-8daf-d2cf96c3a5bc
+id: ocd-organization/904c87ec-9e68-46c1-bdbd-722ec65d84ad
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: Legislative Audit Advisory Commission

--- a/data/pa/committees/legislature-Legislative-Budget-and-Finance-20ecb2f8-b10b-4af7-9864-99d47688d22d.yml
+++ b/data/pa/committees/legislature-Legislative-Budget-and-Finance-20ecb2f8-b10b-4af7-9864-99d47688d22d.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/24032128-6e56-44d0-8ed1-c0d62e0b04ce
+id: ocd-organization/20ecb2f8-b10b-4af7-9864-99d47688d22d
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: Legislative Budget and Finance
@@ -10,33 +10,39 @@ links:
 - url: http://lbfc.legis.state.pa.us/
   note: homepage
 members:
+- name: Kristin Phillips-Hill
+  role: Chairman
+  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
 - name: James R. Brewster
   role: Vice Chairman
   person_id: ocd-person/cac6095b-9793-4edb-835a-70bc551dfd84
+- name: Jarrett Coleman
+  role: Member
+  person_id: ocd-person/ecd51b53-a59b-4b92-b203-c1d24f748cb1
 - name: Cris Dush
   role: Member
   person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
 - name: Art Haywood
   role: Member
   person_id: ocd-person/ea712eba-1da5-45e2-8d9f-022e8307a614
-- name: Kristin Phillips-Hill
-  role: Member
-  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
 - name: Christine M. Tartaglione
   role: Member
   person_id: ocd-person/f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd
-- name: Danilo Burgos
-  role: Member
-  person_id: ocd-person/a2579707-5a31-4f4b-a9ed-49847d35eae6
+- name: Torren C. Ecker
+  role: Secretary
+  person_id: ocd-person/6f375652-451b-4c39-9b29-6ba5a07073c6
 - name: Scott Conklin
   role: Treasurer
   person_id: ocd-person/97b012cd-5cd7-4039-a9ae-fed936aabe37
-- name: Torren C. Ecker
+- name: Danilo Burgos
   role: Member
-  person_id: ocd-person/6f375652-451b-4c39-9b29-6ba5a07073c6
-- name: Patty Kim
+  person_id: ocd-person/a2579707-5a31-4f4b-a9ed-49847d35eae6
+- name: Steve Samuelson
   role: Member
-  person_id: ocd-person/b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29
+  person_id: ocd-person/34472dfb-dae9-4db4-8901-088457d74904
+- name: Brian Smith
+  role: Member
+  person_id: ocd-person/ac7d02d3-9bb7-4cc1-8cee-4283094fe604
 - name: Tim Twardzik
   role: Member
   person_id: ocd-person/686cdc9c-8133-4c1b-a7f0-34b420884559

--- a/data/pa/committees/legislature-Legislative-Reapportionment-Commission-3d738fd4-609c-4128-ab65-8c060544cee1.yml
+++ b/data/pa/committees/legislature-Legislative-Reapportionment-Commission-3d738fd4-609c-4128-ab65-8c060544cee1.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/8266f5d4-5bde-413b-ba4c-fd38c16eeeef
+id: ocd-organization/3d738fd4-609c-4128-ab65-8c060544cee1
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: Legislative Reapportionment Commission

--- a/data/pa/committees/legislature-Local-Government-Commission-ce96beee-f0ef-481d-bf6e-e4d19834065e.yml
+++ b/data/pa/committees/legislature-Local-Government-Commission-ce96beee-f0ef-481d-bf6e-e4d19834065e.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/68a8947b-2c0c-4a8c-a2c7-c867f161f702
+id: ocd-organization/ce96beee-f0ef-481d-bf6e-e4d19834065e
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: Local Government Commission
@@ -13,28 +13,30 @@ members:
 - name: Scott E. Hutchinson
   role: Chair
   person_id: ocd-person/5d3e2203-b11c-4471-8f35-5106c30263ec
-- name: Judy Ward
-  role: Member
-  person_id: ocd-person/b6ed7151-9ea4-4828-b639-785f9e358eb1
 - name: Cris Dush
   role: Member
   person_id: ocd-person/402d7e3b-1935-47fa-8124-61490037d016
-- name: Judith L. Schwank
+- name: Rosemary M. Brown
   role: Member
-  person_id: ocd-person/35362d6e-d00a-4cf1-806d-b4f2f2a55f72
+  person_id: ocd-person/3e2840e6-f904-43be-911e-235b906458a5
 - name: Timothy P. Kearney
   role: Member
   person_id: ocd-person/f9f2479f-0c37-47d1-a4eb-666146e2856f
+- name: Carolyn T. Comitta
+  role: Member
+  person_id: ocd-person/91c58c1d-de9d-471b-8178-f6ef89c1286b
+- name: Robert L. Freeman
+  role: Member
+  person_id: ocd-person/13bfe11c-06e2-4a1d-844d-d195ef18dc06
+- name: Christina D. Sappey
+  role: Member
+  person_id: ocd-person/43d9c3c2-aeec-416c-859d-ad90600bbe0e
+- name: Ismail Smith-Wade-El
+  role: Member
+  person_id: ocd-person/fefff26b-b89a-4400-b633-99e5aa09523b
 - name: R. Lee James
   role: Member
   person_id: ocd-person/b29f8685-d054-4c6c-a8ad-d64f80bd840f
 - name: Dan Moul
   role: Member
   person_id: ocd-person/f4071288-fa18-48bb-99f1-41abd60d215e
-- name: Jerry Knowles
-  role: Member
-- name: Robert L. Freeman
-  role: Member
-- name: Christina D. Sappey
-  role: Member
-  person_id: ocd-person/43d9c3c2-aeec-416c-859d-ad90600bbe0e

--- a/data/pa/committees/legislature-Policy-4463e25c-f094-4b2d-917d-8d0fca6ca315.yml
+++ b/data/pa/committees/legislature-Policy-4463e25c-f094-4b2d-917d-8d0fca6ca315.yml
@@ -1,19 +1,19 @@
-id: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+id: ocd-organization/4463e25c-f094-4b2d-917d-8d0fca6ca315
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
-classification: committee
-name: Sentencing
+classification: subcommittee
+name: Policy
 chamber: legislature
+parent: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 sources:
-- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/members/current-commission-members/
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
   note: Member list page
 links:
 - url: https://pcs.la.psu.edu/
   note: homepage
 members:
-- name: Tamara R. Bernstein
+- name: Rick Krajewski
   role: Chair
-- name: Rick C. Krajewski
-  role: Vice Chair
+  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
 - name: Timothy R. Bonner
   role: Member
   person_id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
@@ -35,7 +35,7 @@ members:
   person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
 - name: David W. Sunday, Jr.
   role: Public Member
-- name: Laurel R. Harry
+- name: C. James Fox
   role: Ex-officio
-- name: Theodore W. Johnson
+- name: Laurel R. Harry
   role: Ex-officio

--- a/data/pa/committees/legislature-Research-and-Data-Analysis-bc5bcfc2-d3a1-45d7-9a5b-17a9a8b4fa38.yml
+++ b/data/pa/committees/legislature-Research-and-Data-Analysis-bc5bcfc2-d3a1-45d7-9a5b-17a9a8b4fa38.yml
@@ -1,9 +1,9 @@
-id: ocd-organization/76007bee-6a7e-41b0-8797-2c7ebbcde8b9
+id: ocd-organization/bc5bcfc2-d3a1-45d7-9a5b-17a9a8b4fa38
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: subcommittee
-name: Education and Outreach
+name: Research and Data Analysis
 chamber: legislature
-parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
+parent: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 sources:
 - url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
   note: Member list page
@@ -11,12 +11,12 @@ links:
 - url: https://pcs.la.psu.edu/
   note: homepage
 members:
-- name: Edward M. Marsico, Jr.
+- name: Wayne Langerholc, Jr.
   role: Chair
-- name: Rick Krajewski
-  role: Member
-  person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
-- name: Douglas K. Marsico
+  person_id: ocd-person/7b3a6244-335b-4407-957d-b7d6b6ab1d97
+- name: Barbara McDermott
+  role: Public Member
+- name: John T. Rago
   role: Public Member
 - name: Tamara Bernstein
   role: Public Member

--- a/data/pa/committees/legislature-Sentencing-d497e31c-37fb-4fcb-bc88-2b7a89a84871.yml
+++ b/data/pa/committees/legislature-Sentencing-d497e31c-37fb-4fcb-bc88-2b7a89a84871.yml
@@ -1,18 +1,19 @@
-id: ocd-organization/7946261a-db12-4ee3-a08b-66e997132634
+id: ocd-organization/d497e31c-37fb-4fcb-bc88-2b7a89a84871
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
-classification: subcommittee
-name: Policy
+classification: committee
+name: Sentencing
 chamber: legislature
-parent: ocd-organization/475d6591-8e69-44bf-a429-f585a16a802c
 sources:
-- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/standing-committees/
+- url: https://pcs.la.psu.edu/policy-administration/about-the-commission/members/current-commission-members/
   note: Member list page
 links:
 - url: https://pcs.la.psu.edu/
   note: homepage
 members:
-- name: Rick Krajewski
+- name: Tamara R. Bernstein
   role: Chair
+- name: Rick C. Krajewski
+  role: Vice Chair
   person_id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
 - name: Timothy R. Bonner
   role: Member
@@ -35,7 +36,7 @@ members:
   person_id: ocd-person/b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a
 - name: David W. Sunday, Jr.
   role: Public Member
-- name: Laurel R. Harry
+- name: C. James Fox
   role: Ex-officio
-- name: Theodore W. Johnson
+- name: Laurel R. Harry
   role: Ex-officio

--- a/data/pa/committees/legislature-State-Government-Commission-59063184-308e-4c68-8893-c31d19c97081.yml
+++ b/data/pa/committees/legislature-State-Government-Commission-59063184-308e-4c68-8893-c31d19c97081.yml
@@ -1,4 +1,4 @@
-id: ocd-organization/98fd59d7-2a29-4891-8d5d-60cfee592ba8
+id: ocd-organization/59063184-308e-4c68-8893-c31d19c97081
 jurisdiction: ocd-jurisdiction/country:us/state:pa/government
 classification: committee
 name: State Government Commission
@@ -42,6 +42,7 @@ members:
   person_id: ocd-person/cf94e0e7-498b-419b-9d3a-36c31d1eaf46
 - name: Kristin Philips-Hill
   role: Member
+  person_id: ocd-person/cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6
 - name: George Dunbar
   role: Member
   person_id: ocd-person/6a971ef6-eb92-434b-a390-c658cfbf2d00


### PR DESCRIPTION
Starting with fresh `ocd-organization` ids to hopefully calm this [duplicate key error](https://github.com/openstates/people/actions/runs/5511647200/jobs/10047472801) on the Update DB workflow