### PR TITLE
Repair Salt Lake City, San Francisco Mayors

### DIFF
--- a/data/ca/municipalities/London-Breed-d8e1c81d-a5a8-47f8-a1ea-126a2c63629f.yml
+++ b/data/ca/municipalities/London-Breed-d8e1c81d-a5a8-47f8-a1ea-126a2c63629f.yml
@@ -4,7 +4,7 @@ given_name: London
 family_name: Breed
 email: MayorLondonBreed@sfgov.org
 roles:
-- end_date: '2023-11-07'
+- end_date: '2025-01-08'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_francisco/government
 offices:

--- a/data/ut/municipalities/Erin-Mendenhall-cd98c525-5eff-4f47-a638-5ca88644e134.yml
+++ b/data/ut/municipalities/Erin-Mendenhall-cd98c525-5eff-4f47-a638-5ca88644e134.yml
@@ -4,7 +4,7 @@ given_name: Erin
 family_name: Mendenhall
 email: Mayor@slcgov.com
 roles:
-- end_date: '2024-01-08'
+- end_date: '2028-01-04'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:ut/place:salt_lake_city/government
 offices:


### PR DESCRIPTION
- Erin Mendenhall was [sworn in for a second term](https://www.slc.gov/mayor/2024/01/03/salt-lake-city-mayor-erin-mendenhall-sworn-in-for-second-term/) on January 2, 2024.
- Following the passage of [Proposition H in 2022](https://ballotpedia.org/San_Francisco,_California,_Proposition_H,_Move_Local_Elections_to_Even-Numbered_Years_and_Change_Initiative_Petition_Signature_Requirements_Amendment_(November_2022)), mayoral elections in San Francisco were rescheduled to coincide with presidential elections. London Breed remains in office until 2025.