### PR TITLE
Update Pennsylvania State Legislators images

### DIFF
--- a/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
+++ b/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
@@ -2,10 +2,10 @@ id: ocd-person/844f3ed7-03df-420f-81bd-3f547c12e61e
 name: Aaron Bernstine
 given_name: Aaron
 family_name: Bernstine
-birth_date: 1984-07-02
 gender: Male
 email: abernstine@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1742.jpg?1703415645672
+birth_date: 1984-07-02
+image: https://www.palegis.us/resources/images/members/200/1742.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
+++ b/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
@@ -4,7 +4,7 @@ given_name: Abby
 family_name: Major
 gender: Female
 email: amajor@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1926.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1926.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Abigail-Salisbury-4bc74848-3896-4a0a-9310-970458f48d1a.yml
+++ b/data/pa/legislature/Abigail-Salisbury-4bc74848-3896-4a0a-9310-970458f48d1a.yml
@@ -2,10 +2,10 @@ id: ocd-person/4bc74848-3896-4a0a-9310-970458f48d1a
 name: Abigail Salisbury
 given_name: Abigail
 family_name: Salisbury
-birth_date: 1982-04-07
 gender: Female
 email: repsalisbury@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2012.jpg?1703415645672
+birth_date: 1982-04-07
+image: https://www.palegis.us/resources/images/members/200/2012.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Aerion-Abney-1b5abb1e-0028-49a3-ae86-cfb90296c796.yml
+++ b/data/pa/legislature/Aerion-Abney-1b5abb1e-0028-49a3-ae86-cfb90296c796.yml
@@ -2,10 +2,10 @@ id: ocd-person/1b5abb1e-0028-49a3-ae86-cfb90296c796
 name: Aerion Abney
 given_name: Aerion
 family_name: Abney
-birth_date: 1988-05-23
 gender: Male
 email: aabney@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1933.jpg?1703415645672
+birth_date: 1988-05-23
+image: https://www.palegis.us/resources/images/members/200/1933.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Alec-J-Ryncavage-be809fa5-6ef4-4071-bb94-ed10fb051f69.yml
+++ b/data/pa/legislature/Alec-J-Ryncavage-be809fa5-6ef4-4071-bb94-ed10fb051f69.yml
@@ -2,10 +2,10 @@ id: ocd-person/be809fa5-6ef4-4071-bb94-ed10fb051f69
 name: Alec Ryncavage
 given_name: Alec
 family_name: Ryncavage
-birth_date: 2001-03-27
 gender: Male
 email: aryncavage@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1967.jpg?1703415645672
+birth_date: 2001-03-27
+image: https://www.palegis.us/resources/images/members/200/1967.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Amen-Brown-a41016aa-660f-4af7-afcd-ef182e544533.yml
+++ b/data/pa/legislature/Amen-Brown-a41016aa-660f-4af7-afcd-ef182e544533.yml
@@ -4,7 +4,7 @@ given_name: Amen
 family_name: Brown
 gender: Male
 email: repbrown@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1919.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1919.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Andre-Carroll-628312bf-7920-44b7-b226-90c92f92a123.yml
+++ b/data/pa/legislature/Andre-Carroll-628312bf-7920-44b7-b226-90c92f92a123.yml
@@ -3,6 +3,7 @@ name: Andre Carroll
 given_name: Andre
 family_name: Carroll
 gender: Male
+image: https://www.palegis.us/resources/images/members/200/2019.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Andrew-Kuzma-0d86d77b-ff68-4182-be53-09ff196b8174.yml
+++ b/data/pa/legislature/Andrew-Kuzma-0d86d77b-ff68-4182-be53-09ff196b8174.yml
@@ -4,7 +4,7 @@ given_name: Andrew
 family_name: Kuzma
 gender: Male
 email: akuzma@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1946.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1946.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
+++ b/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
@@ -2,10 +2,10 @@ id: ocd-person/999d1ffd-b893-4aac-9fbb-ae43b3039038
 name: Anita Kulik
 given_name: Anita
 family_name: Kulik
-birth_date: 1964-05-05
 gender: Female
 email: akulik@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1744.jpg?1703415645672
+birth_date: 1964-05-05
+image: https://www.palegis.us/resources/images/members/200/1744.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ann-Flood-e00e0f63-7058-46a4-8b63-f31dc804c614.yml
+++ b/data/pa/legislature/Ann-Flood-e00e0f63-7058-46a4-8b63-f31dc804c614.yml
@@ -4,7 +4,7 @@ given_name: Ann
 family_name: Flood
 gender: Female
 email: aflood@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1910.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1910.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Anthony-A-Bellmon-57be936d-802b-4d09-b95e-2a5354cb9984.yml
+++ b/data/pa/legislature/Anthony-A-Bellmon-57be936d-802b-4d09-b95e-2a5354cb9984.yml
@@ -2,10 +2,10 @@ id: ocd-person/57be936d-802b-4d09-b95e-2a5354cb9984
 name: Anthony Bellmon
 given_name: Anthony
 family_name: Bellmon
-birth_date: 1990-04-12
 gender: Male
 email: repbellmon@pahouse.com
-image: https://www.legis.state.pa.us/images/members/200/1984.jpg?1703415645672
+birth_date: 1990-04-12
+image: https://www.palegis.us/resources/images/members/200/1984.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Arvind-Venkat-f4e98ad8-2ee6-45e4-8594-0deaaa51190e.yml
+++ b/data/pa/legislature/Arvind-Venkat-f4e98ad8-2ee6-45e4-8594-0deaaa51190e.yml
@@ -2,10 +2,10 @@ id: ocd-person/f4e98ad8-2ee6-45e4-8594-0deaaa51190e
 name: Arvind Venkat
 given_name: Arvind
 family_name: Venkat
-birth_date: 1974-06-06
 gender: Male
 email: repvenkat@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1944.jpg?1703415645672
+birth_date: 1974-06-06
+image: https://www.palegis.us/resources/images/members/200/1944.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
+++ b/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
@@ -2,10 +2,10 @@ id: ocd-person/48c5b966-eef2-456a-8ca0-f47d584e7883
 name: Barb Gleim
 given_name: Barb
 family_name: Gleim
-birth_date: 1964-05-20
 gender: Female
 email: bgleim@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1864.jpg?1703415645672
+birth_date: 1964-05-20
+image: https://www.palegis.us/resources/images/members/200/1864.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ben-Waxman-1f2c3093-8ce7-41f7-8df0-6cd14ddd354b.yml
+++ b/data/pa/legislature/Ben-Waxman-1f2c3093-8ce7-41f7-8df0-6cd14ddd354b.yml
@@ -2,10 +2,10 @@ id: ocd-person/1f2c3093-8ce7-41f7-8df0-6cd14ddd354b
 name: Ben Waxman
 given_name: Ben
 family_name: Waxman
-birth_date: 1985-02-09
 gender: Male
 email: repwaxman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1981.jpg?1703415645672
+birth_date: 1985-02-09
+image: https://www.palegis.us/resources/images/members/200/1981.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
+++ b/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
@@ -2,10 +2,10 @@ id: ocd-person/b64463e2-41f6-4d58-a725-03db71798c1c
 name: Ben Sanchez
 given_name: Ben
 family_name: Sanchez
-birth_date: 1975-03-11
 gender: Male
 email: repsanchez@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1849.jpg?1703415645672
+birth_date: 1975-03-11
+image: https://www.palegis.us/resources/images/members/200/1849.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
+++ b/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
@@ -2,10 +2,10 @@ id: ocd-person/979ea568-4c43-41bd-ba1e-4c2da172bb82
 name: Brad Roae
 given_name: Brad
 family_name: Roae
-birth_date: 1967-04-06
 gender: Male
 email: broae@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1083.jpg?1703415645672
+birth_date: 1967-04-06
+image: https://www.palegis.us/resources/images/members/200/1083.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
+++ b/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
@@ -4,7 +4,7 @@ given_name: Brandon
 family_name: Markosek
 gender: Male
 email: brandonmarkosek@gmail.com
-image: https://www.legis.state.pa.us/images/members/200/1825.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1825.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brenda-Pugh-e12dc574-f19b-4c9c-9a30-42b68371ea4a.yml
+++ b/data/pa/legislature/Brenda-Pugh-e12dc574-f19b-4c9c-9a30-42b68371ea4a.yml
@@ -3,7 +3,7 @@ name: Brenda Pugh
 given_name: Brenda
 family_name: Pugh
 gender: Female
-image: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSqVdrj2w84kNrKi7RN0poR6kywKVZcSV7m-g&s
+image: https://www.palegis.us/resources/images/members/200/2033.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
+++ b/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
@@ -2,10 +2,10 @@ id: ocd-person/1a6e36d3-ff44-4e21-bb9d-397a56482b34
 name: Brett Miller
 given_name: Brett
 family_name: Miller
-birth_date: 1961-07-22
 gender: Male
 email: bmiller@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1699.jpg?1703415645672
+birth_date: 1961-07-22
+image: https://www.palegis.us/resources/images/members/200/1699.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brian-Munroe-0f035e7e-d035-4d8c-bc5b-876ba70452cc.yml
+++ b/data/pa/legislature/Brian-Munroe-0f035e7e-d035-4d8c-bc5b-876ba70452cc.yml
@@ -2,10 +2,10 @@ id: ocd-person/0f035e7e-d035-4d8c-bc5b-876ba70452cc
 name: Brian Munroe
 given_name: Brian
 family_name: Munroe
-birth_date: 1974-01-25
 gender: Male
 email: repmunroe@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1972.jpg?1703415645672
+birth_date: 1974-01-25
+image: https://www.palegis.us/resources/images/members/200/1972.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brian-Rasel-7ec5f0f0-0899-4f54-b284-c4c5931c25bc.yml
+++ b/data/pa/legislature/Brian-Rasel-7ec5f0f0-0899-4f54-b284-c4c5931c25bc.yml
@@ -3,6 +3,7 @@ name: Brian Rasel
 given_name: Brian
 family_name: Rasel
 gender: Male
+image: https://www.palegis.us/resources/images/members/200/2025.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brian-Smith-ac7d02d3-9bb7-4cc1-8cee-4283094fe604.yml
+++ b/data/pa/legislature/Brian-Smith-ac7d02d3-9bb7-4cc1-8cee-4283094fe604.yml
@@ -4,7 +4,7 @@ given_name: Brian
 family_name: Smith
 gender: Male
 email: bsmith@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1902.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1902.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
+++ b/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
@@ -4,7 +4,7 @@ given_name: Bridget
 family_name: Kosierowski
 gender: Female
 email: bkosierowski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1866.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1866.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
+++ b/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
@@ -2,10 +2,10 @@ id: ocd-person/fd5d0580-766c-482c-a12f-e4689e0bcf30
 name: Bryan Cutler
 given_name: Bryan
 family_name: Cutler
-birth_date: 1975-04-02
 gender: Male
 email: bcutler@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1105.jpg?1703415645672
+birth_date: 1975-04-02
+image: https://www.palegis.us/resources/images/members/200/1105.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
+++ b/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
@@ -2,10 +2,10 @@ id: ocd-person/9b9857aa-5fad-4678-a4f9-7e40bc642f64
 name: Bud Cook
 given_name: Bud
 family_name: Cook
-birth_date: 1956-06-29
 gender: Male
 email: bcook@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1745.jpg?1703415645672
+birth_date: 1956-06-29
+image: https://www.palegis.us/resources/images/members/200/1745.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
+++ b/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
@@ -2,10 +2,10 @@ id: ocd-person/462fc474-e481-436e-b47a-7bbde2de3e3a
 name: Carl Metzgar
 given_name: Carl
 family_name: Metzgar
-birth_date: 1981-10-01
 gender: Male
 email: cmetzgar@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1174.jpg?1703415645672
+birth_date: 1981-10-01
+image: https://www.palegis.us/resources/images/members/200/1174.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
+++ b/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
@@ -2,10 +2,10 @@ id: ocd-person/cafbffed-be4d-4e5b-9d99-9aec024675e2
 name: Carol Hill-Evans
 given_name: Carol
 family_name: Hill-Evans
-birth_date: 1949-11-21
 gender: Female
 email: chill-evans@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1749.jpg?1703415645672
+birth_date: 1949-11-21
+image: https://www.palegis.us/resources/images/members/200/1749.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Carol-Kazeem-05f5a4fa-4a1e-4242-8664-eca508f36a3c.yml
+++ b/data/pa/legislature/Carol-Kazeem-05f5a4fa-4a1e-4242-8664-eca508f36a3c.yml
@@ -4,7 +4,7 @@ given_name: Carol
 family_name: Kazeem
 gender: Female
 email: repkazeem@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1976.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1976.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Chad-Reichard-851902e6-5649-4c0c-948a-57fb9c1dd40d.yml
+++ b/data/pa/legislature/Chad-Reichard-851902e6-5649-4c0c-948a-57fb9c1dd40d.yml
@@ -3,7 +3,7 @@ name: Chad Reichard
 given_name: Chad
 family_name: Reichard
 gender: Male
-image: https://seventy.org/uploads/attachments/cly5z27ztjodi7xnpsnqhzmfb-screenshot-2024-07-03-at-11-07-37-am.0.29.1038.1099.max.png
+image: https://www.palegis.us/resources/images/members/200/2028.jpg?20241220
 party:
 - name: Republican
 roles:
@@ -15,4 +15,3 @@ other_names:
 - name: C. Reichard
 - name: C.G. Reichard
 - name: Reichard, C.
-sources: []

--- a/data/pa/legislature/Charity-Grimm-Krupa-d5bd036c-03f5-4111-b770-15cb2dbe3278.yml
+++ b/data/pa/legislature/Charity-Grimm-Krupa-d5bd036c-03f5-4111-b770-15cb2dbe3278.yml
@@ -4,7 +4,7 @@ given_name: Charity
 family_name: Krupa
 gender: Female
 email: ckrupa@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1949.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1949.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Chris-Pielli-d83a0679-02c9-469b-89ed-11f9b46166c5.yml
+++ b/data/pa/legislature/Chris-Pielli-d83a0679-02c9-469b-89ed-11f9b46166c5.yml
@@ -2,10 +2,10 @@ id: ocd-person/d83a0679-02c9-469b-89ed-11f9b46166c5
 name: Chris Pielli
 given_name: Chris
 family_name: Pielli
-birth_date: 1966-01-20
 gender: Male
 email: reppielli@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1975.jpg?1703415645672
+birth_date: 1966-01-20
+image: https://www.palegis.us/resources/images/members/200/1975.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
+++ b/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
@@ -2,10 +2,10 @@ id: ocd-person/43d9c3c2-aeec-416c-859d-ad90600bbe0e
 name: Christina Sappey
 given_name: Christina
 family_name: Sappey
-birth_date: 1962-08-31
 gender: Female
 email: repsappey@pahouse.com
-image: https://www.legis.state.pa.us/images/members/200/1852.jpg?1703415645672
+birth_date: 1962-08-31
+image: https://www.palegis.us/resources/images/members/200/1852.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
+++ b/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
@@ -2,10 +2,10 @@ id: ocd-person/e6a8e555-0d65-4a1f-9673-56ad1e3c7855
 name: Chris Rabb
 given_name: Chris
 family_name: Rabb
-birth_date: 1970-02-21
 gender: Male
 email: chris@chrisrabb.com
-image: https://www.legis.state.pa.us/images/members/200/1760.jpg?1703415645672g
+birth_date: 1970-02-21
+image: https://www.palegis.us/resources/images/members/200/1760.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
+++ b/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
@@ -4,7 +4,7 @@ given_name: Clint
 family_name: Owlett
 gender: Male
 email: cowlett@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1796.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1796.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
+++ b/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
@@ -2,10 +2,10 @@ id: ocd-person/bb324f66-3a5c-4e90-9c75-d142cce81c92
 name: Craig Staats
 given_name: Craig
 family_name: Staats
-birth_date: 1961-02-04
 gender: Male
 email: cstaats@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1707.jpg?1703415645672
+birth_date: 1961-02-04
+image: https://www.palegis.us/resources/images/members/200/1707.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Craig-Williams-e17c51da-556e-4afe-aad4-137ee3a0881e.yml
+++ b/data/pa/legislature/Craig-Williams-e17c51da-556e-4afe-aad4-137ee3a0881e.yml
@@ -2,10 +2,10 @@ id: ocd-person/e17c51da-556e-4afe-aad4-137ee3a0881e
 name: Craig Williams
 given_name: Craig
 family_name: Williams
-birth_date: 1965-11-07
 gender: Male
 email: craig.williams@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1916.jpg?1703415645672
+birth_date: 1965-11-07
+image: https://www.palegis.us/resources/images/members/200/1916.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dallas-Kephart-70d0ff46-746e-47a0-8c5f-cbe73dbf72ce.yml
+++ b/data/pa/legislature/Dallas-Kephart-70d0ff46-746e-47a0-8c5f-cbe73dbf72ce.yml
@@ -4,7 +4,7 @@ given_name: Dallas
 family_name: Kephart
 gender: Male
 email: dkephart@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1952.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1952.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
+++ b/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
@@ -2,10 +2,10 @@ id: ocd-person/96667f6d-d967-4f6a-9cd9-23bf480a98c1
 name: Dan Frankel
 given_name: Dan
 family_name: Frankel
-birth_date: 1956-04-11
 gender: Male
 email: repfrankel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/84.jpg?1703415645672
+birth_date: 1956-04-11
+image: https://www.palegis.us/resources/images/members/200/84.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
+++ b/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
@@ -2,10 +2,10 @@ id: ocd-person/8cb5e285-fdd9-4c63-b7c7-480bf9e477e1
 name: Dan Williams
 given_name: Dan
 family_name: Williams
-birth_date: 1956-09-23
 gender: Male
 email: dwilliams@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1837.jpg?1703415645672
+birth_date: 1956-09-23
+image: https://www.palegis.us/resources/images/members/200/1837.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dan-L-Miller-cf94e0e7-498b-419b-9d3a-36c31d1eaf46.yml
+++ b/data/pa/legislature/Dan-L-Miller-cf94e0e7-498b-419b-9d3a-36c31d1eaf46.yml
@@ -2,10 +2,10 @@ id: ocd-person/cf94e0e7-498b-419b-9d3a-36c31d1eaf46
 name: Dan Miller
 given_name: Dan
 family_name: Miller
-birth_date: 1973-02-09
 gender: Male
 email: repmiller@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1679.jpg?1703415645672
+birth_date: 1973-02-09
+image: https://www.palegis.us/resources/images/members/200/1679.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
+++ b/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
@@ -2,10 +2,10 @@ id: ocd-person/f4071288-fa18-48bb-99f1-41abd60d215e
 name: Dan Moul
 given_name: Dan
 family_name: Moul
-birth_date: 1950-10-10
 gender: Male
 email: dmoul@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1101.jpg?1703415645672
+birth_date: 1950-10-10
+image: https://www.palegis.us/resources/images/members/200/1101.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dane-Watro-d4de5cc2-b3b9-49a0-9f20-62c6f4f6a052.yml
+++ b/data/pa/legislature/Dane-Watro-d4de5cc2-b3b9-49a0-9f20-62c6f4f6a052.yml
@@ -4,7 +4,7 @@ given_name: Dane
 family_name: Watro
 gender: Male
 email: dwatro@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1964.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1964.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
+++ b/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
@@ -2,10 +2,10 @@ id: ocd-person/2608882d-9ae2-4522-b8b2-83d905913d3f
 name: Dan Deasy
 given_name: Dan
 family_name: Deasy
-birth_date: 1966-08-01
 gender: Male
 email: ddeasy@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1166.jpg?1703415645672
+birth_date: 1966-08-01
+image: https://www.palegis.us/resources/images/members/200/1166.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
+++ b/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
@@ -2,10 +2,10 @@ id: ocd-person/6678bcaf-292f-408a-aa36-90ed8bc8fd08
 name: Danielle Otten
 given_name: Danielle
 family_name: Otten
-birth_date: 1977-07-25
 gender: Female
 email: repotten@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1850.jpg?1703415645672
+birth_date: 1977-07-25
+image: https://www.palegis.us/resources/images/members/200/1850.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
+++ b/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
@@ -2,10 +2,10 @@ id: ocd-person/a2579707-5a31-4f4b-a9ed-49847d35eae6
 name: Danilo Burgos
 given_name: Danilo
 family_name: Burgos
-birth_date: 1978-01-19
 gender: Male
 email: dburgos@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1863.jpg?1703415645672
+birth_date: 1978-01-19
+image: https://www.palegis.us/resources/images/members/200/1863.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Darisha-K-Parker-943fdd89-fe0a-43f6-8077-82cd252bdeb2.yml
+++ b/data/pa/legislature/Darisha-K-Parker-943fdd89-fe0a-43f6-8077-82cd252bdeb2.yml
@@ -4,7 +4,7 @@ given_name: Darisha
 family_name: Parker
 gender: Female
 email: repparker@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1920.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1920.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
+++ b/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
@@ -2,10 +2,10 @@ id: ocd-person/c05046a6-87dd-4956-a172-cad035960391
 name: Dave Delloso
 given_name: Dave
 family_name: Delloso
-birth_date: 1965-06-18
 gender: Male
 email: repdelloso@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1853.jpg?1703415645672
+birth_date: 1965-06-18
+image: https://www.palegis.us/resources/images/members/200/1853.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dave-Madsen-4a0c9e5e-07cc-4b4b-a47a-22be60d1623e.yml
+++ b/data/pa/legislature/Dave-Madsen-4a0c9e5e-07cc-4b4b-a47a-22be60d1623e.yml
@@ -4,7 +4,7 @@ given_name: Dave
 family_name: Madsen
 gender: Male
 email: repmadsen@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1959.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1959.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
+++ b/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
@@ -2,10 +2,10 @@ id: ocd-person/2fbada46-9c48-4be5-a49f-e1ca0af132ed
 name: Dave Zimmerman
 given_name: Dave
 family_name: Zimmerman
-birth_date: 1956-04-13
 gender: Male
 email: dzimmerman@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1711.jpg?1703415645672
+birth_date: 1956-04-13
+image: https://www.palegis.us/resources/images/members/200/1711.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
+++ b/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
@@ -2,10 +2,10 @@ id: ocd-person/fb4a0115-dd63-4e25-8d36-0ea6afc55faf
 name: David Maloney
 given_name: David
 family_name: Maloney
-birth_date: 1960-08-25
 gender: Male
 email: dmaloney@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1226.jpg?1703415645672
+birth_date: 1960-08-25
+image: https://www.palegis.us/resources/images/members/200/1226.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
+++ b/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
@@ -2,10 +2,10 @@ id: ocd-person/c88ccd9a-3378-4284-9dc6-767a4826526e
 name: David Rowe
 given_name: David
 family_name: Rowe
-birth_date: 1991-02-10
 gender: Male
 email: drowe@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1871.jpg?1703415645672
+birth_date: 1991-02-10
+image: https://www.palegis.us/resources/images/members/200/1871.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Donna-Scheuren-5913495d-53f8-4c39-8507-650cfe51c08b.yml
+++ b/data/pa/legislature/Donna-Scheuren-5913495d-53f8-4c39-8507-650cfe51c08b.yml
@@ -4,7 +4,7 @@ given_name: Donna
 family_name: Scheuren
 gender: Female
 email: dscheuren@pahousegop.gov
-image: https://www.legis.state.pa.us/images/members/200/1973.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1973.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
+++ b/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
@@ -2,10 +2,10 @@ id: ocd-person/885e9a2a-c18b-4f68-b5d0-0b867ec3268d
 name: Doyle Heffley
 given_name: Doyle
 family_name: Heffley
-birth_date: 1970-02-24
 gender: Male
 email: dheffley@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1211.jpg?1703415645672
+birth_date: 1970-02-24
+image: https://www.palegis.us/resources/images/members/200/1211.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
+++ b/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
@@ -2,10 +2,10 @@ id: ocd-person/3d3d4070-dadd-4382-9d40-be2892745773
 name: Ed Neilson
 given_name: Ed
 family_name: Neilson
-birth_date: 1963-08-23
 gender: Male
 email: repneilson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1615.jpg?1703415645672
+birth_date: 1963-08-23
+image: https://www.palegis.us/resources/images/members/200/1615.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
+++ b/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
@@ -2,10 +2,10 @@ id: ocd-person/c1cb6f95-37c8-4e25-802e-80387e70ad74
 name: Eddie Pashinski
 given_name: Eddie
 family_name: Pashinski
-birth_date: 1945-07-02
 gender: Male
 email: reppashinski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1112.jpg?1703415645672
+birth_date: 1945-07-02
+image: https://www.palegis.us/resources/images/members/200/1112.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
+++ b/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
@@ -2,10 +2,10 @@ id: ocd-person/90d95881-f6ae-4b29-af31-31a8821b8a7c
 name: Elizabeth Fiedler
 given_name: Elizabeth
 family_name: Fiedler
-birth_date: 1980-07-18
 gender: Female
 email: repfiedler@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1861.jpg?1703415645672
+birth_date: 1980-07-18
+image: https://www.palegis.us/resources/images/members/200/1861.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Emily-Kinkead-875b1add-2803-4cc3-964b-0e351ed6ca1c.yml
+++ b/data/pa/legislature/Emily-Kinkead-875b1add-2803-4cc3-964b-0e351ed6ca1c.yml
@@ -2,10 +2,10 @@ id: ocd-person/875b1add-2803-4cc3-964b-0e351ed6ca1c
 name: Emily Kinkead
 given_name: Emily
 family_name: Kinkead
-birth_date: 1987-06-04
 gender: Female
 email: repkinkead@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1896.jpg?1703415645672
+birth_date: 1987-06-04
+image: https://www.palegis.us/resources/images/members/200/1896.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
+++ b/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
@@ -4,7 +4,7 @@ given_name: Eric
 family_name: Davanzo
 gender: Male
 email: edavanzo@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1875.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1875.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
+++ b/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
@@ -2,10 +2,10 @@ id: ocd-person/0910d394-3c42-48ee-aea7-6d4c0c144130
 name: Eric Nelson
 given_name: Eric
 family_name: Nelson
-birth_date: 1968-12-19
 gender: Male
 email: enelson@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1738.jpg?1703415645672
+birth_date: 1968-12-19
+image: https://www.palegis.us/resources/images/members/200/1738.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Eric-Weaknecht-b7373c43-580b-4044-a405-054073ac687b.yml
+++ b/data/pa/legislature/Eric-Weaknecht-b7373c43-580b-4044-a405-054073ac687b.yml
@@ -3,7 +3,7 @@ name: Eric Weaknecht
 given_name: Eric
 family_name: Weaknecht
 gender: Male
-image: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQNTmXpiok-J6R_vUlOit1nC52uvUkP1E-Wag&s
+image: https://www.palegis.us/resources/images/members/200/2021.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
+++ b/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
@@ -2,10 +2,10 @@ id: ocd-person/a60da669-bae3-4e1d-a241-370a7ad2c769
 name: Frank Burns
 given_name: Frank
 family_name: Burns
-birth_date: 1975-10-21
 gender: Male
 email: repburns@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1163.jpg?1703415645672
+birth_date: 1975-10-21
+image: https://www.palegis.us/resources/images/members/200/1163.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/G-Roni-Green-c3ad9b17-c8f5-450e-9aaa-f002e1414bd5.yml
+++ b/data/pa/legislature/G-Roni-Green-c3ad9b17-c8f5-450e-9aaa-f002e1414bd5.yml
@@ -2,10 +2,10 @@ id: ocd-person/c3ad9b17-c8f5-450e-9aaa-f002e1414bd5
 name: Roni Green
 given_name: Roni
 family_name: Green
-birth_date: 1959-06-09
 gender: Female
 email: repgreen@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1874.jpg?1703415645672
+birth_date: 1959-06-09
+image: https://www.palegis.us/resources/images/members/200/1874.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
+++ b/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
@@ -2,9 +2,9 @@ id: ocd-person/3088ff8e-d2d9-46b9-8ea3-bd35af9438c2
 name: Gary Day
 given_name: Gary
 family_name: Day
-birth_date: 1967-01-18
 gender: Male
-image: https://www.legis.state.pa.us/images/members/200/1190.jpg
+birth_date: 1967-01-18
+image: https://www.palegis.us/resources/images/members/200/1190.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Gina-H-Curry-4c88ce64-4ba6-4f5e-a22f-86bf6a0d5b7f.yml
+++ b/data/pa/legislature/Gina-H-Curry-4c88ce64-4ba6-4f5e-a22f-86bf6a0d5b7f.yml
@@ -2,10 +2,10 @@ id: ocd-person/4c88ce64-4ba6-4f5e-a22f-86bf6a0d5b7f
 name: Gina Curry
 given_name: Gina
 family_name: Curry
-birth_date: 1972-10-23
 gender: Female
 email: repcurry@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1932.jpg?1703415645672
+birth_date: 1972-10-23
+image: https://www.palegis.us/resources/images/members/200/1932.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Greg-Scott-969ce6cb-ddcb-4347-b69d-2019cfbd6e18.yml
+++ b/data/pa/legislature/Greg-Scott-969ce6cb-ddcb-4347-b69d-2019cfbd6e18.yml
@@ -4,7 +4,7 @@ given_name: Greg
 family_name: Scott
 gender: Male
 email: repscott@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1950.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1950.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
+++ b/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
@@ -2,10 +2,10 @@ id: ocd-person/7a1f510f-12e0-4018-b6da-556b404399be
 name: Greg Vitali
 given_name: Greg
 family_name: Vitali
-birth_date: 1956-06-04
 gender: Male
 email: gvitali@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/210.jpg?1703415645672
+birth_date: 1956-06-04
+image: https://www.palegis.us/resources/images/members/200/210.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Heather-Boyd-d5f1bbaf-5daf-4266-9b18-16042f49db1b.yml
+++ b/data/pa/legislature/Heather-Boyd-d5f1bbaf-5daf-4266-9b18-16042f49db1b.yml
@@ -4,7 +4,7 @@ given_name: Heather
 family_name: Boyd
 gender: Female
 email: hboyd@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2015.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/2015.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ismail-Smith-Wade-El-fefff26b-b89a-4400-b633-99e5aa09523b.yml
+++ b/data/pa/legislature/Ismail-Smith-Wade-El-fefff26b-b89a-4400-b633-99e5aa09523b.yml
@@ -4,7 +4,7 @@ given_name: Izzy
 family_name: Smith-Wade-El
 gender: Male
 email: repsmithwadeel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1948.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1948.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
+++ b/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
@@ -2,10 +2,10 @@ id: ocd-person/abca93cc-5058-473c-93bc-c8e099c7fa20
 name: Jack Rader
 given_name: Jack
 family_name: Rader
-birth_date: 1954-02-10
 gender: Male
 email: jrader@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1703.jpg?1703415645672
+birth_date: 1954-02-10
+image: https://www.palegis.us/resources/images/members/200/1703.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jacklyn-Rusnock-fe624f82-e44d-4071-a49f-3a0d4965b7b9.yml
+++ b/data/pa/legislature/Jacklyn-Rusnock-fe624f82-e44d-4071-a49f-3a0d4965b7b9.yml
@@ -3,7 +3,7 @@ name: Jacklyn Rusnock
 given_name: Jacklyn
 family_name: Rusnock
 gender: Female
-image: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQQN8TGsUPRmCdJJis2P-yzcJsfaJRABStMDA&s
+image: https://www.palegis.us/resources/images/members/200/2034.jpg?20241220
 party:
 - name: Democratic
 roles:
@@ -15,4 +15,3 @@ other_names:
 - name: J. Rusnock
 - name: J.H. Rusnock
 - name: Rusnock, J.
-sources: []

--- a/data/pa/legislature/Jacob-D-Banta-4657c161-af68-44a8-bd60-8b8e88e702d1.yml
+++ b/data/pa/legislature/Jacob-D-Banta-4657c161-af68-44a8-bd60-8b8e88e702d1.yml
@@ -4,7 +4,7 @@ given_name: Jake
 family_name: Banta
 gender: Male
 email: jbanta@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1937.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1937.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
+++ b/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
@@ -2,10 +2,10 @@ id: ocd-person/4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1
 name: Jim Struzzi
 given_name: Jim
 family_name: Struzzi
-birth_date: 1967-09-23
 gender: Male
 email: jstruzzi@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1835.jpg?1703415645672
+birth_date: 1967-09-23
+image: https://www.palegis.us/resources/images/members/200/1835.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jamie-Barton-82938e14-97ce-44f0-942f-5bd2d7c532ba.yml
+++ b/data/pa/legislature/Jamie-Barton-82938e14-97ce-44f0-942f-5bd2d7c532ba.yml
@@ -4,7 +4,7 @@ given_name: Jamie
 family_name: Barton
 gender: Male
 email: jbarton@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1968.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1968.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jamie-L-Flick-e396f514-a357-404f-bdb9-1ba33d97d0a7.yml
+++ b/data/pa/legislature/Jamie-L-Flick-e396f514-a357-404f-bdb9-1ba33d97d0a7.yml
@@ -4,7 +4,7 @@ given_name: Jamie
 family_name: Flick
 gender: Male
 email: jflick@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1954.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1954.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jamie-Walsh-96cbec5b-b9a4-4325-8346-bd4d08d87237.yml
+++ b/data/pa/legislature/Jamie-Walsh-96cbec5b-b9a4-4325-8346-bd4d08d87237.yml
@@ -3,7 +3,7 @@ name: Jamie Walsh
 given_name: Jamie
 family_name: Walsh
 gender: Male
-image: https://npr.brightspotcdn.com/dims4/default/eb103d1/2147483647/strip/true/crop/326x342+0+0/resize/880x923!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Fed%2F90%2F0e6c8c9a46d28228ce6f3586809d%2Fwalsh.jpg
+image: https://www.palegis.us/resources/images/members/200/2032.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
+++ b/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
@@ -2,10 +2,10 @@ id: ocd-person/6b6602c0-8b45-4e1e-89ba-1782da5d67c6
 name: Jared Solomon
 given_name: Jared
 family_name: Solomon
-birth_date: 1978-11-18
 gender: Male
 email: jsolomon@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1761.jpg?1703415645672
+birth_date: 1978-11-18
+image: https://www.palegis.us/resources/images/members/200/1761.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
+++ b/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
@@ -2,10 +2,10 @@ id: ocd-person/4a2176cc-292b-4d19-aff6-8b4c4b460ba0
 name: Jason Dawkins
 given_name: Jason
 family_name: Dawkins
-birth_date: 1984-03-25
 gender: Male
 email: jdawkins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1685.jpg?1703415645672
+birth_date: 1984-03-25
+image: https://www.palegis.us/resources/images/members/200/1685.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
+++ b/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
@@ -2,10 +2,10 @@ id: ocd-person/1871b5c7-35c4-4d32-9e09-9febf8ba3f66
 name: Jason Ortitay
 given_name: Jason
 family_name: Ortitay
-birth_date: 1983-03-14
 gender: Male
 email: jortitay@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1701.jpg?1703415645672
+birth_date: 1983-03-14
+image: https://www.palegis.us/resources/images/members/200/1701.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
+++ b/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
@@ -2,10 +2,10 @@ id: ocd-person/ddd14a2f-ebef-4918-bf91-578b71c085e4
 name: Jeanne McNeill
 given_name: Jeanne
 family_name: McNeill
-birth_date: 1960-08-09
 gender: Female
 email: jmcneill@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1793.jpg?1703415645672
+birth_date: 1960-08-09
+image: https://www.palegis.us/resources/images/members/200/1793.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jeff-Olsommer-08211014-af0e-4d71-92a7-e0045ba8062a.yml
+++ b/data/pa/legislature/Jeff-Olsommer-08211014-af0e-4d71-92a7-e0045ba8062a.yml
@@ -4,7 +4,7 @@ given_name: Jeff
 family_name: Olsommer
 gender: Male
 email: jolsommer@pahousegop.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/Jeff_Olsommer.jpeg
+image: https://www.palegis.us/resources/images/members/200/2018.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
+++ b/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
@@ -2,10 +2,10 @@ id: ocd-person/7c8e87fe-1c8e-4736-a03c-35cf729b80e9
 name: Jenn O'Mara
 given_name: Jenn
 family_name: O'Mara
-birth_date: 1989-11-12
 gender: Female
 email: repomara@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1855.jpg?1703415645672
+birth_date: 1989-11-12
+image: https://www.palegis.us/resources/images/members/200/1855.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jeremy-Shaffer-0df3f8d5-b6df-4cd8-a2c7-1dee651e60a8.yml
+++ b/data/pa/legislature/Jeremy-Shaffer-0df3f8d5-b6df-4cd8-a2c7-1dee651e60a8.yml
@@ -4,7 +4,7 @@ given_name: Jeremy
 family_name: Shaffer
 gender: Male
 email: jshaffer@pahousegop.com
-image: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQSorGMaPu0r-cmKNo0wUJlamXWmBuybfdPUA&s
+image: https://www.palegis.us/resources/images/members/200/2023.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
+++ b/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
@@ -2,10 +2,10 @@ id: ocd-person/865dbfc4-e6ec-400e-bd5c-257f9a947519
 name: Jesse Topper
 given_name: Jesse
 family_name: Topper
-birth_date: 1981-09-19
 gender: Male
 email: jtopper@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1681.jpg?1703415645672g
+birth_date: 1981-09-19
+image: https://www.palegis.us/resources/images/members/200/1681.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jessica-Benham-8b6409e9-8ab6-4222-b6f3-fb8f33800c95.yml
+++ b/data/pa/legislature/Jessica-Benham-8b6409e9-8ab6-4222-b6f3-fb8f33800c95.yml
@@ -2,10 +2,10 @@ id: ocd-person/8b6409e9-8ab6-4222-b6f3-fb8f33800c95
 name: Jessica Benham
 given_name: Jessica
 family_name: Benham
-birth_date: 1990-12-13
 gender: Female
 email: repbenham@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1899.jpg?1703415645672
+birth_date: 1990-12-13
+image: https://www.palegis.us/resources/images/members/200/1899.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jill-N-Cooper-6ae972c8-aff3-4886-a7d7-bd2cc5e40a38.yml
+++ b/data/pa/legislature/Jill-N-Cooper-6ae972c8-aff3-4886-a7d7-bd2cc5e40a38.yml
@@ -4,7 +4,7 @@ given_name: Jill
 family_name: Cooper
 gender: Female
 email: jcooper@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1951.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1951.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jim-Haddock-3b91abb8-4b49-4fa2-85ed-beea4919bccc.yml
+++ b/data/pa/legislature/Jim-Haddock-3b91abb8-4b49-4fa2-85ed-beea4919bccc.yml
@@ -4,7 +4,7 @@ given_name: Jim
 family_name: Haddock
 gender: Male
 email: rephaddock@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1966.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1966.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jim-Prokopiak-3c3cd25a-658f-4aab-a648-ef2509469c34.yml
+++ b/data/pa/legislature/Jim-Prokopiak-3c3cd25a-658f-4aab-a648-ef2509469c34.yml
@@ -4,7 +4,7 @@ given_name: Jim
 family_name: Prokopiak
 gender: Male
 email: repprokopiak@pahouse.net
-image: https://www.palegis.us/resources/images/members/200/2017.jpg?20240411
+image: https://www.palegis.us/resources/images/members/200/2017.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
+++ b/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
@@ -4,7 +4,7 @@ given_name: Jim
 family_name: Rigby
 gender: Male
 email: jrigby@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1836.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1836.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
+++ b/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
@@ -2,10 +2,10 @@ id: ocd-person/1951ae06-881a-4c43-9635-224878c3ecb5
 name: Joanna McClinton
 given_name: Joanna
 family_name: McClinton
-birth_date: 1982-08-19
 gender: Female
 email: repjoanna191@gmail.com
-image: https://www.legis.state.pa.us/images/members/200/1734.jpg?1703415645672
+birth_date: 1982-08-19
+image: https://www.palegis.us/resources/images/members/200/1734.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joanne-Stehr-6e7b8baa-4fa3-404e-b8f8-bab3077221b7.yml
+++ b/data/pa/legislature/Joanne-Stehr-6e7b8baa-4fa3-404e-b8f8-bab3077221b7.yml
@@ -4,7 +4,7 @@ given_name: Joanne
 family_name: Stehr
 gender: Female
 email: jstehr@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1961.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1961.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
+++ b/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
@@ -2,10 +2,10 @@ id: ocd-person/c9521d0e-56ca-40d2-b9bc-7a1f1be639bc
 name: Joe Ciresi
 given_name: Joe
 family_name: Ciresi
-birth_date: 1970-09-15
 gender: Male
 email: jciresi@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1847.jpg?1703415645672
+birth_date: 1970-09-15
+image: https://www.palegis.us/resources/images/members/200/1847.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
+++ b/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Emrick
 gender: Male
 email: jemrick@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1207.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1207.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Hamm-acc00fca-50e5-46f7-8676-d502ecfc94ac.yml
+++ b/data/pa/legislature/Joe-Hamm-acc00fca-50e5-46f7-8676-d502ecfc94ac.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Hamm
 gender: Male
 email: jhamm@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1904.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1904.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Hogan-b1beaa5c-93d2-479e-9408-47c7687cd212.yml
+++ b/data/pa/legislature/Joe-Hogan-b1beaa5c-93d2-479e-9408-47c7687cd212.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Hogan
 gender: Male
 email: jhogan@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1971.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1971.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Kerwin-8a7494a6-3d82-432b-a5c2-6dc46d192611.yml
+++ b/data/pa/legislature/Joe-Kerwin-8a7494a6-3d82-432b-a5c2-6dc46d192611.yml
@@ -2,10 +2,10 @@ id: ocd-person/8a7494a6-3d82-432b-a5c2-6dc46d192611
 name: Joe Kerwin
 given_name: Joe
 family_name: Kerwin
-birth_date: 1993-01-20
 gender: Male
 email: jkerwin@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1907.jpg?1703415645672
+birth_date: 1993-01-20
+image: https://www.palegis.us/resources/images/members/200/1907.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-McAndrew-d31e549e-2c3d-4ea3-850b-5285955c3c2f.yml
+++ b/data/pa/legislature/Joe-McAndrew-d31e549e-2c3d-4ea3-850b-5285955c3c2f.yml
@@ -2,10 +2,10 @@ id: ocd-person/d31e549e-2c3d-4ea3-850b-5285955c3c2f
 name: Joe McAndrew
 given_name: Joe
 family_name: McAndrew
-birth_date: 1990-08-01
 gender: Male
 email: repmcandrew@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2011.jpg?1703415645672
+birth_date: 1990-08-01
+image: https://www.palegis.us/resources/images/members/200/2011.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
+++ b/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
@@ -2,10 +2,10 @@ id: ocd-person/676410b6-c3aa-4c17-856f-7d896e6fbc83
 name: Joe Webster
 given_name: Joe
 family_name: Webster
-birth_date: 1958-03-23
 gender: Male
 email: repwebster@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1848.jpg?1703415645672
+birth_date: 1958-03-23
+image: https://www.palegis.us/resources/images/members/200/1848.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Johanny-Cepeda-Freytiz-8d5ab463-45d5-4cf0-9c65-85820c08e506.yml
+++ b/data/pa/legislature/Johanny-Cepeda-Freytiz-8d5ab463-45d5-4cf0-9c65-85820c08e506.yml
@@ -2,10 +2,10 @@ id: ocd-person/8d5ab463-45d5-4cf0-9c65-85820c08e506
 name: Johanny Cepeda-Freytiz
 given_name: Johanny
 family_name: Cepeda-Freytiz
-birth_date: 1973-08-31
 gender: Female
 email: repcepedafreytiz@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1969.jpg?1703415645672
+birth_date: 1973-08-31
+image: https://www.palegis.us/resources/images/members/200/1969.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
+++ b/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
@@ -2,10 +2,10 @@ id: ocd-person/8c1966e4-80f4-4a98-bf55-b1de0b9705b3
 name: John Lawrence
 given_name: John
 family_name: Lawrence
-birth_date: 1978-06-15
 gender: Male
 email: jlawrenc@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1215.jpg?1703415645672
+birth_date: 1978-06-15
+image: https://www.palegis.us/resources/images/members/200/1215.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/John-A-Schlegel-b6a10f6b-3f2e-42df-adf9-7184222af2c2.yml
+++ b/data/pa/legislature/John-A-Schlegel-b6a10f6b-3f2e-42df-adf9-7184222af2c2.yml
@@ -4,7 +4,7 @@ given_name: John
 family_name: Schlegel
 gender: Male
 email: jschlegel@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1958.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1958.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/John-Inglis-0b0beeaf-a1b0-4049-95cb-4ad5a3952336.yml
+++ b/data/pa/legislature/John-Inglis-0b0beeaf-a1b0-4049-95cb-4ad5a3952336.yml
@@ -4,7 +4,7 @@ given_name: John
 family_name: Inglis
 gender: Male
 email: repinglis@pahouse.net
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/JohnInglis2024.jpg
+image: https://www.palegis.us/resources/images/members/200/2024.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
+++ b/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
@@ -2,10 +2,10 @@ id: ocd-person/23a2b079-dc91-49b0-b08e-f3ae80fba11f
 name: Jonathan Fritz
 given_name: Jonathan
 family_name: Fritz
-birth_date: 1976-11-30
 gender: Male
 email: jfritz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1752.jpg?1703415645672
+birth_date: 1976-11-30
+image: https://www.palegis.us/resources/images/members/200/1752.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
+++ b/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
@@ -2,10 +2,10 @@ id: ocd-person/2313ce98-7ac4-44b9-a61d-5b128338a405
 name: Jordan Harris
 given_name: Jordan
 family_name: Harris
-birth_date: 1984-05-12
 gender: Male
 email: repharris@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1633.jpg?1703415645672
+birth_date: 1984-05-12
+image: https://www.palegis.us/resources/images/members/200/1633.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jose-Giral-d390f1ac-1f16-478a-9e0d-462c9ed79818.yml
+++ b/data/pa/legislature/Jose-Giral-d390f1ac-1f16-478a-9e0d-462c9ed79818.yml
@@ -4,7 +4,7 @@ given_name: "Jos\xE9"
 family_name: Giral
 gender: Male
 email: repgiral@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1980.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1980.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
+++ b/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
@@ -2,10 +2,10 @@ id: ocd-person/99728978-f905-406c-8b52-f2912f374602
 name: Joe Hohenstein
 given_name: Joe
 family_name: Hohenstein
-birth_date: 1967-06-24
 gender: Male
 email: jhohenstein@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1858.jpg?1703415645672
+birth_date: 1967-06-24
+image: https://www.palegis.us/resources/images/members/200/1858.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joseph-DOrsie-b698d343-137d-423b-a102-c471f1fd1768.yml
+++ b/data/pa/legislature/Joseph-DOrsie-b698d343-137d-423b-a102-c471f1fd1768.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: D'Orsie
 gender: Male
 email: jdorsie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1947.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1947.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Josh-Bashline-2062ecc5-049f-44c4-83bf-850a34b75531.yml
+++ b/data/pa/legislature/Josh-Bashline-2062ecc5-049f-44c4-83bf-850a34b75531.yml
@@ -3,7 +3,7 @@ name: Josh Bashline
 given_name: Josh
 family_name: Bashline
 gender: Male
-image: https://www.exploreclarion.com/wp-content/uploads/sites/2/2024/02/Josh-Bashline-Enters-Race-for-63rd-State-House-District.jpg
+image: https://www.palegis.us/resources/images/members/200/2026.jpg?20241220
 party:
 - name: Republican
 roles:
@@ -15,4 +15,3 @@ other_names:
 - name: J. Bashline
 - name: J.K. Bashline
 - name: Bashline, J.
-sources: []

--- a/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
+++ b/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
@@ -2,10 +2,10 @@ id: ocd-person/fbb14b8a-8940-4679-9ed8-3ec48096a3a2
 name: Josh Kail
 given_name: Josh
 family_name: Kail
-birth_date: 1986-03-29
 gender: Male
 email: jkail@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1823.jpg?1703415645672
+birth_date: 1986-03-29
+image: https://www.palegis.us/resources/images/members/200/1823.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joshua-Siegel-52f7d2da-ab1a-4cac-a08a-249b4d0507fe.yml
+++ b/data/pa/legislature/Joshua-Siegel-52f7d2da-ab1a-4cac-a08a-249b4d0507fe.yml
@@ -2,10 +2,10 @@ id: ocd-person/52f7d2da-ab1a-4cac-a08a-249b4d0507fe
 name: Josh Siegel
 given_name: Josh
 family_name: Siegel
-birth_date: 1993-11-15
 gender: Male
 email: repsiegel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1940.jpg?1703415645672
+birth_date: 1993-11-15
+image: https://www.palegis.us/resources/images/members/200/1940.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Justin-C-Fleming-98b96b05-81eb-4871-a81b-2e03c0b92267.yml
+++ b/data/pa/legislature/Justin-C-Fleming-98b96b05-81eb-4871-a81b-2e03c0b92267.yml
@@ -2,10 +2,10 @@ id: ocd-person/98b96b05-81eb-4871-a81b-2e03c0b92267
 name: Justin Fleming
 given_name: Justin
 family_name: Fleming
-birth_date: 1980-07-05
 gender: Male
 email: repfleming@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1960.jpg?1703415645672
+birth_date: 1980-07-05
+image: https://www.palegis.us/resources/images/members/200/1960.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
+++ b/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
@@ -2,10 +2,10 @@ id: ocd-person/08283fbe-18bc-4daf-972c-617d1e35d746
 name: Kate Klunk
 given_name: Kate
 family_name: Klunk
-birth_date: 1982-06-04
 gender: Female
 email: kklunk@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1694.jpg?1703415645672
+birth_date: 1982-06-04
+image: https://www.palegis.us/resources/images/members/200/1694.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
+++ b/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
@@ -2,10 +2,10 @@ id: ocd-person/26925ace-f614-409d-80a2-9b6a42e7ddb5
 name: K.C. Tomlinson
 given_name: K.C.
 family_name: Tomlinson
-birth_date: 1988-09-29
 gender: Female
 email: kctomlinsonpa18@gmail.com
-image: https://www.legis.state.pa.us/images/members/200/1876.jpg?1703415645672
+birth_date: 1988-09-29
+image: https://www.palegis.us/resources/images/members/200/1876.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
+++ b/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
@@ -2,10 +2,10 @@ id: ocd-person/36348b5e-47fe-404a-b6c3-99359115846c
 name: Kathy Rapp
 given_name: Kathy
 family_name: Rapp
-birth_date: 1951-02-23
 gender: Female
 email: klrapp23@verizon.net
-image: https://www.legis.state.pa.us/images/members/200/1028.jpg?1703415645672
+birth_date: 1951-02-23
+image: https://www.palegis.us/resources/images/members/200/1028.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Keith-Harris-99c32bc9-33c2-4394-94e6-2f9d0ff43133.yml
+++ b/data/pa/legislature/Keith-Harris-99c32bc9-33c2-4394-94e6-2f9d0ff43133.yml
@@ -3,6 +3,7 @@ name: Keith Harris
 given_name: Keith
 family_name: Harris
 gender: Male
+image: https://www.palegis.us/resources/images/members/200/2020.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
+++ b/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
@@ -2,10 +2,10 @@ id: ocd-person/dcd0037e-7833-416d-9523-5f25802bd43a
 name: Keith Greiner
 given_name: Keith
 family_name: Greiner
-birth_date: 1965-05-02
 gender: Male
 email: kgreiner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1632.jpg?1703415645672g
+birth_date: 1965-05-02
+image: https://www.palegis.us/resources/images/members/200/1632.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
+++ b/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
@@ -2,10 +2,10 @@ id: ocd-person/5a5a7a42-bc5e-4a07-aee1-d1a01e810385
 name: Kerry Benninghoff
 given_name: Kerry
 family_name: Benninghoff
-birth_date: 1962-01-14
 gender: Male
 email: kbenning@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/215.jpg?1703415645672
+birth_date: 1962-01-14
+image: https://www.palegis.us/resources/images/members/200/215.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kristin-Marcell-f1c8d8ab-0220-4b1e-96d0-6e0ae0b6df87.yml
+++ b/data/pa/legislature/Kristin-Marcell-f1c8d8ab-0220-4b1e-96d0-6e0ae0b6df87.yml
@@ -2,10 +2,10 @@ id: ocd-person/f1c8d8ab-0220-4b1e-96d0-6e0ae0b6df87
 name: Kristin Marcell
 given_name: Kristin
 family_name: Marcell
-birth_date: 1977-12-14
 gender: Female
 email: kmarcell@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1979.jpg?1703415645672
+birth_date: 1977-12-14
+image: https://www.palegis.us/resources/images/members/200/1979.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
+++ b/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
@@ -2,10 +2,10 @@ id: ocd-person/f451e90b-e93a-4768-a294-67d1ff000396
 name: Kristine Howard
 given_name: Kristine
 family_name: Howard
-birth_date: 1961-06-07
 gender: Female
 email: khoward@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1856.jpg?1703415645672
+birth_date: 1961-06-07
+image: https://www.palegis.us/resources/images/members/200/1856.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kyle-Donahue-009be4f2-d613-4353-8126-6b5642d868bc.yml
+++ b/data/pa/legislature/Kyle-Donahue-009be4f2-d613-4353-8126-6b5642d868bc.yml
@@ -2,10 +2,10 @@ id: ocd-person/009be4f2-d613-4353-8126-6b5642d868bc
 name: Kyle Donahue
 given_name: Kyle
 family_name: Donahue
-birth_date: 1986-02-23
 gender: Male
 email: repdonahue@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1963.jpg?1703415645672
+birth_date: 1986-02-23
+image: https://www.palegis.us/resources/images/members/200/1963.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
+++ b/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
@@ -4,7 +4,7 @@ given_name: Kyle
 family_name: Mullins
 gender: Male
 email: repmullins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1844.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1844.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/LaTasha-D-Mayes-526967db-cef3-4f64-a380-1377f5c6f1fe.yml
+++ b/data/pa/legislature/LaTasha-D-Mayes-526967db-cef3-4f64-a380-1377f5c6f1fe.yml
@@ -4,7 +4,7 @@ given_name: La'Tasha
 family_name: Mayes
 gender: Female
 email: repmayes@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1941.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1941.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
+++ b/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
@@ -2,10 +2,10 @@ id: ocd-person/8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93
 name: Leanne Krueger
 given_name: Leanne
 family_name: Krueger
-birth_date: 1977-02-14
 gender: Female
 email: repkrueger@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1735.jpg?1703415645672
+birth_date: 1977-02-14
+image: https://www.palegis.us/resources/images/members/200/1735.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Leslie-Rossi-71bb086e-11d9-496d-b274-91d7a8b85eaf.yml
+++ b/data/pa/legislature/Leslie-Rossi-71bb086e-11d9-496d-b274-91d7a8b85eaf.yml
@@ -4,7 +4,7 @@ given_name: Leslie
 family_name: Rossi
 gender: Female
 email: lrossi@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1927.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1927.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Lindsay-Powell-b7c8d063-8db4-4cdf-a159-a0b064b7cae5.yml
+++ b/data/pa/legislature/Lindsay-Powell-b7c8d063-8db4-4cdf-a159-a0b064b7cae5.yml
@@ -4,7 +4,7 @@ given_name: Lindsay
 family_name: Powell
 gender: Female
 email: reppowell@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2016.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/2016.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Lisa-A-Borowski-d927a6f9-9878-4375-ac7d-9996e8968c9d.yml
+++ b/data/pa/legislature/Lisa-A-Borowski-d927a6f9-9878-4375-ac7d-9996e8968c9d.yml
@@ -4,7 +4,7 @@ given_name: Lisa
 family_name: Borowski
 gender: Female
 email: repborowski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1977.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1977.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
+++ b/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
@@ -4,7 +4,7 @@ given_name: Liz
 family_name: Hanbidge
 gender: Female
 email: lhanbidge@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1834.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1834.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Louis-C-Schmitt-e19d3bae-7d48-4e27-af66-e9453633edca.yml
+++ b/data/pa/legislature/Louis-C-Schmitt-e19d3bae-7d48-4e27-af66-e9453633edca.yml
@@ -2,10 +2,10 @@ id: ocd-person/e19d3bae-7d48-4e27-af66-e9453633edca
 name: Lou Schmitt
 given_name: Lou
 family_name: Schmitt
-birth_date: 1962-03-21
 gender: Male
 email: lschmitt@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1839.jpg?1703415645672
+birth_date: 1962-03-21
+image: https://www.palegis.us/resources/images/members/200/1839.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
+++ b/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
@@ -2,10 +2,10 @@ id: ocd-person/96711736-a47d-4bd6-bcc3-92297ec01516
 name: Malcolm Kenyatta
 given_name: Malcolm
 family_name: Kenyatta
-birth_date: 1990-07-30
 gender: Male
 email: mkenyatta@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1860.jpg?1703415645672
+birth_date: 1990-07-30
+image: https://www.palegis.us/resources/images/members/200/1860.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Mandy-Steele-63f8d7ea-b621-48b7-a326-4e2a732a521c.yml
+++ b/data/pa/legislature/Mandy-Steele-63f8d7ea-b621-48b7-a326-4e2a732a521c.yml
@@ -4,7 +4,7 @@ given_name: Mandy
 family_name: Steele
 gender: Female
 email: repsteele@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1945.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1945.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Manuel-Guzman-d26c016b-27e5-4171-849b-94773178023d.yml
+++ b/data/pa/legislature/Manuel-Guzman-d26c016b-27e5-4171-849b-94773178023d.yml
@@ -2,10 +2,10 @@ id: ocd-person/d26c016b-27e5-4171-849b-94773178023d
 name: Manny Guzman
 given_name: Manny
 family_name: Guzman
-birth_date: 1988-03-28
 gender: Male
 email: repguzman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1908.jpg?1703415645672
+birth_date: 1988-03-28
+image: https://www.palegis.us/resources/images/members/200/1908.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Marc-Anderson-8d16f666-803c-4946-8adc-32f1e80d79d9.yml
+++ b/data/pa/legislature/Marc-Anderson-8d16f666-803c-4946-8adc-32f1e80d79d9.yml
@@ -3,7 +3,7 @@ name: Marc Anderson
 given_name: Marc
 family_name: Anderson
 gender: Male
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/Marc_Anderson_20241007_034013.jpeg
+image: https://www.palegis.us/resources/images/members/200/2029.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
+++ b/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
@@ -2,10 +2,10 @@ id: ocd-person/dc7a449c-43cf-4522-b2a3-efb4707907c4
 name: Marci Mustello
 given_name: Marci
 family_name: Mustello
-birth_date: 1970-07-25
 gender: Female
 email: mmustello@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1868.jpg?1703415645672
+birth_date: 1970-07-25
+image: https://www.palegis.us/resources/images/members/200/1868.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
+++ b/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
@@ -2,10 +2,10 @@ id: ocd-person/cd92c819-d5aa-4df3-ba96-2315dbdf4555
 name: Mark Gillen
 given_name: Mark
 family_name: Gillen
-birth_date: 1955-11-06
 gender: Male
 email: mgillen@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1209.jpg?1703415645672
+birth_date: 1955-11-06
+image: https://www.palegis.us/resources/images/members/200/1209.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Marla-Brown-68e26db9-10ba-414b-9d06-440dd1fd3f10.yml
+++ b/data/pa/legislature/Marla-Brown-68e26db9-10ba-414b-9d06-440dd1fd3f10.yml
@@ -4,7 +4,7 @@ given_name: Marla
 family_name: Brown
 gender: Female
 email: mbrown@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1938.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1938.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
+++ b/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
@@ -4,7 +4,7 @@ given_name: Marty
 family_name: Causer
 gender: Male
 email: mcauser@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/982.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/982.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
+++ b/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
@@ -2,10 +2,10 @@ id: ocd-person/93435394-e853-45f2-9e88-65399b3f9042
 name: Martina White
 given_name: Martina
 family_name: White
-birth_date: 1988-07-07
 gender: Female
 email: mwhite@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1732.jpg?1703415645672
+birth_date: 1988-07-07
+image: https://www.palegis.us/resources/images/members/200/1732.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
+++ b/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
@@ -2,10 +2,10 @@ id: ocd-person/2b9c199b-dd4e-477a-a5d0-849180c956a0
 name: Mary Jo Daley
 given_name: Mary Jo
 family_name: Daley
-birth_date: 1949-09-16
 gender: Female
 email: repmaryjodaley@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1622.jpg?1703415645672
+birth_date: 1949-09-16
+image: https://www.palegis.us/resources/images/members/200/1622.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
+++ b/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
@@ -2,10 +2,10 @@ id: ocd-person/ac9d319c-4df3-489a-890e-f7daba8c4bda
 name: Mary Isaacson
 given_name: Mary
 family_name: Isaacson
-birth_date: 1970-11-15
 gender: Female
 email: misaacson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1857.jpg?1703415645672
+birth_date: 1970-11-15
+image: https://www.palegis.us/resources/images/members/200/1857.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
+++ b/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
@@ -2,10 +2,10 @@ id: ocd-person/a15da78b-2475-4606-854f-7477dfc4233d
 name: Matt Bradford
 given_name: Matt
 family_name: Bradford
-birth_date: 1975-05-23
 gender: Male
 email: repbradford@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1161.jpg?1703415645672
+birth_date: 1975-05-23
+image: https://www.palegis.us/resources/images/members/200/1161.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Matthew-Gergely-2a6db8e9-a94e-4f79-82d3-23cbba25e79a.yml
+++ b/data/pa/legislature/Matthew-Gergely-2a6db8e9-a94e-4f79-82d3-23cbba25e79a.yml
@@ -2,10 +2,10 @@ id: ocd-person/2a6db8e9-a94e-4f79-82d3-23cbba25e79a
 name: Matt Gergely
 given_name: Matt
 family_name: Gergely
-birth_date: 1979-10-05
 gender: Male
 email: repgergely@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2013.jpg?1703415645672
+birth_date: 1979-10-05
+image: https://www.palegis.us/resources/images/members/200/2013.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
+++ b/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
@@ -2,10 +2,10 @@ id: ocd-person/8ec333cd-97c4-4f5a-92de-13bf8cbc0020
 name: Maureen Madden
 given_name: Maureen
 family_name: Madden
-birth_date: 1959-12-13
 gender: Female
 email: maureen@maureenmadden.com
-image: https://www.legis.state.pa.us/images/members/200/2013.jpg?1703415645672
+birth_date: 1959-12-13
+image: https://www.palegis.us/resources/images/members/200/1753.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Melissa-Cerrato-610a353c-8973-48ea-a4d4-dac21efc3422.yml
+++ b/data/pa/legislature/Melissa-Cerrato-610a353c-8973-48ea-a4d4-dac21efc3422.yml
@@ -4,7 +4,7 @@ given_name: Missy
 family_name: Cerrato
 gender: Female
 email: repcerrato@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1974.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1974.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
+++ b/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
@@ -2,10 +2,10 @@ id: ocd-person/2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc
 name: Melissa Shusterman
 given_name: Melissa
 family_name: Shusterman
-birth_date: 1967-09-08
 gender: Female
 email: repshusterman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1851.jpg?1703415645672
+birth_date: 1967-09-08
+image: https://www.palegis.us/resources/images/members/200/1851.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Michael-A-Stender-ef4ff98e-baba-4655-b24f-66ec5933fcb0.yml
+++ b/data/pa/legislature/Michael-A-Stender-ef4ff98e-baba-4655-b24f-66ec5933fcb0.yml
@@ -4,7 +4,7 @@ given_name: Michael
 family_name: Stender
 gender: Male
 email: mstender@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/2014.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/2014.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
+++ b/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
@@ -2,10 +2,10 @@ id: ocd-person/fc1f0752-9166-4d7f-987a-ec15b8bf4048
 name: Mike Schlossberg
 given_name: Mike
 family_name: Schlossberg
-birth_date: 1983-05-15
 gender: Male
 email: repschlossberg@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1649.jpg?1703415645672
+birth_date: 1983-05-15
+image: https://www.palegis.us/resources/images/members/200/1649.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Mike-Armanini-32c83f92-2bcc-4c2f-bcd0-8b367af29e28.yml
+++ b/data/pa/legislature/Mike-Armanini-32c83f92-2bcc-4c2f-bcd0-8b367af29e28.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Armanini
 gender: Male
 email: marmanini@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1903.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1903.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
+++ b/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Jones
 gender: Male
 email: mjones@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1842.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1842.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Milou-Mackenzie-b4559406-2139-4c7c-9ce9-7a2a604a8a95.yml
+++ b/data/pa/legislature/Milou-Mackenzie-b4559406-2139-4c7c-9ce9-7a2a604a8a95.yml
@@ -4,7 +4,7 @@ given_name: Milou
 family_name: Mackenzie
 gender: Female
 email: mmackenzie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1909.jpg?1703415645672g
+image: https://www.palegis.us/resources/images/members/200/1909.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
+++ b/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
@@ -2,10 +2,10 @@ id: ocd-person/f5b2ec4d-1d69-483a-a6ec-143d50ad395b
 name: Mindy Fee
 given_name: Mindy
 family_name: Fee
-birth_date: 1965-04-16
 gender: Female
 email: mfee@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1625.jpg?1703415645672
+birth_date: 1965-04-16
+image: https://www.palegis.us/resources/images/members/200/1625.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
+++ b/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
@@ -4,7 +4,7 @@ given_name: Morgan
 family_name: Cephas
 gender: Female
 email: mcephas@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1759.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1759.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Nancy-Guenst-d18ccbd7-270a-46c2-8bbd-a19ea82d0e51.yml
+++ b/data/pa/legislature/Nancy-Guenst-d18ccbd7-270a-46c2-8bbd-a19ea82d0e51.yml
@@ -4,7 +4,7 @@ given_name: Nancy
 family_name: Guenst
 gender: Female
 email: repguenst@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1913.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1913.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Napoleon-J-Nelson-94e57e39-e58d-4374-9506-ece1a01e0ebd.yml
+++ b/data/pa/legislature/Napoleon-J-Nelson-94e57e39-e58d-4374-9506-ece1a01e0ebd.yml
@@ -4,7 +4,7 @@ given_name: Napoleon
 family_name: Nelson
 gender: Male
 email: repnelson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1914.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1914.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
+++ b/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
@@ -4,7 +4,7 @@ given_name: Natalie
 family_name: Mihalek
 gender: Female
 email: nmihalek@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1830.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1830.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Nate-Davidson-c7f76970-11d0-483e-81b4-b4750220932c.yml
+++ b/data/pa/legislature/Nate-Davidson-c7f76970-11d0-483e-81b4-b4750220932c.yml
@@ -3,7 +3,7 @@ name: Nate Davidson
 given_name: Nate
 family_name: Davidson
 gender: Male
-image: https://storage.googleapis.com/enview-dev-public-general/legislative-people-photos/133354.jpg
+image: https://www.palegis.us/resources/images/members/200/2031.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Nikki-Rivera-5df981dc-0f0f-498e-8e0e-72cfa5410b2a.yml
+++ b/data/pa/legislature/Nikki-Rivera-5df981dc-0f0f-498e-8e0e-72cfa5410b2a.yml
@@ -3,7 +3,7 @@ name: Nikki Rivera
 given_name: Nikki
 family_name: Rivera
 gender: Female
-image: https://static.wixstatic.com/media/ac23d4_f90c7e4f91684d28939b38f61d2cd0ae~mv2.jpg/v1/fill/w_640,h_554,al_t,q_80,usm_0.66_1.00_0.01,enc_auto/ac23d4_f90c7e4f91684d28939b38f61d2cd0ae~mv2.jpg
+image: https://www.palegis.us/resources/images/members/200/2030.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
+++ b/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
@@ -2,10 +2,10 @@ id: ocd-person/8f7a2783-e165-4bf2-aead-113d98dd7dd2
 name: Parke Wentling
 given_name: Parke
 family_name: Wentling
-birth_date: 1972-05-14
 gender: Male
 email: pwentling@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1709.jpg?1703415645672
+birth_date: 1972-05-14
+image: https://www.palegis.us/resources/images/members/200/1709.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Pat-Gallagher-36e7e815-87a3-4c58-baae-71f210e48114.yml
+++ b/data/pa/legislature/Pat-Gallagher-36e7e815-87a3-4c58-baae-71f210e48114.yml
@@ -2,10 +2,10 @@ id: ocd-person/36e7e815-87a3-4c58-baae-71f210e48114
 name: Pat Gallagher
 given_name: Pat
 family_name: Gallagher
-birth_date: 1974-04-21
 gender: Male
 email: repgallagher@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1978.jpg?1703415645672
+birth_date: 1974-04-21
+image: https://www.palegis.us/resources/images/members/200/1978.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
+++ b/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
@@ -2,10 +2,10 @@ id: ocd-person/c4a1a8f4-cb29-4700-8235-b103fcb40279
 name: Pat Harkins
 given_name: Pat
 family_name: Harkins
-birth_date: 1963-12-22
 gender: Male
 email: pharkins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1081.jpg?1703415645672
+birth_date: 1963-12-22
+image: https://www.palegis.us/resources/images/members/200/1081.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Paul-Friel-494797a5-3d84-414a-9c8c-caaadd621cdd.yml
+++ b/data/pa/legislature/Paul-Friel-494797a5-3d84-414a-9c8c-caaadd621cdd.yml
@@ -4,7 +4,7 @@ given_name: Paul
 family_name: Friel
 gender: Male
 email: repfriel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1942.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1942.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Paul-Takac-dd35ae63-5dee-4f87-b64e-65907b8adaba.yml
+++ b/data/pa/legislature/Paul-Takac-dd35ae63-5dee-4f87-b64e-65907b8adaba.yml
@@ -4,7 +4,7 @@ given_name: Paul
 family_name: Takac
 gender: Male
 email: reptakac@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1953.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1953.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Perry-A-Stambaugh-eb33e206-fb08-40bc-8b9b-1d9a72fcb8fc.yml
+++ b/data/pa/legislature/Perry-A-Stambaugh-eb33e206-fb08-40bc-8b9b-1d9a72fcb8fc.yml
@@ -2,10 +2,10 @@ id: ocd-person/eb33e206-fb08-40bc-8b9b-1d9a72fcb8fc
 name: Perry Stambaugh
 given_name: Perry
 family_name: Stambaugh
-birth_date: 1960-03-08
 gender: Male
 email: pstambaugh@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1905.jpg?1703415645672
+birth_date: 1960-03-08
+image: https://www.palegis.us/resources/images/members/200/1905.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
+++ b/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
@@ -2,10 +2,10 @@ id: ocd-person/e2bc8bc4-33ab-46dd-8f67-da218949efb6
 name: Perry Warren
 given_name: Perry
 family_name: Warren
-birth_date: 1963-07-23
 gender: Male
 email: repwarren@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1743.jpg?1703415645672
+birth_date: 1963-07-23
+image: https://www.palegis.us/resources/images/members/200/1743.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
+++ b/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
@@ -2,10 +2,10 @@ id: ocd-person/63936c68-ec65-40a9-9a68-0d956939404a
 name: Pete Schweyer
 given_name: Pete
 family_name: Schweyer
-birth_date: 1978-07-26
 gender: Male
 email: repschweyer@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1706.jpg?1703415645672
+birth_date: 1978-07-26
+image: https://www.palegis.us/resources/images/members/200/1706.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
+++ b/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
@@ -2,10 +2,10 @@ id: ocd-person/b29f8685-d054-4c6c-a8ad-d64f80bd840f
 name: Lee James
 given_name: Lee
 family_name: James
-birth_date: 1948-11-20
 gender: Male
 email: rljames@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1634.jpg?1703415645672
+birth_date: 1948-11-20
+image: https://www.palegis.us/resources/images/members/200/1634.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Regina-G-Young-a737f4d4-5b45-469b-8d51-98c7aa78183a.yml
+++ b/data/pa/legislature/Regina-G-Young-a737f4d4-5b45-469b-8d51-98c7aa78183a.yml
@@ -2,10 +2,10 @@ id: ocd-person/a737f4d4-5b45-469b-8d51-98c7aa78183a
 name: Regina Young
 given_name: Regina
 family_name: Young
-birth_date: 1973-08-23
 gender: Female
 email: ryoung@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1917.jpg?1703415645672
+birth_date: 1973-08-23
+image: https://www.palegis.us/resources/images/members/200/1917.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
+++ b/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
@@ -2,10 +2,10 @@ id: ocd-person/ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc
 name: Rich Irvin
 given_name: Rich
 family_name: Irvin
-birth_date: 1971-07-07
 gender: Male
 email: rirvin@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1691.jpg?1703415645672
+birth_date: 1971-07-07
+image: https://www.palegis.us/resources/images/members/200/1691.jpg?20241220
 party:
 - name: Republican
 roles:
@@ -15,7 +15,7 @@ roles:
   district: '81'
 offices:
 - classification: capitol
-  address: Room 106, Ryan Office Building P.O. Box  202081, Harrisburg, PA 17120
+  address: Room 106, Ryan Office Building P.O. Box 202081, Harrisburg, PA 17120
   voice: 717-787-3335
   fax: 717-782-2884
 - classification: district

--- a/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
+++ b/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
@@ -2,10 +2,10 @@ id: ocd-person/42ffbed1-2284-4018-a60f-b5bfa3f35833
 name: Rick Krajewski
 given_name: Rick
 family_name: Krajewski
-birth_date: 1991-06-21
 gender: Male
 email: repkrajewski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1918.jpg?1703415645672
+birth_date: 1991-06-21
+image: https://www.palegis.us/resources/images/members/200/1918.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
+++ b/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
@@ -2,10 +2,10 @@ id: ocd-person/17e1e676-8e83-4883-8cf5-4c8ddcce076e
 name: Rob Kauffman
 given_name: Rob
 family_name: Kauffman
-birth_date: 1974-08-27
 gender: Male
 email: rkauffma@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1022.jpg?1703415645672
+birth_date: 1974-08-27
+image: https://www.palegis.us/resources/images/members/200/1022.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
+++ b/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
@@ -2,10 +2,10 @@ id: ocd-person/bd4c3d05-059a-4084-b8f8-e8598e4eb955
 name: Bob Merski
 given_name: Bob
 family_name: Merski
-birth_date: 1975-05-14
 gender: Male
 email: rmerski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1822.jpg?1703415645672
+birth_date: 1975-05-14
+image: https://www.palegis.us/resources/images/members/200/1822.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
+++ b/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
@@ -2,10 +2,10 @@ id: ocd-person/a7b2e50f-90a6-4f35-b1fb-c33406dc4277
 name: Rob Matzie
 given_name: Rob
 family_name: Matzie
-birth_date: 1968-09-22
 gender: Male
 email: rmatzie@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1173.jpg?1703415645672
+birth_date: 1968-09-22
+image: https://www.palegis.us/resources/images/members/200/1173.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
+++ b/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
@@ -2,10 +2,10 @@ id: ocd-person/13bfe11c-06e2-4a1d-844d-d195ef18dc06
 name: Bob Freeman
 given_name: Bob
 family_name: Freeman
-birth_date: 1956-03-09
 gender: Male
 email: rfreeman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/136.jpg?1703415645672
+birth_date: 1956-03-09
+image: https://www.palegis.us/resources/images/members/200/136.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-Leadbeter-1d775faf-9231-420a-b62e-979bb6a1fc78.yml
+++ b/data/pa/legislature/Robert-Leadbeter-1d775faf-9231-420a-b62e-979bb6a1fc78.yml
@@ -4,7 +4,7 @@ given_name: Robert
 family_name: Leadbeter
 gender: Male
 email: rleadbeter@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1962.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1962.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Roman-Kozak-69faf85a-c63c-4d75-9801-047fffddf228.yml
+++ b/data/pa/legislature/Roman-Kozak-69faf85a-c63c-4d75-9801-047fffddf228.yml
@@ -3,7 +3,7 @@ name: Roman Kozak
 given_name: Roman
 family_name: Kozak
 gender: Male
-image: https://www.beavercountygop.com/wp-content/uploads/RK.jpg
+image: https://www.palegis.us/resources/images/members/200/2022.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
+++ b/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
@@ -2,10 +2,10 @@ id: ocd-person/5348e28d-bbbe-493f-8f77-a509cb315abe
 name: Russ Diamond
 given_name: Russ
 family_name: Diamond
-birth_date: 1963-07-26
 gender: Male
 email: rdiamond@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1686.jpg?1703415645672
+birth_date: 1963-07-26
+image: https://www.palegis.us/resources/images/members/200/1686.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
+++ b/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
@@ -2,10 +2,10 @@ id: ocd-person/32370423-acb8-4a8e-8336-67af5ed32bb9
 name: Ryan Bizzarro
 given_name: Ryan
 family_name: Bizzarro
-birth_date: 1985-11-13
 gender: Male
 email: ryanbizzarroerie@gmail.com
-image: https://www.legis.state.pa.us/images/members/200/1619.jpg?1703415645672
+birth_date: 1985-11-13
+image: https://www.palegis.us/resources/images/members/200/1619.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
+++ b/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
@@ -4,7 +4,7 @@ given_name: Ryan
 family_name: Warner
 gender: Male
 email: rwarner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1708.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1708.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Scott-Barger-983dc33a-559e-4f01-9c60-08fed48a1415.yml
+++ b/data/pa/legislature/Scott-Barger-983dc33a-559e-4f01-9c60-08fed48a1415.yml
@@ -3,7 +3,7 @@ name: Scott Barger
 given_name: Scott
 family_name: Barger
 gender: Male
-image: https://ogden_images.s3.amazonaws.com/www.altoonamirror.com/images/2023/02/06211342/Scott-barger-561x840.jpg
+image: https://www.palegis.us/resources/images/members/200/2027.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
+++ b/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
@@ -2,10 +2,10 @@ id: ocd-person/97b012cd-5cd7-4039-a9ae-fed936aabe37
 name: Scott Conklin
 given_name: Scott
 family_name: Conklin
-birth_date: 1958-10-07
 gender: Male
 email: sconklin@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1096.jpg?1703415645672
+birth_date: 1958-10-07
+image: https://www.palegis.us/resources/images/members/200/1096.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Sean-Dougherty-d8624d56-a38e-4918-98ac-d7795569ad06.yml
+++ b/data/pa/legislature/Sean-Dougherty-d8624d56-a38e-4918-98ac-d7795569ad06.yml
@@ -3,7 +3,7 @@ name: Sean Dougherty
 given_name: Sean
 family_name: Dougherty
 gender: Male
-image: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRDqcsfeSV2Emc5tJreNLOLeI1PEIX1XE82Hw&s
+image: https://www.palegis.us/resources/images/members/200/2035.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Seth-M-Grove-f10a1cb3-df7f-432c-8d33-e6d3293b7f88.yml
+++ b/data/pa/legislature/Seth-M-Grove-f10a1cb3-df7f-432c-8d33-e6d3293b7f88.yml
@@ -2,10 +2,10 @@ id: ocd-person/f10a1cb3-df7f-432c-8d33-e6d3293b7f88
 name: Seth Grove
 given_name: Seth
 family_name: Grove
-birth_date: 1979-09-14
 gender: Male
 email: sgrove@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1171.jpg?1703415645672
+birth_date: 1979-09-14
+image: https://www.palegis.us/resources/images/members/200/1171.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Shelby-Labs-7c0b9792-8ece-4ae8-b0f3-f5d4b79ff9f1.yml
+++ b/data/pa/legislature/Shelby-Labs-7c0b9792-8ece-4ae8-b0f3-f5d4b79ff9f1.yml
@@ -4,7 +4,7 @@ given_name: Shelby
 family_name: Labs
 gender: Female
 email: slabs@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1911.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1911.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
+++ b/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
@@ -4,7 +4,7 @@ given_name: Sheryl
 family_name: Delozier
 gender: Female
 email: sdelozie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1167.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1167.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
+++ b/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
@@ -2,10 +2,10 @@ id: ocd-person/bccfe530-42ce-47b0-aadf-ae863b37cf9a
 name: Stephanie Borowicz
 given_name: Stephanie
 family_name: Borowicz
-birth_date: 1977-03-23
 gender: Female
 email: sborowicz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1838.jpg?1703415645672
+birth_date: 1977-03-23
+image: https://www.palegis.us/resources/images/members/200/1838.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Stephenie-Scialabba-a3db05d0-b346-4e85-b6b1-71247b190f8e.yml
+++ b/data/pa/legislature/Stephenie-Scialabba-a3db05d0-b346-4e85-b6b1-71247b190f8e.yml
@@ -4,7 +4,7 @@ given_name: Stephenie
 family_name: Scialabba
 gender: Female
 email: sscialabba@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1939.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1939.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
+++ b/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
@@ -2,10 +2,10 @@ id: ocd-person/34472dfb-dae9-4db4-8901-088457d74904
 name: Steve Samuelson
 given_name: Steve
 family_name: Samuelson
-birth_date: 1960-09-21
 gender: Male
 email: ssamuels@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/80.jpg?1703415645672
+birth_date: 1960-09-21
+image: https://www.palegis.us/resources/images/members/200/80.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
+++ b/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
@@ -2,10 +2,10 @@ id: ocd-person/4463dd94-6a9d-41bd-830f-0d03e192f896
 name: Steve Mentzer
 given_name: Steve
 family_name: Mentzer
-birth_date: 1956-10-24
 gender: Male
 email: smentzer@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1642.jpg?1703415645672
+birth_date: 1956-10-24
+image: https://www.palegis.us/resources/images/members/200/1642.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
+++ b/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
@@ -2,10 +2,10 @@ id: ocd-person/fa1e1564-0a13-4b26-8416-098b39627df7
 name: Steve Malagari
 given_name: Steve
 family_name: Malagari
-birth_date: 1983-10-17
 gender: Male
 email: smalagari@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1832.jpg?1703415645672
+birth_date: 1983-10-17
+image: https://www.palegis.us/resources/images/members/200/1832.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tarah-Probst-8caab7df-f601-45f0-9be5-35d94175e766.yml
+++ b/data/pa/legislature/Tarah-Probst-8caab7df-f601-45f0-9be5-35d94175e766.yml
@@ -4,7 +4,7 @@ given_name: Tarah
 family_name: Probst
 gender: Female
 email: repprobst@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1982.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1982.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tarik-Khan-6fa30029-d933-4f6d-b0fb-343a0c82772c.yml
+++ b/data/pa/legislature/Tarik-Khan-6fa30029-d933-4f6d-b0fb-343a0c82772c.yml
@@ -2,10 +2,10 @@ id: ocd-person/6fa30029-d933-4f6d-b0fb-343a0c82772c
 name: Tarik Khan
 given_name: Tarik
 family_name: Khan
-birth_date: 1978-10-14
 gender: Male
 email: reptarik@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1983.jpg?1703415645672
+birth_date: 1978-10-14
+image: https://www.palegis.us/resources/images/members/200/1983.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Thomas-H-Kutz-932682ef-c7da-4383-8c50-58879fba0ca6.yml
+++ b/data/pa/legislature/Thomas-H-Kutz-932682ef-c7da-4383-8c50-58879fba0ca6.yml
@@ -4,7 +4,7 @@ given_name: Thomas
 family_name: Kutz
 gender: Male
 email: tkutz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1955.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1955.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
+++ b/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
@@ -2,10 +2,10 @@ id: ocd-person/bda0ab75-036f-49bd-9dd5-cfc9c55eec02
 name: Tom Mehaffie
 given_name: Tom
 family_name: Mehaffie
-birth_date: 1971-02-22
 gender: Male
 email: tmehaffie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1751.jpg?1703415645672
+birth_date: 1971-02-22
+image: https://www.palegis.us/resources/images/members/200/1751.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tim-Brennan-de68158e-3cc9-4651-b3a1-71f5e77b7dab.yml
+++ b/data/pa/legislature/Tim-Brennan-de68158e-3cc9-4651-b3a1-71f5e77b7dab.yml
@@ -4,7 +4,7 @@ given_name: Tim
 family_name: Brennan
 gender: Male
 email: repbrennan@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1943.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1943.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
+++ b/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
@@ -2,10 +2,10 @@ id: ocd-person/5c752a95-ba5d-4f1f-81aa-6cb1c7875581
 name: Tim Briggs
 given_name: Tim
 family_name: Briggs
-birth_date: 1970-01-03
 gender: Male
 email: repbriggs@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1159.jpg?1703415645672
+birth_date: 1970-01-03
+image: https://www.palegis.us/resources/images/members/200/1159.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tim-Twardzik-686cdc9c-8133-4c1b-a7f0-34b420884559.yml
+++ b/data/pa/legislature/Tim-Twardzik-686cdc9c-8133-4c1b-a7f0-34b420884559.yml
@@ -4,7 +4,7 @@ given_name: Tim
 family_name: Twardzik
 gender: Male
 email: ttwardzik@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1906.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1906.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
+++ b/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
@@ -2,10 +2,10 @@ id: ocd-person/2c5551d6-71a8-4099-b1a4-a30721320869
 name: Tim O'Neal
 given_name: Tim
 family_name: O'Neal
-birth_date: 1980-11-28
 gender: Male
 email: toneal@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1797.jpg?1703415645672
+birth_date: 1980-11-28
+image: https://www.palegis.us/resources/images/members/200/1797.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
+++ b/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
@@ -2,10 +2,10 @@ id: ocd-person/105c6361-0cb6-46f4-9222-ff0ffb727d29
 name: Tim Bonner
 given_name: Tim
 family_name: Bonner
-birth_date: 1950-06-07
 gender: Male
 email: tbonner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1877.jpg?1703415645672
+birth_date: 1950-06-07
+image: https://www.palegis.us/resources/images/members/200/1877.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
+++ b/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
@@ -2,10 +2,10 @@ id: ocd-person/f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7
 name: Tina Davis
 given_name: Tina
 family_name: Davis
-birth_date: 1960-04-21
 gender: Female
 email: repdavis@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1204.jpg?1703415645672
+birth_date: 1960-04-21
+image: https://www.palegis.us/resources/images/members/200/1204.jpg?20241220
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
+++ b/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
@@ -2,10 +2,10 @@ id: ocd-person/8e174923-d514-4240-b6cd-cbb7927410ba
 name: Tina Pickett
 given_name: Tina
 family_name: Pickett
-birth_date: 1943-05-28
 gender: Female
 email: tpickett@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/97.jpg?1703415645672
+birth_date: 1943-05-28
+image: https://www.palegis.us/resources/images/members/200/97.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tom-Jones-7f6b3c0e-4446-4243-ae49-d2d33ab30273.yml
+++ b/data/pa/legislature/Tom-Jones-7f6b3c0e-4446-4243-ae49-d2d33ab30273.yml
@@ -4,7 +4,7 @@ given_name: Tom
 family_name: Jones
 gender: Male
 email: tjones@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1957.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1957.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Torren-C-Ecker-6f375652-451b-4c39-9b29-6ba5a07073c6.yml
+++ b/data/pa/legislature/Torren-C-Ecker-6f375652-451b-4c39-9b29-6ba5a07073c6.yml
@@ -2,10 +2,10 @@ id: ocd-person/6f375652-451b-4c39-9b29-6ba5a07073c6
 name: Torren Ecker
 given_name: Torren
 family_name: Ecker
-birth_date: 1985-09-02
 gender: Male
 email: tecker@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1862.jpg?1703415645672
+birth_date: 1985-09-02
+image: https://www.palegis.us/resources/images/members/200/1862.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
+++ b/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
@@ -2,10 +2,10 @@ id: ocd-person/590df273-5587-46bd-98dc-f3943cd1ddd8
 name: Valerie Gaydos
 given_name: Valerie
 family_name: Gaydos
-birth_date: 1967-07-03
 gender: Female
 email: vgaydos@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1831.jpg?1703415645672
+birth_date: 1967-07-03
+image: https://www.palegis.us/resources/images/members/200/1831.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Wendy-Fink-1300735f-1441-4861-b20f-c1fa3e222c08.yml
+++ b/data/pa/legislature/Wendy-Fink-1300735f-1441-4861-b20f-c1fa3e222c08.yml
@@ -4,7 +4,7 @@ given_name: Wendy
 family_name: Fink
 gender: Female
 email: wfink@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1956.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/200/1956.jpg?20241220
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
+++ b/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
@@ -2,10 +2,10 @@ id: ocd-person/c3b27985-614c-434d-b3c0-3e032fad4d6c
 name: Zach Mako
 given_name: Zach
 family_name: Mako
-birth_date: 1988-12-17
 gender: Male
 email: zmako@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1758.jpg?1703415645672
+birth_date: 1988-12-17
+image: https://www.palegis.us/resources/images/members/200/1758.jpg?20241220
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
Issue: Pennsylvania images were no longer working (I assume due to the new website they are moving to palegis versus legis.state.pa.us) this is my attempt to fix PA state legislator images.

Example:

Aaron Bernstine:

Old: https://www.legis.state.pa.us/images/members/200/1742.jpg?1703415645672

New: https://www.palegis.us/resources/images/members/200/1742.jpg?20241220


I'm not sure why the python yaml dumper moved all of the birth_date fields to be closer to the image field, but the values are unchanged so shouldn't affect anything since yaml fields have no ordering per the spec.

