### PR TITLE
AK: add lt_governor role to Dahlstrom, add attorney general

### DIFF
--- a/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
+++ b/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
@@ -7,6 +7,10 @@ image: https://ltgov.alaska.gov/wp-content/uploads/Screenshot-2022-12-14-150552-
 party:
 - name: Republican
 roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
 - end_date: '2026-12-07'
   type: chief election officer
   jurisdiction: ocd-jurisdiction/country:us/state:ak/government
@@ -23,3 +27,4 @@ ids:
 sources:
 - url: https://ltgov.alaska.gov/email-the-lt-governor/
 - url: https://www.nass.org/memberships/secretaries-statelieutenant-governors
+- url: https://ballotpedia.org/Nancy_Dahlstrom

--- a/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
+++ b/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
@@ -1,0 +1,23 @@
+id: ocd-person/671acdf5-e1ec-4259-ba3d-19d1df9a146e
+name: Stephen Cox
+given_name: Stephen
+family_name: Cox
+email: attorney.general@alaska.gov
+image: https://law.alaska.gov/img/headshot_CoxLG2601.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-08-29'
+  end_date: '2026-12-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
+offices:
+- classification: capitol
+  address: 1031 West 4th Avenue, Suite 200; Anchorage, AK 99501-1994
+  voice: 907-269-5100
+  fax: 907-276-3697
+links:
+- url: https://law.alaska.gov/
+sources:
+- url: https://law.alaska.gov/
+- url: https://ballotpedia.org/Stephen_Cox


### PR DESCRIPTION
## Summary

- **Nancy Dahlstrom** (Lt Governor) — added `lt_governor` role alongside existing `chief election officer` role, added Ballotpedia source. She was already in the repo but only had the chief election officer role.
- **Stephen Cox** (Attorney General) — new record with new UUID generated for OCD ID since he had no prior record in the repo. If there's a preferred process for assigning new OCD person IDs, please let me know and I'll update.

## Sources

All data sourced from official .gov websites and Ballotpedia.