### PR TITLE
IL photo url corrections

### DIFF
--- a/data/al/legislature/Artis-Mccampbell-474c3552-b3cd-4015-ac15-3c6301a0ce0e.yml
+++ b/data/al/legislature/Artis-Mccampbell-474c3552-b3cd-4015-ac15-3c6301a0ce0e.yml
@@ -3,7 +3,7 @@ name: A.J. McCampbell
 given_name: A.J.
 family_name: McCampbell
 gender: Male
-email: artis.mccampbell@alhouse.gov
+email: ajmc1@bellsouth.net
 image: https://www.legislature.state.al.us/pdf/house/members/McCampbell_71.png
 party:
 - name: Democratic

--- a/data/al/legislature/Brett-Easterbrook-def57a9e-a907-4e62-b990-41dc19661c06.yml
+++ b/data/al/legislature/Brett-Easterbrook-def57a9e-a907-4e62-b990-41dc19661c06.yml
@@ -4,7 +4,7 @@ given_name: Brett
 family_name: Easterbrook
 birth_date: 1963-10-10
 gender: Male
-email: brett@bretteasterbrook.com
+email: brett.easterbrook@yahoo.com
 image: https://www.legislature.state.al.us/pdf/house/members/Easterbrook_65.png
 party:
 - name: Republican

--- a/data/al/legislature/Chip-Brown-04a1794d-93f0-435f-8c68-1b435f2fc1a0.yml
+++ b/data/al/legislature/Chip-Brown-04a1794d-93f0-435f-8c68-1b435f2fc1a0.yml
@@ -3,7 +3,7 @@ name: Chip Brown
 given_name: Chip
 family_name: Brown
 gender: Male
-email: chip@chipbrown2018.com
+email: chip.brown@alhouse.gov
 image: https://www.legislature.state.al.us/pdf/house/members/Brown_105.png
 party:
 - name: Republican

--- a/data/al/legislature/Donna-Givens-ef19bb65-dc3c-4815-ac71-b1ffd9abf28b.yml
+++ b/data/al/legislature/Donna-Givens-ef19bb65-dc3c-4815-ac71-b1ffd9abf28b.yml
@@ -3,7 +3,7 @@ name: Donna Givens
 given_name: Donna
 family_name: Givens
 gender: Female
-email: donnagivens64@gmail.com
+email: donnagivens55@gmail.com
 image: https://www.legislature.state.al.us/pdf/house/members/Givens_64.png
 party:
 - name: Republican

--- a/data/al/legislature/Ritchie-Whorton-7e00e45e-24bf-4939-83b8-a56a90e3ea61.yml
+++ b/data/al/legislature/Ritchie-Whorton-7e00e45e-24bf-4939-83b8-a56a90e3ea61.yml
@@ -4,7 +4,7 @@ given_name: Ritchie
 family_name: Whorton
 birth_date: 1960-03-04
 gender: Male
-email: ritchie.whorton@alhouse.gov
+email: ritchiewhorton@gmail.com
 image: https://www.legislature.state.al.us/pdf/house/members/Whorton_22.png
 party:
 - name: Republican

--- a/data/al/legislature/Steve-Hurst-4f0a4d5d-b27a-4f33-b394-f27d306f8a42.yml
+++ b/data/al/legislature/Steve-Hurst-4f0a4d5d-b27a-4f33-b394-f27d306f8a42.yml
@@ -3,7 +3,7 @@ name: Steve Hurst
 given_name: Steve
 family_name: Hurst
 gender: Male
-email: steve.hurst@alhouse.gov
+email: repstevehurst98@gmail.com
 image: https://www.legislature.state.al.us/pdf/house/members/Hurst_35.png
 party:
 - name: Republican

--- a/data/al/legislature/Tracy-Estes-25308613-cda5-4e1c-aef7-821ada580575.yml
+++ b/data/al/legislature/Tracy-Estes-25308613-cda5-4e1c-aef7-821ada580575.yml
@@ -4,7 +4,7 @@ given_name: Tracy
 family_name: Estes
 birth_date: 1967-06-20
 gender: Male
-email: tracy.estes@alhouse.gov
+email: jtracyestes@gmail.com
 image: https://www.legislature.state.al.us/pdf/house/members/Estes_17.png
 party:
 - name: Republican

--- a/data/ar/legislature/Reginald-Murdock-f148aa6d-abfe-4577-9c15-44f2ea79c707.yml
+++ b/data/ar/legislature/Reginald-Murdock-f148aa6d-abfe-4577-9c15-44f2ea79c707.yml
@@ -4,7 +4,7 @@ given_name: Reginald
 family_name: Murdock
 birth_date: 1966-04-29
 gender: Male
-email: rkm_72390@yahoo.com
+email: rkm_72360@yahoo.com
 image: https://www.arkleg.state.ar.us/Content/photos/2023/Senate/639_sm.jpg
 party:
 - name: Democratic

--- a/data/ca/legislature/Tasha-Boerner-Horvath-9e69729e-4383-410b-840e-ad4ea0f1ab4a.yml
+++ b/data/ca/legislature/Tasha-Boerner-Horvath-9e69729e-4383-410b-840e-ad4ea0f1ab4a.yml
@@ -4,7 +4,7 @@ given_name: Tasha
 family_name: Boerner
 birth_date: 1973-02-01
 gender: Female
-email: assemblymember.boerner@assembly.ca.gov
+email: assemblymember.BoernerHorvath@assembly.ca.gov
 image: https://www.assembly.ca.gov/sites/assembly.ca.gov/files/memberphotos/a76_t_b_horvath.jpg
 party:
 - name: Democratic

--- a/data/co/legislature/Lori-Sander-d450c0d3-b829-4855-ad0d-1228c5284a4f.yml
+++ b/data/co/legislature/Lori-Sander-d450c0d3-b829-4855-ad0d-1228c5284a4f.yml
@@ -4,7 +4,7 @@ given_name: Lori
 family_name: Garcia Sander
 birth_date: 1972-08-15
 gender: Female
-email: lori garciasander.house@coleg.gov
+email: lori.garciasander.house@coleg.gov
 image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/LoriSander2024.jpg
 party:
 - name: Republican

--- a/data/ct/legislature/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
+++ b/data/ct/legislature/Eric-C-Berthel-58a9b2fa-cd93-420c-a9bc-6326a75a218a.yml
@@ -4,7 +4,7 @@ given_name: Eric
 family_name: Berthel
 birth_date: 1967-03-28
 gender: Male
-email: eric.berthel@cga.ct.gov.
+email: eric.berthel@cga.ct.gov
 image: https://ctsenaterepublicans.com/wp-content/uploads/2019/01/Berthel2019forWeb.jpg
 party:
 - name: Republican

--- a/data/ct/legislature/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
+++ b/data/ct/legislature/Gary-A-Winfield-102845da-9b93-400d-b58a-fa3e7df1806e.yml
@@ -4,7 +4,7 @@ given_name: Gary
 family_name: Winfield
 birth_date: 1974-03-11
 gender: Male
-email: winfield@senatedems.ct.gov
+email: gary.winfield@cga.ct.gov
 image: http://www.senatedems.ct.gov/templates/winfield/images/winfield-hi.jpg
 party:
 - name: Democratic

--- a/data/il/legislature/Aaron-M-Ortiz-a76e0c0e-81d3-4f3b-8cc8-b8360d3cecb4.yml
+++ b/data/il/legislature/Aaron-M-Ortiz-a76e0c0e-81d3-4f3b-8cc8-b8360d3cecb4.yml
@@ -5,7 +5,7 @@ family_name: "Ort\xEDz"
 birth_date: 1991-06-18
 gender: Male
 email: district@repaaronortiz.com
-image: https://ilga.gov/images/members/{D96B0DF9-0E06-487B-825C-AB0BE8C3CA1E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D96B0DF9-0E06-487B-825C-AB0BE8C3CA1E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Abdelnasser-Rashid-4101db1f-a913-4d16-88fb-001f120bb092.yml
+++ b/data/il/legislature/Abdelnasser-Rashid-4101db1f-a913-4d16-88fb-001f120bb092.yml
@@ -5,7 +5,7 @@ family_name: Rashid
 birth_date: 1989-07-24
 gender: Male
 email: office@reprashid.com
-image: https://ilga.gov/images/members/{48E00B1D-C5BE-4210-A9A8-F68739D935D6}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{48E00B1D-C5BE-4210-A9A8-F68739D935D6}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Adam-Niemerg-9729745e-386d-4f4b-8d04-0e762dcd87b2.yml
+++ b/data/il/legislature/Adam-Niemerg-9729745e-386d-4f4b-8d04-0e762dcd87b2.yml
@@ -5,7 +5,7 @@ family_name: Niemerg
 birth_date: 1984-03-17
 gender: Male
 email: niemerg@ilhousegop.org
-image: https://ilga.gov/images/members/{EDDABDD8-51A3-413F-B2A0-FA5953D29598}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{EDDABDD8-51A3-413F-B2A0-FA5953D29598}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Adriane-Johnson-e4e9607b-dd1b-4c3d-b3a3-f09927800864.yml
+++ b/data/il/legislature/Adriane-Johnson-e4e9607b-dd1b-4c3d-b3a3-f09927800864.yml
@@ -4,7 +4,7 @@ given_name: Adriane
 family_name: Johnson
 gender: Female
 email: info@senatoradrianejohnson.com
-image: https://ilga.gov/images/members/{991EBDF6-BC13-4260-A2B8-E10751629780}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{991EBDF6-BC13-4260-A2B8-E10751629780}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Amy-Elik-b13c7ff5-806e-426d-afd5-181f53e9fed1.yml
+++ b/data/il/legislature/Amy-Elik-b13c7ff5-806e-426d-afd5-181f53e9fed1.yml
@@ -4,7 +4,7 @@ given_name: Amy
 family_name: Elik
 gender: Female
 email: elik@ilhousegop.org
-image: https://ilga.gov/images/members/{D070CEE6-55DF-4D51-961B-CCA4A0E49A8C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D070CEE6-55DF-4D51-961B-CCA4A0E49A8C}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Amy-Grant-f8dc94db-66cf-4d5e-b1af-0b6307140524.yml
+++ b/data/il/legislature/Amy-Grant-f8dc94db-66cf-4d5e-b1af-0b6307140524.yml
@@ -4,7 +4,7 @@ given_name: Amy
 family_name: Grant
 gender: Female
 email: grant@ilhousegop.org
-image: https://ilga.gov/images/members/{41DCC207-977E-45DC-BD10-A8AFDCEB673E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{41DCC207-977E-45DC-BD10-A8AFDCEB673E}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Andrew-S-Chesney-9def23d3-81e9-4baf-b0c8-eeb4e5587778.yml
+++ b/data/il/legislature/Andrew-S-Chesney-9def23d3-81e9-4baf-b0c8-eeb4e5587778.yml
@@ -5,7 +5,7 @@ family_name: Chesney
 birth_date: 1982-01-11
 gender: Male
 email: chesney@ilsenategop.org
-image: https://ilga.gov/images/members/{D79AFB6D-F47C-47F7-988D-A3E99A0100E5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D79AFB6D-F47C-47F7-988D-A3E99A0100E5}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Angelica-Guerrero-Cuellar-8b2bc102-d62b-47b2-91d8-5f9b3a172cea.yml
+++ b/data/il/legislature/Angelica-Guerrero-Cuellar-8b2bc102-d62b-47b2-91d8-5f9b3a172cea.yml
@@ -4,7 +4,7 @@ given_name: Angie
 family_name: Guerrero-Cuellar
 gender: Female
 email: angieguerrerocuellar22@gmail.com
-image: https://ilga.gov/images/members/{22FBB36E-8A65-4E83-81F1-A20247A6B8F2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{22FBB36E-8A65-4E83-81F1-A20247A6B8F2}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Ann-M-Williams-02f2799d-4633-48e9-b5ab-379d48e70b40.yml
+++ b/data/il/legislature/Ann-M-Williams-02f2799d-4633-48e9-b5ab-379d48e70b40.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1968-04-28
 gender: Female
 email: ann@repannwilliams.com
-image: https://ilga.gov/images/members/{C45B418C-4848-4467-ADC2-739B2D1E4418}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C45B418C-4848-4467-ADC2-739B2D1E4418}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Anna-Moeller-f38a2b8a-b0e4-4e7d-92cf-7855d42e9c2d.yml
+++ b/data/il/legislature/Anna-Moeller-f38a2b8a-b0e4-4e7d-92cf-7855d42e9c2d.yml
@@ -4,7 +4,7 @@ given_name: Anna
 family_name: Moeller
 gender: Female
 email: staterepmoeller@gmail.com
-image: https://ilga.gov/images/members/{DCE9D682-0582-49BD-AD67-98C2502D89C2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{DCE9D682-0582-49BD-AD67-98C2502D89C2}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Anne-Stava-Murray-8dfe2e37-8a40-4be0-b44d-0bf65861f4e0.yml
+++ b/data/il/legislature/Anne-Stava-Murray-8dfe2e37-8a40-4be0-b44d-0bf65861f4e0.yml
@@ -4,7 +4,7 @@ given_name: Anne
 family_name: Stava
 gender: Female
 email: office@repstavamurray.com
-image: https://ilga.gov/images/members/{0322F94E-013C-4237-9808-4462138AC595}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0322F94E-013C-4237-9808-4462138AC595}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Anthony-DeLuca-aecf9fb4-3e54-4963-941f-8dc6b4658584.yml
+++ b/data/il/legislature/Anthony-DeLuca-aecf9fb4-3e54-4963-941f-8dc6b4658584.yml
@@ -5,7 +5,7 @@ family_name: DeLuca
 birth_date: 1970-07-25
 gender: Male
 email: repdeluca@sbcglobal.net
-image: https://ilga.gov/images/members/{64399002-8B14-4D8E-80A4-54A77F25421C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{64399002-8B14-4D8E-80A4-54A77F25421C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Barbara-Hernandez-fb481641-3999-4fe4-9bac-878becdde97d.yml
+++ b/data/il/legislature/Barbara-Hernandez-fb481641-3999-4fe4-9bac-878becdde97d.yml
@@ -4,7 +4,7 @@ given_name: Barbara
 family_name: Hernandez
 gender: Female
 email: repbarbarahernandez@gmail.com
-image: https://ilga.gov/images/members/{E3518E4F-7AAF-4D93-8985-336197D96094}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E3518E4F-7AAF-4D93-8985-336197D96094}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Blaine-Wilhour-500ffee4-de06-4a0b-b4df-f8e6f52c4e96.yml
+++ b/data/il/legislature/Blaine-Wilhour-500ffee4-de06-4a0b-b4df-f8e6f52c4e96.yml
@@ -5,7 +5,7 @@ family_name: Wilhour
 birth_date: 1982-03-10
 gender: Male
 email: wilhour@ilhousegop.org
-image: https://ilga.gov/images/members/{66C5580C-A414-41BB-B3AC-638925AC34CD}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{66C5580C-A414-41BB-B3AC-638925AC34CD}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Bob-Morgan-55a824f4-04c7-4834-8a5d-d204ca3bece5.yml
+++ b/data/il/legislature/Bob-Morgan-55a824f4-04c7-4834-8a5d-d204ca3bece5.yml
@@ -4,7 +4,7 @@ given_name: Bob
 family_name: Morgan
 gender: Male
 email: info@repbobmorgan.com
-image: https://ilga.gov/images/members/{A3460802-617C-4097-B043-6D63A11278AC}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{A3460802-617C-4097-B043-6D63A11278AC}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Brad-E-Halbrook-e05f1a87-b75d-450e-9cd1-3b7a66cb703e.yml
+++ b/data/il/legislature/Brad-E-Halbrook-e05f1a87-b75d-450e-9cd1-3b7a66cb703e.yml
@@ -5,7 +5,7 @@ family_name: Halbrook
 birth_date: 1961-07-22
 gender: Male
 email: halbrook@ilhousegop.org
-image: https://ilga.gov/images/members/{3F3C3739-E087-440D-B006-33043A8F5083}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{3F3C3739-E087-440D-B006-33043A8F5083}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Bradley-Fritts-be767c3e-58d9-41c0-b930-79c0f47b9960.yml
+++ b/data/il/legislature/Bradley-Fritts-be767c3e-58d9-41c0-b930-79c0f47b9960.yml
@@ -5,7 +5,7 @@ family_name: Fritts
 birth_date: 2000-01-08
 gender: Male
 email: fritts@ilhousegop.org
-image: https://ilga.gov/images/members/{3A924147-7119-4921-BDF6-14B5D5BA4B8D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{3A924147-7119-4921-BDF6-14B5D5BA4B8D}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Bradley-Stephens-49c0fac1-8cf0-48d2-8166-811afe9ac5c5.yml
+++ b/data/il/legislature/Bradley-Stephens-49c0fac1-8cf0-48d2-8166-811afe9ac5c5.yml
@@ -5,7 +5,7 @@ family_name: Stephens
 birth_date: 1963-12-07
 gender: Male
 email: stephens@ilhousegop.org
-image: https://ilga.gov/images/members/{BD3836AC-CD0C-4E20-AD4C-1F2AEA56A8A2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BD3836AC-CD0C-4E20-AD4C-1F2AEA56A8A2}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Brandun-Schweizer-8c6f0ed1-f28f-408a-9b59-156fa7a7f1e0.yml
+++ b/data/il/legislature/Brandun-Schweizer-8c6f0ed1-f28f-408a-9b59-156fa7a7f1e0.yml
@@ -4,7 +4,7 @@ given_name: Brandun
 family_name: Schweizer
 gender: Male
 email: repschweizer@district104.com
-image: https://ilga.gov/images/members/{7520D666-0725-4963-B643-C1106551E922}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7520D666-0725-4963-B643-C1106551E922}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/CD-Davidsmeyer-384c08f3-49fd-45a7-bb7b-5689bdeae7a7.yml
+++ b/data/il/legislature/CD-Davidsmeyer-384c08f3-49fd-45a7-bb7b-5689bdeae7a7.yml
@@ -5,7 +5,7 @@ family_name: Davidsmeyer
 birth_date: 1979-07-12
 gender: Male
 email: davidsmeyer@ilhousegop.org
-image: https://ilga.gov/images/members/{E54250D5-EB1C-4CB6-9CF9-CA95CAA2F269}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E54250D5-EB1C-4CB6-9CF9-CA95CAA2F269}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Camille-Y-Lilly-a51455ff-b0ae-47f6-b3ee-2722adbe38c2.yml
+++ b/data/il/legislature/Camille-Y-Lilly-a51455ff-b0ae-47f6-b3ee-2722adbe38c2.yml
@@ -4,7 +4,7 @@ given_name: Camille
 family_name: Lilly
 gender: Female
 email: staterepcamilleylilly@gmail.com
-image: https://ilga.gov/images/members/{84D8FB64-9F82-405A-9376-A69ADFB46E53}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{84D8FB64-9F82-405A-9376-A69ADFB46E53}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Carol-Ammons-bc409660-f360-4624-914f-ba785bbf9b7b.yml
+++ b/data/il/legislature/Carol-Ammons-bc409660-f360-4624-914f-ba785bbf9b7b.yml
@@ -4,7 +4,7 @@ given_name: Carol
 family_name: Ammons
 gender: Female
 email: assistance@staterepcarolammons.com
-image: https://ilga.gov/images/members/{BD4B7A5C-6D24-4E82-9C18-D5A0F3C42F6C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BD4B7A5C-6D24-4E82-9C18-D5A0F3C42F6C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Celina-Villanueva-013d012f-a50e-43c8-af40-f12aa852a0da.yml
+++ b/data/il/legislature/Celina-Villanueva-013d012f-a50e-43c8-af40-f12aa852a0da.yml
@@ -4,7 +4,7 @@ given_name: Celina
 family_name: Villanueva
 gender: Female
 email: district@senatorvillanueva.com
-image: https://ilga.gov/images/members/{F8A21A81-5453-4E94-AC51-E644E1B0C00B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F8A21A81-5453-4E94-AC51-E644E1B0C00B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Chapin-Rose-b748f1e8-6cfd-47d6-9398-5817aa879f39.yml
+++ b/data/il/legislature/Chapin-Rose-b748f1e8-6cfd-47d6-9398-5817aa879f39.yml
@@ -5,7 +5,7 @@ family_name: Rose
 birth_date: 1973-12-27
 gender: Male
 email: senatorchapinrose@gmail.com
-image: https://ilga.gov/images/members/{BA95E1D1-0570-4492-B739-D1F593F183FD}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BA95E1D1-0570-4492-B739-D1F593F183FD}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Charles-E-Meier-c425f2ef-cad0-4dad-93c4-be11b80af613.yml
+++ b/data/il/legislature/Charles-E-Meier-c425f2ef-cad0-4dad-93c4-be11b80af613.yml
@@ -4,7 +4,7 @@ given_name: Charlie
 family_name: Meier
 gender: Male
 email: repcmeier@gmail.com
-image: https://ilga.gov/images/members/{9D43D019-A58A-47EC-B769-A7050C4B49DB}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{9D43D019-A58A-47EC-B769-A7050C4B49DB}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Chris-Balkema-fe9dc27f-4e47-4cb0-a008-df80642f6be0.yml
+++ b/data/il/legislature/Chris-Balkema-fe9dc27f-4e47-4cb0-a008-df80642f6be0.yml
@@ -4,7 +4,7 @@ given_name: Chris
 family_name: Balkema
 gender: Male
 email: chris@chrisbalkema.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/ChrisBalkema.jpg
+image: https://cdn.ilga.gov/assets/img/members/{29C38AB6-DBAB-4E53-A4B1-9DA8D64AD699}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Chris-Miller-f5a10a95-3160-4cac-9f4e-ba31e5362e7b.yml
+++ b/data/il/legislature/Chris-Miller-f5a10a95-3160-4cac-9f4e-ba31e5362e7b.yml
@@ -5,7 +5,7 @@ family_name: Miller
 birth_date: 1954-06-15
 gender: Male
 email: miller@ilhousegop.org
-image: https://ilga.gov/images/members/{2A519012-9070-494B-9FFC-C2646374202E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{2A519012-9070-494B-9FFC-C2646374202E}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Christopher-Belt-ce79408a-9923-4ab4-9c3a-805a2b4162d5.yml
+++ b/data/il/legislature/Christopher-Belt-ce79408a-9923-4ab4-9c3a-805a2b4162d5.yml
@@ -4,7 +4,7 @@ given_name: Christopher
 family_name: Belt
 gender: Male
 email: christophbeltforilsenate@yahoo.com
-image: https://ilga.gov/images/members/{EFE7513C-260C-46DE-BAB3-A12F250B2937}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{EFE7513C-260C-46DE-BAB3-A12F250B2937}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Craig-Wilcox-07e2527a-ae7d-4c58-b20b-ea2266a03a9e.yml
+++ b/data/il/legislature/Craig-Wilcox-07e2527a-ae7d-4c58-b20b-ea2266a03a9e.yml
@@ -4,7 +4,7 @@ given_name: Craig
 family_name: Wilcox
 gender: Male
 email: senatorwilcox@gmail.com
-image: https://ilga.gov/images/members/{E397F861-68AA-4CC2-9A23-50B9A8E13031}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E397F861-68AA-4CC2-9A23-50B9A8E13031}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Cristina-Castro-f5add4b7-0c7e-4909-8e31-3042698f5b49.yml
+++ b/data/il/legislature/Cristina-Castro-f5add4b7-0c7e-4909-8e31-3042698f5b49.yml
@@ -5,7 +5,7 @@ family_name: Castro
 birth_date: 1978-02-25
 gender: Female
 email: senatorcastro@gmail.com
-image: https://ilga.gov/images/members/{F09EB558-EB8D-48B1-91F0-EF47A07632F5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F09EB558-EB8D-48B1-91F0-EF47A07632F5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Curtis-J-Tarver-II-7a4c9172-6836-453c-94a8-1254b76fa08f.yml
+++ b/data/il/legislature/Curtis-J-Tarver-II-7a4c9172-6836-453c-94a8-1254b76fa08f.yml
@@ -4,7 +4,7 @@ given_name: Curtis
 family_name: Tarver
 gender: Male
 email: office@repcurtisjtarverii.com
-image: https://ilga.gov/images/members/{E9404756-F108-41DB-A7A8-87C36BBF763D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E9404756-F108-41DB-A7A8-87C36BBF763D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Dagmara-Avelar-4c05af2c-7756-4002-a45d-cc9f2f5acbfd.yml
+++ b/data/il/legislature/Dagmara-Avelar-4c05af2c-7756-4002-a45d-cc9f2f5acbfd.yml
@@ -4,7 +4,7 @@ given_name: Dee
 family_name: Avelar
 gender: Female
 email: info@repdagmara.org
-image: https://ilga.gov/images/members/{EFDA6EE7-57E6-4ACA-BE60-02A042FF5D5D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{EFDA6EE7-57E6-4ACA-BE60-02A042FF5D5D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Dale-Fowler-5a84a944-7d29-454e-aec6-85e6c3238d53.yml
+++ b/data/il/legislature/Dale-Fowler-5a84a944-7d29-454e-aec6-85e6c3238d53.yml
@@ -4,7 +4,7 @@ given_name: Dale
 family_name: Fowler
 gender: Male
 email: senatorfowler59@gmail.com
-image: https://ilga.gov/images/members/{1E60CA94-7006-4CAB-841D-C9D99569D9D3}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1E60CA94-7006-4CAB-841D-C9D99569D9D3}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Dan-Ugaste-ab6db17a-e7dc-43c8-9770-32c1da1d7f40.yml
+++ b/data/il/legislature/Dan-Ugaste-ab6db17a-e7dc-43c8-9770-32c1da1d7f40.yml
@@ -4,7 +4,7 @@ given_name: Dan
 family_name: Ugaste
 gender: Male
 email: ugaste@ilhousegop.org
-image: https://ilga.gov/images/members/{2552FBE4-D977-4283-B00C-78FC085BD955}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{2552FBE4-D977-4283-B00C-78FC085BD955}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Daniel-Didech-c5786e99-12fd-41eb-b40e-372187dde261.yml
+++ b/data/il/legislature/Daniel-Didech-c5786e99-12fd-41eb-b40e-372187dde261.yml
@@ -4,7 +4,7 @@ given_name: Dan
 family_name: Didech
 gender: Male
 email: info@repdidech.com
-image: https://ilga.gov/images/members/{1EA869A9-B93D-4E72-824B-E14992452581}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1EA869A9-B93D-4E72-824B-E14992452581}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Daniel-Swanson-6e9ee3b5-fb44-49f3-81f6-5a470bfaf009.yml
+++ b/data/il/legislature/Daniel-Swanson-6e9ee3b5-fb44-49f3-81f6-5a470bfaf009.yml
@@ -5,7 +5,7 @@ family_name: Swanson
 birth_date: 1959-07-30
 gender: Male
 email: swanson@ilhousegop.org
-image: https://ilga.gov/images/members/{F7512D74-4694-4272-9A1E-6935F4AD4F1D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F7512D74-4694-4272-9A1E-6935F4AD4F1D}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Darby-Hills-3249a901-9d57-4623-a9a0-4cbb1240f2a1.yml
+++ b/data/il/legislature/Darby-Hills-3249a901-9d57-4623-a9a0-4cbb1240f2a1.yml
@@ -3,6 +3,7 @@ name: Darby Hills
 given_name: Darby
 family_name: Hills
 gender: Female
+image: https://cdn.ilga.gov/assets/img/members/{16AC56CC-B697-41D8-8E62-F9DEE3CE75C1}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Dave-Severin-cbbd1430-7c0b-4be0-9d45-deabdb0c3d0f.yml
+++ b/data/il/legislature/Dave-Severin-cbbd1430-7c0b-4be0-9d45-deabdb0c3d0f.yml
@@ -4,7 +4,7 @@ given_name: Dave
 family_name: Severin
 gender: Male
 email: severin@ilhousegop.org
-image: https://ilga.gov/images/members/{FC792043-4CE1-4796-BA38-E68B39A9847A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{FC792043-4CE1-4796-BA38-E68B39A9847A}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Dave-Syverson-d02beb7e-1f30-48f2-8418-4c9287452562.yml
+++ b/data/il/legislature/Dave-Syverson-d02beb7e-1f30-48f2-8418-4c9287452562.yml
@@ -5,7 +5,7 @@ family_name: Syverson
 birth_date: 1957-06-29
 gender: Male
 email: info@senatordavesyverson.com
-image: https://ilga.gov/images/members/{6FD168B8-C34B-4399-8E39-7373F7600882}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{6FD168B8-C34B-4399-8E39-7373F7600882}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Dave-Vella-5da7b2ff-c086-49cd-80bc-9802e426cc00.yml
+++ b/data/il/legislature/Dave-Vella-5da7b2ff-c086-49cd-80bc-9802e426cc00.yml
@@ -4,7 +4,7 @@ given_name: Dave
 family_name: Vella
 gender: Male
 email: repdavevella@gmail.com
-image: https://ilga.gov/images/members/{E0F72B4C-2737-483E-84FE-E596DB8F2DCF}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E0F72B4C-2737-483E-84FE-E596DB8F2DCF}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/David-Friess-abda0ae5-9ecb-4363-9a6a-487f1cf8899e.yml
+++ b/data/il/legislature/David-Friess-abda0ae5-9ecb-4363-9a6a-487f1cf8899e.yml
@@ -4,7 +4,7 @@ given_name: David
 family_name: Friess
 gender: Male
 email: friess@ilhousegop.org
-image: https://ilga.gov/images/members/{C1F3982E-6DA7-4AE6-96B9-77E9FBC87A2A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C1F3982E-6DA7-4AE6-96B9-77E9FBC87A2A}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/David-Koehler-997e8947-dadd-4c8d-9538-0b58c077a812.yml
+++ b/data/il/legislature/David-Koehler-997e8947-dadd-4c8d-9538-0b58c077a812.yml
@@ -5,7 +5,7 @@ family_name: Koehler
 birth_date: 1948-12-16
 gender: Male
 email: 46illinois@gmail.com
-image: https://ilga.gov/images/members/{2C57E551-D82A-4C7D-8746-3F83913F0D7D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{2C57E551-D82A-4C7D-8746-3F83913F0D7D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Debbie-Meyers-Martin-e1d4b5b4-34b8-4d91-ab9f-08c8a361e12a.yml
+++ b/data/il/legislature/Debbie-Meyers-Martin-e1d4b5b4-34b8-4d91-ab9f-08c8a361e12a.yml
@@ -4,7 +4,7 @@ given_name: Debbie
 family_name: Meyers-Martin
 gender: Female
 email: staterepdebbiemm@gmail.com
-image: https://ilga.gov/images/members/{E3E2099C-AB6A-442B-B191-3A83D6D3A1E2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E3E2099C-AB6A-442B-B191-3A83D6D3A1E2}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Dennis-Tipsword-Jr-13dc4688-95d1-4a5d-abc7-fb9a46a432c8.yml
+++ b/data/il/legislature/Dennis-Tipsword-Jr-13dc4688-95d1-4a5d-abc7-fb9a46a432c8.yml
@@ -4,7 +4,7 @@ given_name: Dennis
 family_name: Tipsword
 gender: Male
 email: tipsword@ilhousegop.org
-image: https://ilga.gov/images/members/{D8E9F62C-6A73-4CCD-8148-332CD9806264}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D8E9F62C-6A73-4CCD-8148-332CD9806264}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Diane-Blair-Sherlock-d5c22b1c-8057-40bf-aea6-0298070ad67b.yml
+++ b/data/il/legislature/Diane-Blair-Sherlock-d5c22b1c-8057-40bf-aea6-0298070ad67b.yml
@@ -4,7 +4,7 @@ given_name: Diane
 family_name: Blair-Sherlock
 gender: Female
 email: staterep46@gmail.com
-image: https://ilga.gov/images/members/{C9D7B27E-2484-4917-A5CA-F85BA458950A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C9D7B27E-2484-4917-A5CA-F85BA458950A}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Don-Harmon-15c56180-21e1-492d-874f-25d511f804ee.yml
+++ b/data/il/legislature/Don-Harmon-15c56180-21e1-492d-874f-25d511f804ee.yml
@@ -5,7 +5,7 @@ family_name: Harmon
 birth_date: 1966-11-26
 gender: Male
 email: dharmon@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{CF3F6473-4E6D-4E84-A0A4-4FF7335132E2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{CF3F6473-4E6D-4E84-A0A4-4FF7335132E2}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Donald-P-DeWitte-c4a1e37c-3c81-448c-9349-199a8fa5c2d3.yml
+++ b/data/il/legislature/Donald-P-DeWitte-c4a1e37c-3c81-448c-9349-199a8fa5c2d3.yml
@@ -4,7 +4,7 @@ given_name: Don
 family_name: DeWitte
 gender: Male
 email: dewitte@ilsenategop.org
-image: https://ilga.gov/images/members/{21A3B029-3423-410E-818A-84512CD0D231}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{21A3B029-3423-410E-818A-84512CD0D231}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Doris-Turner-5db8d260-f850-406c-8e26-d618762c10cd.yml
+++ b/data/il/legislature/Doris-Turner-5db8d260-f850-406c-8e26-d618762c10cd.yml
@@ -4,7 +4,7 @@ given_name: Doris
 family_name: Turner
 gender: Female
 email: senatorturnermac@gmail.com
-image: https://ilga.gov/images/members/{D114C73A-2295-431C-8250-38AC3353A20E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D114C73A-2295-431C-8250-38AC3353A20E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Edgar-Gonzalez-Jr-e8bba8fb-50a8-4ddd-9bed-785c5f1bb70d.yml
+++ b/data/il/legislature/Edgar-Gonzalez-Jr-e8bba8fb-50a8-4ddd-9bed-785c5f1bb70d.yml
@@ -5,7 +5,7 @@ family_name: "Gonz\xE1lez"
 birth_date: 1996-12-25
 gender: Male
 email: office@repedgargonzalez.com
-image: https://ilga.gov/images/members/{370B1494-7F8F-48BC-BD66-4756E15442E1}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{370B1494-7F8F-48BC-BD66-4756E15442E1}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Elgie-R-Sims-Jr-50ad4838-140d-4cb7-80cb-46da37a8827f.yml
+++ b/data/il/legislature/Elgie-R-Sims-Jr-50ad4838-140d-4cb7-80cb-46da37a8827f.yml
@@ -5,7 +5,7 @@ family_name: Sims
 birth_date: 1970-09-21
 gender: Male
 email: info@senatorelgiesims.com
-image: https://ilga.gov/images/members/{1EAF7721-A189-4CD1-B31D-CD39F79DBD04}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1EAF7721-A189-4CD1-B31D-CD39F79DBD04}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Elizabeth-Hernandez-b6ebf45f-ac97-423b-b5c3-eba0a5766a8d.yml
+++ b/data/il/legislature/Elizabeth-Hernandez-b6ebf45f-ac97-423b-b5c3-eba0a5766a8d.yml
@@ -5,7 +5,7 @@ family_name: Hernandez
 birth_date: 1961-07-14
 gender: Female
 email: office@repehernandez.com
-image: https://ilga.gov/images/members/{4E4C2A21-FDC2-48CA-9BA8-462A62E7A33B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4E4C2A21-FDC2-48CA-9BA8-462A62E7A33B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Emanuel-Chris-Welch-00cc6415-b2a7-45ab-8f69-be5c3ca6752a.yml
+++ b/data/il/legislature/Emanuel-Chris-Welch-00cc6415-b2a7-45ab-8f69-be5c3ca6752a.yml
@@ -5,7 +5,7 @@ family_name: Welch
 birth_date: 1971-02-06
 gender: Male
 email: repwelch@emanuelchriswelch.com
-image: https://ilga.gov/images/members/{5D419B94-66B4-4F3B-86F1-BFF37B3FA55C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{5D419B94-66B4-4F3B-86F1-BFF37B3FA55C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Emil-Jones-III-05030c23-9600-4d1c-ab77-46c17aec2059.yml
+++ b/data/il/legislature/Emil-Jones-III-05030c23-9600-4d1c-ab77-46c17aec2059.yml
@@ -5,7 +5,7 @@ family_name: Jones
 birth_date: 1978-05-16
 gender: Male
 email: ejones3@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{2C0EE719-E9D8-4625-990D-69FCE146BC0F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{2C0EE719-E9D8-4625-990D-69FCE146BC0F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Erica-Conway-Harriss-4dadb374-d534-4ba0-8323-6e41a19933f5.yml
+++ b/data/il/legislature/Erica-Conway-Harriss-4dadb374-d534-4ba0-8323-6e41a19933f5.yml
@@ -4,7 +4,7 @@ given_name: Erica
 family_name: Harriss
 gender: Female
 email: harris@ilsenategop.org
-image: https://ilga.gov/images/members/{7762DCAD-269B-472B-BDD4-5F5A28D47817}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7762DCAD-269B-472B-BDD4-5F5A28D47817}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Eva-Dina-Delgado-01201203-526d-4d02-b6fc-cbe5a749b6ab.yml
+++ b/data/il/legislature/Eva-Dina-Delgado-01201203-526d-4d02-b6fc-cbe5a749b6ab.yml
@@ -4,7 +4,7 @@ given_name: Eva-Dina
 family_name: Delgado
 gender: Female
 email: staterepdelgado@gmail.com
-image: https://ilga.gov/images/members/{D02A93E7-7D84-4429-92AB-60B61084EBA1}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D02A93E7-7D84-4429-92AB-60B61084EBA1}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Fred-Crespo-3806ac4f-5290-4eb7-ba30-aa406036dd7a.yml
+++ b/data/il/legislature/Fred-Crespo-3806ac4f-5290-4eb7-ba30-aa406036dd7a.yml
@@ -4,7 +4,7 @@ given_name: Fred
 family_name: Crespo
 gender: Male
 email: fred@fredcrespo.com
-image: https://ilga.gov/images/members/{B92F7A2F-6517-4A3F-87B3-56FAA240285F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{B92F7A2F-6517-4A3F-87B3-56FAA240285F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Graciela-Guzmn-95d8f5ae-4cc9-483b-913f-ccd07aa73e13.yml
+++ b/data/il/legislature/Graciela-Guzmn-95d8f5ae-4cc9-483b-913f-ccd07aa73e13.yml
@@ -4,7 +4,7 @@ given_name: Graciela
 family_name: "Guzm\xE1n"
 gender: Female
 email: info@senatorguzman.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/GracielaGuzman2024.jpeg
+image: https://cdn.ilga.gov/assets/img/members/{5790FB4D-5540-4784-A354-6172684368C9}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Gregg-Johnson-26a0642d-d0b6-450f-9438-018a36b04cbf.yml
+++ b/data/il/legislature/Gregg-Johnson-26a0642d-d0b6-450f-9438-018a36b04cbf.yml
@@ -4,7 +4,7 @@ given_name: Gregg
 family_name: Johnson
 gender: Male
 email: support@repgreggjohnson.com
-image: https://ilga.gov/images/members/{8746A238-F14D-428E-A0AD-E3D3F28F80F5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{8746A238-F14D-428E-A0AD-E3D3F28F80F5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Harry-Benton-1574a50f-6d50-4d7d-87ee-db0254e5093e.yml
+++ b/data/il/legislature/Harry-Benton-1574a50f-6d50-4d7d-87ee-db0254e5093e.yml
@@ -4,7 +4,7 @@ given_name: Harry
 family_name: Benton
 gender: Male
 email: info@repharrybenton.com
-image: https://ilga.gov/images/members/{591DB385-5E0D-41CC-8B13-2FDA10A73D7F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{591DB385-5E0D-41CC-8B13-2FDA10A73D7F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Hoan-Huynh-c7156dc3-31a6-4582-bf3a-b325c9dc868f.yml
+++ b/data/il/legislature/Hoan-Huynh-c7156dc3-31a6-4582-bf3a-b325c9dc868f.yml
@@ -4,7 +4,7 @@ given_name: Hoan
 family_name: Huynh
 gender: Male
 email: hello@rephoanhuynh.com
-image: https://ilga.gov/images/members/{A6CE6A23-9F62-4C37-B297-4E48D79A3CE1}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{A6CE6A23-9F62-4C37-B297-4E48D79A3CE1}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jackie-Haas-5da74880-f9e4-4c20-bc17-74d88526a7a4.yml
+++ b/data/il/legislature/Jackie-Haas-5da74880-f9e4-4c20-bc17-74d88526a7a4.yml
@@ -4,7 +4,7 @@ given_name: Jackie
 family_name: Haas
 gender: Female
 email: haas@ilhousegop.org
-image: https://ilga.gov/images/members/{9E211C98-BCB9-43CF-8A78-57D295FB9D78}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{9E211C98-BCB9-43CF-8A78-57D295FB9D78}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Jaime-M-Andrade-Jr-c0d481c5-9d31-4780-b2b0-bc5327291d6b.yml
+++ b/data/il/legislature/Jaime-M-Andrade-Jr-c0d481c5-9d31-4780-b2b0-bc5327291d6b.yml
@@ -5,7 +5,7 @@ family_name: Andrade
 birth_date: 1972-10-07
 gender: Male
 email: info@staterep40.com
-image: https://ilga.gov/images/members/{34A19039-7BF5-44A7-9A06-4EC121E52514}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{34A19039-7BF5-44A7-9A06-4EC121E52514}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Janet-Yang-Rohr-dc08395b-8a74-4795-b104-d7b11c1e42ca.yml
+++ b/data/il/legislature/Janet-Yang-Rohr-dc08395b-8a74-4795-b104-d7b11c1e42ca.yml
@@ -4,7 +4,7 @@ given_name: Janet
 family_name: Yang Rohr
 gender: Female
 email: info@repyangrohr.com
-image: https://ilga.gov/images/members/{4B315A2D-F104-4613-BD17-77ECA3955B30}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4B315A2D-F104-4613-BD17-77ECA3955B30}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jason-Bunting-4a588ccf-b32f-4b66-978a-3415f71d2774.yml
+++ b/data/il/legislature/Jason-Bunting-4a588ccf-b32f-4b66-978a-3415f71d2774.yml
@@ -4,7 +4,7 @@ given_name: Jason
 family_name: Bunting
 gender: Male
 email: bunting@ilhousegop.org
-image: https://ilga.gov/images/members/{5F0F6F55-F573-4F05-B495-878685C2C00A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{5F0F6F55-F573-4F05-B495-878685C2C00A}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Jason-Plummer-d868bc8f-f51c-4f5b-a9a3-3608b8b44b29.yml
+++ b/data/il/legislature/Jason-Plummer-d868bc8f-f51c-4f5b-a9a3-3608b8b44b29.yml
@@ -5,7 +5,7 @@ family_name: Plummer
 birth_date: 1982-06-04
 gender: Male
 email: senator@senatorjasonplummer.com
-image: https://ilga.gov/images/members/{CE75DC7E-2CD4-4D01-B697-C2866F828E25}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{CE75DC7E-2CD4-4D01-B697-C2866F828E25}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Javier-L-Cervantes-caf27c44-2fec-4e26-a102-e6a30ca56be0.yml
+++ b/data/il/legislature/Javier-L-Cervantes-caf27c44-2fec-4e26-a102-e6a30ca56be0.yml
@@ -4,7 +4,7 @@ given_name: Javier
 family_name: Cervantes
 gender: Male
 email: senator.jcervantes@gmail.com
-image: https://ilga.gov/images/members/{C05FD6B2-E0A9-4446-AAE5-D67396FCE7D5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C05FD6B2-E0A9-4446-AAE5-D67396FCE7D5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jawaharial-Williams-b79ed17d-30a6-4d03-af90-ad3b34610395.yml
+++ b/data/il/legislature/Jawaharial-Williams-b79ed17d-30a6-4d03-af90-ad3b34610395.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1975-03-13
 gender: Male
 email: repwilliamsoffice@gmail.com
-image: https://ilga.gov/images/members/{32750D93-496F-42CA-9CCE-93C3451713A1}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{32750D93-496F-42CA-9CCE-93C3451713A1}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jay-C-Hoffman-21e2f7d1-8073-4ee1-a5b5-b32ccdd321d5.yml
+++ b/data/il/legislature/Jay-C-Hoffman-21e2f7d1-8073-4ee1-a5b5-b32ccdd321d5.yml
@@ -5,7 +5,7 @@ family_name: Hoffman
 birth_date: 1961-11-06
 gender: Male
 email: repjayhoffman@gmail.com
-image: https://ilga.gov/images/members/{FCD7EF06-36D9-46A7-8085-4B5A5ED81A80}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{FCD7EF06-36D9-46A7-8085-4B5A5ED81A80}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jed-Davis-a9c919a3-8fba-4bad-8589-315491cd9b0e.yml
+++ b/data/il/legislature/Jed-Davis-a9c919a3-8fba-4bad-8589-315491cd9b0e.yml
@@ -4,7 +4,7 @@ given_name: Jed
 family_name: Davis
 gender: Male
 email: davisstaff@ilhousegop.org
-image: https://ilga.gov/images/members/{AFBDE3F1-DE4D-419A-A7AB-D27678B015BE}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{AFBDE3F1-DE4D-419A-A7AB-D27678B015BE}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Jeff-Keicher-1055f952-0000-4628-9584-c2a3fc9e991c.yml
+++ b/data/il/legislature/Jeff-Keicher-1055f952-0000-4628-9584-c2a3fc9e991c.yml
@@ -4,7 +4,7 @@ given_name: Jeff
 family_name: Keicher
 gender: Male
 email: keicher@ilhousegop.org
-image: https://ilga.gov/images/members/{FD009EA6-624D-45C7-A093-BC66B8B3C090}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{FD009EA6-624D-45C7-A093-BC66B8B3C090}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Jehan-A-Gordon-Booth-968d7e1e-e0e8-47f0-a258-586eb6cfbac9.yml
+++ b/data/il/legislature/Jehan-A-Gordon-Booth-968d7e1e-e0e8-47f0-a258-586eb6cfbac9.yml
@@ -4,7 +4,7 @@ given_name: Jehan
 family_name: Gordon-Booth
 gender: Female
 email: repjgordon@gmail.com
-image: https://ilga.gov/images/members/{A81D0C01-0A50-446D-B796-3A5A6D046EB1}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{A81D0C01-0A50-446D-B796-3A5A6D046EB1}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jennifer-Gong-Gershowitz-cf97f459-e1cd-474b-8306-3c55d7c009b0.yml
+++ b/data/il/legislature/Jennifer-Gong-Gershowitz-cf97f459-e1cd-474b-8306-3c55d7c009b0.yml
@@ -4,7 +4,7 @@ given_name: Jen
 family_name: Gong-Gershowitz
 gender: Female
 email: info@gonggershowitz.com
-image: https://ilga.gov/images/members/{395E8140-10ED-4C70-81B9-2673676BF467}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{395E8140-10ED-4C70-81B9-2673676BF467}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Jennifer-Sanalitro-0069021e-b341-44fd-9d02-d876839c5c23.yml
+++ b/data/il/legislature/Jennifer-Sanalitro-0069021e-b341-44fd-9d02-d876839c5c23.yml
@@ -4,7 +4,7 @@ given_name: Jennifer
 family_name: Sanalitro
 gender: Female
 email: sanalitro@ilhousegop.org
-image: https://ilga.gov/images/members/{07C35999-DEF2-49BA-8A46-7D9D8204BCEA}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{07C35999-DEF2-49BA-8A46-7D9D8204BCEA}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
+++ b/data/il/legislature/Jil-Tracy-be85f354-7f46-48aa-afc7-850502fda3cb.yml
@@ -5,7 +5,7 @@ family_name: Tracy
 birth_date: 1956-02-29
 gender: Female
 email: tracy@ilsenategop.org
-image: https://ilga.gov/images/members/{21C0F860-E9DD-4215-A3AA-703E275C8526}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{21C0F860-E9DD-4215-A3AA-703E275C8526}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Joe-Sosnowski-6471a51f-0707-4966-b122-9597554d3c19.yml
+++ b/data/il/legislature/Joe-Sosnowski-6471a51f-0707-4966-b122-9597554d3c19.yml
@@ -5,7 +5,7 @@ family_name: Sosnowski
 birth_date: 1977-04-13
 gender: Male
 email: sosnowski@ilhousegop.org
-image: https://ilga.gov/images/members/{7DEBF89C-D2BA-4952-94A2-40F564A00144}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7DEBF89C-D2BA-4952-94A2-40F564A00144}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/John-F-Curran-cb63cb04-f84b-4fc9-91cf-05c4e1f93345.yml
+++ b/data/il/legislature/John-F-Curran-cb63cb04-f84b-4fc9-91cf-05c4e1f93345.yml
@@ -4,7 +4,7 @@ given_name: John
 family_name: Curran
 gender: Male
 email: senatorcurran@gmail.com
-image: https://ilga.gov/images/members/{7FC724D0-C297-4D20-AC25-3D879DE286B8}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7FC724D0-C297-4D20-AC25-3D879DE286B8}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/John-M-Cabello-b442db35-fab4-4318-a07b-0e88c314fbaa.yml
+++ b/data/il/legislature/John-M-Cabello-b442db35-fab4-4318-a07b-0e88c314fbaa.yml
@@ -4,7 +4,7 @@ given_name: John
 family_name: Cabello
 gender: Male
 email: cabello@ilhousegop.org
-image: https://ilga.gov/images/members/{9E64DAD4-4264-42B1-AFDA-AB8F652472A3}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{9E64DAD4-4264-42B1-AFDA-AB8F652472A3}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Joyce-Mason-96f00b4c-0a56-4fe0-bd59-7d49eb93531c.yml
+++ b/data/il/legislature/Joyce-Mason-96f00b4c-0a56-4fe0-bd59-7d49eb93531c.yml
@@ -4,7 +4,7 @@ given_name: Joyce
 family_name: Mason
 gender: Female
 email: info@repjoycemason.com
-image: https://ilga.gov/images/members/{26C52E17-9395-4BF8-B6E6-3E1CE6234032}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{26C52E17-9395-4BF8-B6E6-3E1CE6234032}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Julie-A-Morrison-1e106d7c-5aba-40d1-932b-760b599c70ae.yml
+++ b/data/il/legislature/Julie-A-Morrison-1e106d7c-5aba-40d1-932b-760b599c70ae.yml
@@ -5,7 +5,7 @@ family_name: Morrison
 birth_date: 1956-09-20
 gender: Female
 email: morrison@senatedem.illinois.gov
-image: https://ilga.gov/images/members/{0E6BF8A6-C5C8-4F54-977B-D5FD11707FA5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0E6BF8A6-C5C8-4F54-977B-D5FD11707FA5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Justin-Cochran-afff2974-37d0-428c-be7a-0240395544f6.yml
+++ b/data/il/legislature/Justin-Cochran-afff2974-37d0-428c-be7a-0240395544f6.yml
@@ -4,7 +4,7 @@ given_name: Justin
 family_name: Cochran
 gender: Male
 email: contact@repjustincochran.com
-image: https://www.journal-topics.com/wp-content/uploads/2020/12/cochran.jpg
+image: https://cdn.ilga.gov/assets/img/members/{54FFB767-E6F6-4F20-951A-2CBCD1B06211}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Justin-Slaughter-c296134a-f9b3-4c65-9ed5-3ecccde59386.yml
+++ b/data/il/legislature/Justin-Slaughter-c296134a-f9b3-4c65-9ed5-3ecccde59386.yml
@@ -5,7 +5,7 @@ family_name: Slaughter
 birth_date: 1980-04-24
 gender: Male
 email: justin@repslaughter.com
-image: https://ilga.gov/images/members/{170C17F3-38A1-42E5-B222-020B43077D53}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{170C17F3-38A1-42E5-B222-020B43077D53}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kambium-Buckner-8b7174cd-4081-4717-8ba9-184518f7b31e.yml
+++ b/data/il/legislature/Kambium-Buckner-8b7174cd-4081-4717-8ba9-184518f7b31e.yml
@@ -5,7 +5,7 @@ family_name: Buckner
 birth_date: 1985-05-12
 gender: Male
 email: buckner@illinois26.com
-image: https://ilga.gov/images/members/{37E72FD2-6318-45FD-9FF1-C750EB26137D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{37E72FD2-6318-45FD-9FF1-C750EB26137D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Karina-Villa-ca80672a-9d02-4287-9cd2-d2a7d08f604a.yml
+++ b/data/il/legislature/Karina-Villa-ca80672a-9d02-4287-9cd2-d2a7d08f604a.yml
@@ -5,7 +5,7 @@ family_name: Villa
 birth_date: 1978-09-20
 gender: Female
 email: info@senatorvilla.com
-image: https://ilga.gov/images/members/{C8126F4D-472E-4738-85B5-87A229F8174A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C8126F4D-472E-4738-85B5-87A229F8174A}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Katie-Stuart-ceb7f558-3a2c-4041-bf3b-f5a9a511e8b3.yml
+++ b/data/il/legislature/Katie-Stuart-ceb7f558-3a2c-4041-bf3b-f5a9a511e8b3.yml
@@ -4,7 +4,7 @@ given_name: Katie
 family_name: Stuart
 gender: Female
 email: repkatiestuart@gmail.com
-image: https://ilga.gov/images/members/{D6DC8152-9760-4BEA-ACF5-C41785E6F6C4}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D6DC8152-9760-4BEA-ACF5-C41785E6F6C4}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kelly-M-Cassidy-e1652f78-fa2e-46de-8630-f3e1e69040a3.yml
+++ b/data/il/legislature/Kelly-M-Cassidy-e1652f78-fa2e-46de-8630-f3e1e69040a3.yml
@@ -4,7 +4,7 @@ given_name: Kelly
 family_name: Cassidy
 gender: Female
 email: info@repcassidy.com
-image: https://ilga.gov/images/members/{3EFBDD50-41FF-4677-AA47-FB35B70C4667}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{3EFBDD50-41FF-4677-AA47-FB35B70C4667}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kevin-Olickal-c2c8c6a1-ef1b-4a38-92fa-bde7563b7f23.yml
+++ b/data/il/legislature/Kevin-Olickal-c2c8c6a1-ef1b-4a38-92fa-bde7563b7f23.yml
@@ -5,7 +5,7 @@ family_name: Olickal
 birth_date: 1993-02-18
 gender: Male
 email: info@repkevinolickal.com
-image: https://ilga.gov/images/members/{23C3BBA7-3179-41B5-A3EF-A372F88DD9C9}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{23C3BBA7-3179-41B5-A3EF-A372F88DD9C9}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kevin-Schmidt-266780c2-6b08-469e-9d78-10d618e16f4e.yml
+++ b/data/il/legislature/Kevin-Schmidt-266780c2-6b08-469e-9d78-10d618e16f4e.yml
@@ -4,7 +4,7 @@ given_name: Kevin
 family_name: Schmidt
 gender: Male
 email: schmidt@ilhousegop.org
-image: https://ilga.gov/images/members/{385A4AC4-BA7A-42A3-987F-85EA620B1F2B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{385A4AC4-BA7A-42A3-987F-85EA620B1F2B}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Kimberly-A-Lightford-595f7bf4-5bd7-4238-94a3-e14d8b6d4545.yml
+++ b/data/il/legislature/Kimberly-A-Lightford-595f7bf4-5bd7-4238-94a3-e14d8b6d4545.yml
@@ -5,7 +5,7 @@ family_name: Lightford
 birth_date: 1968-05-10
 gender: Female
 email: klightford@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{7FBA8DB0-281E-406F-BF9F-ABEB75B7B38E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7FBA8DB0-281E-406F-BF9F-ABEB75B7B38E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kimberly-du-Buclet-3b2af944-b2b7-4b13-87db-1c8cdd45de3c.yml
+++ b/data/il/legislature/Kimberly-du-Buclet-3b2af944-b2b7-4b13-87db-1c8cdd45de3c.yml
@@ -4,7 +4,7 @@ given_name: Kimberly
 family_name: Du Buclet
 gender: Female
 email: rep5information@gmail.com
-image: https://ilga.gov/images/members/{4858CB21-EEE1-409B-9A4C-FA760BB6905E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4858CB21-EEE1-409B-9A4C-FA760BB6905E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Kyle-Moore-6f9e28df-bdf5-4493-aac1-68f1b7be39cb.yml
+++ b/data/il/legislature/Kyle-Moore-6f9e28df-bdf5-4493-aac1-68f1b7be39cb.yml
@@ -4,7 +4,7 @@ given_name: Kyle
 family_name: Moore
 gender: Male
 email: moore@ilhousegop.org
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/Kyle_Moore_Illinois.jpg
+image: https://cdn.ilga.gov/assets/img/members/%7BBB70A39A-DE8F-4EF5-A923-0EE51834A45F%7D.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/LaShawn-K-Ford-91164a3d-fc17-4252-a31f-a8d0d113b74b.yml
+++ b/data/il/legislature/LaShawn-K-Ford-91164a3d-fc17-4252-a31f-a8d0d113b74b.yml
@@ -4,7 +4,7 @@ given_name: La Shawn
 family_name: Ford
 gender: Male
 email: repford@lashawnford.com
-image: https://ilga.gov/images/members/{BCC3C8D6-5728-4A69-8A3B-F203314DD563}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BCC3C8D6-5728-4A69-8A3B-F203314DD563}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Lakesia-Collins-37f0e4e6-fd0c-4bae-8def-f0ab80f722ff.yml
+++ b/data/il/legislature/Lakesia-Collins-37f0e4e6-fd0c-4bae-8def-f0ab80f722ff.yml
@@ -4,7 +4,7 @@ given_name: Lakesia
 family_name: Collins
 gender: Female
 email: office@lakesiacollins.com
-image: https://ilga.gov/images/members/{07674912-6AF6-4045-B60C-094B530D9FDB}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{07674912-6AF6-4045-B60C-094B530D9FDB}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Laura-Ellman-9bc8c9e8-ed36-42a1-ae80-4b2dfe591839.yml
+++ b/data/il/legislature/Laura-Ellman-9bc8c9e8-ed36-42a1-ae80-4b2dfe591839.yml
@@ -4,7 +4,7 @@ given_name: Laura
 family_name: Ellman
 gender: Female
 email: ellman@senatedem.illinois.gov
-image: https://ilga.gov/images/members/{423E6DDE-1AFB-4F10-A767-C869B0E51483}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{423E6DDE-1AFB-4F10-A767-C869B0E51483}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Laura-Faver-Dias-f0ab36db-6498-4d90-9b11-0191637421d2.yml
+++ b/data/il/legislature/Laura-Faver-Dias-f0ab36db-6498-4d90-9b11-0191637421d2.yml
@@ -4,7 +4,7 @@ given_name: Laura
 family_name: Faver Dias
 gender: Female
 email: info@repfaverdias.com
-image: https://ilga.gov/images/members/{B0DFD215-F36D-47A7-B7BE-909CDF14DC07}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{B0DFD215-F36D-47A7-B7BE-909CDF14DC07}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Laura-Fine-0ce44c13-37aa-4560-8489-67c309da913a.yml
+++ b/data/il/legislature/Laura-Fine-0ce44c13-37aa-4560-8489-67c309da913a.yml
@@ -4,7 +4,7 @@ given_name: Laura
 family_name: Fine
 gender: Female
 email: laura@senatorfine.com
-image: https://ilga.gov/images/members/{A4F70929-881C-4003-B10A-D1A775D3D94B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{A4F70929-881C-4003-B10A-D1A775D3D94B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Laura-M-Murphy-55be467f-1dd9-4cb7-96b8-050c113f5975.yml
+++ b/data/il/legislature/Laura-M-Murphy-55be467f-1dd9-4cb7-96b8-050c113f5975.yml
@@ -4,7 +4,7 @@ given_name: Laura
 family_name: Murphy
 gender: Female
 email: lmurphy@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{E8C6FBF1-611C-4DD5-A81D-F0FF8917556D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E8C6FBF1-611C-4DD5-A81D-F0FF8917556D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Lawrence-M-Walsh-Jr-9eda7be9-b2c6-45e6-bea6-098bd7f47595.yml
+++ b/data/il/legislature/Lawrence-M-Walsh-Jr-9eda7be9-b2c6-45e6-bea6-098bd7f47595.yml
@@ -4,7 +4,7 @@ given_name: Larry
 family_name: Walsh
 gender: Male
 email: statereplarrywalshjr@gmail.com
-image: https://ilga.gov/images/members/{F11DA3BE-D8FF-48F0-8450-43231B4DD28F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F11DA3BE-D8FF-48F0-8450-43231B4DD28F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Li-Arellano-8f61ddbc-3976-49b0-8c80-1d24cca80dc0.yml
+++ b/data/il/legislature/Li-Arellano-8f61ddbc-3976-49b0-8c80-1d24cca80dc0.yml
@@ -5,7 +5,7 @@ family_name: Arellano
 birth_date: 1981-02-02
 gender: Male
 email: liandroarellano@gmail.com
-image: https://www.pjstar.com/gcdn/authoring/authoring-images/2024/07/12/NJOS/74380276007-li-arellano-jr.jpg?width=1200&disable=upscale&format=pjpg&auto=webp
+image: https://cdn.ilga.gov/assets/img/members/{90648554-4D16-4FEE-AC7E-4A8A7872B885}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Lilian-Jimenez-256a1090-5fef-4f0c-b016-263735573c77.yml
+++ b/data/il/legislature/Lilian-Jimenez-256a1090-5fef-4f0c-b016-263735573c77.yml
@@ -4,7 +4,7 @@ given_name: Lilian
 family_name: "Jim\xE9nez"
 gender: Female
 email: info@replilianjimenez.com
-image: https://ilga.gov/images/members/{6C475229-0B41-4F93-A2C7-5B1396A1D1FA}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{6C475229-0B41-4F93-A2C7-5B1396A1D1FA}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Linda-Holmes-8d0beff8-000c-470a-a6c8-a05e1b6816cb.yml
+++ b/data/il/legislature/Linda-Holmes-8d0beff8-000c-470a-a6c8-a05e1b6816cb.yml
@@ -5,7 +5,7 @@ family_name: Holmes
 birth_date: 1959-03-16
 gender: Female
 email: holmes42@senatedem.illinois.gov
-image: https://ilga.gov/images/members/{9A39C8B9-4B06-4BF7-85CE-4C6F4FD07769}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{9A39C8B9-4B06-4BF7-85CE-4C6F4FD07769}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Lindsey-LaPointe-ea4595af-64f9-4d91-9c12-48accdc04ff8.yml
+++ b/data/il/legislature/Lindsey-LaPointe-ea4595af-64f9-4d91-9c12-48accdc04ff8.yml
@@ -4,7 +4,7 @@ given_name: Lindsey
 family_name: LaPointe
 gender: Female
 email: info@replapointe.com
-image: https://ilga.gov/images/members/{7447C9D9-48D0-457E-BDC9-847FB8D35DB5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{7447C9D9-48D0-457E-BDC9-847FB8D35DB5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Lisa-Davis-607e0b8f-4f4a-46ae-bfac-24b179d67542.yml
+++ b/data/il/legislature/Lisa-Davis-607e0b8f-4f4a-46ae-bfac-24b179d67542.yml
@@ -4,7 +4,7 @@ given_name: Lisa
 family_name: Davis
 gender: Female
 email: districtdirector32@gmail.com
-image: https://images.squarespace-cdn.com/content/v1/65bbdb61df5dfe26e91c299a/9f48b1b6-db6d-445a-9144-966d387170c6/Unknown-3+copy.jpg?format=750w
+image: https://cdn.ilga.gov/assets/img/members/{A61D2D11-9A19-483B-9C3E-C99CCC4CF5F4}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Marcus-C-Evans-Jr-4e02286b-b560-4837-8b9c-efa2c679e437.yml
+++ b/data/il/legislature/Marcus-C-Evans-Jr-4e02286b-b560-4837-8b9c-efa2c679e437.yml
@@ -4,7 +4,7 @@ given_name: Marcus
 family_name: Evans
 gender: Male
 email: marcus@repevans.com
-image: https://ilga.gov/images/members/{BFD8B13A-CD65-452C-8F20-9D32C3A013BF}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BFD8B13A-CD65-452C-8F20-9D32C3A013BF}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Margaret-Croke-adf823d2-7e3e-4a4d-898c-2dd404679012.yml
+++ b/data/il/legislature/Margaret-Croke-adf823d2-7e3e-4a4d-898c-2dd404679012.yml
@@ -4,7 +4,7 @@ given_name: Margaret
 family_name: Croke
 gender: Female
 email: info@repcroke.com
-image: https://ilga.gov/images/members/{1719759C-D601-4575-A753-1244D0FE550A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1719759C-D601-4575-A753-1244D0FE550A}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Margaret-DeLaRosa-9e3e61af-e205-47a0-8d7c-d50475941ba8.yml
+++ b/data/il/legislature/Margaret-DeLaRosa-9e3e61af-e205-47a0-8d7c-d50475941ba8.yml
@@ -4,6 +4,7 @@ given_name: Margaret
 family_name: DeLaRosa
 gender: Female
 email: ilhouse42@gmail.com
+image: https://cdn.ilga.gov/assets/img/members/{9E520EC6-A7D1-4749-BCBC-D178535ACB04}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mark-L-Walker-d1c2870a-8fee-47bf-a48e-4320311f06fd.yml
+++ b/data/il/legislature/Mark-L-Walker-d1c2870a-8fee-47bf-a48e-4320311f06fd.yml
@@ -4,7 +4,7 @@ given_name: Mark
 family_name: Walker
 gender: Male
 email: contact@staterepwalker53.com
-image: https://ilga.gov/images/members/{BC2AF76D-FAE4-44C4-8632-AA4E629A9678}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{BC2AF76D-FAE4-44C4-8632-AA4E629A9678}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Marti-Deuter-035b25c2-e97c-413e-8d84-d5c618f6a2fa.yml
+++ b/data/il/legislature/Marti-Deuter-035b25c2-e97c-413e-8d84-d5c618f6a2fa.yml
@@ -4,7 +4,7 @@ given_name: Marti
 family_name: Deuter
 gender: Female
 email: office@repmartideuter.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/MarthaDeuter2024.jpg
+image: https://cdn.ilga.gov/assets/img/members/{345BE0B5-CE9C-4A36-B292-6190B845C34B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Martin-McLaughlin-eb9a9c6e-1173-4c03-848e-167eb2762673.yml
+++ b/data/il/legislature/Martin-McLaughlin-eb9a9c6e-1173-4c03-848e-167eb2762673.yml
@@ -4,7 +4,7 @@ given_name: Marty
 family_name: McLaughlin
 gender: Male
 email: mclaughlin@ilhousegop.org
-image: https://ilga.gov/images/members/{F90CD638-AB1B-4A73-A003-02D9A911B599}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F90CD638-AB1B-4A73-A003-02D9A911B599}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Mary-Beth-Canty-48d73b90-0109-4fb2-8689-57e803c8294a.yml
+++ b/data/il/legislature/Mary-Beth-Canty-48d73b90-0109-4fb2-8689-57e803c8294a.yml
@@ -4,7 +4,7 @@ given_name: Mary Beth
 family_name: Canty
 gender: Female
 email: info@repmbc.com
-image: https://ilga.gov/images/members/{1A73F23E-9C8D-4392-B6BD-154AB570C66E}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1A73F23E-9C8D-4392-B6BD-154AB570C66E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mary-Edly-Allen-1a1cd310-b42c-4da3-b9ac-6278b1e95a02.yml
+++ b/data/il/legislature/Mary-Edly-Allen-1a1cd310-b42c-4da3-b9ac-6278b1e95a02.yml
@@ -4,6 +4,7 @@ given_name: Mary
 family_name: Edly-Allen
 gender: Female
 email: info@senatoredlyallen.com
+image: https://cdn.ilga.gov/assets/img/members/{5E1DAFA0-4C11-43FF-9231-8D4EB3A1CFFE}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mary-Gill-f2231f6c-1ed7-4106-8909-1d87557b2f04.yml
+++ b/data/il/legislature/Mary-Gill-f2231f6c-1ed7-4106-8909-1d87557b2f04.yml
@@ -4,7 +4,7 @@ given_name: Mary
 family_name: Gill
 gender: Female
 email: repmarygill@gmail.com
-image: https://ilga.gov/images/members/{28C54907-9CC9-428D-BD6B-361B91A10441}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{28C54907-9CC9-428D-BD6B-361B91A10441}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Matt-Hanson-14b940c9-8843-4709-97a9-9faee25bb201.yml
+++ b/data/il/legislature/Matt-Hanson-14b940c9-8843-4709-97a9-9faee25bb201.yml
@@ -4,7 +4,7 @@ given_name: Matt
 family_name: Hanson
 gender: Male
 email: info@repmatthanson.com
-image: https://ilga.gov/images/members/{457B8F0B-1DF6-4107-A5FC-9B2BFAAE1008}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{457B8F0B-1DF6-4107-A5FC-9B2BFAAE1008}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mattie-Hunter-879afbe3-9394-4a84-b57f-af36ca92cb14.yml
+++ b/data/il/legislature/Mattie-Hunter-879afbe3-9394-4a84-b57f-af36ca92cb14.yml
@@ -5,7 +5,7 @@ family_name: Hunter
 birth_date: 1954-06-01
 gender: Female
 email: senator03district@gmail.com
-image: https://ilga.gov/images/members/{F4630DDB-11F0-417E-8C0A-B4ED6426116F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F4630DDB-11F0-417E-8C0A-B4ED6426116F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Maura-Hirschauer-ef519ea9-e143-44e0-95b2-49d37c4ea3c8.yml
+++ b/data/il/legislature/Maura-Hirschauer-ef519ea9-e143-44e0-95b2-49d37c4ea3c8.yml
@@ -4,7 +4,7 @@ given_name: Maura
 family_name: Hirschauer
 gender: Female
 email: office@repmaura49.com
-image: https://ilga.gov/images/members/{F62525B8-2C23-49B7-AAB8-EFA6AE575F68}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F62525B8-2C23-49B7-AAB8-EFA6AE575F68}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Maurice-A-West-77906cdf-58a8-4329-bb24-c65e6e38342f.yml
+++ b/data/il/legislature/Maurice-A-West-77906cdf-58a8-4329-bb24-c65e6e38342f.yml
@@ -5,7 +5,7 @@ family_name: West
 birth_date: 1985-06-20
 gender: Male
 email: assistance@staterepwest.com
-image: https://ilga.gov/images/members/{AFB160BE-629B-4C70-8541-877D6FCDE529}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{AFB160BE-629B-4C70-8541-877D6FCDE529}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Meg-Loughran-Cappel-d218f82f-ce03-4277-9408-119857d1e61f.yml
+++ b/data/il/legislature/Meg-Loughran-Cappel-d218f82f-ce03-4277-9408-119857d1e61f.yml
@@ -4,7 +4,7 @@ given_name: Meg
 family_name: Loughran Cappel
 gender: Female
 email: info@senatorloughrancappel.com
-image: https://ilga.gov/images/members/{344F07C5-9853-49B6-902A-89D5F81637BF}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{344F07C5-9853-49B6-902A-89D5F81637BF}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Michael-E-Hastings-fb433923-65ca-475a-b106-7293c3483c57.yml
+++ b/data/il/legislature/Michael-E-Hastings-fb433923-65ca-475a-b106-7293c3483c57.yml
@@ -5,7 +5,7 @@ family_name: Hastings
 birth_date: 1980-10-06
 gender: Male
 email: mhastings@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{C6E534EB-7243-4687-8A65-04BD4DA5DF72}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C6E534EB-7243-4687-8A65-04BD4DA5DF72}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Michael-Halpin-8021b51f-4acc-459e-a038-786ebaca8666.yml
+++ b/data/il/legislature/Michael-Halpin-8021b51f-4acc-459e-a038-786ebaca8666.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Halpin
 gender: Male
 email: senatormikehalpin@gmail.com
-image: https://ilga.gov/images/members/{35F1D456-C798-4A8B-9180-4608CB0FDB78}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{35F1D456-C798-4A8B-9180-4608CB0FDB78}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Michael-J-Coffey-Jr-868db7f8-5f9e-48a4-83ba-a5404b87276a.yml
+++ b/data/il/legislature/Michael-J-Coffey-Jr-868db7f8-5f9e-48a4-83ba-a5404b87276a.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Coffey
 gender: Male
 email: coffey@ilhousegop.org
-image: https://ilga.gov/images/members/{EA682659-0B02-4A60-8244-1D5D2ABCD620}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{EA682659-0B02-4A60-8244-1D5D2ABCD620}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Michael-Kelly-c98bae02-b0dd-40ea-96a8-8a5fa994d211.yml
+++ b/data/il/legislature/Michael-Kelly-c98bae02-b0dd-40ea-96a8-8a5fa994d211.yml
@@ -5,7 +5,7 @@ family_name: Kelly
 birth_date: 1975-06-23
 gender: Male
 email: district@repkelly.com
-image: https://ilga.gov/images/members/{90B28E06-84A0-47EB-A80B-403DF4CDA607}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{90B28E06-84A0-47EB-A80B-403DF4CDA607}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Michelle-Mussman-394eec6a-ad20-447e-b72c-f09d76e66fa2.yml
+++ b/data/il/legislature/Michelle-Mussman-394eec6a-ad20-447e-b72c-f09d76e66fa2.yml
@@ -5,7 +5,7 @@ family_name: Mussman
 birth_date: 1972-08-17
 gender: Female
 email: staterepmussman@gmail.com
-image: https://ilga.gov/images/members/{63BBD5DE-333E-4015-8658-4F7B2D45E1B7}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{63BBD5DE-333E-4015-8658-4F7B2D45E1B7}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mike-Crawford-08699f92-8a4f-4dfa-8e8c-8bf129fb08d0.yml
+++ b/data/il/legislature/Mike-Crawford-08699f92-8a4f-4dfa-8e8c-8bf129fb08d0.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Crawford
 gender: Male
 email: districtdirector31@gmail.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/Michael_Crawford_20240808_093203.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C79CCD19-74A9-494F-BE14-E0D1E0A9D326}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mike-Porfirio-4666ba31-e78b-48f5-9d88-f4823527df6b.yml
+++ b/data/il/legislature/Mike-Porfirio-4666ba31-e78b-48f5-9d88-f4823527df6b.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Porfirio
 gender: Male
 email: info@senatorporfirio.com
-image: https://ilga.gov/images/members/{0824C110-5C93-4CBA-92E2-C330BBD6FE02}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0824C110-5C93-4CBA-92E2-C330BBD6FE02}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Mike-Simmons-0125b0ac-65ba-443e-b418-53cdf42b9f85.yml
+++ b/data/il/legislature/Mike-Simmons-0125b0ac-65ba-443e-b418-53cdf42b9f85.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Simmons-Gessesse
 gender: Male
 email: senatormikesimmons@gmail.com
-image: https://ilga.gov/images/members/{6EDEB1E8-2566-4659-ABF5-A9107C2912F0}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{6EDEB1E8-2566-4659-ABF5-A9107C2912F0}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Murri-Briel-d717abc0-a4ec-4ce9-bd24-cbda0a48c361.yml
+++ b/data/il/legislature/Murri-Briel-d717abc0-a4ec-4ce9-bd24-cbda0a48c361.yml
@@ -5,7 +5,7 @@ family_name: Briel
 birth_date: 1974-12-05
 gender: Female
 email: contact@staterepbriel.com
-image: https://bloximages.newyork1.vip.townnews.com/wspynews.com/content/tncms/assets/v3/editorial/8/8f/88fd0fdc-5dfe-11ee-bee5-ef29df344d91/651578259d452.image.jpg?crop=1219%2C837%2C465%2C0&resize=750%2C515&order=crop%2Cresize
+image: https://cdn.ilga.gov/assets/img/members/{E820664D-DF76-4A22-88DC-736A218A001E}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Nabeela-Syed-3115335b-b84e-49e5-b0ed-8ee2ab139784.yml
+++ b/data/il/legislature/Nabeela-Syed-3115335b-b84e-49e5-b0ed-8ee2ab139784.yml
@@ -4,7 +4,7 @@ given_name: Nabeela
 family_name: Syed
 gender: Female
 email: info@repsyed.com
-image: https://ilga.gov/images/members/{1B81D1C2-BEE3-408C-B52D-8B269BC5DA24}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{1B81D1C2-BEE3-408C-B52D-8B269BC5DA24}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Napoleon-Harris-III-f8e78760-4ec7-44f4-a00f-54f42fb834d5.yml
+++ b/data/il/legislature/Napoleon-Harris-III-f8e78760-4ec7-44f4-a00f-54f42fb834d5.yml
@@ -5,7 +5,7 @@ family_name: Harris
 birth_date: 1979-02-25
 gender: Male
 email: nharris@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{87402198-6E85-4CFE-BDD2-B9DC58948869}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{87402198-6E85-4CFE-BDD2-B9DC58948869}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Natalie-A-Manley-d7b735a6-3b70-4a3d-ae53-948fde86e4e7.yml
+++ b/data/il/legislature/Natalie-A-Manley-d7b735a6-3b70-4a3d-ae53-948fde86e4e7.yml
@@ -5,7 +5,7 @@ family_name: Manley
 birth_date: 1961-12-25
 gender: Female
 email: repmanley@gmail.com
-image: https://ilga.gov/images/members/{F3781CCA-4285-44C3-8E60-811B9229EA1B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F3781CCA-4285-44C3-8E60-811B9229EA1B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Neil-Anderson-b676c70e-0bc2-45d2-bd4c-9f3fa70bf60e.yml
+++ b/data/il/legislature/Neil-Anderson-b676c70e-0bc2-45d2-bd4c-9f3fa70bf60e.yml
@@ -5,7 +5,7 @@ family_name: Anderson
 birth_date: 1982-04-14
 gender: Male
 email: senatorneilanderson@gmail.com
-image: https://ilga.gov/images/members/{90CDA259-1DEA-4D18-AE97-30051E03D154}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{90CDA259-1DEA-4D18-AE97-30051E03D154}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Nicholas-K-Smith-a5e32db2-c1a9-4b4a-b42e-d2d541bd5825.yml
+++ b/data/il/legislature/Nicholas-K-Smith-a5e32db2-c1a9-4b4a-b42e-d2d541bd5825.yml
@@ -4,7 +4,7 @@ given_name: Nick
 family_name: Smith
 gender: Male
 email: repsmith34@gmail.com
-image: https://ilga.gov/images/members/{4D7D283C-73C8-40F8-A3F0-7FA9301456F5}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4D7D283C-73C8-40F8-A3F0-7FA9301456F5}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Nicole-La-Ha-3846d812-409f-4726-8e46-3624bfe92812.yml
+++ b/data/il/legislature/Nicole-La-Ha-3846d812-409f-4726-8e46-3624bfe92812.yml
@@ -4,6 +4,7 @@ given_name: Nicole
 family_name: La Ha
 gender: Female
 email: repnicolelaha@gmail.com
+image: https://cdn.ilga.gov/assets/img/members/{08891F3D-4342-4F2E-A5E5-6CCBCD415423}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Nicolle-Grasse-0394df12-4d09-4844-80aa-269ccc9c1d54.yml
+++ b/data/il/legislature/Nicolle-Grasse-0394df12-4d09-4844-80aa-269ccc9c1d54.yml
@@ -4,7 +4,7 @@ given_name: Nicolle
 family_name: Grasse
 gender: Female
 email: contact@staterepgrasse.com
-image: https://s3.amazonaws.com/ballotpedia-api4/files/thumbs/200/300/NicoleGrasse2024.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D2D7C6E1-5147-4488-90CD-D4FC0982A738}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Norine-K-Hammond-cce820c8-7ce2-4b30-8ebd-4734eab16a94.yml
+++ b/data/il/legislature/Norine-K-Hammond-cce820c8-7ce2-4b30-8ebd-4734eab16a94.yml
@@ -5,7 +5,7 @@ family_name: Hammond
 birth_date: 1952-09-21
 gender: Female
 email: rephammond@macomb.com
-image: https://ilga.gov/images/members/{07D3914D-440A-4891-99AE-256F657BBFFF}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{07D3914D-440A-4891-99AE-256F657BBFFF}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Norma-Hernandez-c0d6eed8-422f-4e17-a4df-5e546b704e91.yml
+++ b/data/il/legislature/Norma-Hernandez-c0d6eed8-422f-4e17-a4df-5e546b704e91.yml
@@ -4,7 +4,7 @@ given_name: Norma
 family_name: Hernandez
 gender: Female
 email: district@repnormahernandez.com
-image: https://ilga.gov/images/members/{3E520E2E-5D7A-491B-9744-0F0137816162}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{3E520E2E-5D7A-491B-9744-0F0137816162}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Omar-Aquino-436c1e53-1203-4ce3-9931-d22f9e3c406a.yml
+++ b/data/il/legislature/Omar-Aquino-436c1e53-1203-4ce3-9931-d22f9e3c406a.yml
@@ -5,7 +5,7 @@ family_name: Aquino
 birth_date: 1987-06-24
 gender: Male
 email: aquino.senate2il@gmail.com
-image: https://ilga.gov/images/members/{79A5CDE2-DD9F-423E-83F0-4643FDB13ABB}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{79A5CDE2-DD9F-423E-83F0-4643FDB13ABB}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Patrick-J-Joyce-1ae7c123-b1a4-4c6e-b4d3-dc22db461e44.yml
+++ b/data/il/legislature/Patrick-J-Joyce-1ae7c123-b1a4-4c6e-b4d3-dc22db461e44.yml
@@ -4,7 +4,7 @@ given_name: Patrick
 family_name: Joyce
 gender: Male
 email: pjoyce2133@yahoo.com
-image: https://ilga.gov/images/members/{39D6F100-DAEC-4C4B-A4F5-F20299B79152}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{39D6F100-DAEC-4C4B-A4F5-F20299B79152}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Patrick-Sheehan-075c5ab4-12bf-4573-8091-1539a081256e.yml
+++ b/data/il/legislature/Patrick-Sheehan-075c5ab4-12bf-4573-8091-1539a081256e.yml
@@ -4,7 +4,7 @@ given_name: Patrick
 family_name: Sheehan
 gender: Male
 email: sheehan@ilhousegop.org
-image: https://storage.googleapis.com/enview-public-general/legislative-people-photos/142046.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4F33CDD4-F7DD-40AC-B11E-DA5066173803}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Patrick-Windhorst-6cb9bc2c-97b3-4dd1-b5ba-36a644360057.yml
+++ b/data/il/legislature/Patrick-Windhorst-6cb9bc2c-97b3-4dd1-b5ba-36a644360057.yml
@@ -4,7 +4,7 @@ given_name: Patrick
 family_name: Windhorst
 gender: Male
 email: windhorst@ilhousegop.org
-image: https://ilga.gov/images/members/{547F9C92-7368-4390-B625-5BB795568D50}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{547F9C92-7368-4390-B625-5BB795568D50}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Paul-Faraci-8392abef-edd4-4e47-b649-ce4ac82ebb21.yml
+++ b/data/il/legislature/Paul-Faraci-8392abef-edd4-4e47-b649-ce4ac82ebb21.yml
@@ -3,6 +3,7 @@ name: Paul Faraci
 given_name: Paul
 family_name: Faraci
 gender: Male
+image: https://cdn.ilga.gov/assets/img/members/{1A24C379-4D87-4EA7-B9DA-BA65568F1408}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Paul-Jacobs-2febe0de-8b57-43c9-b8cd-a5363af4eae3.yml
+++ b/data/il/legislature/Paul-Jacobs-2febe0de-8b57-43c9-b8cd-a5363af4eae3.yml
@@ -4,7 +4,7 @@ given_name: Paul
 family_name: Jacobs
 gender: Male
 email: jacobs@ilhousegop.org
-image: https://ilga.gov/images/members/{0E151A06-57C8-4261-9577-278F5DD4B717}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0E151A06-57C8-4261-9577-278F5DD4B717}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Rachel-Ventura-ed666567-961a-43f1-8ca3-ddd29e07f8af.yml
+++ b/data/il/legislature/Rachel-Ventura-ed666567-961a-43f1-8ca3-ddd29e07f8af.yml
@@ -5,7 +5,7 @@ family_name: Ventura
 birth_date: 1981-04-04
 gender: Female
 email: info@senatorventura.com
-image: https://ilga.gov/images/members/{F4164483-CA9E-423B-ADF4-FA52EE9A3F08}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{F4164483-CA9E-423B-ADF4-FA52EE9A3F08}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Ram-Villivalam-d01a10b0-e391-4c65-ba1f-304ee6130f5c.yml
+++ b/data/il/legislature/Ram-Villivalam-d01a10b0-e391-4c65-ba1f-304ee6130f5c.yml
@@ -4,7 +4,7 @@ given_name: Ram
 family_name: Villivalam
 gender: Male
 email: senator@senatorram.com
-image: https://ilga.gov/images/members/{DBF0BBF0-0E16-4C5F-894A-16C4A14CAF51}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{DBF0BBF0-0E16-4C5F-894A-16C4A14CAF51}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Regan-Deering-8d81a4e9-f895-4a60-8064-2ddd2bd785c8.yml
+++ b/data/il/legislature/Regan-Deering-8d81a4e9-f895-4a60-8064-2ddd2bd785c8.yml
@@ -4,7 +4,7 @@ given_name: Regan
 family_name: Deering
 gender: Female
 email: deering@ilhousegop.org
-image: https://storage.googleapis.com/enview-dev-public-general/legislative-people-photos/121364.jpg
+image: https://cdn.ilga.gov/assets/img/members/{57C9E73B-E152-4B7D-B42B-6EA67289504E}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Rick-Ryan-749cc87c-81a8-48ba-9cee-a6be77e1d333.yml
+++ b/data/il/legislature/Rick-Ryan-749cc87c-81a8-48ba-9cee-a6be77e1d333.yml
@@ -4,7 +4,7 @@ given_name: Rick
 family_name: Ryan
 gender: Male
 email: ryanrep36@gmail.com
-image: https://images.squarespace-cdn.com/content/v1/6568caeb90af1162590f09de/eb461991-f5eb-4bd0-8701-9fa643e1c6e6/Screen+Shot+2023-12-03+at+9.18.47+PM.jpg?format=1500w
+image: https://cdn.ilga.gov/assets/img/members/{D636B7BF-6A7A-4F82-8429-018FF5E1CE36}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Rita-Mayfield-cb9d1283-1029-46cf-8507-1e7ed6937606.yml
+++ b/data/il/legislature/Rita-Mayfield-cb9d1283-1029-46cf-8507-1e7ed6937606.yml
@@ -4,7 +4,7 @@ given_name: Rita
 family_name: Mayfield
 gender: Female
 email: 60thdistrict@gmail.com
-image: https://ilga.gov/images/members/{3A2DAB8B-B5F8-48EE-85D3-05894ED42A5D}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{3A2DAB8B-B5F8-48EE-85D3-05894ED42A5D}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Robert-F-Martwick-4a3645fe-2a56-400f-ae2a-18e50f2b0bea.yml
+++ b/data/il/legislature/Robert-F-Martwick-4a3645fe-2a56-400f-ae2a-18e50f2b0bea.yml
@@ -5,7 +5,7 @@ family_name: Martwick
 birth_date: 1966-02-28
 gender: Male
 email: info@senatormartwick.com
-image: https://ilga.gov/images/members/{8FA2A22C-6775-4098-905C-0C7D8BBD7AEE}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{8FA2A22C-6775-4098-905C-0C7D8BBD7AEE}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Robert-Peters-86ee52dd-dc32-4895-bf16-746eb76df012.yml
+++ b/data/il/legislature/Robert-Peters-86ee52dd-dc32-4895-bf16-746eb76df012.yml
@@ -5,7 +5,7 @@ family_name: Peters
 birth_date: 1985-04-26
 gender: Male
 email: info@senatorrobertpeters.com
-image: https://ilga.gov/images/members/{05AD9CBA-EA20-489D-9C33-3F39DC1F9B0C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{05AD9CBA-EA20-489D-9C33-3F39DC1F9B0C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Robert-Rita-3ce631a4-7a4f-4905-a959-574f1f0d3d6d.yml
+++ b/data/il/legislature/Robert-Rita-3ce631a4-7a4f-4905-a959-574f1f0d3d6d.yml
@@ -5,7 +5,7 @@ family_name: Rita
 birth_date: 1969-10-02
 gender: Male
 email: robertbobrita@aol.com
-image: https://ilga.gov/images/members/{AC16F1E8-0988-4A08-A2E5-EF4D06371A24}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{AC16F1E8-0988-4A08-A2E5-EF4D06371A24}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Robyn-Gabel-7d68f174-3504-4479-80c5-e3fbe69fd354.yml
+++ b/data/il/legislature/Robyn-Gabel-7d68f174-3504-4479-80c5-e3fbe69fd354.yml
@@ -5,7 +5,7 @@ family_name: Gabel
 birth_date: 1953-02-07
 gender: Female
 email: contact@robyngabel.com
-image: https://ilga.gov/images/members/{739CC8F9-E9E4-40A1-AB86-883EF9A5E313}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{739CC8F9-E9E4-40A1-AB86-883EF9A5E313}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Ryan-Spain-139cce29-08b9-4731-a7e9-bdeec8129eaa.yml
+++ b/data/il/legislature/Ryan-Spain-139cce29-08b9-4731-a7e9-bdeec8129eaa.yml
@@ -5,7 +5,7 @@ family_name: Spain
 birth_date: 1982-10-11
 gender: Male
 email: repryanspain@gmail.com
-image: https://ilga.gov/images/members/{4C25C70B-0E39-406B-9318-A899C2A6D1B0}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4C25C70B-0E39-406B-9318-A899C2A6D1B0}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Sally-Turner-cb406eb3-673a-4715-8d87-d5963220ad6b.yml
+++ b/data/il/legislature/Sally-Turner-cb406eb3-673a-4715-8d87-d5963220ad6b.yml
@@ -4,7 +4,7 @@ given_name: Sally
 family_name: Turner
 gender: Female
 email: turner@ilsenategop.org
-image: https://ilga.gov/images/members/{C47C199A-2C77-4A73-BAE5-AB139ED85CAC}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C47C199A-2C77-4A73-BAE5-AB139ED85CAC}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Sara-Feigenholtz-6c0069de-c064-412e-ae45-9e87d6ee3dae.yml
+++ b/data/il/legislature/Sara-Feigenholtz-6c0069de-c064-412e-ae45-9e87d6ee3dae.yml
@@ -5,7 +5,7 @@ family_name: Feigenholtz
 birth_date: 1956-12-11
 gender: Female
 email: sara@senatorsara.com
-image: https://ilga.gov/images/members/{E77394AE-D896-4FEB-A325-B33A553554EB}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E77394AE-D896-4FEB-A325-B33A553554EB}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Seth-Lewis-0b9e2838-eeb0-4d10-8292-64a9e9f54dc1.yml
+++ b/data/il/legislature/Seth-Lewis-0b9e2838-eeb0-4d10-8292-64a9e9f54dc1.yml
@@ -4,7 +4,7 @@ given_name: Seth
 family_name: Lewis
 gender: Male
 email: lewis@ilsenategop.org
-image: https://ilga.gov/images/members/{E714499E-C9C6-4A01-AE84-6CB703AFB9B7}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{E714499E-C9C6-4A01-AE84-6CB703AFB9B7}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Sharon-Chung-95032a7e-18c4-40be-b89f-1f61b132533a.yml
+++ b/data/il/legislature/Sharon-Chung-95032a7e-18c4-40be-b89f-1f61b132533a.yml
@@ -4,7 +4,7 @@ given_name: Sharon
 family_name: Chung
 gender: Female
 email: info@repchung.com
-image: https://ilga.gov/images/members/{0555ECBC-C0A4-4E09-ABA2-F8D6E8E03246}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0555ECBC-C0A4-4E09-ABA2-F8D6E8E03246}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Sonya-M-Harper-8a39d16f-edbf-454b-8a77-33030fa9a8c2.yml
+++ b/data/il/legislature/Sonya-M-Harper-8a39d16f-edbf-454b-8a77-33030fa9a8c2.yml
@@ -4,7 +4,7 @@ given_name: Sonya
 family_name: Harper
 gender: Female
 email: repsonyaharper@gmail.com
-image: https://ilga.gov/images/members/{04C99384-69F8-4ACE-9E43-11E21CC5F820}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{04C99384-69F8-4ACE-9E43-11E21CC5F820}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Stephanie-A-Kifowit-0ecdbb3f-7593-4959-8b27-4a03a925d927.yml
+++ b/data/il/legislature/Stephanie-A-Kifowit-0ecdbb3f-7593-4959-8b27-4a03a925d927.yml
@@ -5,7 +5,7 @@ family_name: Kifowit
 birth_date: 1971-09-14
 gender: Female
 email: stephanie.kifowit@att.net
-image: https://ilga.gov/images/members/{96E18070-8D3D-4EEC-8432-8A30FEC19E5C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{96E18070-8D3D-4EEC-8432-8A30FEC19E5C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Steve-McClure-d3450848-4552-4b8f-97dc-fb3c26c2566c.yml
+++ b/data/il/legislature/Steve-McClure-d3450848-4552-4b8f-97dc-fb3c26c2566c.yml
@@ -5,7 +5,7 @@ family_name: McClure
 birth_date: 1984-03-08
 gender: Male
 email: senatormcclure@gmail.com
-image: https://ilga.gov/images/members/{EB86B3C4-3F25-4D5C-8944-7B4CBCA7CACE}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{EB86B3C4-3F25-4D5C-8944-7B4CBCA7CACE}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Steve-Stadelman-ba9c4927-bf9b-4bd5-879f-c515a12a046c.yml
+++ b/data/il/legislature/Steve-Stadelman-ba9c4927-bf9b-4bd5-879f-c515a12a046c.yml
@@ -5,7 +5,7 @@ family_name: Stadelman
 birth_date: 1960-10-30
 gender: Male
 email: stadelman@senatedem.ilga.gov
-image: https://ilga.gov/images/members/{47906765-AB0A-48BF-8C14-B5443B8F27C4}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{47906765-AB0A-48BF-8C14-B5443B8F27C4}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Steven-Reick-56914fff-eda2-403a-869a-895764908cd9.yml
+++ b/data/il/legislature/Steven-Reick-56914fff-eda2-403a-869a-895764908cd9.yml
@@ -4,7 +4,7 @@ given_name: Steve
 family_name: Reick
 gender: Male
 email: reick@ilhousegop.org
-image: https://ilga.gov/images/members/{D4845B6E-9A2E-4F0E-9F70-503B2E5891CA}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{D4845B6E-9A2E-4F0E-9F70-503B2E5891CA}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Sue-Rezin-a1ac69ba-49db-4529-926f-999e73ef9654.yml
+++ b/data/il/legislature/Sue-Rezin-a1ac69ba-49db-4529-926f-999e73ef9654.yml
@@ -5,7 +5,7 @@ family_name: Rezin
 birth_date: 1963-08-09
 gender: Female
 email: senatorrezin@gmail.com
-image: https://ilga.gov/images/members/{45666230-B77D-4162-A45E-6AC5587C4E56}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{45666230-B77D-4162-A45E-6AC5587C4E56}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Sue-Scherer-e9bf3918-daaa-4fa4-b58d-538c147335dd.yml
+++ b/data/il/legislature/Sue-Scherer-e9bf3918-daaa-4fa4-b58d-538c147335dd.yml
@@ -4,7 +4,7 @@ given_name: Sue
 family_name: Scherer
 gender: Female
 email: staterepsue@gmail.com
-image: https://ilga.gov/images/members/{A0B92E66-B4F7-4B85-A7F2-14C0153B426F}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{A0B92E66-B4F7-4B85-A7F2-14C0153B426F}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Suzanne-Ness-68505842-e93c-42ce-adc8-9354f4a0db7a.yml
+++ b/data/il/legislature/Suzanne-Ness-68505842-e93c-42ce-adc8-9354f4a0db7a.yml
@@ -4,7 +4,7 @@ given_name: Suzanne
 family_name: Ness
 gender: Female
 email: info@repsnessil66.com
-image: https://ilga.gov/images/members/{735B1C5A-1929-4EC8-92B4-72E58D74E743}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{735B1C5A-1929-4EC8-92B4-72E58D74E743}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Suzy-Glowiak-Hilton-16483678-e06e-4551-8cec-266335b56fff.yml
+++ b/data/il/legislature/Suzy-Glowiak-Hilton-16483678-e06e-4551-8cec-266335b56fff.yml
@@ -4,7 +4,7 @@ given_name: Suzy
 family_name: Glowiak Hilton
 gender: Female
 email: suzy@suzyforsenate.com
-image: https://ilga.gov/images/members/{8DE2D7E5-9F3D-43FD-B0EC-0010BDA8849A}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{8DE2D7E5-9F3D-43FD-B0EC-0010BDA8849A}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Terri-Bryant-372be8dc-8177-47e7-b128-1e6a81621f3a.yml
+++ b/data/il/legislature/Terri-Bryant-372be8dc-8177-47e7-b128-1e6a81621f3a.yml
@@ -5,7 +5,7 @@ family_name: Bryant
 birth_date: 1963-03-31
 gender: Female
 email: staterepterribryant@gmail.com
-image: https://ilga.gov/images/members/{58FBFE5F-39EE-4F3C-853A-0DB98E83E893}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{58FBFE5F-39EE-4F3C-853A-0DB98E83E893}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Thaddeus-Jones-a38c9ab5-48b6-417c-baf1-bae5e8f3b7c0.yml
+++ b/data/il/legislature/Thaddeus-Jones-a38c9ab5-48b6-417c-baf1-bae5e8f3b7c0.yml
@@ -4,7 +4,7 @@ given_name: Thaddeus
 family_name: Jones
 gender: Male
 email: repjones.jones@gmail.com
-image: https://ilga.gov/images/members/{6EE82A11-2CC6-48E9-9DE6-61D83EBCAB6B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{6EE82A11-2CC6-48E9-9DE6-61D83EBCAB6B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Theresa-Mah-c1ebba3c-4fc2-4b66-9ecc-e20aa4f793a9.yml
+++ b/data/il/legislature/Theresa-Mah-c1ebba3c-4fc2-4b66-9ecc-e20aa4f793a9.yml
@@ -4,7 +4,7 @@ given_name: Theresa
 family_name: Mah
 gender: Female
 email: office@reptheresamah.com
-image: https://ilga.gov/images/members/{808BAA30-BB82-437A-9A76-386F9A65A073}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{808BAA30-BB82-437A-9A76-386F9A65A073}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Tom-Weber-ba3dd226-a1c6-47af-917a-e12696d5aae5.yml
+++ b/data/il/legislature/Tom-Weber-ba3dd226-a1c6-47af-917a-e12696d5aae5.yml
@@ -4,7 +4,7 @@ given_name: Tom
 family_name: Weber
 gender: Male
 email: weber@ilhousegop.org
-image: https://ilga.gov/images/members/{4C80DF49-91D2-4C24-981E-BBE946A671D2}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{4C80DF49-91D2-4C24-981E-BBE946A671D2}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Tony-McCombie-d6d5becd-7733-4849-b2a2-b543bbfea1ec.yml
+++ b/data/il/legislature/Tony-McCombie-d6d5becd-7733-4849-b2a2-b543bbfea1ec.yml
@@ -5,7 +5,7 @@ family_name: McCombie
 birth_date: 1972-10-09
 gender: Female
 email: mccombie@ilhousegop.org
-image: https://ilga.gov/images/members/{0766A6E9-981F-491B-B3A1-12DF91F1DBDA}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0766A6E9-981F-491B-B3A1-12DF91F1DBDA}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Tracy-Katz-Muhl-4b7dfbae-dc1a-4226-9b42-00c8bbc46b06.yml
+++ b/data/il/legislature/Tracy-Katz-Muhl-4b7dfbae-dc1a-4226-9b42-00c8bbc46b06.yml
@@ -4,6 +4,7 @@ given_name: Tracy
 family_name: Katz Muhl
 gender: Female
 email: info@staterepkatzmuhl.com
+image: https://cdn.ilga.gov/assets/img/members/{31ED8E80-A147-47D1-A4B9-70A51C651C48}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Travis-Weaver-63883963-04b0-454c-8d18-81dcca230b55.yml
+++ b/data/il/legislature/Travis-Weaver-63883963-04b0-454c-8d18-81dcca230b55.yml
@@ -5,7 +5,7 @@ family_name: Weaver
 birth_date: 1992-06-18
 gender: Male
 email: weaver@ilhousegop.org
-image: https://ilga.gov/images/members/{0A077509-6D57-4C96-8525-0480C8338827}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{0A077509-6D57-4C96-8525-0480C8338827}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Wayne-A-Rosenthal-5a23473f-1af0-4f7d-8b08-cb287d93db6f.yml
+++ b/data/il/legislature/Wayne-A-Rosenthal-5a23473f-1af0-4f7d-8b08-cb287d93db6f.yml
@@ -5,7 +5,7 @@ family_name: Rosenthal
 birth_date: 1950-05-16
 gender: Male
 email: rosenthal@ilhousegop.org
-image: https://ilga.gov/images/members/{43DB5751-834C-4CA0-B8A4-6D1016E3CB28}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{43DB5751-834C-4CA0-B8A4-6D1016E3CB28}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Will-Guzzardi-df11068d-eb77-4eb8-90c8-95056891e633.yml
+++ b/data/il/legislature/Will-Guzzardi-df11068d-eb77-4eb8-90c8-95056891e633.yml
@@ -4,7 +4,7 @@ given_name: Will
 family_name: Guzzardi
 gender: Male
 email: will@repguzzardi.com
-image: https://ilga.gov/images/members/{C127AF36-0EAE-48B6-8C31-86AAE3935790}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{C127AF36-0EAE-48B6-8C31-86AAE3935790}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/William-Cunningham-5fe6a4a5-da36-4fa0-8c36-739648b9ce0c.yml
+++ b/data/il/legislature/William-Cunningham-5fe6a4a5-da36-4fa0-8c36-739648b9ce0c.yml
@@ -5,7 +5,7 @@ family_name: Cunningham
 birth_date: 1967-07-21
 gender: Male
 email: staterepbillcunningham@gmail.com
-image: https://ilga.gov/images/members/{402F0454-4EAF-4721-993D-53C7459BA35B}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{402F0454-4EAF-4721-993D-53C7459BA35B}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/William-Davis-fcc072f5-5cbc-4c8e-bc3d-e70b0e102878.yml
+++ b/data/il/legislature/William-Davis-fcc072f5-5cbc-4c8e-bc3d-e70b0e102878.yml
@@ -5,7 +5,7 @@ family_name: Davis
 birth_date: 1968-07-02
 gender: Male
 email: williamd@ilga.gov
-image: https://ilga.gov/images/members/{6012DCA8-7486-49F9-A387-8703A2CF469C}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{6012DCA8-7486-49F9-A387-8703A2CF469C}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/William-E-Hauter-fb6cc95a-0c98-41e3-a481-8d5dc51d6c54.yml
+++ b/data/il/legislature/William-E-Hauter-fb6cc95a-0c98-41e3-a481-8d5dc51d6c54.yml
@@ -4,7 +4,7 @@ given_name: Bill
 family_name: Hauter
 gender: Male
 email: hauter@ilhousegop.org
-image: https://ilga.gov/images/members/{999C86E0-F35D-4F02-81BE-F4FEBF930114}.jpg
+image: https://cdn.ilga.gov/assets/img/members/{999C86E0-F35D-4F02-81BE-F4FEBF930114}.jpg
 party:
 - name: Republican
 roles:

--- a/data/il/legislature/Willie-Preston-34274113-7ea1-4e6e-aa7a-da2c9d1037b4.yml
+++ b/data/il/legislature/Willie-Preston-34274113-7ea1-4e6e-aa7a-da2c9d1037b4.yml
@@ -4,6 +4,7 @@ given_name: Willie
 family_name: Preston
 birth_date: 1985-02-01
 gender: Male
+image: https://cdn.ilga.gov/assets/img/members/{CFF4C1DD-FC97-428B-9D19-A520A543F4AC}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/il/legislature/Yolonda-Morris-753dc145-9162-4e02-9b76-836be48498cb.yml
+++ b/data/il/legislature/Yolonda-Morris-753dc145-9162-4e02-9b76-836be48498cb.yml
@@ -4,6 +4,7 @@ given_name: Yolonda
 family_name: Morris
 gender: Female
 email: 9thdistrictinfo@gmail.com
+image: https://cdn.ilga.gov/assets/img/members/{2EDE65F3-F463-4E44-B703-6B06D2ECB787}.jpg
 party:
 - name: Democratic
 roles:

--- a/data/ny/legislature/Brian-Miller-ad93da57-8a9a-4dc0-bc2c-2488c0331d16.yml
+++ b/data/ny/legislature/Brian-Miller-ad93da57-8a9a-4dc0-bc2c-2488c0331d16.yml
@@ -3,7 +3,7 @@ name: Brian Miller
 given_name: Brian
 family_name: Miller
 gender: Male
-email: millerb@nysassembly.gov
+email: millerb@nyassembly.gov
 image: https://assembly.state.ny.us/write/upload/member_files/122/headshot/122.jpg?hst=1660074350
 party:
 - name: Republican


### PR DESCRIPTION
The URLs for photos changed:
From: https://ilga.gov/images/members
To: https://cdn.ilga.gov/assets/img/members