### PR TITLE
Add new Cincinnati mayor

### DIFF
--- a/data/oh/municipalities/Aftab-Pureval-aa81e0c6-dba7-4f08-b70e-a71c3f537200.yml
+++ b/data/oh/municipalities/Aftab-Pureval-aa81e0c6-dba7-4f08-b70e-a71c3f537200.yml
@@ -1,0 +1,17 @@
+id: ocd-person/aa81e0c6-dba7-4f08-b70e-a71c3f537200
+name: Aftab Pureval
+given_name: Aftab
+family_name: Pureval
+email: mayor.aftab@cincinnati-oh.gov
+roles:
+- end_date: '2025-12-31'
+  type: mayor
+  jurisdiction: ocd-jurisdiction/country:us/state:oh/place:cincinnati/government
+offices:
+- classification: primary
+  address: 801 Plum St., Suite 150;Cincinnati, OH 45202
+  voice: 513-352-3250
+links:
+- url: https://www.cincinnati-oh.gov/mayor/contact-the-mayor/
+sources:
+- url: https://www.cincinnati-oh.gov/mayor/contact-the-mayor/


### PR DESCRIPTION
The mayor of Cincinnati, Ohio since 2022 is Aftab Pureval. For the end_date of his mayoral role, I've put the last day of 2025 as a best guess, because the next Cincinnati election will be held in November 2025.