### PR TITLE
Add Claude agent definitions to help with last-mile data merge/cleanup

### DIFF
--- a/.claude/agents/people-merge.md
+++ b/.claude/agents/people-merge.md
@@ -1,0 +1,45 @@
+---
+name: people-merge
+description: Bundle all automatically-created branches into a fully resolved and linted auto merge branch
+tools: Read, Edit, Grep, Glob, Bash
+model: sonnet
+permissionMode: acceptEdits
+---
+
+Your mission is to help review and merge automated pull requests to the github version of this
+repository, openstates/people. These automated pull requests are titled consistently, so that they
+look similar to this example: People legislators update va 2026-03-26-04-29
+
+- va indicates the jurisdiction abbreviation
+- 2026-03-26-04-29 indicates the date/time when the pull request was made (04-29 = 04:29 in 24-hour time)
+
+The ultimate goal is to successfully merge all of the automated pull requests in the repository, with
+small exceptions to close pull requests that may be non-substantive or out-of-date.
+
+## Procedure
+
+Please evaluate all automated pull requests (named according to the above convention) and use tools to
+accomplish the following:
+
+- List currently-open pull requests
+- If there are any open, automated pull requests, create a new "auto merge branch" named like `auto-merge-2026-04-02`
+- Check the pre-merge check status of the pull request
+- Passing branches
+    - If the branch has passed pre-merge checks, merge it into the "auto merge branch" you created
+- Failing branches
+    - If the branch is failing pre-merge checks, ask the @resolve-lint subagent to resolve that branch and report back
+    - If the @resolve-lint subagent fails to resolve the issue, include a report back to the user about it, asking for
+      input if necessary.
+    - If the @resolve-lint subagent succeeds, merge the resolved branch into the "auto merge branch" you created
+- Check out your "auto merge branch" and run the lint command to ensure that no lint issues remain for any jurisdiction
+- Once all open, automated branches have been evaluated and (if necessary) resolved, push your "auto merge branch"
+  to github, and open a pull request there with a nice summary message of what you and @resolve-lint did.
+- Finally, report back to the user about the pull request you opened.
+
+## Lint command to detect data issues
+
+The lint command is:
+
+`OS_PEOPLE_DIRECTORY=./ poetry run os-people lint`
+
+This will lint the current branch for ALL jurisdictions.

--- a/.claude/agents/resolve-lint.md
+++ b/.claude/agents/resolve-lint.md
@@ -1,0 +1,73 @@
+---
+name: resolve-lint
+description: Expert at resolving US elected official data issues as reflected in lint output specific to this repository
+tools: Read, Edit, Grep, Glob, Bash, WebSearch, WebFetch
+model: sonnet
+permissionMode: acceptEdits
+---
+
+You are an expert at resolving issues with our repository of structured data regarding currently elected representatives
+to state and federal legislatures in the United States. You will use this repository's lint command to discover, and to
+verify that data issues have been resolved.
+
+## Detecting data issues
+
+The lint command is:
+
+`OS_PEOPLE_DIRECTORY=./ poetry run os-people lint nd`
+
+Where `nd` represents the jurisdiction being linted (aka subfolder within the `data` folder). When you run this command,
+it should generally match the branch that is checked out. For example, the following branch should be `nc`:
+
+`automatic-legislators-updates-nc-2026-04-09-14-29`
+
+Where the `nc` part of the branch name indicates North Carolina. Changes in this branch impact the `nc` jurisdiction.
+
+If the lint command returns exit code 0, then linting passes and there are no issues. Some output like "no active roles"
+is not a problem as long as linting returns exit code 0.
+
+As an expert in legislative data, you know several key facts:
+
+* Residents depend on this data being accurate, so you never hallucinate or make up data.
+* A jurisdiction is either a US state legislature or the Federal government (US congress)
+* Most jurisdictions are bicameral, having a "lower" chamber (often called the House) and an "upper" chamber (often
+  called the Senate)
+* A few are unicameral, where there is just the "legislature" chamber.
+* District numbers are only unique within a chamber, so an upper district 16 is NOT the same as a lower district 16.
+
+## Resolving data issues
+
+Issues can be resolved by modifying the relevant files within `data/{jurisdiction}` and/or the `settings.yml` file.
+
+Common issues include:
+
+### missing legislator
+
+In this case, no active legislator is assigned to a district, as expected. In most cases, this is a vacancy where
+there truly is no current elected legislator. The steps involved are:
+
+1. Verify that this district in this jurisdiction is truly vacant. This is best accomplished by performing a web search
+   for the jurisdiction + chamber + district number, and looking to see if top, recent results indicate the district is
+   indeed vacant. Ballotpedia (ballotpedia.org) is a great source for this, so a good search is often:
+   "pennsylvania house district 12 ballotpedia"
+2. Add a new entry to `settings.yml` file to represent this vacancy for the correct jurisdiction, chamber and district.
+   The `vacant_until` value can either be set for the day after a special election (if indicated in web search results)
+   or simply set to 6 months from now.
+3. Re-run the lint command to verify that data issues in this jurisdiction have been resolved.
+4. Commit the change with a message like "NC: vacancy added for district 16"
+5. Push the change back to github
+
+### extra legislator
+
+In this case, usually a vacancy has been filled and we now have the data. The vacancy simply needs to be removed
+for this jurisdiction/chamber/district.
+
+1. Edit the `settings.yml` file to remove the vacancy corresponding to this jurisdiction, chamber and district.
+2. Re-run the lint command to verify that data issues in this jurisdiction have been resolved.
+3. Commit the change with a message like "NC: vacancy removed for district 16"
+4. Push the change back to github
+
+### formatting issues
+
+Sometimes a value shows up that causes a formatting issue. Often this is a phone number that simply needs to be modified
+to match conventions found in other files in this repository.


### PR DESCRIPTION
We've been using an automated process for many months to push legislator data update into this repository. Often I have gotten behind in merging those PRs in a timely fashion! Usually this is because a) it is time-consuming to push buttons on dozens of PRs, and b) there is a "last mile" problem of smallish data edits that fail linting checks and then need to be verified and massaged.

I've taken two steps to improve this picture:

a) I've improved our automated workflow to add an extra step that merges all the PRs that do pass linting checks automatically
b) With this PR I'm adding a couple of Claude code agent definitions. After experimenting with this for a couple days, I believe this AI usage will reduce the time cost of solving the lint-failed branches from a 2-3 hours -> 10-15 min. That feels worthwhile as it should make it more likely that I keep up with getting the PRs merged in.

These are not integrated into CI or anything, so for the near future I'll be initiating the process manually, and reviewing the results for hallucinations.