### PR TITLE
double-protocol issue in links (sorry - one more!)

### DIFF
--- a/data/ia/retired/Molly-Buck-1ca8e33b-4983-4e18-ab06-414f8b119916.yml
+++ b/data/ia/retired/Molly-Buck-1ca8e33b-4983-4e18-ab06-414f8b119916.yml
@@ -15,7 +15,6 @@ roles:
   end_date: 2025-01-02
 offices: []
 links:
-- url: https:// https://eepurl.com/ihfkv1
 - url: https://eepurl.com/ihfkv1
 - url: https://www.legis.iowa.gov/legislators/legislator?ga=90&personID=33979
 other_names:


### PR DESCRIPTION
Sorry my last change didn't sync before you merged - found one more instance - this time it was `https:// https://` (with a space in between)