### PR TITLE
USA: add other_names to match Votes

### DIFF
--- a/data/us/legislature/Alex-Padilla-fadd82ac-5031-5efd-ae39-1afc3f3cd6fb.yml
+++ b/data/us/legislature/Alex-Padilla-fadd82ac-5031-5efd-ae39-1afc3f3cd6fb.yml
@@ -61,6 +61,8 @@ links:
   note: contact form
 ids:
   twitter: SenAlexPadilla
+other_names:
+- name: Padilla (D-CA)
 other_identifiers:
 - scheme: bioguide
   identifier: P000145

--- a/data/us/legislature/Amy-Klobuchar-2722e0b1-650d-5f77-a348-f7f0d66aa3e2.yml
+++ b/data/us/legislature/Amy-Klobuchar-2722e0b1-650d-5f77-a348-f7f0d66aa3e2.yml
@@ -58,6 +58,8 @@ links:
 ids:
   twitter: SenAmyKlobuchar
   youtube: UCvdeJsDsV51tFb_hVqvtYGA
+other_names:
+- name: Klobuchar (D-MN)
 other_identifiers:
 - scheme: bioguide
   identifier: K000367

--- a/data/us/legislature/Angus-S-King-Jr-273dd641-da15-5fc0-bdc9-496cc9b65fbd.yml
+++ b/data/us/legislature/Angus-S-King-Jr-273dd641-da15-5fc0-bdc9-496cc9b65fbd.yml
@@ -52,6 +52,7 @@ ids:
   facebook: SenatorAngusSKingJr
 other_names:
 - name: Angus S. King
+- name: King (I-ME)
 other_identifiers:
 - scheme: bioguide
   identifier: K000383

--- a/data/us/legislature/Ben-Ray-Lujn-5f5817b7-43b0-5bb3-93de-0f838a801635.yml
+++ b/data/us/legislature/Ben-Ray-Lujn-5f5817b7-43b0-5bb3-93de-0f838a801635.yml
@@ -89,6 +89,7 @@ ids:
   twitter: SenatorLujan
 other_names:
 - name: Ben R. Lujan
+- name: Lujan (D-NM)
 other_identifiers:
 - scheme: bioguide
   identifier: L000570

--- a/data/us/legislature/Benjamin-L-Cardin-18b53a95-c658-5a23-8c3e-074a7e0d27e3.yml
+++ b/data/us/legislature/Benjamin-L-Cardin-18b53a95-c658-5a23-8c3e-074a7e0d27e3.yml
@@ -116,6 +116,7 @@ ids:
   facebook: senatorbencardin
 other_names:
 - name: Ben Cardin
+- name: Cardin (D-MD)
 other_identifiers:
 - scheme: bioguide
   identifier: C000141

--- a/data/us/legislature/Bernard-Sanders-a1ec37b6-9f54-529a-8165-ff96e9d8d93e.yml
+++ b/data/us/legislature/Bernard-Sanders-a1ec37b6-9f54-529a-8165-ff96e9d8d93e.yml
@@ -88,6 +88,8 @@ ids:
   twitter: SenSanders
   youtube: UCD_DaKNac0Ta-2PeHuoQ1uA
   facebook: senatorsanders
+other_names:
+- name: Sanders (I-VT)
 other_identifiers:
 - scheme: bioguide
   identifier: S000033

--- a/data/us/legislature/Bill-Cassidy-851546e4-4af0-5505-8a1c-4f2a83813589.yml
+++ b/data/us/legislature/Bill-Cassidy-851546e4-4af0-5505-8a1c-4f2a83813589.yml
@@ -82,6 +82,8 @@ links:
 ids:
   twitter: SenBillCassidy
   youtube: UCCEyGhUzxgkxFzWCY-rxz8g
+other_names:
+- name: Cassidy (R-LA)
 other_identifiers:
 - scheme: bioguide
   identifier: C001075

--- a/data/us/legislature/Bill-Hagerty-fb408324-49e1-56ad-8425-65c2a1e88103.yml
+++ b/data/us/legislature/Bill-Hagerty-fb408324-49e1-56ad-8425-65c2a1e88103.yml
@@ -27,6 +27,8 @@ links:
   note: contact form
 ids:
   twitter: SenatorHagerty
+other_names:
+- name: Hagerty (R-TN)
 other_identifiers:
 - scheme: bioguide
   identifier: H000601

--- a/data/us/legislature/Brian-Schatz-bd24fe60-5756-5d23-bcbf-4734f366c257.yml
+++ b/data/us/legislature/Brian-Schatz-bd24fe60-5756-5d23-bcbf-4734f366c257.yml
@@ -49,6 +49,8 @@ ids:
   twitter: SenBrianSchatz
   youtube: UC8-mSYp2WqBiB_5iwtwKfow
   facebook: SenBrianSchatz
+other_names:
+- name: Schatz (D-HI)
 other_identifiers:
 - scheme: lis
   identifier: S353

--- a/data/us/legislature/Catherine-Cortez-Masto-00bdfb60-1b6f-5a4a-9157-b7cafc399c46.yml
+++ b/data/us/legislature/Catherine-Cortez-Masto-00bdfb60-1b6f-5a4a-9157-b7cafc399c46.yml
@@ -43,6 +43,8 @@ ids:
   twitter: SenCortezMasto
   youtube: UCip_83SiKUqwnUT57VOXrCg
   facebook: SenatorCortezMasto
+other_names:
+- name: Cortez Masto (D-NV)
 other_identifiers:
 - scheme: bioguide
   identifier: C001113

--- a/data/us/legislature/Charles-E-Schumer-ced62f94-88a6-5a4b-b470-89cf1ee4bdac.yml
+++ b/data/us/legislature/Charles-E-Schumer-ced62f94-88a6-5a4b-b470-89cf1ee4bdac.yml
@@ -134,6 +134,8 @@ ids:
   twitter: SenSchumer
   youtube: UC-ABttxh8uQv_10qmwGaidw
   facebook: senschumer
+other_names:
+- name: Schumer (D-NY)
 other_identifiers:
 - scheme: bioguide
   identifier: S000148

--- a/data/us/legislature/Chris-Van-Hollen-6b768c01-2e7d-5316-9ece-d5e215648f85.yml
+++ b/data/us/legislature/Chris-Van-Hollen-6b768c01-2e7d-5316-9ece-d5e215648f85.yml
@@ -93,6 +93,8 @@ ids:
   twitter: ChrisVanHollen
   youtube: UCkpfJWu1N9Okd6PE_NidtBQ
   facebook: chrisvanhollen
+other_names:
+- name: Van Hollen (D-MD)
 other_identifiers:
 - scheme: bioguide
   identifier: V000128

--- a/data/us/legislature/Christopher-A-Coons-792faee4-b972-54ed-b42d-47b41a22ccb3.yml
+++ b/data/us/legislature/Christopher-A-Coons-792faee4-b972-54ed-b42d-47b41a22ccb3.yml
@@ -49,6 +49,8 @@ ids:
   twitter: ChrisCoons
   youtube: UC2lOVbsddn1HIkcDnmCw6tA
   facebook: senatorchriscoons
+other_names:
+- name: Coons (D-DE)
 other_identifiers:
 - scheme: bioguide
   identifier: C001088

--- a/data/us/legislature/Christopher-Murphy-ef439b89-0461-56c7-aec5-93b6369e18a7.yml
+++ b/data/us/legislature/Christopher-Murphy-ef439b89-0461-56c7-aec5-93b6369e18a7.yml
@@ -56,6 +56,7 @@ ids:
   facebook: chrismurphyct
 other_names:
 - name: Christopher S. Murphy
+- name: Murphy (D-CT)
 other_identifiers:
 - scheme: bioguide
   identifier: M001169

--- a/data/us/legislature/Chuck-Grassley-259d896b-e9b5-5237-9243-f5597ae0db7c.yml
+++ b/data/us/legislature/Chuck-Grassley-259d896b-e9b5-5237-9243-f5597ae0db7c.yml
@@ -109,6 +109,8 @@ ids:
   twitter: ChuckGrassley
   youtube: UCiCPRkcLMInpDeOqGkMTt4w
   facebook: grassley
+other_names:
+- name: Grassley (R-IA)
 other_identifiers:
 - scheme: bioguide
   identifier: G000386

--- a/data/us/legislature/Cindy-Hyde-Smith-3827ab20-4901-56bc-a6ea-e7c275da9eb9.yml
+++ b/data/us/legislature/Cindy-Hyde-Smith-3827ab20-4901-56bc-a6ea-e7c275da9eb9.yml
@@ -52,6 +52,8 @@ links:
 ids:
   twitter: SenHydeSmith
   youtube: UCJHxkJhGST0NTlkzJHWV03Q
+other_names:
+- name: Hyde-Smith (R-MS)
 other_identifiers:
 - scheme: bioguide
   identifier: H001079

--- a/data/us/legislature/Cory-A-Booker-d0bb2662-40b6-52d2-94e6-2bf9d588c954.yml
+++ b/data/us/legislature/Cory-A-Booker-d0bb2662-40b6-52d2-94e6-2bf9d588c954.yml
@@ -50,6 +50,7 @@ ids:
   youtube: UC6FlymqNS1VettnVZa7goPA
 other_names:
 - name: Cory Booker
+- name: Booker (D-NJ)
 other_identifiers:
 - scheme: bioguide
   identifier: B001288

--- a/data/us/legislature/Cynthia-M-Lummis-b6ae1e91-803f-5ce8-98fe-86f85c52dd42.yml
+++ b/data/us/legislature/Cynthia-M-Lummis-b6ae1e91-803f-5ce8-98fe-86f85c52dd42.yml
@@ -47,6 +47,8 @@ links:
   note: contact form
 ids:
   twitter: SenLummis
+other_names:
+- name: Lummis (R-WY)
 other_identifiers:
 - scheme: bioguide
   identifier: L000571

--- a/data/us/legislature/Dan-Sullivan-a6b5e853-563f-5b87-a14a-a1427f56b262.yml
+++ b/data/us/legislature/Dan-Sullivan-a6b5e853-563f-5b87-a14a-a1427f56b262.yml
@@ -63,6 +63,8 @@ ids:
   twitter: SenDanSullivan
   youtube: UC7tXCm8gKlAhTFo2kuf5ylw
   facebook: SenDanSullivan
+other_names:
+- name: Sullivan (R-AK)
 other_identifiers:
 - scheme: bioguide
   identifier: S001198

--- a/data/us/legislature/Deb-Fischer-1e87267c-1e9f-5e46-a266-b1d557a8571b.yml
+++ b/data/us/legislature/Deb-Fischer-1e87267c-1e9f-5e46-a266-b1d557a8571b.yml
@@ -53,6 +53,8 @@ ids:
   twitter: SenatorFischer
   youtube: UCrbEfZaG_WhB0PBHI1hefPQ
   facebook: senatordebfischer
+other_names:
+- name: Fischer (R-NE)
 other_identifiers:
 - scheme: bioguide
   identifier: F000463

--- a/data/us/legislature/Debbie-Stabenow-a18130ac-79f6-54ad-a80d-14b143f0742f.yml
+++ b/data/us/legislature/Debbie-Stabenow-a18130ac-79f6-54ad-a80d-14b143f0742f.yml
@@ -78,6 +78,8 @@ ids:
   twitter: SenStabenow
   youtube: UCFoDKCvxSwCUfDv-4Eg4K5A
   facebook: SenatorStabenow
+other_names:
+- name: Stabenow (D-MI)
 other_identifiers:
 - scheme: bioguide
   identifier: S000770

--- a/data/us/legislature/Edward-J-Markey-bceb5ccd-31b0-5d03-894d-03cf2cbb2771.yml
+++ b/data/us/legislature/Edward-J-Markey-bceb5ccd-31b0-5d03-894d-03cf2cbb2771.yml
@@ -152,6 +152,8 @@ ids:
   twitter: SenMarkey
   youtube: UCT1ujew5yQy2uMhGrjiKHoA
   facebook: EdJMarkey
+other_names:
+- name: Markey (D-MA)
 other_identifiers:
 - scheme: bioguide
   identifier: M000133

--- a/data/us/legislature/Elizabeth-Warren-3de20aaf-f982-5aa3-8280-c5154be829aa.yml
+++ b/data/us/legislature/Elizabeth-Warren-3de20aaf-f982-5aa3-8280-c5154be829aa.yml
@@ -43,6 +43,7 @@ ids:
   facebook: senatorelizabethwarren
 other_names:
 - name: Elizabeth A. Warren
+- name: Warren (D-MA)
 other_identifiers:
 - scheme: bioguide
   identifier: W000817

--- a/data/us/legislature/Eric-Schmitt-999df51b-9318-55b9-b0f6-d738ffc1d62d.yml
+++ b/data/us/legislature/Eric-Schmitt-999df51b-9318-55b9-b0f6-d738ffc1d62d.yml
@@ -27,6 +27,7 @@ links:
   note: contact form
 other_names:
 - name: Eric S. Schmitt
+- name: Schmitt (R-MO)F
 other_identifiers:
 - scheme: bioguide
   identifier: S001227

--- a/data/us/legislature/Gary-C-Peters-edbfabfd-d26b-5d22-9a5d-f079181608f8.yml
+++ b/data/us/legislature/Gary-C-Peters-edbfabfd-d26b-5d22-9a5d-f079181608f8.yml
@@ -79,6 +79,7 @@ ids:
   facebook: SenGaryPeters
 other_names:
 - name: Gary Peters
+- name: Peters (D-MI)
 other_identifiers:
 - scheme: bioguide
   identifier: P000595

--- a/data/us/legislature/JD-Vance-5a8792bc-1520-56aa-ab19-729008cd559b.yml
+++ b/data/us/legislature/JD-Vance-5a8792bc-1520-56aa-ab19-729008cd559b.yml
@@ -27,6 +27,7 @@ links:
   note: contact form
 other_names:
 - name: J.D. Vance
+- name: Vance (R-OH)
 other_identifiers:
 - scheme: bioguide
   identifier: V000137

--- a/data/us/legislature/Jack-Reed-e62576aa-1bf5-5664-ad0f-b1fdbcdead56.yml
+++ b/data/us/legislature/Jack-Reed-e62576aa-1bf5-5664-ad0f-b1fdbcdead56.yml
@@ -76,6 +76,7 @@ ids:
   facebook: SenJackReed
 other_names:
 - name: John F. Reed
+- name: Reed (D-RI)
 other_identifiers:
 - scheme: bioguide
   identifier: R000122

--- a/data/us/legislature/Jacky-Rosen-2f7f8ec5-f652-5c47-8dcb-06d7bc54557c.yml
+++ b/data/us/legislature/Jacky-Rosen-2f7f8ec5-f652-5c47-8dcb-06d7bc54557c.yml
@@ -40,6 +40,8 @@ links:
 ids:
   twitter: SenJackyRosen
   facebook: RepJackyRosen
+other_names:
+- name: Rosen (D-NV)
 other_identifiers:
 - scheme: bioguide
   identifier: R000608

--- a/data/us/legislature/James-E-Risch-e8bb2501-1603-543f-9667-9089f781aa97.yml
+++ b/data/us/legislature/James-E-Risch-e8bb2501-1603-543f-9667-9089f781aa97.yml
@@ -69,6 +69,8 @@ ids:
   twitter: SenatorRisch
   youtube: UCncKW8xyT5UbPNO27YuQnBA
   facebook: senatorjimrisch
+other_names:
+- name: Risch (R-ID)
 other_identifiers:
 - scheme: bioguide
   identifier: R000584

--- a/data/us/legislature/James-Lankford-62a44404-9be2-5bbc-b672-0ed5f1aba53d.yml
+++ b/data/us/legislature/James-Lankford-62a44404-9be2-5bbc-b672-0ed5f1aba53d.yml
@@ -56,6 +56,8 @@ ids:
   twitter: SenatorLankford
   youtube: UCz8T6sK5fEycyWmVz6Vpe5Q
   facebook: SenatorLankford
+other_names:
+- name: Lankford (R-OK)
 other_identifiers:
 - scheme: bioguide
   identifier: L000575

--- a/data/us/legislature/Jeanne-Shaheen-6d497134-2c53-5987-add8-6fffeaa96cda.yml
+++ b/data/us/legislature/Jeanne-Shaheen-6d497134-2c53-5987-add8-6fffeaa96cda.yml
@@ -62,6 +62,8 @@ ids:
   twitter: SenatorShaheen
   youtube: UCjLZAZMbDrybHyttdEC9LFA
   facebook: SenatorShaheen
+other_names:
+- name: Shaheen (D-NH)
 other_identifiers:
 - scheme: bioguide
   identifier: S001181

--- a/data/us/legislature/Jeff-Merkley-96291b83-ea59-594a-97cf-630189e0b8ed.yml
+++ b/data/us/legislature/Jeff-Merkley-96291b83-ea59-594a-97cf-630189e0b8ed.yml
@@ -63,6 +63,8 @@ ids:
   twitter: SenJeffMerkley
   youtube: UCRoXttCJhMnLVCxCaa6VnNQ
   facebook: jeffmerkley
+other_names:
+- name: Merkley (D-OR)
 other_identifiers:
 - scheme: bioguide
   identifier: M001176

--- a/data/us/legislature/Jerry-Moran-00c39487-8eec-5494-af5e-96e9b025a39b.yml
+++ b/data/us/legislature/Jerry-Moran-00c39487-8eec-5494-af5e-96e9b025a39b.yml
@@ -98,6 +98,8 @@ ids:
   twitter: JerryMoran
   youtube: UC1oRxeUPam6-53wPBZ3N02A
   facebook: jerrymoran
+other_names:
+- name: Moran (R-KS)
 other_identifiers:
 - scheme: bioguide
   identifier: M000934

--- a/data/us/legislature/Joe-Manchin-III-3da2fb45-0c89-544c-b41d-888d623cf99c.yml
+++ b/data/us/legislature/Joe-Manchin-III-3da2fb45-0c89-544c-b41d-888d623cf99c.yml
@@ -55,6 +55,7 @@ ids:
   facebook: JoeManchinIII
 other_names:
 - name: Joseph Manchin
+- name: Manchin (D-WV)
 other_identifiers:
 - scheme: bioguide
   identifier: M001183

--- a/data/us/legislature/John-Barrasso-80f88c07-5f6d-5ca3-8121-9202259a50f2.yml
+++ b/data/us/legislature/John-Barrasso-80f88c07-5f6d-5ca3-8121-9202259a50f2.yml
@@ -59,6 +59,8 @@ ids:
   twitter: SenJohnBarrasso
   youtube: UC80PfiCAB2Fe1MFayWlR6GQ
   facebook: johnbarrasso
+other_names:
+- name: Barrasso (R-WY)
 other_identifiers:
 - scheme: bioguide
   identifier: B001261

--- a/data/us/legislature/John-Boozman-b352dd8b-dd06-57b0-833a-2b0b3bd33ad6.yml
+++ b/data/us/legislature/John-Boozman-b352dd8b-dd06-57b0-833a-2b0b3bd33ad6.yml
@@ -98,6 +98,8 @@ ids:
   twitter: JohnBoozman
   youtube: UC9vWHKL5OfIYh6kIV0rF2yw
   facebook: JohnBoozman
+other_names:
+- name: Boozman (R-AR)
 other_identifiers:
 - scheme: bioguide
   identifier: B001236

--- a/data/us/legislature/John-Cornyn-d274933a-e19d-5d3b-ab91-dc6611aaadd1.yml
+++ b/data/us/legislature/John-Cornyn-d274933a-e19d-5d3b-ab91-dc6611aaadd1.yml
@@ -83,6 +83,8 @@ ids:
   twitter: JohnCornyn
   youtube: UCyQwLQavlOaJ64YuY_VMtiQ
   facebook: sen.johncornyn
+other_names:
+- name: Cornyn (R-TX)
 other_identifiers:
 - scheme: bioguide
   identifier: C001056

--- a/data/us/legislature/John-Fetterman-6f500f52-75ce-5cf0-afc6-5be71f0921d2.yml
+++ b/data/us/legislature/John-Fetterman-6f500f52-75ce-5cf0-afc6-5be71f0921d2.yml
@@ -27,6 +27,7 @@ links:
   note: contact form
 other_names:
 - name: John K. Fetterman
+- name: Fetterman (D-PA)
 other_identifiers:
 - scheme: bioguide
   identifier: F000479

--- a/data/us/legislature/John-Hoeven-18c027d3-52ca-5a48-a4d2-73167e382096.yml
+++ b/data/us/legislature/John-Hoeven-18c027d3-52ca-5a48-a4d2-73167e382096.yml
@@ -60,6 +60,8 @@ ids:
   twitter: SenJohnHoeven
   youtube: UC1kQIC2Q_Fq9_NRqdb6eHiw
   facebook: SenatorJohnHoeven
+other_names:
+- name: Hoeven (R-ND)
 other_identifiers:
 - scheme: bioguide
   identifier: H001061

--- a/data/us/legislature/John-Kennedy-7a996578-ee76-59c8-856c-4f63861a62da.yml
+++ b/data/us/legislature/John-Kennedy-7a996578-ee76-59c8-856c-4f63861a62da.yml
@@ -69,6 +69,8 @@ links:
 ids:
   twitter: SenJohnKennedy
   facebook: JohnKennedyLouisiana
+other_names:
+- name: Kennedy (R-LA)
 other_identifiers:
 - scheme: bioguide
   identifier: K000393

--- a/data/us/legislature/John-Thune-342214ae-2e66-50a4-9a10-acc467bd5d98.yml
+++ b/data/us/legislature/John-Thune-342214ae-2e66-50a4-9a10-acc467bd5d98.yml
@@ -69,6 +69,8 @@ links:
 ids:
   twitter: SenJohnThune
   youtube: UCRu6lpRfxhkDGUrKDgQNZYQ
+other_names:
+- name: Thune (R-SD)
 other_identifiers:
 - scheme: bioguide
   identifier: T000250

--- a/data/us/legislature/John-W-Hickenlooper-e4ea61a6-63ea-53e6-b61e-4c735a0b7818.yml
+++ b/data/us/legislature/John-W-Hickenlooper-e4ea61a6-63ea-53e6-b61e-4c735a0b7818.yml
@@ -27,6 +27,8 @@ links:
   note: contact form
 ids:
   twitter: SenatorHick
+other_names:
+- name: Hickenlooper (D-CO)
 other_identifiers:
 - scheme: bioguide
   identifier: H000273

--- a/data/us/legislature/Jon-Ossoff-4e48da38-17ab-5580-bced-2ea00b9b2843.yml
+++ b/data/us/legislature/Jon-Ossoff-4e48da38-17ab-5580-bced-2ea00b9b2843.yml
@@ -26,6 +26,8 @@ links:
   note: contact form
 ids:
   twitter: SenOssoff
+other_names:
+- name: Ossoff (D-GA)
 other_identifiers:
 - scheme: bioguide
   identifier: O000174

--- a/data/us/legislature/Jon-Tester-9f388589-39f3-5470-af3d-d74720d56afc.yml
+++ b/data/us/legislature/Jon-Tester-9f388589-39f3-5470-af3d-d74720d56afc.yml
@@ -73,6 +73,8 @@ ids:
   twitter: SenatorTester
   youtube: UCgXAF-CON1coZFMxQkfj0fg
   facebook: senatortester
+other_names:
+- name: Tester (D-MT)
 other_identifiers:
 - scheme: bioguide
   identifier: T000464

--- a/data/us/legislature/Joni-Ernst-86133add-b3ff-52c2-a71e-442b9afeff6b.yml
+++ b/data/us/legislature/Joni-Ernst-86133add-b3ff-52c2-a71e-442b9afeff6b.yml
@@ -58,6 +58,8 @@ ids:
   twitter: SenJoniErnst
   youtube: UCLwrmtF_84FIcK3TyMs4MIw
   facebook: senjoniernst
+other_names:
+- name: Ernst (R-IA)
 other_identifiers:
 - scheme: bioguide
   identifier: E000295

--- a/data/us/legislature/Josh-Hawley-0a7d370e-88bd-5b83-9b93-c8607c036d7a.yml
+++ b/data/us/legislature/Josh-Hawley-0a7d370e-88bd-5b83-9b93-c8607c036d7a.yml
@@ -50,6 +50,8 @@ links:
   note: contact form
 ids:
   twitter: SenHawleyPress
+other_names:
+- name: Hawley (R-MO)
 other_identifiers:
 - scheme: bioguide
   identifier: H001089

--- a/data/us/legislature/Katie-Boyd-Britt-7bf077d8-e8b9-503e-b9c2-d18b55951e93.yml
+++ b/data/us/legislature/Katie-Boyd-Britt-7bf077d8-e8b9-503e-b9c2-d18b55951e93.yml
@@ -25,6 +25,8 @@ links:
   note: website
 - url: https://www.britt.senate.gov/
   note: contact form
+other_names:
+- name: Britt (R-AL)
 other_identifiers:
 - scheme: bioguide
   identifier: B001319

--- a/data/us/legislature/Kevin-Cramer-b18c868c-a789-5a02-8070-c0c473d55304.yml
+++ b/data/us/legislature/Kevin-Cramer-b18c868c-a789-5a02-8070-c0c473d55304.yml
@@ -61,6 +61,8 @@ ids:
   twitter: SenKevinCramer
   youtube: UCqUPdO9XaAW-dvwwXKbIVdA
   facebook: CongressmanKevinCramer
+other_names:
+- name: Cramer (R-ND)
 other_identifiers:
 - scheme: govtrack
   identifier: '412555'

--- a/data/us/legislature/Kirsten-E-Gillibrand-d3f90fd1-5f64-5d18-a658-bdd021b89f46.yml
+++ b/data/us/legislature/Kirsten-E-Gillibrand-d3f90fd1-5f64-5d18-a658-bdd021b89f46.yml
@@ -89,6 +89,8 @@ ids:
   twitter: GillibrandNY
   youtube: UCVEloQogVsmnkd5vxJInmYg
   facebook: SenKirstenGillibrand
+other_names:
+- name: Gillibrand (D-NY)
 other_identifiers:
 - scheme: bioguide
   identifier: G000555

--- a/data/us/legislature/Kyrsten-Sinema-37a72ecf-c1ae-5c91-b4ee-d72f4e9e8894.yml
+++ b/data/us/legislature/Kyrsten-Sinema-37a72ecf-c1ae-5c91-b4ee-d72f4e9e8894.yml
@@ -50,6 +50,8 @@ ids:
   twitter: SenatorSinema
   youtube: UC4NzhW7D4lQdukSGWmFnK9w
   facebook: CongresswomanSinema
+other_names:
+- name: Sinema (I-AZ)
 other_identifiers:
 - scheme: govtrack
   identifier: '412509'

--- a/data/us/legislature/Laphonza-R-Butler-0490575c-d32c-56f5-9d82-c0511ebe4fb8.yml
+++ b/data/us/legislature/Laphonza-R-Butler-0490575c-d32c-56f5-9d82-c0511ebe4fb8.yml
@@ -43,6 +43,7 @@ links:
   note: contact form
 other_names:
 - name: Laphonza Butler
+- name: Butler (D-CA)
 other_identifiers:
 - scheme: bioguide
   identifier: B001320

--- a/data/us/legislature/Lindsey-Graham-111e4df8-6815-5549-9833-57120f302f81.yml
+++ b/data/us/legislature/Lindsey-Graham-111e4df8-6815-5549-9833-57120f302f81.yml
@@ -94,6 +94,8 @@ ids:
   twitter: GrahamBlog
   youtube: UClLGZMA5Ei2Z8fR1PLEx6yQ
   facebook: USSenatorLindseyGraham
+other_names:
+- name: Graham (R-SC)
 other_identifiers:
 - scheme: bioguide
   identifier: G000359

--- a/data/us/legislature/Lisa-Murkowski-cd76253c-a786-586d-aaac-bd14db985c3b.yml
+++ b/data/us/legislature/Lisa-Murkowski-cd76253c-a786-586d-aaac-bd14db985c3b.yml
@@ -79,6 +79,8 @@ ids:
   twitter: LisaMurkowski
   youtube: UCaigku16AErqvD0wRuwGb9A
   facebook: SenLisaMurkowski
+other_names:
+- name: Murkowski (R-AK)
 other_identifiers:
 - scheme: bioguide
   identifier: M001153

--- a/data/us/legislature/Marco-Rubio-014b069e-c444-50fe-99ef-bf72ae5aecd5.yml
+++ b/data/us/legislature/Marco-Rubio-014b069e-c444-50fe-99ef-bf72ae5aecd5.yml
@@ -71,6 +71,8 @@ ids:
   twitter: SenRubioPress
   youtube: UCh8t7sV_DBKz4A-RkL9feyg
   facebook: SenatorMarcoRubio
+other_names:
+- name: Rubio (R-FL)
 other_identifiers:
 - scheme: bioguide
   identifier: R000595

--- a/data/us/legislature/Margaret-Wood-Hassan-c59c2d02-3a1e-55a7-b1eb-638a902899d5.yml
+++ b/data/us/legislature/Margaret-Wood-Hassan-c59c2d02-3a1e-55a7-b1eb-638a902899d5.yml
@@ -55,6 +55,7 @@ ids:
   facebook: SenatorHassan
 other_names:
 - name: Maggie Hassan
+- name: Hassan (D-NH)
 other_identifiers:
 - scheme: bioguide
   identifier: H001076

--- a/data/us/legislature/Maria-Cantwell-46c3b77a-7d00-5ecc-83d0-04c8fa05bf04.yml
+++ b/data/us/legislature/Maria-Cantwell-46c3b77a-7d00-5ecc-83d0-04c8fa05bf04.yml
@@ -78,6 +78,8 @@ ids:
   twitter: SenatorCantwell
   youtube: UCN52UDqKgvHRk39ncySrIMw
   facebook: senatorcantwell
+other_names:
+- name: Cantwell (D-WA)
 other_identifiers:
 - scheme: bioguide
   identifier: C000127

--- a/data/us/legislature/Mark-Kelly-30665d55-5695-5ede-930d-c92e63e4ee65.yml
+++ b/data/us/legislature/Mark-Kelly-30665d55-5695-5ede-930d-c92e63e4ee65.yml
@@ -32,6 +32,8 @@ links:
 ids:
   twitter: SenMarkKelly
   facebook: SenMarkKelly
+other_names:
+- name: Kelly (D-AZ)
 other_identifiers:
 - scheme: bioguide
   identifier: K000377

--- a/data/us/legislature/Mark-R-Warner-0149412b-3e52-5743-bf11-a11ef4a98856.yml
+++ b/data/us/legislature/Mark-R-Warner-0149412b-3e52-5743-bf11-a11ef4a98856.yml
@@ -59,6 +59,8 @@ ids:
   twitter: MarkWarner
   youtube: UCwyivNlEGf4sGd1oDLfY5jw
   facebook: MarkRWarner
+other_names:
+- name: Warner (D-VA)
 other_identifiers:
 - scheme: bioguide
   identifier: W000805

--- a/data/us/legislature/Markwayne-Mullin-c1fcdb86-e58e-59ed-94f2-40e481824423.yml
+++ b/data/us/legislature/Markwayne-Mullin-c1fcdb86-e58e-59ed-94f2-40e481824423.yml
@@ -68,6 +68,8 @@ ids:
   twitter: SenMullin
   youtube: UCLQlm-cbGbJj9baZC6oFsag
   facebook: RepMullin
+other_names:
+- name: Mullin (R-OK)
 other_identifiers:
 - scheme: govtrack
   identifier: '412568'

--- a/data/us/legislature/Marsha-Blackburn-fad2ab8c-d191-5eb8-9bd8-5bbc44a35f0d.yml
+++ b/data/us/legislature/Marsha-Blackburn-fad2ab8c-d191-5eb8-9bd8-5bbc44a35f0d.yml
@@ -99,6 +99,8 @@ ids:
   twitter: MarshaBlackburn
   youtube: UCvNnmu5mUm7xr8QXBlbtQ9w
   facebook: marshablackburn
+other_names:
+- name: Blackburn (R-TN)
 other_identifiers:
 - scheme: bioguide
   identifier: B001243

--- a/data/us/legislature/Martin-Heinrich-fb46b038-d2a8-5824-bb36-deb07f8d9f54.yml
+++ b/data/us/legislature/Martin-Heinrich-fb46b038-d2a8-5824-bb36-deb07f8d9f54.yml
@@ -70,6 +70,7 @@ ids:
   facebook: MartinHeinrich
 other_names:
 - name: Martin T. Heinrich
+- name: Heinrich (D-NM)
 other_identifiers:
 - scheme: bioguide
   identifier: H001046

--- a/data/us/legislature/Mazie-K-Hirono-ee89a520-227a-575d-8379-5d36b6e6b2a2.yml
+++ b/data/us/legislature/Mazie-K-Hirono-ee89a520-227a-575d-8379-5d36b6e6b2a2.yml
@@ -54,6 +54,8 @@ ids:
   twitter: MazieHirono
   youtube: UCcoKhxad156flzPYJ8JMFOA
   facebook: senatorhirono
+other_names:
+- name: Hirono (D-HI)
 other_identifiers:
 - scheme: bioguide
   identifier: H001042

--- a/data/us/legislature/Michael-F-Bennet-16a0a125-6ebe-58b3-810f-df10c0e7df1f.yml
+++ b/data/us/legislature/Michael-F-Bennet-16a0a125-6ebe-58b3-810f-df10c0e7df1f.yml
@@ -77,6 +77,7 @@ ids:
   facebook: senbennetco
 other_names:
 - name: Michael Bennet
+- name: Bennet (D-CO)
 other_identifiers:
 - scheme: bioguide
   identifier: B001267

--- a/data/us/legislature/Mike-Braun-c3e17251-9796-592a-a8ed-8dea288dadf7.yml
+++ b/data/us/legislature/Mike-Braun-c3e17251-9796-592a-a8ed-8dea288dadf7.yml
@@ -43,6 +43,8 @@ links:
   note: contact form
 ids:
   twitter: SenatorBraun
+other_names:
+- name: Braun (R-IN)
 other_identifiers:
 - scheme: bioguide
   identifier: B001310

--- a/data/us/legislature/Mike-Crapo-9243a3a9-4e91-5fc8-9643-ae46455b688b.yml
+++ b/data/us/legislature/Mike-Crapo-9243a3a9-4e91-5fc8-9643-ae46455b688b.yml
@@ -94,6 +94,8 @@ ids:
   twitter: MikeCrapo
   youtube: UCMHzKHg1BE7dEcFjnayw1lA
   facebook: mikecrapo
+other_names:
+- name: Crapo (R-ID)
 other_identifiers:
 - scheme: bioguide
   identifier: C000880

--- a/data/us/legislature/Mike-Lee-461257ff-088f-5edd-b342-4652ce1c111f.yml
+++ b/data/us/legislature/Mike-Lee-461257ff-088f-5edd-b342-4652ce1c111f.yml
@@ -52,6 +52,8 @@ ids:
   twitter: SenMikeLee
   youtube: UCplVxs_j_sLAt0fkplXcl4A
   facebook: senatormikelee
+other_names:
+- name: Lee (R-UT)
 other_identifiers:
 - scheme: bioguide
   identifier: L000577

--- a/data/us/legislature/Mike-Rounds-bfd392c5-2d61-56fa-94c6-ea12aaee7ea6.yml
+++ b/data/us/legislature/Mike-Rounds-bfd392c5-2d61-56fa-94c6-ea12aaee7ea6.yml
@@ -52,6 +52,8 @@ ids:
   twitter: SenatorRounds
   youtube: UC-pvzimyBdpdkcIfsicrfrQ
   facebook: SenatorMikeRounds
+other_names:
+- name: Rounds (R-SD)
 other_identifiers:
 - scheme: bioguide
   identifier: R000605

--- a/data/us/legislature/Mitch-McConnell-200bd7b3-ce8e-5541-a649-b53e30862567.yml
+++ b/data/us/legislature/Mitch-McConnell-200bd7b3-ce8e-5541-a649-b53e30862567.yml
@@ -81,6 +81,8 @@ links:
 ids:
   twitter: McConnellPress
   facebook: mitchmcconnell
+other_names:
+- name: McConnell (R-KY)
 other_identifiers:
 - scheme: bioguide
   identifier: M000355

--- a/data/us/legislature/Mitt-Romney-2279327b-86e8-5baf-ad04-7b3e20f3da0c.yml
+++ b/data/us/legislature/Mitt-Romney-2279327b-86e8-5baf-ad04-7b3e20f3da0c.yml
@@ -30,6 +30,8 @@ links:
   note: contact form
 ids:
   twitter: SenatorRomney
+other_names:
+- name: Romney (R-UT)
 other_identifiers:
 - scheme: bioguide
   identifier: R000615

--- a/data/us/legislature/Patty-Murray-eb3ab543-13a1-53db-a8a1-459e8e91b701.yml
+++ b/data/us/legislature/Patty-Murray-eb3ab543-13a1-53db-a8a1-459e8e91b701.yml
@@ -82,6 +82,8 @@ links:
 ids:
   twitter: PattyMurray
   youtube: UCb8jq3TvQ3AzKsexhWfFLoA
+other_names:
+- name: Murray (D-WA)
 other_identifiers:
 - scheme: bioguide
   identifier: M001111

--- a/data/us/legislature/Pete-Ricketts-e1b9405a-e695-5bc5-b3b0-6cdc1415f53c.yml
+++ b/data/us/legislature/Pete-Ricketts-e1b9405a-e695-5bc5-b3b0-6cdc1415f53c.yml
@@ -22,6 +22,8 @@ offices:
 links:
 - url: https://www.ricketts.senate.gov
   note: website
+other_names:
+- name: Ricketts (R-NE)
 other_identifiers:
 - scheme: bioguide
   identifier: R000618

--- a/data/us/legislature/Peter-Welch-8addb5a8-a569-54b2-811b-b5d091350411.yml
+++ b/data/us/legislature/Peter-Welch-8addb5a8-a569-54b2-811b-b5d091350411.yml
@@ -73,6 +73,8 @@ ids:
   twitter: PeterWelch
   youtube: UC0YfApJx6qNaAQ-ir93U8xA
   facebook: PeterWelch
+other_names:
+- name: Welch (D-VT)
 other_identifiers:
 - scheme: bioguide
   identifier: W000800

--- a/data/us/legislature/Rand-Paul-7a1c13f9-1aac-5461-aa2a-11642749828d.yml
+++ b/data/us/legislature/Rand-Paul-7a1c13f9-1aac-5461-aa2a-11642749828d.yml
@@ -42,6 +42,8 @@ ids:
   twitter: SenRandPaul
   youtube: UCeM9I-20oWUs8daIIpsNHoQ
   facebook: SenatorRandPaul
+other_names:
+- name: Paul (R-KY)
 other_identifiers:
 - scheme: bioguide
   identifier: P000603

--- a/data/us/legislature/Raphael-G-Warnock-37f5a4b9-98b2-5c3d-857b-6e02f5123345.yml
+++ b/data/us/legislature/Raphael-G-Warnock-37f5a4b9-98b2-5c3d-857b-6e02f5123345.yml
@@ -34,6 +34,7 @@ ids:
   twitter: SenatorWarnock
 other_names:
 - name: Raphael Warnock
+- name: Warnock (D-GA)
 other_identifiers:
 - scheme: bioguide
   identifier: W000790

--- a/data/us/legislature/Richard-Blumenthal-62fd9e8b-80ea-5484-b1f1-3f3b4c350cc3.yml
+++ b/data/us/legislature/Richard-Blumenthal-62fd9e8b-80ea-5484-b1f1-3f3b4c350cc3.yml
@@ -48,6 +48,8 @@ ids:
   twitter: SenBlumenthal
   youtube: UCHH-fn3_LVt0Q4od56rOi5g
   facebook: SenBlumenthal
+other_names:
+- name: Blumenthal (D-CT)
 other_identifiers:
 - scheme: bioguide
   identifier: B001277

--- a/data/us/legislature/Richard-J-Durbin-7d0c4665-2bcf-5e53-b450-25461cd13d85.yml
+++ b/data/us/legislature/Richard-J-Durbin-7d0c4665-2bcf-5e53-b450-25461cd13d85.yml
@@ -104,6 +104,8 @@ ids:
   twitter: SenatorDurbin
   youtube: UCkbixlNCxcKAffEhe3X5-lw
   facebook: SenatorDurbin
+other_names:
+- name: Durbin (D-IL)
 other_identifiers:
 - scheme: bioguide
   identifier: D000563

--- a/data/us/legislature/Rick-Scott-3a57e816-1e10-58b5-8394-0272542ca567.yml
+++ b/data/us/legislature/Rick-Scott-3a57e816-1e10-58b5-8394-0272542ca567.yml
@@ -64,6 +64,8 @@ ids:
   twitter: SenRickScott
   youtube: UC-Y9pFmW4PYGZHkC8lcqSkQ
   facebook: RickScottSenOffice
+other_names:
+- name: Scott (R-FL)
 other_identifiers:
 - scheme: bioguide
   identifier: S001217

--- a/data/us/legislature/Robert-Menendez-cf399eb8-e1d0-58b8-ac90-fd10441d660b.yml
+++ b/data/us/legislature/Robert-Menendez-cf399eb8-e1d0-58b8-ac90-fd10441d660b.yml
@@ -88,6 +88,8 @@ ids:
   twitter: SenatorMenendez
   youtube: UC0PV0K9Z5a9p3D5917KF5fw
   facebook: senatormenendez
+other_names:
+- name: Menendez (D-NJ)
 other_identifiers:
 - scheme: bioguide
   identifier: M000639

--- a/data/us/legislature/Robert-P-Casey-Jr-18aff1ad-b362-53c8-bc7c-59cda8993c62.yml
+++ b/data/us/legislature/Robert-P-Casey-Jr-18aff1ad-b362-53c8-bc7c-59cda8993c62.yml
@@ -76,6 +76,7 @@ ids:
   facebook: SenatorBobCasey
 other_names:
 - name: Bob Casey
+- name: Casey (D-PA)
 other_identifiers:
 - scheme: bioguide
   identifier: C001070

--- a/data/us/legislature/Roger-F-Wicker-8fe2b037-b8ff-5161-9bb4-196e9f1d9dca.yml
+++ b/data/us/legislature/Roger-F-Wicker-8fe2b037-b8ff-5161-9bb4-196e9f1d9dca.yml
@@ -94,6 +94,8 @@ ids:
   twitter: SenatorWicker
   youtube: UCIlKHiTjSkcQP_knBcXHWSg
   facebook: SenatorWicker
+other_names:
+- name: Wicker (R-MS)
 other_identifiers:
 - scheme: bioguide
   identifier: W000437

--- a/data/us/legislature/Roger-Marshall-09a67947-f66a-55ac-b4ba-5c656ad7f67d.yml
+++ b/data/us/legislature/Roger-Marshall-09a67947-f66a-55ac-b4ba-5c656ad7f67d.yml
@@ -44,6 +44,8 @@ links:
   note: contact form
 ids:
   twitter: SenatorMarshall
+other_names:
+- name: Marshall (R-KS)
 other_identifiers:
 - scheme: bioguide
   identifier: M001198

--- a/data/us/legislature/Ron-Johnson-67d8f8b5-1fad-5132-9da8-3210783163a8.yml
+++ b/data/us/legislature/Ron-Johnson-67d8f8b5-1fad-5132-9da8-3210783163a8.yml
@@ -53,6 +53,8 @@ ids:
   twitter: SenRonJohnson
   youtube: UCG9XyTVtOAs7VX_q_QVHoaw
   facebook: senronjohnson
+other_names:
+- name: Johnson (R-WI)
 other_identifiers:
 - scheme: bioguide
   identifier: J000293

--- a/data/us/legislature/Ron-Wyden-7b0a82d1-eb2f-53a3-8352-de8b64d41060.yml
+++ b/data/us/legislature/Ron-Wyden-7b0a82d1-eb2f-53a3-8352-de8b64d41060.yml
@@ -116,6 +116,8 @@ links:
 ids:
   twitter: RonWyden
   youtube: UCsd3UEaoLoqX60P88BdpGGw
+other_names:
+- name: Wyden (D-OR)
 other_identifiers:
 - scheme: bioguide
   identifier: W000779

--- a/data/us/legislature/Sheldon-Whitehouse-fd0623ac-bbc8-5c5e-839f-37148d89c36e.yml
+++ b/data/us/legislature/Sheldon-Whitehouse-fd0623ac-bbc8-5c5e-839f-37148d89c36e.yml
@@ -43,6 +43,8 @@ ids:
   twitter: SenWhitehouse
   youtube: UCnG0N70SNBkNqvIMLodPTIA
   facebook: SenatorWhitehouse
+other_names:
+- name: Whitehouse (D-RI)
 other_identifiers:
 - scheme: bioguide
   identifier: W000802

--- a/data/us/legislature/Shelley-Moore-Capito-793e5b46-2682-51ff-bfca-adf217ca9a65.yml
+++ b/data/us/legislature/Shelley-Moore-Capito-793e5b46-2682-51ff-bfca-adf217ca9a65.yml
@@ -85,6 +85,8 @@ ids:
   twitter: SenCapito
   youtube: UCbiXdR4XQ3vD9Xp5lfR9QXw
   facebook: senshelley
+other_names:
+- name: Capito (R-WV)
 other_identifiers:
 - scheme: bioguide
   identifier: C001047

--- a/data/us/legislature/Sherrod-Brown-b84b6427-85e2-5d0c-b9e8-a44270378405.yml
+++ b/data/us/legislature/Sherrod-Brown-b84b6427-85e2-5d0c-b9e8-a44270378405.yml
@@ -93,6 +93,8 @@ ids:
   twitter: SenSherrodBrown
   youtube: UCgy8jfERh-t_ixkKKoCmglQ
   facebook: SenatorSherrodBrown
+other_names:
+- name: Brown (D-OH)
 other_identifiers:
 - scheme: bioguide
   identifier: B000944

--- a/data/us/legislature/Steve-Daines-75cfdbf0-b681-5535-8a97-b53310335e72.yml
+++ b/data/us/legislature/Steve-Daines-75cfdbf0-b681-5535-8a97-b53310335e72.yml
@@ -70,6 +70,8 @@ ids:
   twitter: SteveDaines
   youtube: UC-ny-W5mEUGytiyMdXbQ20Q
   facebook: SteveDainesMT
+other_names:
+- name: Daines (R-MT)
 other_identifiers:
 - scheme: govtrack
   identifier: '412549'

--- a/data/us/legislature/Susan-M-Collins-a6f624bf-9a40-53ad-a0da-92f115d619aa.yml
+++ b/data/us/legislature/Susan-M-Collins-a6f624bf-9a40-53ad-a0da-92f115d619aa.yml
@@ -73,6 +73,8 @@ ids:
   twitter: SenatorCollins
   youtube: UC6GYaBx5kT2r4PN8KENxC-w
   facebook: susancollins
+other_names:
+- name: Collins (R-ME)
 other_identifiers:
 - scheme: bioguide
   identifier: C001035

--- a/data/us/legislature/Tammy-Baldwin-d7c97bc3-b7cb-585b-b9e3-def97fcb9db6.yml
+++ b/data/us/legislature/Tammy-Baldwin-d7c97bc3-b7cb-585b-b9e3-def97fcb9db6.yml
@@ -96,6 +96,8 @@ ids:
   twitter: SenatorBaldwin
   youtube: UC_XjYCRbbI2_TDDjJidwk0Q
   facebook: senatortammybaldwin
+other_names:
+- name: Baldwin (D-WI)
 other_identifiers:
 - scheme: bioguide
   identifier: B001230

--- a/data/us/legislature/Tammy-Duckworth-c02182c1-3275-5f3e-9c66-2f0873cc72c7.yml
+++ b/data/us/legislature/Tammy-Duckworth-c02182c1-3275-5f3e-9c66-2f0873cc72c7.yml
@@ -66,6 +66,8 @@ ids:
   twitter: SenDuckworth
   youtube: UCYRWRvUxtjaHnFMCbdd94tg
   facebook: SenDuckworth
+other_names:
+- name: Duckworth (D-IL)
 other_identifiers:
 - scheme: govtrack
   identifier: '412533'

--- a/data/us/legislature/Ted-Budd-67c3f0bb-7182-51b8-98d0-253144992bfe.yml
+++ b/data/us/legislature/Ted-Budd-67c3f0bb-7182-51b8-98d0-253144992bfe.yml
@@ -50,6 +50,8 @@ links:
 ids:
   twitter: RepTedBudd
   facebook: RepTedBudd
+other_names:
+- name: Budd (R-NC)
 other_identifiers:
 - scheme: bioguide
   identifier: B001305

--- a/data/us/legislature/Ted-Cruz-c4d35f64-f25b-5888-9fcb-f3cb97df500e.yml
+++ b/data/us/legislature/Ted-Cruz-c4d35f64-f25b-5888-9fcb-f3cb97df500e.yml
@@ -61,6 +61,8 @@ ids:
   twitter: SenTedCruz
   youtube: UCOTZ-6H1rri1lSsj6IzhUyw
   facebook: SenatorTedCruz
+other_names:
+- name: Cruz (R-TX)
 other_identifiers:
 - scheme: bioguide
   identifier: C001098

--- a/data/us/legislature/Thom-Tillis-3ad2df38-e817-50b9-924d-9dbd4bba94a8.yml
+++ b/data/us/legislature/Thom-Tillis-3ad2df38-e817-50b9-924d-9dbd4bba94a8.yml
@@ -60,6 +60,7 @@ ids:
   facebook: SenatorThomTillis
 other_names:
 - name: Thomas Roland Tillis
+- name: Tillis (R-NC)
 other_identifiers:
 - scheme: bioguide
   identifier: T000476

--- a/data/us/legislature/Thomas-R-Carper-762f36c5-6766-5708-9066-d1d6340500d3.yml
+++ b/data/us/legislature/Thomas-R-Carper-762f36c5-6766-5708-9066-d1d6340500d3.yml
@@ -84,6 +84,8 @@ ids:
   twitter: SenatorCarper
   youtube: UCgLnvbKwu4B3navofj6Qvvw
   facebook: tomcarper
+other_names:
+- name: Carper (D-DE)
 other_identifiers:
 - scheme: bioguide
   identifier: C000174

--- a/data/us/legislature/Tim-Kaine-4d537f5f-04fd-578a-a8d2-61dd4972e758.yml
+++ b/data/us/legislature/Tim-Kaine-4d537f5f-04fd-578a-a8d2-61dd4972e758.yml
@@ -64,6 +64,7 @@ ids:
   facebook: SenatorKaine
 other_names:
 - name: Timothy M. Kaine
+- name: Kaine (D-VA)
 other_identifiers:
 - scheme: bioguide
   identifier: K000384

--- a/data/us/legislature/Tim-Scott-3bb4a99e-9448-5b35-86cd-114bd035535e.yml
+++ b/data/us/legislature/Tim-Scott-3bb4a99e-9448-5b35-86cd-114bd035535e.yml
@@ -63,6 +63,8 @@ ids:
   twitter: SenatorTimScott
   youtube: UCSfAsbG80CNInSKrtpKoL-w
   facebook: SenatorTimScott
+other_names:
+- name: Scott (R-SC)
 other_identifiers:
 - scheme: bioguide
   identifier: S001184

--- a/data/us/legislature/Tina-Smith-f82067c3-a257-54ae-b6bd-ebe5178372e7.yml
+++ b/data/us/legislature/Tina-Smith-f82067c3-a257-54ae-b6bd-ebe5178372e7.yml
@@ -54,6 +54,8 @@ links:
 ids:
   twitter: SenTinaSmith
   facebook: USSenTinaSmith
+other_names:
+- name: Smith (D-MN)
 other_identifiers:
 - scheme: bioguide
   identifier: S001203

--- a/data/us/legislature/Todd-Young-7ec39cbb-df0e-5970-aba1-5722964f55bb.yml
+++ b/data/us/legislature/Todd-Young-7ec39cbb-df0e-5970-aba1-5722964f55bb.yml
@@ -63,6 +63,8 @@ ids:
   twitter: SenToddYoung
   youtube: UCuknj4PGn91gHDNAfboZEgQ
   facebook: SenatorToddYoung
+other_names:
+- name: Young (R-IN)
 other_identifiers:
 - scheme: bioguide
   identifier: Y000064

--- a/data/us/legislature/Tom-Cotton-a0c9885f-b9f8-5045-9e74-044a886b9a6e.yml
+++ b/data/us/legislature/Tom-Cotton-a0c9885f-b9f8-5045-9e74-044a886b9a6e.yml
@@ -58,6 +58,8 @@ ids:
   twitter: SenTomCotton
   youtube: UCXEk6mokWBajIpNatbjnwSg
   facebook: SenatorTomCotton
+other_names:
+- name: Cotton (R-AR)
 other_identifiers:
 - scheme: govtrack
   identifier: '412508'

--- a/data/us/legislature/Tommy-Tuberville-0ee1b661-2035-5dc1-ab1c-b87d25682775.yml
+++ b/data/us/legislature/Tommy-Tuberville-0ee1b661-2035-5dc1-ab1c-b87d25682775.yml
@@ -27,6 +27,8 @@ links:
   note: contact form
 ids:
   twitter: SenTuberville
+other_names:
+- name: Tuberville (R-AL)
 other_identifiers:
 - scheme: bioguide
   identifier: T000278


### PR DESCRIPTION
Senators weren't matching up with Vote events since they use the last name, party & state as identifiers