### PR TITLE
AL: add lieutenant governor and attorney general

### DIFF
--- a/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
+++ b/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
@@ -1,0 +1,21 @@
+id: ocd-person/3636b6ed-56b0-44bb-97b8-dee266b6d9c8
+name: Steve Marshall
+given_name: Steve
+family_name: Marshall
+image: https://live-al-ago.pantheonsite.io/wp-content/uploads/2023/04/Steve-Marshall-headshot-283x300.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2017-02-10'
+  end_date: '2027-01-18'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 501 Washington Avenue; Montgomery, AL 36104
+  voice: 334-242-7335
+links:
+- url: https://www.alabamaag.gov/
+sources:
+- url: https://www.alabamaag.gov/about/
+- url: https://ballotpedia.org/Steve_Marshall

--- a/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
+++ b/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
@@ -1,0 +1,21 @@
+id: ocd-person/cb01dcb8-b382-48af-a781-d4019eb3dfa6
+name: Will Ainsworth
+given_name: Will
+family_name: Ainsworth
+image: https://ltgov.alabama.gov/wp-content/uploads/2019/03/LtGov-Will-Ainsworth.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-18'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 11 S Union Street; Montgomery, AL 36130
+  voice: 334-261-9590
+links:
+- url: https://ltgov.alabama.gov/
+sources:
+- url: https://ltgov.alabama.gov/
+- url: https://ballotpedia.org/Will_Ainsworth


### PR DESCRIPTION
## Summary

- **Will Ainsworth** (Lt Governor) — reuses existing OCD ID from `al/retired/` (`cb01dcb8-b382-48af-a781-d4019eb3dfa6`)
- **Steve Marshall** (Attorney General) — new UUID generated for OCD ID since he had no prior record in the repo. If there's a preferred process for assigning new OCD person IDs, please let me know and I'll update.

## Sources

All data sourced from official .gov websites and Ballotpedia.