### PR TITLE
Update San Diego mayor term end date

### DIFF
--- a/data/ca/municipalities/Todd-Gloria-1465de6a-ec39-4986-b3e4-e30ef7a47c20.yml
+++ b/data/ca/municipalities/Todd-Gloria-1465de6a-ec39-4986-b3e4-e30ef7a47c20.yml
@@ -11,7 +11,7 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:ca/government
   district: '78'
-- end_date: '2024-12-31'
+- end_date: '2028-12-10'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:ca/place:san_diego/government
 offices:

--- a/data/ca/municipalities/Todd-Gloria-1465de6a-ec39-4986-b3e4-e30ef7a47c20.yml
+++ b/data/ca/municipalities/Todd-Gloria-1465de6a-ec39-4986-b3e4-e30ef7a47c20.yml
@@ -19,9 +19,9 @@ offices:
   address: 202 C Street, 11th Floor;San Diego, CA 92101
   voice: 619-236-6330
 links:
-- url: https://www.sandiego.gov/contact
+- url: https://www.sandiego.gov/mayor
 other_identifiers:
 - scheme: legacy_openstates
   identifier: CAL000527
 sources:
-- url: https://www.sandiego.gov/contact
+- url: https://www.sandiego.gov/mayor/contact


### PR DESCRIPTION
Reelected for his final term in 2024: https://www.cbs8.com/article/news/politics/elections/san-diego-mayor-live-election-results-todd-gloria-larry-turner/509-e91ee437-2d97-4050-b52e-67df1c47d21d

December 10th seems to be the more accurate end date for SD mayoral terms.