### PR TITLE
Tampa, Fla. Mayor

### DIFF
--- a/data/fl/municipalities/Jane-Castor-56a74356-58b3-487e-a265-e950776bc249.yml
+++ b/data/fl/municipalities/Jane-Castor-56a74356-58b3-487e-a265-e950776bc249.yml
@@ -4,7 +4,7 @@ given_name: Jane
 family_name: Castor
 email: jane.castor@tampagov.net
 roles:
-- end_date: '2023-03-14'
+- end_date: '2027-05-01'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:fl/place:tampa/government
 offices:


### PR DESCRIPTION
Jane Castor was [re-elected on March 7, 2023](https://ballotpedia.org/Jane_Castor#:~:text=Her%20current%20term%20ends%20on,elections%20in%20Tampa%20are%20nonpartisan.) and is not retired.