### PR TITLE
CT: add lieutenant governor and attorney general

### DIFF
--- a/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
+++ b/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
@@ -1,0 +1,20 @@
+id: ocd-person/e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3
+name: Susan Bysiewicz
+given_name: Susan
+family_name: Bysiewicz
+image: https://portal.ct.gov/lt-governor/-/media/otlg/02-site-images/official-portraits-of-the-lt-governor/about-lt-governor-susan-bysiewicz.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: State Capitol, 210 Capitol Avenue, Room 304; Hartford, CT 06106
+links:
+- url: https://portal.ct.gov/lt-governor
+sources:
+- url: https://portal.ct.gov/lt-governor
+- url: https://ballotpedia.org/Susan_Bysiewicz

--- a/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
+++ b/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
@@ -1,0 +1,23 @@
+id: ocd-person/4e747abf-37ad-41ba-aba5-064e420d2cc8
+name: William Tong
+given_name: William
+family_name: Tong
+image: https://portal.ct.gov/-/media/ag/about-the-ag/agtong-headshot.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: 165 Capitol Avenue; Hartford, CT 06106
+  voice: 860-808-5318
+  fax: 860-808-5387
+links:
+- url: https://portal.ct.gov/ag
+sources:
+- url: https://portal.ct.gov/AG/About-the-AG/William-Tong-Biography-page
+- url: https://ballotpedia.org/William_Tong
+- url: https://www.naag.org/attorney-general/william-tong/


### PR DESCRIPTION
## Summary

- **Susan Bysiewicz** (Lt Governor) — new UUID generated, no prior record in repo
- **William Tong** (Attorney General) — reuses existing OCD ID from `ct/retired/` (`4e747abf-37ad-41ba-aba5-064e420d2cc8`)

If there's a preferred process for assigning new OCD person IDs, please let me know and I'll update.

## Sources

All data sourced from official .gov websites, Ballotpedia, and NAAG.