### PR TITLE
US: MT at large congressional district removed in 2020

### DIFF
--- a/data/us/legislature/Matthew-M-Rosendale-Sr-5b030c5d-0d50-5452-b2f8-95f8659056fb.yml
+++ b/data/us/legislature/Matthew-M-Rosendale-Sr-5b030c5d-0d50-5452-b2f8-95f8659056fb.yml
@@ -12,11 +12,6 @@ party:
   name: Republican
 roles:
 - start_date: '2021-01-03'
-  end_date: '2023-01-03'
-  type: lower
-  jurisdiction: ocd-jurisdiction/country:us/government
-  district: MT-AL
-- start_date: '2023-01-03'
   end_date: '2025-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government

--- a/data/us/legislature/Ryan-K-Zinke-23aee4a1-f0aa-5803-9678-aebad9194f19.yml
+++ b/data/us/legislature/Ryan-K-Zinke-23aee4a1-f0aa-5803-9678-aebad9194f19.yml
@@ -14,12 +14,12 @@ roles:
   end_date: '2017-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
-  district: MT-AL
+  district: MT-1
 - start_date: '2017-01-03'
   end_date: '2017-03-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
-  district: MT-AL
+  district: MT-1
 - start_date: '2023-01-03'
   end_date: '2025-01-03'
   type: lower

--- a/data/us/legislature/Steve-Daines-75cfdbf0-b681-5535-8a97-b53310335e72.yml
+++ b/data/us/legislature/Steve-Daines-75cfdbf0-b681-5535-8a97-b53310335e72.yml
@@ -14,7 +14,7 @@ roles:
   end_date: '2015-01-03'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/government
-  district: MT-AL
+  district: MT-1
 - start_date: '2015-01-06'
   end_date: '2021-01-03'
   type: upper


### PR DESCRIPTION
Adjusts historical data to match currently supported post.

Not sure if this is the correct approach, please let me know if this causes problems. 

The motivation to fix here is that the unchanged data causes errors in loading up people into a new (local) OS DB, because the current set of Posts in metadata does not include this `MT-AL` Post.