### PR TITLE
Add some fields to John Marsi

### DIFF
--- a/data/ma/legislature/John-Marsi-0e8c6c71-bca0-46fd-86d1-223d41ed5517.yml
+++ b/data/ma/legislature/John-Marsi-0e8c6c71-bca0-46fd-86d1-223d41ed5517.yml
@@ -3,6 +3,7 @@ name: John Marsi
 given_name: John J.
 family_name: Marsi
 gender: Male
+email: john.marsi@mahouse.gov
 image: https://malegislature.gov/Legislators/Profile/170/JJM1.jpg
 party:
 - name: Republican
@@ -14,6 +15,7 @@ roles:
 offices:
 - classification: capitol
   address: State House 24 Beacon St., Boston, MA 02133
+  voice: 617-722-2060
 links:
 - url: https://malegislature.gov/Legislators/Profile/JJM1
 sources:
@@ -22,3 +24,5 @@ sources:
 - url: https://www.marsiforstaterep.com/about
 - url: https://www.linkedin.com/in/johnmarsi
 - url: https://ballotpedia.org/John_Marsi_Jr.
+extras:
+  member code: JJM1


### PR DESCRIPTION
Added email, Boston office phone number, and member code (the ID used by the MA legislature)