### PR TITLE
Make MI start/end dates consistent

### DIFF
--- a/data/mi/legislature/Carol-Glanville-86812673-e63a-4f36-aa3e-26de84380657.yml
+++ b/data/mi/legislature/Carol-Glanville-86812673-e63a-4f36-aa3e-26de84380657.yml
@@ -11,7 +11,8 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '84'
-- end_date: 2022-12-31
+- start_date: 2022-05-09
+  end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '74'

--- a/data/mi/legislature/Tyrone-Carter-38d2f8c4-f40c-44b7-a2dd-57a4d5375572.yml
+++ b/data/mi/legislature/Tyrone-Carter-38d2f8c4-f40c-44b7-a2dd-57a4d5375572.yml
@@ -8,7 +8,8 @@ image: https://housedems.com/sites/default/files/Images/Representative_Images/D0
 party:
 - name: Democratic
 roles:
-- type: lower
+- start_date: 2023-01-01
+  type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '1'
 - end_date: 2022-12-31

--- a/data/mi/retired/Abraham-Aiyash-5a87d637-4763-44a1-b763-a40c9a30b67e.yml
+++ b/data/mi/retired/Abraham-Aiyash-5a87d637-4763-44a1-b763-a40c9a30b67e.yml
@@ -8,10 +8,10 @@ party:
 - name: Democratic
 roles:
 - start_date: 2023-01-01
+  end_date: 2025-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '9'
-  end_date: 2025-01-02
 - end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Andrew-Beeler-77456985-a7be-4384-9dfe-70373b8031f6.yml
+++ b/data/mi/retired/Andrew-Beeler-77456985-a7be-4384-9dfe-70373b8031f6.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '64'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2023-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Andrew-Fink-154e0e09-4da4-449d-9ebe-58c0b720e513.yml
+++ b/data/mi/retired/Andrew-Fink-154e0e09-4da4-449d-9ebe-58c0b720e513.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '35'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Christine-Morse-4c46fce6-3e67-43a0-b396-5130a004c2a4.yml
+++ b/data/mi/retired/Christine-Morse-4c46fce6-3e67-43a0-b396-5130a004c2a4.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '40'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
+++ b/data/mi/retired/Dale-Zorn-f87c906f-bf6e-41db-8ab6-cf736ba589d4.yml
@@ -13,7 +13,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '34'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - start_date: 2011-01-01
   end_date: 2014-12-31
   type: lower

--- a/data/mi/retired/Felicia-Brabec-ccfacab2-ec54-40f8-add5-2dfe02908055.yml
+++ b/data/mi/retired/Felicia-Brabec-ccfacab2-ec54-40f8-add5-2dfe02908055.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '33'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2023-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Graham-Filler-4eab6d53-e023-4314-934a-faffd35d78a2.yml
+++ b/data/mi/retired/Graham-Filler-4eab6d53-e023-4314-934a-faffd35d78a2.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '93'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 offices: []
 links:
 - url: https://gophouse.org/representatives/central/filler/

--- a/data/mi/retired/Jaime-Churches-8a444713-86ab-4a98-b26f-3f19302f0348.yml
+++ b/data/mi/retired/Jaime-Churches-8a444713-86ab-4a98-b26f-3f19302f0348.yml
@@ -8,10 +8,10 @@ party:
 - name: Democratic
 roles:
 - start_date: 2023-01-01
+  end_date: 2025-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '27'
-  end_date: 2025-01-02
 offices: []
 links:
 - url: https://housedems.com/Jaime-Churches/

--- a/data/mi/retired/Jenn-Hill-4f4e9d3d-0e2f-4c10-abcb-8308f0cb33e2.yml
+++ b/data/mi/retired/Jenn-Hill-4f4e9d3d-0e2f-4c10-abcb-8308f0cb33e2.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '109'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 offices: []
 links:
 - url: https://housedems.com/Jenn-Hill/

--- a/data/mi/retired/Jim-Haadsma-7ac8386b-fa1e-4f5d-aaeb-e5614e771141.yml
+++ b/data/mi/retired/Jim-Haadsma-7ac8386b-fa1e-4f5d-aaeb-e5614e771141.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '44'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Nate-Shannon-af52f259-fe60-4903-98b8-739a114a8deb.yml
+++ b/data/mi/retired/Nate-Shannon-af52f259-fe60-4903-98b8-739a114a8deb.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '58'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 offices: []
 links:
 - url: https://housedems.com/nate-shannon/

--- a/data/mi/retired/Neil-Friske-79ed6347-2370-40bc-9570-996894d0b600.yml
+++ b/data/mi/retired/Neil-Friske-79ed6347-2370-40bc-9570-996894d0b600.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '107'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 offices: []
 links:
 - url: https://gophouse.org/member/RepNeilFriske/posts

--- a/data/mi/retired/Rachel-Hood-85cde8af-86e7-4d74-9bf7-2cc79ccfab39.yml
+++ b/data/mi/retired/Rachel-Hood-85cde8af-86e7-4d74-9bf7-2cc79ccfab39.yml
@@ -12,7 +12,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '81'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2022-12-31
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Robert-Bezotte-f5b2c77c-88b8-4ea7-854a-789b660e5a91.yml
+++ b/data/mi/retired/Robert-Bezotte-f5b2c77c-88b8-4ea7-854a-789b660e5a91.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '50'
-  end_date: 2025-01-02
+  end_date: 2025-01-01
 - end_date: 2023-01-01
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government

--- a/data/mi/retired/Terence-Mekoski-9f06fa9b-d9ea-4424-9e2a-3e2e02e979fb.yml
+++ b/data/mi/retired/Terence-Mekoski-9f06fa9b-d9ea-4424-9e2a-3e2e02e979fb.yml
@@ -7,7 +7,8 @@ email: terencemekoski@house.mi.gov
 party:
 - name: Republican
 roles:
-- end_date: '2023-01-01'
+- start_date: '2022-05-09'
+  end_date: '2023-01-01'
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:mi/government
   district: '36'


### PR DESCRIPTION
17 MIchigan legislators have missing or incorrect tenure dates. This PR fixes them and ensures none of them overlap.