### PR TITLE
Update Anthony Albence

### DIFF
--- a/data/de/executive/Anthony-Albence-1fbb3c2f-b3ec-421d-af2a-2f0af26b2939.yml
+++ b/data/de/executive/Anthony-Albence-1fbb3c2f-b3ec-421d-af2a-2f0af26b2939.yml
@@ -6,7 +6,7 @@ email: Anthony.Albence@delaware.gov
 party:
 - name: Independent
 roles:
-- end_date: '2023-06-20'
+- end_date: '2023-12-31'
   type: chief election officer
   jurisdiction: ocd-jurisdiction/country:us/state:de/government
 offices:


### PR DESCRIPTION
His term has an expiration date of 6/20/2023 but all indications are that he's still in office. Going to bump this to the end of the year and will amend if necessary.