### PR TITLE
MA: add lieutenant governor and attorney general

### DIFF
--- a/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
+++ b/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
@@ -7,6 +7,10 @@ image: https://ltgov.alaska.gov/wp-content/uploads/Screenshot-2022-12-14-150552-
 party:
 - name: Republican
 roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
 - end_date: '2026-12-07'
   type: chief election officer
   jurisdiction: ocd-jurisdiction/country:us/state:ak/government
@@ -23,3 +27,4 @@ ids:
 sources:
 - url: https://ltgov.alaska.gov/email-the-lt-governor/
 - url: https://www.nass.org/memberships/secretaries-statelieutenant-governors
+- url: https://ballotpedia.org/Nancy_Dahlstrom

--- a/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
+++ b/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
@@ -1,0 +1,23 @@
+id: ocd-person/671acdf5-e1ec-4259-ba3d-19d1df9a146e
+name: Stephen Cox
+given_name: Stephen
+family_name: Cox
+email: attorney.general@alaska.gov
+image: https://law.alaska.gov/img/headshot_CoxLG2601.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-08-29'
+  end_date: '2026-12-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
+offices:
+- classification: capitol
+  address: 1031 West 4th Avenue, Suite 200; Anchorage, AK 99501-1994
+  voice: 907-269-5100
+  fax: 907-276-3697
+links:
+- url: https://law.alaska.gov/
+sources:
+- url: https://law.alaska.gov/
+- url: https://ballotpedia.org/Stephen_Cox

--- a/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
+++ b/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
@@ -1,0 +1,21 @@
+id: ocd-person/3636b6ed-56b0-44bb-97b8-dee266b6d9c8
+name: Steve Marshall
+given_name: Steve
+family_name: Marshall
+image: https://live-al-ago.pantheonsite.io/wp-content/uploads/2023/04/Steve-Marshall-headshot-283x300.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2017-02-10'
+  end_date: '2027-01-18'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 501 Washington Avenue; Montgomery, AL 36104
+  voice: 334-242-7335
+links:
+- url: https://www.alabamaag.gov/
+sources:
+- url: https://www.alabamaag.gov/about/
+- url: https://ballotpedia.org/Steve_Marshall

--- a/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
+++ b/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
@@ -1,0 +1,21 @@
+id: ocd-person/cb01dcb8-b382-48af-a781-d4019eb3dfa6
+name: Will Ainsworth
+given_name: Will
+family_name: Ainsworth
+image: https://ltgov.alabama.gov/wp-content/uploads/2019/03/LtGov-Will-Ainsworth.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-18'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 11 S Union Street; Montgomery, AL 36130
+  voice: 334-261-9590
+links:
+- url: https://ltgov.alabama.gov/
+sources:
+- url: https://ltgov.alabama.gov/
+- url: https://ballotpedia.org/Will_Ainsworth

--- a/data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml
+++ b/data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml
@@ -1,0 +1,22 @@
+id: ocd-person/29e6b6e2-82fc-48f8-9177-96b1ec30a2a6
+name: Leslie Rutledge
+given_name: Leslie
+family_name: Rutledge
+image: https://ltgovernor.arkansas.gov/wp-content/uploads/LR-photo.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-10'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ar/government
+offices:
+- classification: capitol
+  address: State Capitol, Suite 270; Little Rock, AR 72201-1061
+  voice: 501-682-2144
+  fax: 501-682-2894
+links:
+- url: https://www.ltgovernor.arkansas.gov/
+sources:
+- url: https://www.ltgovernor.arkansas.gov/
+- url: https://ballotpedia.org/Leslie_Rutledge

--- a/data/ar/executive/Tim-Griffin-99f67d4f-c181-46a8-b7a9-4b45ada32c50.yml
+++ b/data/ar/executive/Tim-Griffin-99f67d4f-c181-46a8-b7a9-4b45ada32c50.yml
@@ -1,0 +1,23 @@
+id: ocd-person/99f67d4f-c181-46a8-b7a9-4b45ada32c50
+name: Tim Griffin
+given_name: Tim
+family_name: Griffin
+email: oag@arkansasag.gov
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-AG-Griffin-1.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-10'
+  end_date: '2027-01-12'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ar/government
+offices:
+- classification: capitol
+  address: 101 West Capitol Avenue; Little Rock, AR 72201
+  voice: 501-682-2007
+links:
+- url: https://arkansasag.gov/
+sources:
+- url: https://arkansasag.gov/meet-tim/
+- url: https://ballotpedia.org/Tim_Griffin_(Arkansas)
+- url: https://www.naag.org/attorney-general/tim-griffin/

--- a/data/az/executive/Kris-Mayes-a94ae259-7b2d-4756-9c9b-d9fc778e6c1f.yml
+++ b/data/az/executive/Kris-Mayes-a94ae259-7b2d-4756-9c9b-d9fc778e6c1f.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a94ae259-7b2d-4756-9c9b-d9fc778e6c1f
+name: Kris Mayes
+given_name: Kris
+family_name: Mayes
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-AZ-Mayes.png
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:az/government
+offices:
+- classification: capitol
+  address: 2005 N Central Ave; Phoenix, AZ 85004
+  voice: 602-542-5025
+links:
+- url: https://www.azag.gov/
+sources:
+- url: https://www.azag.gov/
+- url: https://ballotpedia.org/Kris_Mayes
+- url: https://www.naag.org/attorney-general/kris-mayes/

--- a/data/ca/executive/Eleni-Kounalakis-113aeeca-7bac-4407-8ec3-bceab97680e5.yml
+++ b/data/ca/executive/Eleni-Kounalakis-113aeeca-7bac-4407-8ec3-bceab97680e5.yml
@@ -1,0 +1,22 @@
+id: ocd-person/113aeeca-7bac-4407-8ec3-bceab97680e5
+name: Eleni Kounalakis
+given_name: Eleni
+family_name: Kounalakis
+image: https://upload.wikimedia.org/wikipedia/commons/4/41/Ambassador_Eleni_Kounalakis.jpeg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/government
+offices:
+- classification: capitol
+  address: 1021 O Street, Suite 8730; Sacramento, CA 95814
+  voice: 916-445-8994
+links:
+- url: https://ltg.ca.gov/
+sources:
+- url: https://ltg.ca.gov/
+- url: https://ballotpedia.org/Eleni_Kounalakis
+- url: https://commons.wikimedia.org/wiki/File:Ambassador_Eleni_Kounalakis.jpeg

--- a/data/ca/executive/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
+++ b/data/ca/executive/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
@@ -1,0 +1,23 @@
+id: ocd-person/1529b892-b3da-4958-bb3a-5bf04d7b5e0c
+name: Rob Bonta
+given_name: Rob
+family_name: Bonta
+image: https://www.naag.org/wp-content/uploads/2021/04/ag-CA-Bonta.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2021-04-23'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/government
+offices:
+- classification: capitol
+  address: P.O. Box 944255; Sacramento, CA 94244-2550
+  voice: 916-210-6276
+  fax: 916-323-5341
+links:
+- url: https://oag.ca.gov/
+sources:
+- url: https://oag.ca.gov/contact
+- url: https://ballotpedia.org/Rob_Bonta
+- url: https://www.naag.org/attorney-general/rob-bonta/

--- a/data/co/executive/Dianne-Primavera-21632200-6ff5-4b76-9c2e-190d8804ac16.yml
+++ b/data/co/executive/Dianne-Primavera-21632200-6ff5-4b76-9c2e-190d8804ac16.yml
@@ -1,0 +1,22 @@
+id: ocd-person/21632200-6ff5-4b76-9c2e-190d8804ac16
+name: Dianne Primavera
+given_name: Dianne
+family_name: Primavera
+image: https://ltgovernor.colorado.gov/sites/ltgovernor/files/styles/large/public/2019-07/diannep.jpg
+email: gov_dianne.primavera@state.co.us
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+offices:
+- classification: capitol
+  address: State Capitol Building, 200 E. Colfax Ave., Rm. 130; Denver, CO 80203
+  voice: 303-866-4075
+links:
+- url: https://ltgovernor.colorado.gov/
+sources:
+- url: https://ltgovernor.colorado.gov/
+- url: https://ballotpedia.org/Dianne_Primavera

--- a/data/co/executive/Phil-Weiser-fb02dd97-db94-4350-841f-e5adb9065c0c.yml
+++ b/data/co/executive/Phil-Weiser-fb02dd97-db94-4350-841f-e5adb9065c0c.yml
@@ -1,0 +1,22 @@
+id: ocd-person/fb02dd97-db94-4350-841f-e5adb9065c0c
+name: Phil Weiser
+given_name: Phil
+family_name: Weiser
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-CO-weiser.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-12'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+offices:
+- classification: capitol
+  address: Ralph L. Carr Judicial Building, 1300 Broadway, 10th Floor; Denver, CO 80203
+  voice: 720-508-6000
+links:
+- url: https://coag.gov/
+sources:
+- url: https://coag.gov/about-us/attorney-general-phil-weiser/
+- url: https://ballotpedia.org/Phil_Weiser
+- url: https://www.naag.org/attorney-general/phil-weiser/

--- a/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
+++ b/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
@@ -1,0 +1,20 @@
+id: ocd-person/e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3
+name: Susan Bysiewicz
+given_name: Susan
+family_name: Bysiewicz
+image: https://portal.ct.gov/lt-governor/-/media/otlg/02-site-images/official-portraits-of-the-lt-governor/about-lt-governor-susan-bysiewicz.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: State Capitol, 210 Capitol Avenue, Room 304; Hartford, CT 06106
+links:
+- url: https://portal.ct.gov/lt-governor
+sources:
+- url: https://portal.ct.gov/lt-governor
+- url: https://ballotpedia.org/Susan_Bysiewicz

--- a/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
+++ b/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
@@ -1,0 +1,23 @@
+id: ocd-person/4e747abf-37ad-41ba-aba5-064e420d2cc8
+name: William Tong
+given_name: William
+family_name: Tong
+image: https://portal.ct.gov/-/media/ag/about-the-ag/agtong-headshot.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: 165 Capitol Avenue; Hartford, CT 06106
+  voice: 860-808-5318
+  fax: 860-808-5387
+links:
+- url: https://portal.ct.gov/ag
+sources:
+- url: https://portal.ct.gov/AG/About-the-AG/William-Tong-Biography-page
+- url: https://ballotpedia.org/William_Tong
+- url: https://www.naag.org/attorney-general/william-tong/

--- a/data/de/executive/Kathy-Jennings-d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d.yml
+++ b/data/de/executive/Kathy-Jennings-d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d.yml
@@ -1,0 +1,25 @@
+id: ocd-person/d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d
+name: Kathy Jennings
+given_name: Kathy
+family_name: Jennings
+email: attorney.general@delaware.gov
+image: https://attorneygeneral.delaware.gov/wp-content/themes/dosgic_AG_theme/img/ag-jennings-bio-photo.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-05'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:de/government
+offices:
+- classification: capitol
+  address: Carvel State Building, 820 N. French St.; Wilmington, DE 19801
+  voice: 302-577-8400
+  fax: 302-577-6630
+links:
+- url: https://attorneygeneral.delaware.gov/
+sources:
+- url: https://attorneygeneral.delaware.gov/about/
+- url: https://attorneygeneral.delaware.gov/contact/
+- url: https://ballotpedia.org/Kathy_Jennings
+- url: https://www.naag.org/attorney-general/kathy-jennings/

--- a/data/de/executive/Kyle-Evans-Gay-96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036.yml
+++ b/data/de/executive/Kyle-Evans-Gay-96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036.yml
@@ -1,0 +1,21 @@
+id: ocd-person/96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036
+name: Kyle Evans Gay
+given_name: Kyle
+family_name: Gay
+image: https://ltgov.delaware.gov/wp-content/uploads/sites/222/2024/12/kyle-evans-gay-hero-landscape.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-21'
+  end_date: '2029-01-16'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:de/government
+offices:
+- classification: capitol
+  address: 150 Martin Luther King Jr Blvd South, 3rd Floor; Dover, DE 19901
+  voice: 302-744-4333
+links:
+- url: https://ltgov.delaware.gov/
+sources:
+- url: https://ltgov.delaware.gov/
+- url: https://ballotpedia.org/Kyle_Evans_Gay

--- a/data/fl/executive/James-Uthmeier-669df589-03af-4b3a-9588-d95ab977e171.yml
+++ b/data/fl/executive/James-Uthmeier-669df589-03af-4b3a-9588-d95ab977e171.yml
@@ -1,0 +1,22 @@
+id: ocd-person/669df589-03af-4b3a-9588-d95ab977e171
+name: James Uthmeier
+given_name: James
+family_name: Uthmeier
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-FL-Uthmeier-James.png
+party:
+- name: Republican
+roles:
+- start_date: '2025-02-17'
+  end_date: '2029-01-02'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+offices:
+- classification: capitol
+  address: The Capitol, PL 01; Tallahassee, FL 32399-1050
+  voice: 850-414-3300
+links:
+- url: https://myfloridalegal.com/
+sources:
+- url: https://myfloridalegal.com/
+- url: https://ballotpedia.org/James_Uthmeier
+- url: https://www.naag.org/attorney-general/james-uthmeier/

--- a/data/fl/executive/Jay-Collins-34dac893-eae3-495e-9237-9689a1114895.yml
+++ b/data/fl/executive/Jay-Collins-34dac893-eae3-495e-9237-9689a1114895.yml
@@ -1,0 +1,21 @@
+id: ocd-person/34dac893-eae3-495e-9237-9689a1114895
+name: Jay Collins
+given_name: Jay
+family_name: Collins
+image: https://upload.wikimedia.org/wikipedia/commons/6/65/Official_portrait_of_Lieutenant_Governor_of_Florida_Jay_Collins.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-08-12'
+  end_date: '2027-01-05'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+offices:
+- classification: capitol
+  address: 400 S Monroe St; Tallahassee, FL 32399
+links:
+- url: https://www.flgov.com/lt-governor/
+sources:
+- url: https://www.flgov.com/eog/leadership/people/jay-collins
+- url: https://ballotpedia.org/Jay_Collins
+- url: https://commons.wikimedia.org/wiki/File:Official_portrait_of_Lieutenant_Governor_of_Florida_Jay_Collins.jpg

--- a/data/ga/executive/Burt-Jones-ddfab174-3a42-42c0-946e-0ce3169c4d1b.yml
+++ b/data/ga/executive/Burt-Jones-ddfab174-3a42-42c0-946e-0ce3169c4d1b.yml
@@ -1,0 +1,21 @@
+id: ocd-person/ddfab174-3a42-42c0-946e-0ce3169c4d1b
+name: Burt Jones
+given_name: Burt
+family_name: Jones
+image: https://ltgov.georgia.gov/sites/ltgov.georgia.gov/files/styles/4_3_720px_x_540px_/public/2022-12/burt-jones.jpeg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-09'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+offices:
+- classification: capitol
+  address: 240 State Capitol; Atlanta, GA 30334
+  voice: 404-656-5030
+links:
+- url: https://ltgov.georgia.gov/
+sources:
+- url: https://ltgov.georgia.gov/
+- url: https://ballotpedia.org/Burt_Jones

--- a/data/ga/executive/Chris-Carr-57002bfc-2ba0-48cd-85d4-94673c5bf75a.yml
+++ b/data/ga/executive/Chris-Carr-57002bfc-2ba0-48cd-85d4-94673c5bf75a.yml
@@ -1,0 +1,21 @@
+id: ocd-person/57002bfc-2ba0-48cd-85d4-94673c5bf75a
+name: Chris Carr
+given_name: Chris
+family_name: Carr
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-GA-Carr1.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2016-11-01'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+offices:
+- classification: capitol
+  address: 40 Capitol Square, SW; Atlanta, GA 30334-1300
+  voice: 404-656-3300
+links:
+- url: https://law.georgia.gov/
+sources:
+- url: https://ballotpedia.org/Chris_Carr_(Georgia)
+- url: https://www.naag.org/attorney-general/chris-carr/

--- a/data/hi/executive/Anne-Lopez-8145b3ac-aaee-43d1-a534-d51d5e80f178.yml
+++ b/data/hi/executive/Anne-Lopez-8145b3ac-aaee-43d1-a534-d51d5e80f178.yml
@@ -1,0 +1,23 @@
+id: ocd-person/8145b3ac-aaee-43d1-a534-d51d5e80f178
+name: Anne Lopez
+given_name: Anne
+family_name: Lopez
+image: https://www.naag.org/wp-content/uploads/2023/01/ag-HI-Lopez-2024.jpg
+party:
+- name: Nonpartisan
+roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:hi/government
+offices:
+- classification: capitol
+  address: 425 Queen Street; Honolulu, HI 96813
+  voice: 808-586-1500
+  fax: 808-586-1239
+links:
+- url: https://ag.hawaii.gov/
+sources:
+- url: https://ag.hawaii.gov/contact-us/
+- url: https://ballotpedia.org/Anne_Lopez
+- url: https://www.naag.org/attorney-general/anne-lopez/

--- a/data/hi/executive/Sylvia-Luke-f3a50da6-6c22-4c5a-ba48-d10ee2188333.yml
+++ b/data/hi/executive/Sylvia-Luke-f3a50da6-6c22-4c5a-ba48-d10ee2188333.yml
@@ -1,0 +1,21 @@
+id: ocd-person/f3a50da6-6c22-4c5a-ba48-d10ee2188333
+name: Sylvia Luke
+given_name: Sylvia
+family_name: Luke
+image: https://ltgov.hawaii.gov/wp-content/uploads/2025/06/LG-Sylvia-Luke-2025-by-Russell-Tanoue-2-cropped-683x1024.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:hi/government
+offices:
+- classification: capitol
+  address: State Capitol; Honolulu, HI 96813
+  voice: 808-586-0255
+links:
+- url: https://ltgov.hawaii.gov/
+sources:
+- url: https://ltgov.hawaii.gov/
+- url: https://ballotpedia.org/Sylvia_Luke

--- a/data/ia/executive/Brenna-Bird-fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6.yml
+++ b/data/ia/executive/Brenna-Bird-fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6.yml
@@ -1,0 +1,21 @@
+id: ocd-person/fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6
+name: Brenna Bird
+given_name: Brenna
+family_name: Bird
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-IA-Bird.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ia/government
+offices:
+- classification: capitol
+  address: Hoover State Office Bldg., 1305 E. Walnut; Des Moines, IA 50319
+links:
+- url: https://www.iowaattorneygeneral.gov/
+sources:
+- url: https://www.iowaattorneygeneral.gov/about-us/about-attorney-general-brenna-bird
+- url: https://ballotpedia.org/Brenna_Bird
+- url: https://www.naag.org/attorney-general/brenna-bird/

--- a/data/ia/executive/Chris-Cournoyer-a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f.yml
+++ b/data/ia/executive/Chris-Cournoyer-a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f
+name: Chris Cournoyer
+given_name: Chris
+family_name: Cournoyer
+image: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Iowa_State_Senator_Chris_Cournoyer.jpg/250px-Iowa_State_Senator_Chris_Cournoyer.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2024-12-16'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ia/government
+offices:
+- classification: capitol
+  address: 1007 East Grand Avenue; Des Moines, IA 50319
+  voice: 515-281-5211
+links:
+- url: https://governor.iowa.gov/meet-governor-kim-reynolds/meet-lieutenant-governor-chris-cournoyer
+sources:
+- url: https://governor.iowa.gov/meet-governor-kim-reynolds/meet-lieutenant-governor-chris-cournoyer
+- url: https://ballotpedia.org/Chris_Cournoyer
+- url: https://commons.wikimedia.org/wiki/File:Iowa_State_Senator_Chris_Cournoyer.jpg

--- a/data/id/executive/Raul-Labrador-a6d731ea-af56-43f8-ba93-124774ae97c4.yml
+++ b/data/id/executive/Raul-Labrador-a6d731ea-af56-43f8-ba93-124774ae97c4.yml
@@ -1,0 +1,23 @@
+id: ocd-person/a6d731ea-af56-43f8-ba93-124774ae97c4
+name: Raúl Labrador
+given_name: Raúl
+family_name: Labrador
+image: https://www.ag.idaho.gov/content/uploads/2025/07/320A4720.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:id/government
+offices:
+- classification: capitol
+  address: 700 W. Jefferson Street, Suite 210; Boise, ID 83720-0010
+  voice: 208-334-2400
+  fax: 208-854-8071
+links:
+- url: https://www.ag.idaho.gov/
+sources:
+- url: https://www.ag.idaho.gov/about/
+- url: https://ballotpedia.org/Ra%C3%BAl_Labrador
+- url: https://www.naag.org/attorney-general/raul-labrador/

--- a/data/id/executive/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
+++ b/data/id/executive/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
@@ -1,0 +1,23 @@
+id: ocd-person/8f948dc8-8e7a-4a63-8fa8-b65efa9236f8
+name: Scott Bedke
+given_name: Scott
+family_name: Bedke
+email: contact@lgo.idaho.gov
+image: https://lgo.idaho.gov/wp-content/uploads/2026/02/Bedke.head_.shot_.2025.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:id/government
+offices:
+- classification: capitol
+  address: State Capitol Building, 700 W. Jefferson Street; Boise, ID 83702-0057
+  voice: 208-334-2200
+  fax: 208-334-3259
+links:
+- url: https://lgo.idaho.gov/
+sources:
+- url: https://lgo.idaho.gov/about/
+- url: https://ballotpedia.org/Scott_Bedke

--- a/data/il/executive/Juliana-Stratton-c8b35f07-1a0b-4019-b476-9fa032494c5e.yml
+++ b/data/il/executive/Juliana-Stratton-c8b35f07-1a0b-4019-b476-9fa032494c5e.yml
@@ -1,0 +1,23 @@
+id: ocd-person/c8b35f07-1a0b-4019-b476-9fa032494c5e
+name: Juliana Stratton
+given_name: Juliana
+family_name: Stratton
+email: LtGovStratton@illinois.gov
+image: https://s7d1.scene7.com/is/image/isp/lg-web-about-portrait-smaller
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+offices:
+- classification: capitol
+  address: 214 State House; Springfield, IL 62706
+  voice: 217-558-3085
+  fax: 217-558-3086
+links:
+- url: https://ltgov.illinois.gov/
+sources:
+- url: https://ltgov.illinois.gov/contact-us.html
+- url: https://ballotpedia.org/Juliana_Stratton

--- a/data/il/executive/Kwame-Raoul-65ee6848-68bd-430d-890c-a121fb6e8577.yml
+++ b/data/il/executive/Kwame-Raoul-65ee6848-68bd-430d-890c-a121fb6e8577.yml
@@ -1,0 +1,22 @@
+id: ocd-person/65ee6848-68bd-430d-890c-a121fb6e8577
+name: Kwame Raoul
+given_name: Kwame
+family_name: Raoul
+image: https://illinoisattorneygeneral.gov/images/AG_BioPhoto.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-15'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+offices:
+- classification: capitol
+  address: 500 S. 2nd St.; Springfield, IL 62701
+  voice: 217-782-1090
+links:
+- url: https://illinoisattorneygeneral.gov/
+sources:
+- url: https://illinoisattorneygeneral.gov/about/biography/
+- url: https://ballotpedia.org/Kwame_Raoul
+- url: https://www.naag.org/attorney-general/kwame-raoul/

--- a/data/in/executive/Micah-Beckwith-f3361ebb-630c-4160-9f66-68c7c9eb7419.yml
+++ b/data/in/executive/Micah-Beckwith-f3361ebb-630c-4160-9f66-68c7c9eb7419.yml
@@ -1,0 +1,17 @@
+id: ocd-person/f3361ebb-630c-4160-9f66-68c7c9eb7419
+name: Micah Beckwith
+given_name: Micah
+family_name: Beckwith
+image: https://www.in.gov/lg/images/LG-Headshot-26.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-08'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+links:
+- url: https://www.in.gov/lg/
+sources:
+- url: https://www.in.gov/lg/about-the-office/biography/
+- url: https://ballotpedia.org/Micah_Beckwith

--- a/data/in/executive/Todd-Rokita-b2cb0fa8-b426-4c50-94d8-dedd948175cd.yml
+++ b/data/in/executive/Todd-Rokita-b2cb0fa8-b426-4c50-94d8-dedd948175cd.yml
@@ -1,0 +1,23 @@
+id: ocd-person/b2cb0fa8-b426-4c50-94d8-dedd948175cd
+name: Todd Rokita
+given_name: Todd
+family_name: Rokita
+image: https://www.naag.org/wp-content/uploads/2021/02/ag-IN-Rokita.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2021-01-11'
+  end_date: '2029-01-08'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+offices:
+- classification: capitol
+  address: 302 W. Washington St., 5th Floor; Indianapolis, IN 46204
+  voice: 317-232-6201
+  fax: 317-232-7979
+links:
+- url: https://www.in.gov/attorneygeneral/
+sources:
+- url: https://www.in.gov/attorneygeneral/contact-us/
+- url: https://ballotpedia.org/Todd_Rokita
+- url: https://www.naag.org/attorney-general/todd-rokita/

--- a/data/ks/executive/David-Toland-33e1e312-76c0-4d83-81d3-fa07768eab34.yml
+++ b/data/ks/executive/David-Toland-33e1e312-76c0-4d83-81d3-fa07768eab34.yml
@@ -1,0 +1,21 @@
+id: ocd-person/33e1e312-76c0-4d83-81d3-fa07768eab34
+name: David Toland
+given_name: David
+family_name: Toland
+image: https://www.governor.ks.gov/home/showpublishedimage/827/638816867442470000
+party:
+- name: Democratic
+roles:
+- start_date: '2021-01-04'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ks/government
+offices:
+- classification: capitol
+  address: Kansas Statehouse, 300 SW 10th Ave., Ste. 241S; Topeka, KS 66612-1590
+  voice: 785-296-3232
+links:
+- url: https://www.governor.ks.gov/about-the-office/lt-governor-david-toland
+sources:
+- url: https://www.governor.ks.gov/about-the-office/lt-governor-david-toland
+- url: https://ballotpedia.org/David_Toland

--- a/data/ks/executive/Kris-Kobach-10fdb8a1-6fed-43c9-a7ee-289b859b60ab.yml
+++ b/data/ks/executive/Kris-Kobach-10fdb8a1-6fed-43c9-a7ee-289b859b60ab.yml
@@ -1,0 +1,21 @@
+id: ocd-person/10fdb8a1-6fed-43c9-a7ee-289b859b60ab
+name: Kris Kobach
+given_name: Kris
+family_name: Kobach
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-KS-Kobach.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-09'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ks/government
+offices:
+- classification: capitol
+  address: 120 S.W. 10th Ave., 2nd Fl.; Topeka, KS 66612-1597
+  voice: 785-296-2215
+links:
+- url: https://www.ag.ks.gov/
+sources:
+- url: https://ballotpedia.org/Kris_Kobach
+- url: https://www.naag.org/attorney-general/kris-kobach/

--- a/data/ky/executive/Jacqueline-Coleman-9b07a848-b96c-4424-826a-5194b65e43d9.yml
+++ b/data/ky/executive/Jacqueline-Coleman-9b07a848-b96c-4424-826a-5194b65e43d9.yml
@@ -1,0 +1,22 @@
+id: ocd-person/9b07a848-b96c-4424-826a-5194b65e43d9
+name: Jacqueline Coleman
+given_name: Jacqueline
+family_name: Coleman
+image: https://governor.ky.gov/PublishingImages/Lt-Governor-Jacqueline-Coleman-Crop.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-12-10'
+  end_date: '2027-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ky/government
+offices:
+- classification: capitol
+  address: 501 High Street, 2nd Floor; Frankfort, KY 40602
+  voice: 502-564-2611
+  fax: 502-564-2517
+links:
+- url: https://governor.ky.gov/about/lt-governor-jacqueline-coleman
+sources:
+- url: https://governor.ky.gov/about/lt-governor-jacqueline-coleman
+- url: https://ballotpedia.org/Jacqueline_Coleman

--- a/data/ky/executive/Russell-Coleman-542cf596-f393-4fcf-b2d6-7439e7726328.yml
+++ b/data/ky/executive/Russell-Coleman-542cf596-f393-4fcf-b2d6-7439e7726328.yml
@@ -1,0 +1,23 @@
+id: ocd-person/542cf596-f393-4fcf-b2d6-7439e7726328
+name: Russell Coleman
+given_name: Russell
+family_name: Coleman
+image: https://www.ag.ky.gov/about/SiteAssets/Pages/Attorney-General/Russell-Coleman-400x500.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2024-01-01'
+  end_date: '2028-01-03'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ky/government
+offices:
+- classification: capitol
+  address: 1024 Capital Center Drive, Suite 200; Frankfort, KY 40601
+  voice: 502-696-5300
+  fax: 502-564-2894
+links:
+- url: https://www.ag.ky.gov/
+sources:
+- url: https://www.ag.ky.gov/about/Pages/Attorney-General.aspx
+- url: https://ballotpedia.org/Russell_Coleman
+- url: https://www.naag.org/attorney-general/russell-coleman/

--- a/data/la/executive/Billy-Nungesser-003d1e83-14f4-4bda-8484-c552e036f421.yml
+++ b/data/la/executive/Billy-Nungesser-003d1e83-14f4-4bda-8484-c552e036f421.yml
@@ -1,0 +1,23 @@
+id: ocd-person/003d1e83-14f4-4bda-8484-c552e036f421
+name: Billy Nungesser
+given_name: Billy
+family_name: Nungesser
+email: ltgov@crt.la.gov
+image: https://www.crt.state.la.us/Assets/LTG/nungesser.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2016-01-11'
+  end_date: '2028-01-10'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:la/government
+offices:
+- classification: capitol
+  address: Capitol Annex Building, 1051 North Third Street; Baton Rouge, LA 70802
+  voice: 225-342-7009
+  fax: 225-342-1949
+links:
+- url: https://www.crt.state.la.us/lt-governor/
+sources:
+- url: https://www.crt.state.la.us/lt-governor/contact/
+- url: https://ballotpedia.org/Billy_Nungesser

--- a/data/la/executive/Liz-Murrill-6beaac02-1e0d-4aee-96d3-9033f9f918e8.yml
+++ b/data/la/executive/Liz-Murrill-6beaac02-1e0d-4aee-96d3-9033f9f918e8.yml
@@ -1,0 +1,22 @@
+id: ocd-person/6beaac02-1e0d-4aee-96d3-9033f9f918e8
+name: Liz Murrill
+given_name: Liz
+family_name: Murrill
+image: https://www.naag.org/wp-content/uploads/2024/02/ag-LA-Murrill-Liz.png
+party:
+- name: Republican
+roles:
+- start_date: '2024-01-08'
+  end_date: '2028-01-10'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:la/government
+offices:
+- classification: capitol
+  address: 1885 North Third Street; Baton Rouge, LA 70802
+  voice: 225-326-6000
+links:
+- url: https://www.aglizmurrill.com/
+sources:
+- url: https://www.aglizmurrill.com/About
+- url: https://ballotpedia.org/Liz_Murrill
+- url: https://www.naag.org/attorney-general/liz-murrill/

--- a/data/ma/executive/Andrea-Campbell-4e8f36fb-9017-4a35-a692-7f09958dcf61.yml
+++ b/data/ma/executive/Andrea-Campbell-4e8f36fb-9017-4a35-a692-7f09958dcf61.yml
@@ -1,0 +1,21 @@
+id: ocd-person/4e8f36fb-9017-4a35-a692-7f09958dcf61
+name: Andrea Joy Campbell
+given_name: Andrea
+family_name: Campbell
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-MA-Campbell.png
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-04'
+  end_date: '2027-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ma/government
+offices:
+- classification: capitol
+  voice: 617-727-2200
+links:
+- url: https://www.mass.gov/orgs/office-of-the-attorney-general
+sources:
+- url: https://www.mass.gov/person/andrea-joy-campbell-attorney-general
+- url: https://ballotpedia.org/Andrea_Joy_Campbell
+- url: https://www.naag.org/attorney-general/andrea-campbell/

--- a/data/ma/executive/Kim-Driscoll-0587c400-b81a-4ced-b560-a4009519076a.yml
+++ b/data/ma/executive/Kim-Driscoll-0587c400-b81a-4ced-b560-a4009519076a.yml
@@ -1,0 +1,20 @@
+id: ocd-person/0587c400-b81a-4ced-b560-a4009519076a
+name: Kim Driscoll
+given_name: Kim
+family_name: Driscoll
+image: https://www.mass.gov/files/2023-01/PRINTFINAL-Shopper-Kim_Driscoll_91R_1.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-05'
+  end_date: '2027-01-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ma/government
+offices:
+- classification: capitol
+  voice: 617-725-4005
+links:
+- url: https://www.mass.gov/person/kim-driscoll-lieutenant-governor
+sources:
+- url: https://www.mass.gov/person/kim-driscoll-lieutenant-governor
+- url: https://ballotpedia.org/Kim_Driscoll

--- a/data/md/executive/Anthony-Brown-1ad81709-e1d6-42bd-86bc-afdec934288c.yml
+++ b/data/md/executive/Anthony-Brown-1ad81709-e1d6-42bd-86bc-afdec934288c.yml
@@ -1,0 +1,22 @@
+id: ocd-person/1ad81709-e1d6-42bd-86bc-afdec934288c
+name: Anthony G. Brown
+given_name: Anthony
+family_name: Brown
+image: https://oag.maryland.gov/our-office/PublishingImages/AttorneyGeneral.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-03'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:md/government
+offices:
+- classification: capitol
+  address: 200 St. Paul Place; Baltimore, MD 21202
+  voice: 410-576-6300
+links:
+- url: https://oag.maryland.gov/
+sources:
+- url: https://oag.maryland.gov/Pages/oag.aspx
+- url: https://ballotpedia.org/Anthony_Brown_(Maryland)
+- url: https://www.naag.org/attorney-general/anthony-brown/

--- a/data/md/executive/Aruna-Miller-27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1.yml
+++ b/data/md/executive/Aruna-Miller-27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1.yml
@@ -1,0 +1,22 @@
+id: ocd-person/27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1
+name: Aruna Miller
+given_name: Aruna
+family_name: Miller
+image: https://governor.maryland.gov/leadership/ltgovernor/PublishingImages/Pages/biography/Lt.%20Governor%20Aruna%20K.%20Miller.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-18'
+  end_date: '2027-01-20'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:md/government
+offices:
+- classification: capitol
+  address: 100 State Circle; Annapolis, MD 21401-1925
+  voice: 410-974-3901
+links:
+- url: https://governor.maryland.gov/leadership/ltgovernor/Pages/default.aspx
+sources:
+- url: https://governor.maryland.gov/leadership/ltgovernor/Pages/biography.aspx
+- url: https://governor.maryland.gov/leadership/ltgovernor/contact-us/Pages/default.aspx
+- url: https://ballotpedia.org/Aruna_Miller

--- a/data/me/executive/Aaron-Frey-530fa17b-8a45-4d39-adb1-e9492081a761.yml
+++ b/data/me/executive/Aaron-Frey-530fa17b-8a45-4d39-adb1-e9492081a761.yml
@@ -1,0 +1,22 @@
+id: ocd-person/530fa17b-8a45-4d39-adb1-e9492081a761
+name: Aaron Frey
+given_name: Aaron
+family_name: Frey
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-ME-Frey-Aaron-2025.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-05'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:me/government
+offices:
+- classification: capitol
+  address: State House Station 6; Augusta, ME 04333
+  voice: 207-626-8800
+links:
+- url: https://www.maine.gov/ag/
+sources:
+- url: https://www.maine.gov/ag/about/message.shtml
+- url: https://ballotpedia.org/Aaron_Frey
+- url: https://www.naag.org/attorney-general/aaron-frey/


### PR DESCRIPTION
## Summary

- **Kim Driscoll** (Lt Governor) — reuses existing OCD ID from `ma/retired/` (`0587c400-b81a-4ced-b560-a4009519076a`)
- **Andrea Joy Campbell** (Attorney General) — new UUID generated

## Sources

All data sourced from official .gov websites, Ballotpedia, and NAAG.