### PR TITLE
Un-retire Eric Johnson, mayor of Dallas TX

### DIFF
--- a/data/tx/municipalities/Eric-Johnson-9b26a8d9-1ccb-4c21-8b68-193aafb04c3f.yml
+++ b/data/tx/municipalities/Eric-Johnson-9b26a8d9-1ccb-4c21-8b68-193aafb04c3f.yml
@@ -4,7 +4,7 @@ given_name: Eric
 family_name: Johnson
 email: eric.johnson@dallascityhall.com
 roles:
-- end_date: '2023-05-06'
+- end_date: '2027-05-06'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:tx/place:dallas/government
 offices:


### PR DESCRIPTION
Eric Johnson was re-elected for another 4-year term as Dallas, TX mayor.

https://dallascityhall.com/government/citymayor/pages/default.aspx