### PR TITLE
Make TX legislature start/end dates consistent

### DIFF
--- a/data/tx/legislature/Borris-L-Miles-3475b324-1c9b-4513-90e6-063aba5ac04e.yml
+++ b/data/tx/legislature/Borris-L-Miles-3475b324-1c9b-4513-90e6-063aba5ac04e.yml
@@ -13,13 +13,8 @@ roles:
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '13'
-- end_date: 2017-01-09
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '13'
-  start_date: 2017-01-10
-- start_date: 2011-01-01
-  end_date: 2018-12-31
+- start_date: 2011-01-11
+  end_date: 2017-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '146'

--- a/data/tx/legislature/Bryan-Hughes-8326538c-c907-43b2-a6db-76434036afd7.yml
+++ b/data/tx/legislature/Bryan-Hughes-8326538c-c907-43b2-a6db-76434036afd7.yml
@@ -15,11 +15,6 @@ roles:
   district: '1'
 - start_date: 2003-01-14
   end_date: 2017-01-09
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '1'
-- start_date: 2009-01-01
-  end_date: 2018-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '5'

--- a/data/tx/legislature/Carol-Alvarado-e78373de-6d96-44db-b552-6da34ed992fc.yml
+++ b/data/tx/legislature/Carol-Alvarado-e78373de-6d96-44db-b552-6da34ed992fc.yml
@@ -15,10 +15,6 @@ roles:
   district: '6'
 - start_date: 2009-01-13
   end_date: 2018-12-21
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '6'
-- end_date: 2018-12-21
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '145'

--- a/data/tx/legislature/Claudia-Ordaz-Perez-6feda596-fd20-429b-ae4e-bedab7e5a1c5.yml
+++ b/data/tx/legislature/Claudia-Ordaz-Perez-6feda596-fd20-429b-ae4e-bedab7e5a1c5.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '79'
 - start_date: 2021-01-12
-  end_date: 2023-01-09
-  type: lower
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '79'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '76'

--- a/data/tx/legislature/Csar-Blanco-3e0f0e51-20c0-4da4-82b5-ff81606148d0.yml
+++ b/data/tx/legislature/Csar-Blanco-3e0f0e51-20c0-4da4-82b5-ff81606148d0.yml
@@ -14,11 +14,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '29'
 - start_date: 2015-01-13
-  end_date: 2021-01-11
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '29'
-- start_date: 2015-01-13
   end_date: 2021-01-12
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government

--- a/data/tx/legislature/Gary-Gates-5ff88048-ebd8-4ac3-af9c-d02e1305ef37.yml
+++ b/data/tx/legislature/Gary-Gates-5ff88048-ebd8-4ac3-af9c-d02e1305ef37.yml
@@ -9,7 +9,7 @@ image: https://house.texas.gov/members/photos/3920.jpg?v=88.25
 party:
 - name: Republican
 roles:
-- start_date: 2020-01-11
+- start_date: 2020-02-11
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '28'

--- a/data/tx/legislature/James-Talarico-5e4e2fd2-e8a9-46f3-aab5-ffbc782afa8b.yml
+++ b/data/tx/legislature/James-Talarico-5e4e2fd2-e8a9-46f3-aab5-ffbc782afa8b.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '50'
 - start_date: 2018-11-20
-  end_date: 2023-01-09
-  type: lower
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '50'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '52'

--- a/data/tx/legislature/Mayes-Middleton-1399b6ba-cbfa-45ca-bf91-6ba89fe777bf.yml
+++ b/data/tx/legislature/Mayes-Middleton-1399b6ba-cbfa-45ca-bf91-6ba89fe777bf.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '11'
 - start_date: 2019-01-08
-  end_date: 2023-01-09
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '11'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '23'

--- a/data/tx/legislature/Phil-King-98bef50a-73c7-4139-9b8e-628d0e89d659.yml
+++ b/data/tx/legislature/Phil-King-98bef50a-73c7-4139-9b8e-628d0e89d659.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '10'
 - start_date: 1999-01-12
-  end_date: 2023-01-09
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '10'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '61'

--- a/data/tx/legislature/Richard-Pea-Raymond-d4a94a68-02a7-44c0-901f-9cd57350229a.yml
+++ b/data/tx/legislature/Richard-Pea-Raymond-d4a94a68-02a7-44c0-901f-9cd57350229a.yml
@@ -9,7 +9,8 @@ image: https://house.texas.gov/members/photos/4215.jpg?v=88.25
 party:
 - name: Democratic
 roles:
-- type: lower
+- start_date: 2021-01-24
+  type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '42'
 offices:

--- a/data/tx/legislature/Roland-Gutierrez-68767ec3-151c-413f-aeb8-f35dd6c5f35c.yml
+++ b/data/tx/legislature/Roland-Gutierrez-68767ec3-151c-413f-aeb8-f35dd6c5f35c.yml
@@ -14,11 +14,6 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '19'
 - start_date: 2008-05-14
-  end_date: 2021-01-11
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '19'
-- start_date: 2008-05-14
   end_date: 2021-01-12
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government

--- a/data/tx/legislature/Ryan-Guillen-f0ede995-2253-4f7b-a922-6da34e4de194.yml
+++ b/data/tx/legislature/Ryan-Guillen-f0ede995-2253-4f7b-a922-6da34e4de194.yml
@@ -9,12 +9,7 @@ image: https://house.texas.gov/members/photos/3045.jpg?v=88.25
 party:
 - name: Republican
 roles:
-- start_date: 2021-11-15
-  type: lower
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '31'
 - start_date: 2003-01-14
-  end_date: 2021-11-14
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '31'

--- a/data/tx/legislature/Tan-Parker-fa4817bf-6dc6-4deb-9965-cf3f208ec976.yml
+++ b/data/tx/legislature/Tan-Parker-fa4817bf-6dc6-4deb-9965-cf3f208ec976.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '12'
 - start_date: 2007-01-09
-  end_date: 2023-01-09
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '12'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '63'

--- a/data/tx/legislature/Trent-Ashby-68f05872-16c8-4d3a-ab5f-ea667ca52b27.yml
+++ b/data/tx/legislature/Trent-Ashby-68f05872-16c8-4d3a-ab5f-ea667ca52b27.yml
@@ -14,11 +14,7 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '9'
 - start_date: 2013-01-08
-  end_date: 2023-01-09
-  type: lower
-  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
-  district: '9'
-- end_date: 2023-01-10
+  end_date: 2023-01-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: '57'

--- a/data/tx/retired/Charles-Doc-Anderson-a289901c-76aa-4288-a4b9-3bb1bf081c89.yml
+++ b/data/tx/retired/Charles-Doc-Anderson-a289901c-76aa-4288-a4b9-3bb1bf081c89.yml
@@ -10,10 +10,10 @@ party:
 - name: Republican
 roles:
 - start_date: 2005-01-11
+  end_date: 2024-08-05
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government
   district: 56
-  end_date: 2024-01-01
 offices:
 - classification: capitol-mail
   address: Room 1N.88, P.O. Box 2910, Austin, TX 78768

--- a/data/tx/retired/Drew-Springer-f1332c39-f120-4ccd-ac64-cae40b2be91a.yml
+++ b/data/tx/retired/Drew-Springer-f1332c39-f120-4ccd-ac64-cae40b2be91a.yml
@@ -9,7 +9,7 @@ image: https://senate.texas.gov/members/d30/img/Springer_87-0036D-009-web.jpg
 party:
 - name: Republican
 roles:
-- start_date: 2021-01-12
+- start_date: 2021-01-06
   end_date: 2025-01-13
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government

--- a/data/tx/retired/Jacey-Jetton-8c82ede2-a4c6-4625-92ca-2b24c370de17.yml
+++ b/data/tx/retired/Jacey-Jetton-8c82ede2-a4c6-4625-92ca-2b24c370de17.yml
@@ -9,7 +9,7 @@ image: https://house.texas.gov/members/photos/3980.jpg?v=88.25
 party:
 - name: Republican
 roles:
-- start_date: 2023-10-06
+- start_date: 2021-01-12
   end_date: 2025-01-13
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government

--- a/data/tx/retired/Shawn-Thierry-26b8304b-24ea-411d-8d85-e348ba6951c7.yml
+++ b/data/tx/retired/Shawn-Thierry-26b8304b-24ea-411d-8d85-e348ba6951c7.yml
@@ -9,7 +9,7 @@ image: https://house.texas.gov/members/photos/3390.jpg?v=88.25
 party:
 - name: Republican
 roles:
-- start_date: 2024-08-30
+- start_date: 2017-01-10
   end_date: 2025-01-13
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:tx/government


### PR DESCRIPTION
18 Texas legislators have incorrect or duplicate tenure dates. This PR fixes them and ensures none of them overlap.