### PR TITLE
Add Denver Mayor

### DIFF
--- a/data/co/municipalities/Mike-Johnston-3b5c8213-a8a7-474b-903f-f5d67e75c4bc.yml
+++ b/data/co/municipalities/Mike-Johnston-3b5c8213-a8a7-474b-903f-f5d67e75c4bc.yml
@@ -1,0 +1,17 @@
+id: ocd-person/3b5c8213-a8a7-474b-903f-f5d67e75c4bc
+name: Mike Johnston
+given_name: Michael
+family_name: Johnston
+email: mike.johnston@denvergov.org
+roles:
+- end_date: '2027-05-04'
+  type: mayor
+  jurisdiction: ocd-jurisdiction/country:us/state:co/place:denver/government
+offices:
+- classification: primary
+  address: 1437 N Bannock St Rm 350;Denver, CO 80202-5390
+  voice: 720-865-9000
+links:
+- url: https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Mayors-Office
+sources:
+- url: https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Mayors-Office


### PR DESCRIPTION
- Mike Johnston [assumed office on July 17, 2023](https://ballotpedia.org/Mayoral_election_in_Denver,_Colorado_(2023))