### PR TITLE
Extend end_date of reelected Frisco, TX mayor

### DIFF
--- a/data/tx/municipalities/Jeff-Cheney-8f4cc828-656a-4037-82ab-9f1ed324c825.yml
+++ b/data/tx/municipalities/Jeff-Cheney-8f4cc828-656a-4037-82ab-9f1ed324c825.yml
@@ -4,7 +4,7 @@ given_name: Jeff
 family_name: Cheney
 email: jcheney@friscotexas.gov
 roles:
-- end_date: '2023-12-31'
+- end_date: '2025-12-31'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:frisco/government
 offices:


### PR DESCRIPTION
Per [friscotexas.gov](https://www.friscotexas.gov/586/Jeff-Cheney), Jeff Cheney was reelected in November and will serve until 2026. So I updated his end_date to 12-31-2025, not seeing an exact date listed for his new term expiration.