### PR TITLE
Fix John Mahoney's bad data with old member code

### DIFF
--- a/data/ma/legislature/John-J-Mahoney-2abbc0cb-6339-42d9-9947-69412a24301b.yml
+++ b/data/ma/legislature/John-J-Mahoney-2abbc0cb-6339-42d9-9947-69412a24301b.yml
@@ -4,7 +4,7 @@ given_name: John J.
 family_name: Mahoney
 gender: Male
 email: john.mahoney@mahouse.gov
-image: https://malegislature.gov/Legislators/Profile/170/JJM1.jpg
+image: https://malegislature.gov/Legislators/Profile/170/JJM2.jpg
 party:
 - name: Democratic
 roles:
@@ -19,7 +19,6 @@ offices:
   fax: 617-626-0247
 links:
 - url: https://malegislature.gov/Legislators/Profile/JJM2
-- url: https://malegislature.gov/Legislators/Profile/JJM1
 other_names:
 - name: John J. Mahoney
 other_identifiers:
@@ -30,15 +29,12 @@ other_identifiers:
 - scheme: openstates
   identifier: ocd-person/04e214f0-7982-4d03-ab06-aedb0ff12570
 sources:
-- url: https://malegislature.gov/api/GeneralCourts/192/LegislativeMembers/
-- url: https://malegislature.gov/api/GeneralCourts/193/LegislativeMembers/
-- url: https://malegislature.gov/Legislators/Profile/JJM1
+- url: https://malegislature.gov/Legislators/Profile/JJM2
 - url: https://en.wikipedia.org/wiki/John_J._Mahoney
 - url: https://www.linkedin.com/in/john-mahoney-86105565
 - url: https://ballotpedia.org/John_J._Mahoney
-- url: https://malegislature.gov/api/GeneralCourts/192/LegislativeMembers/JJM1
 - url: https://malegislature.gov/api/GeneralCourts/192/LegislativeMembers
-- url: https://malegislature.gov/api/GeneralCourts/193/LegislativeMembers/JJM1
+- url: https://malegislature.gov/api/GeneralCourts/192/LegislativeMembers/JJM2
 - url: https://malegislature.gov/api/GeneralCourts/193/LegislativeMembers
 - url: https://malegislature.gov/api/GeneralCourts/193/LegislativeMembers/JJM2
 extras:


### PR DESCRIPTION
It looks like the MA legislature website changed John Mahoney's member code from JJM1 to JJM2, and gave JJM1 to John Marsi who was elected earlier this year, breaking all of John Mahoney's existing links. Weird stuff! I checked on John Marsi's record and it looks fine, so this commit just cleans up Mahoney's.