### PR TITLE
Fix start/end dates for 3 legislators

### DIFF
--- a/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
+++ b/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
@@ -12,7 +12,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:pa/government
   district: '31'
-- start_date: 2016-12-01
+- start_date: 2017-01-03
   end_date: 2024-12-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:pa/government

--- a/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
+++ b/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
@@ -13,7 +13,7 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:pa/government
   district: '28'
-- end_date: 2018-12-31
+- end_date: 2018-12-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:pa/government
   district: '93'

--- a/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
+++ b/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
@@ -8,7 +8,7 @@ image: https://www.palegis.us/resources/images/members/200/1842.jpg?20241220
 party:
 - name: Republican
 roles:
-- start_date: 2018-12-01
+- start_date: 2019-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:pa/government
   district: '93'


### PR DESCRIPTION
These updates match data found on Ballotpedia/Wikipedia and add consistency to the PA legislator terms.

Also performed some validation of all the start/end dates I could after this fix – this data is visualized here:

![DB tenures (dev)](https://github.com/user-attachments/assets/f56ba2cb-e0e6-405c-b214-7e03b45e8020)
