### PR TITLE
WY: add attorney general

### DIFF
--- a/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
+++ b/data/ak/executive/Nancy-Dahlstrom-6b940121-937e-47ba-916a-626b67fe54f4.yml
@@ -7,6 +7,10 @@ image: https://ltgov.alaska.gov/wp-content/uploads/Screenshot-2022-12-14-150552-
 party:
 - name: Republican
 roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
 - end_date: '2026-12-07'
   type: chief election officer
   jurisdiction: ocd-jurisdiction/country:us/state:ak/government
@@ -23,3 +27,4 @@ ids:
 sources:
 - url: https://ltgov.alaska.gov/email-the-lt-governor/
 - url: https://www.nass.org/memberships/secretaries-statelieutenant-governors
+- url: https://ballotpedia.org/Nancy_Dahlstrom

--- a/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
+++ b/data/ak/executive/Stephen-Cox-671acdf5-e1ec-4259-ba3d-19d1df9a146e.yml
@@ -1,0 +1,23 @@
+id: ocd-person/671acdf5-e1ec-4259-ba3d-19d1df9a146e
+name: Stephen Cox
+given_name: Stephen
+family_name: Cox
+email: attorney.general@alaska.gov
+image: https://law.alaska.gov/img/headshot_CoxLG2601.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-08-29'
+  end_date: '2026-12-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ak/government
+offices:
+- classification: capitol
+  address: 1031 West 4th Avenue, Suite 200; Anchorage, AK 99501-1994
+  voice: 907-269-5100
+  fax: 907-276-3697
+links:
+- url: https://law.alaska.gov/
+sources:
+- url: https://law.alaska.gov/
+- url: https://ballotpedia.org/Stephen_Cox

--- a/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
+++ b/data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml
@@ -1,0 +1,21 @@
+id: ocd-person/3636b6ed-56b0-44bb-97b8-dee266b6d9c8
+name: Steve Marshall
+given_name: Steve
+family_name: Marshall
+image: https://live-al-ago.pantheonsite.io/wp-content/uploads/2023/04/Steve-Marshall-headshot-283x300.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2017-02-10'
+  end_date: '2027-01-18'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 501 Washington Avenue; Montgomery, AL 36104
+  voice: 334-242-7335
+links:
+- url: https://www.alabamaag.gov/
+sources:
+- url: https://www.alabamaag.gov/about/
+- url: https://ballotpedia.org/Steve_Marshall

--- a/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
+++ b/data/al/executive/Will-Ainsworth-cb01dcb8-b382-48af-a781-d4019eb3dfa6.yml
@@ -1,0 +1,21 @@
+id: ocd-person/cb01dcb8-b382-48af-a781-d4019eb3dfa6
+name: Will Ainsworth
+given_name: Will
+family_name: Ainsworth
+image: https://ltgov.alabama.gov/wp-content/uploads/2019/03/LtGov-Will-Ainsworth.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-18'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:al/government
+offices:
+- classification: capitol
+  address: 11 S Union Street; Montgomery, AL 36130
+  voice: 334-261-9590
+links:
+- url: https://ltgov.alabama.gov/
+sources:
+- url: https://ltgov.alabama.gov/
+- url: https://ballotpedia.org/Will_Ainsworth

--- a/data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml
+++ b/data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml
@@ -1,0 +1,22 @@
+id: ocd-person/29e6b6e2-82fc-48f8-9177-96b1ec30a2a6
+name: Leslie Rutledge
+given_name: Leslie
+family_name: Rutledge
+image: https://ltgovernor.arkansas.gov/wp-content/uploads/LR-photo.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-10'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ar/government
+offices:
+- classification: capitol
+  address: State Capitol, Suite 270; Little Rock, AR 72201-1061
+  voice: 501-682-2144
+  fax: 501-682-2894
+links:
+- url: https://www.ltgovernor.arkansas.gov/
+sources:
+- url: https://www.ltgovernor.arkansas.gov/
+- url: https://ballotpedia.org/Leslie_Rutledge

--- a/data/ar/executive/Tim-Griffin-99f67d4f-c181-46a8-b7a9-4b45ada32c50.yml
+++ b/data/ar/executive/Tim-Griffin-99f67d4f-c181-46a8-b7a9-4b45ada32c50.yml
@@ -1,0 +1,23 @@
+id: ocd-person/99f67d4f-c181-46a8-b7a9-4b45ada32c50
+name: Tim Griffin
+given_name: Tim
+family_name: Griffin
+email: oag@arkansasag.gov
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-AG-Griffin-1.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-10'
+  end_date: '2027-01-12'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ar/government
+offices:
+- classification: capitol
+  address: 101 West Capitol Avenue; Little Rock, AR 72201
+  voice: 501-682-2007
+links:
+- url: https://arkansasag.gov/
+sources:
+- url: https://arkansasag.gov/meet-tim/
+- url: https://ballotpedia.org/Tim_Griffin_(Arkansas)
+- url: https://www.naag.org/attorney-general/tim-griffin/

--- a/data/az/executive/Kris-Mayes-a94ae259-7b2d-4756-9c9b-d9fc778e6c1f.yml
+++ b/data/az/executive/Kris-Mayes-a94ae259-7b2d-4756-9c9b-d9fc778e6c1f.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a94ae259-7b2d-4756-9c9b-d9fc778e6c1f
+name: Kris Mayes
+given_name: Kris
+family_name: Mayes
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-AZ-Mayes.png
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:az/government
+offices:
+- classification: capitol
+  address: 2005 N Central Ave; Phoenix, AZ 85004
+  voice: 602-542-5025
+links:
+- url: https://www.azag.gov/
+sources:
+- url: https://www.azag.gov/
+- url: https://ballotpedia.org/Kris_Mayes
+- url: https://www.naag.org/attorney-general/kris-mayes/

--- a/data/ca/executive/Eleni-Kounalakis-113aeeca-7bac-4407-8ec3-bceab97680e5.yml
+++ b/data/ca/executive/Eleni-Kounalakis-113aeeca-7bac-4407-8ec3-bceab97680e5.yml
@@ -1,0 +1,22 @@
+id: ocd-person/113aeeca-7bac-4407-8ec3-bceab97680e5
+name: Eleni Kounalakis
+given_name: Eleni
+family_name: Kounalakis
+image: https://upload.wikimedia.org/wikipedia/commons/4/41/Ambassador_Eleni_Kounalakis.jpeg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/government
+offices:
+- classification: capitol
+  address: 1021 O Street, Suite 8730; Sacramento, CA 95814
+  voice: 916-445-8994
+links:
+- url: https://ltg.ca.gov/
+sources:
+- url: https://ltg.ca.gov/
+- url: https://ballotpedia.org/Eleni_Kounalakis
+- url: https://commons.wikimedia.org/wiki/File:Ambassador_Eleni_Kounalakis.jpeg

--- a/data/ca/executive/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
+++ b/data/ca/executive/Rob-Bonta-1529b892-b3da-4958-bb3a-5bf04d7b5e0c.yml
@@ -1,0 +1,23 @@
+id: ocd-person/1529b892-b3da-4958-bb3a-5bf04d7b5e0c
+name: Rob Bonta
+given_name: Rob
+family_name: Bonta
+image: https://www.naag.org/wp-content/uploads/2021/04/ag-CA-Bonta.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2021-04-23'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ca/government
+offices:
+- classification: capitol
+  address: P.O. Box 944255; Sacramento, CA 94244-2550
+  voice: 916-210-6276
+  fax: 916-323-5341
+links:
+- url: https://oag.ca.gov/
+sources:
+- url: https://oag.ca.gov/contact
+- url: https://ballotpedia.org/Rob_Bonta
+- url: https://www.naag.org/attorney-general/rob-bonta/

--- a/data/co/executive/Dianne-Primavera-21632200-6ff5-4b76-9c2e-190d8804ac16.yml
+++ b/data/co/executive/Dianne-Primavera-21632200-6ff5-4b76-9c2e-190d8804ac16.yml
@@ -1,0 +1,22 @@
+id: ocd-person/21632200-6ff5-4b76-9c2e-190d8804ac16
+name: Dianne Primavera
+given_name: Dianne
+family_name: Primavera
+image: https://ltgovernor.colorado.gov/sites/ltgovernor/files/styles/large/public/2019-07/diannep.jpg
+email: gov_dianne.primavera@state.co.us
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+offices:
+- classification: capitol
+  address: State Capitol Building, 200 E. Colfax Ave., Rm. 130; Denver, CO 80203
+  voice: 303-866-4075
+links:
+- url: https://ltgovernor.colorado.gov/
+sources:
+- url: https://ltgovernor.colorado.gov/
+- url: https://ballotpedia.org/Dianne_Primavera

--- a/data/co/executive/Phil-Weiser-fb02dd97-db94-4350-841f-e5adb9065c0c.yml
+++ b/data/co/executive/Phil-Weiser-fb02dd97-db94-4350-841f-e5adb9065c0c.yml
@@ -1,0 +1,22 @@
+id: ocd-person/fb02dd97-db94-4350-841f-e5adb9065c0c
+name: Phil Weiser
+given_name: Phil
+family_name: Weiser
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-CO-weiser.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-12'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:co/government
+offices:
+- classification: capitol
+  address: Ralph L. Carr Judicial Building, 1300 Broadway, 10th Floor; Denver, CO 80203
+  voice: 720-508-6000
+links:
+- url: https://coag.gov/
+sources:
+- url: https://coag.gov/about-us/attorney-general-phil-weiser/
+- url: https://ballotpedia.org/Phil_Weiser
+- url: https://www.naag.org/attorney-general/phil-weiser/

--- a/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
+++ b/data/ct/executive/Susan-Bysiewicz-e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3.yml
@@ -1,0 +1,20 @@
+id: ocd-person/e5e49f6f-a9d8-4f9c-b235-53f7f571c3e3
+name: Susan Bysiewicz
+given_name: Susan
+family_name: Bysiewicz
+image: https://portal.ct.gov/lt-governor/-/media/otlg/02-site-images/official-portraits-of-the-lt-governor/about-lt-governor-susan-bysiewicz.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: State Capitol, 210 Capitol Avenue, Room 304; Hartford, CT 06106
+links:
+- url: https://portal.ct.gov/lt-governor
+sources:
+- url: https://portal.ct.gov/lt-governor
+- url: https://ballotpedia.org/Susan_Bysiewicz

--- a/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
+++ b/data/ct/executive/William-Tong-4e747abf-37ad-41ba-aba5-064e420d2cc8.yml
@@ -1,0 +1,23 @@
+id: ocd-person/4e747abf-37ad-41ba-aba5-064e420d2cc8
+name: William Tong
+given_name: William
+family_name: Tong
+image: https://portal.ct.gov/-/media/ag/about-the-ag/agtong-headshot.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ct/government
+offices:
+- classification: capitol
+  address: 165 Capitol Avenue; Hartford, CT 06106
+  voice: 860-808-5318
+  fax: 860-808-5387
+links:
+- url: https://portal.ct.gov/ag
+sources:
+- url: https://portal.ct.gov/AG/About-the-AG/William-Tong-Biography-page
+- url: https://ballotpedia.org/William_Tong
+- url: https://www.naag.org/attorney-general/william-tong/

--- a/data/de/executive/Kathy-Jennings-d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d.yml
+++ b/data/de/executive/Kathy-Jennings-d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d.yml
@@ -1,0 +1,25 @@
+id: ocd-person/d1ed8b9a-53e1-4cd6-b1b2-ef6632fbde5d
+name: Kathy Jennings
+given_name: Kathy
+family_name: Jennings
+email: attorney.general@delaware.gov
+image: https://attorneygeneral.delaware.gov/wp-content/themes/dosgic_AG_theme/img/ag-jennings-bio-photo.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-05'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:de/government
+offices:
+- classification: capitol
+  address: Carvel State Building, 820 N. French St.; Wilmington, DE 19801
+  voice: 302-577-8400
+  fax: 302-577-6630
+links:
+- url: https://attorneygeneral.delaware.gov/
+sources:
+- url: https://attorneygeneral.delaware.gov/about/
+- url: https://attorneygeneral.delaware.gov/contact/
+- url: https://ballotpedia.org/Kathy_Jennings
+- url: https://www.naag.org/attorney-general/kathy-jennings/

--- a/data/de/executive/Kyle-Evans-Gay-96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036.yml
+++ b/data/de/executive/Kyle-Evans-Gay-96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036.yml
@@ -1,0 +1,21 @@
+id: ocd-person/96f29b7f-bd5a-4a83-8ed0-7a5c6d3c6036
+name: Kyle Evans Gay
+given_name: Kyle
+family_name: Gay
+image: https://ltgov.delaware.gov/wp-content/uploads/sites/222/2024/12/kyle-evans-gay-hero-landscape.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-21'
+  end_date: '2029-01-16'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:de/government
+offices:
+- classification: capitol
+  address: 150 Martin Luther King Jr Blvd South, 3rd Floor; Dover, DE 19901
+  voice: 302-744-4333
+links:
+- url: https://ltgov.delaware.gov/
+sources:
+- url: https://ltgov.delaware.gov/
+- url: https://ballotpedia.org/Kyle_Evans_Gay

--- a/data/fl/executive/James-Uthmeier-669df589-03af-4b3a-9588-d95ab977e171.yml
+++ b/data/fl/executive/James-Uthmeier-669df589-03af-4b3a-9588-d95ab977e171.yml
@@ -1,0 +1,22 @@
+id: ocd-person/669df589-03af-4b3a-9588-d95ab977e171
+name: James Uthmeier
+given_name: James
+family_name: Uthmeier
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-FL-Uthmeier-James.png
+party:
+- name: Republican
+roles:
+- start_date: '2025-02-17'
+  end_date: '2029-01-02'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+offices:
+- classification: capitol
+  address: The Capitol, PL 01; Tallahassee, FL 32399-1050
+  voice: 850-414-3300
+links:
+- url: https://myfloridalegal.com/
+sources:
+- url: https://myfloridalegal.com/
+- url: https://ballotpedia.org/James_Uthmeier
+- url: https://www.naag.org/attorney-general/james-uthmeier/

--- a/data/fl/executive/Jay-Collins-34dac893-eae3-495e-9237-9689a1114895.yml
+++ b/data/fl/executive/Jay-Collins-34dac893-eae3-495e-9237-9689a1114895.yml
@@ -1,0 +1,21 @@
+id: ocd-person/34dac893-eae3-495e-9237-9689a1114895
+name: Jay Collins
+given_name: Jay
+family_name: Collins
+image: https://upload.wikimedia.org/wikipedia/commons/6/65/Official_portrait_of_Lieutenant_Governor_of_Florida_Jay_Collins.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-08-12'
+  end_date: '2027-01-05'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:fl/government
+offices:
+- classification: capitol
+  address: 400 S Monroe St; Tallahassee, FL 32399
+links:
+- url: https://www.flgov.com/lt-governor/
+sources:
+- url: https://www.flgov.com/eog/leadership/people/jay-collins
+- url: https://ballotpedia.org/Jay_Collins
+- url: https://commons.wikimedia.org/wiki/File:Official_portrait_of_Lieutenant_Governor_of_Florida_Jay_Collins.jpg

--- a/data/ga/executive/Burt-Jones-ddfab174-3a42-42c0-946e-0ce3169c4d1b.yml
+++ b/data/ga/executive/Burt-Jones-ddfab174-3a42-42c0-946e-0ce3169c4d1b.yml
@@ -1,0 +1,21 @@
+id: ocd-person/ddfab174-3a42-42c0-946e-0ce3169c4d1b
+name: Burt Jones
+given_name: Burt
+family_name: Jones
+image: https://ltgov.georgia.gov/sites/ltgov.georgia.gov/files/styles/4_3_720px_x_540px_/public/2022-12/burt-jones.jpeg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-09'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+offices:
+- classification: capitol
+  address: 240 State Capitol; Atlanta, GA 30334
+  voice: 404-656-5030
+links:
+- url: https://ltgov.georgia.gov/
+sources:
+- url: https://ltgov.georgia.gov/
+- url: https://ballotpedia.org/Burt_Jones

--- a/data/ga/executive/Chris-Carr-57002bfc-2ba0-48cd-85d4-94673c5bf75a.yml
+++ b/data/ga/executive/Chris-Carr-57002bfc-2ba0-48cd-85d4-94673c5bf75a.yml
@@ -1,0 +1,21 @@
+id: ocd-person/57002bfc-2ba0-48cd-85d4-94673c5bf75a
+name: Chris Carr
+given_name: Chris
+family_name: Carr
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-GA-Carr1.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2016-11-01'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+offices:
+- classification: capitol
+  address: 40 Capitol Square, SW; Atlanta, GA 30334-1300
+  voice: 404-656-3300
+links:
+- url: https://law.georgia.gov/
+sources:
+- url: https://ballotpedia.org/Chris_Carr_(Georgia)
+- url: https://www.naag.org/attorney-general/chris-carr/

--- a/data/hi/executive/Anne-Lopez-8145b3ac-aaee-43d1-a534-d51d5e80f178.yml
+++ b/data/hi/executive/Anne-Lopez-8145b3ac-aaee-43d1-a534-d51d5e80f178.yml
@@ -1,0 +1,23 @@
+id: ocd-person/8145b3ac-aaee-43d1-a534-d51d5e80f178
+name: Anne Lopez
+given_name: Anne
+family_name: Lopez
+image: https://www.naag.org/wp-content/uploads/2023/01/ag-HI-Lopez-2024.jpg
+party:
+- name: Nonpartisan
+roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:hi/government
+offices:
+- classification: capitol
+  address: 425 Queen Street; Honolulu, HI 96813
+  voice: 808-586-1500
+  fax: 808-586-1239
+links:
+- url: https://ag.hawaii.gov/
+sources:
+- url: https://ag.hawaii.gov/contact-us/
+- url: https://ballotpedia.org/Anne_Lopez
+- url: https://www.naag.org/attorney-general/anne-lopez/

--- a/data/hi/executive/Sylvia-Luke-f3a50da6-6c22-4c5a-ba48-d10ee2188333.yml
+++ b/data/hi/executive/Sylvia-Luke-f3a50da6-6c22-4c5a-ba48-d10ee2188333.yml
@@ -1,0 +1,21 @@
+id: ocd-person/f3a50da6-6c22-4c5a-ba48-d10ee2188333
+name: Sylvia Luke
+given_name: Sylvia
+family_name: Luke
+image: https://ltgov.hawaii.gov/wp-content/uploads/2025/06/LG-Sylvia-Luke-2025-by-Russell-Tanoue-2-cropped-683x1024.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2022-12-05'
+  end_date: '2026-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:hi/government
+offices:
+- classification: capitol
+  address: State Capitol; Honolulu, HI 96813
+  voice: 808-586-0255
+links:
+- url: https://ltgov.hawaii.gov/
+sources:
+- url: https://ltgov.hawaii.gov/
+- url: https://ballotpedia.org/Sylvia_Luke

--- a/data/ia/executive/Brenna-Bird-fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6.yml
+++ b/data/ia/executive/Brenna-Bird-fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6.yml
@@ -1,0 +1,21 @@
+id: ocd-person/fcb94ca1-9a57-4378-9568-ecbe6c3ae0d6
+name: Brenna Bird
+given_name: Brenna
+family_name: Bird
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-IA-Bird.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ia/government
+offices:
+- classification: capitol
+  address: Hoover State Office Bldg., 1305 E. Walnut; Des Moines, IA 50319
+links:
+- url: https://www.iowaattorneygeneral.gov/
+sources:
+- url: https://www.iowaattorneygeneral.gov/about-us/about-attorney-general-brenna-bird
+- url: https://ballotpedia.org/Brenna_Bird
+- url: https://www.naag.org/attorney-general/brenna-bird/

--- a/data/ia/executive/Chris-Cournoyer-a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f.yml
+++ b/data/ia/executive/Chris-Cournoyer-a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a32d2cef-0ce9-4a2d-bbf6-8c8a53eaad4f
+name: Chris Cournoyer
+given_name: Chris
+family_name: Cournoyer
+image: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Iowa_State_Senator_Chris_Cournoyer.jpg/250px-Iowa_State_Senator_Chris_Cournoyer.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2024-12-16'
+  end_date: '2027-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ia/government
+offices:
+- classification: capitol
+  address: 1007 East Grand Avenue; Des Moines, IA 50319
+  voice: 515-281-5211
+links:
+- url: https://governor.iowa.gov/meet-governor-kim-reynolds/meet-lieutenant-governor-chris-cournoyer
+sources:
+- url: https://governor.iowa.gov/meet-governor-kim-reynolds/meet-lieutenant-governor-chris-cournoyer
+- url: https://ballotpedia.org/Chris_Cournoyer
+- url: https://commons.wikimedia.org/wiki/File:Iowa_State_Senator_Chris_Cournoyer.jpg

--- a/data/id/executive/Raul-Labrador-a6d731ea-af56-43f8-ba93-124774ae97c4.yml
+++ b/data/id/executive/Raul-Labrador-a6d731ea-af56-43f8-ba93-124774ae97c4.yml
@@ -1,0 +1,23 @@
+id: ocd-person/a6d731ea-af56-43f8-ba93-124774ae97c4
+name: Raúl Labrador
+given_name: Raúl
+family_name: Labrador
+image: https://www.ag.idaho.gov/content/uploads/2025/07/320A4720.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:id/government
+offices:
+- classification: capitol
+  address: 700 W. Jefferson Street, Suite 210; Boise, ID 83720-0010
+  voice: 208-334-2400
+  fax: 208-854-8071
+links:
+- url: https://www.ag.idaho.gov/
+sources:
+- url: https://www.ag.idaho.gov/about/
+- url: https://ballotpedia.org/Ra%C3%BAl_Labrador
+- url: https://www.naag.org/attorney-general/raul-labrador/

--- a/data/id/executive/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
+++ b/data/id/executive/Scott-Bedke-8f948dc8-8e7a-4a63-8fa8-b65efa9236f8.yml
@@ -1,0 +1,23 @@
+id: ocd-person/8f948dc8-8e7a-4a63-8fa8-b65efa9236f8
+name: Scott Bedke
+given_name: Scott
+family_name: Bedke
+email: contact@lgo.idaho.gov
+image: https://lgo.idaho.gov/wp-content/uploads/2026/02/Bedke.head_.shot_.2025.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:id/government
+offices:
+- classification: capitol
+  address: State Capitol Building, 700 W. Jefferson Street; Boise, ID 83702-0057
+  voice: 208-334-2200
+  fax: 208-334-3259
+links:
+- url: https://lgo.idaho.gov/
+sources:
+- url: https://lgo.idaho.gov/about/
+- url: https://ballotpedia.org/Scott_Bedke

--- a/data/il/executive/Juliana-Stratton-c8b35f07-1a0b-4019-b476-9fa032494c5e.yml
+++ b/data/il/executive/Juliana-Stratton-c8b35f07-1a0b-4019-b476-9fa032494c5e.yml
@@ -1,0 +1,23 @@
+id: ocd-person/c8b35f07-1a0b-4019-b476-9fa032494c5e
+name: Juliana Stratton
+given_name: Juliana
+family_name: Stratton
+email: LtGovStratton@illinois.gov
+image: https://s7d1.scene7.com/is/image/isp/lg-web-about-portrait-smaller
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+offices:
+- classification: capitol
+  address: 214 State House; Springfield, IL 62706
+  voice: 217-558-3085
+  fax: 217-558-3086
+links:
+- url: https://ltgov.illinois.gov/
+sources:
+- url: https://ltgov.illinois.gov/contact-us.html
+- url: https://ballotpedia.org/Juliana_Stratton

--- a/data/il/executive/Kwame-Raoul-65ee6848-68bd-430d-890c-a121fb6e8577.yml
+++ b/data/il/executive/Kwame-Raoul-65ee6848-68bd-430d-890c-a121fb6e8577.yml
@@ -1,0 +1,22 @@
+id: ocd-person/65ee6848-68bd-430d-890c-a121fb6e8577
+name: Kwame Raoul
+given_name: Kwame
+family_name: Raoul
+image: https://illinoisattorneygeneral.gov/images/AG_BioPhoto.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-15'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+offices:
+- classification: capitol
+  address: 500 S. 2nd St.; Springfield, IL 62701
+  voice: 217-782-1090
+links:
+- url: https://illinoisattorneygeneral.gov/
+sources:
+- url: https://illinoisattorneygeneral.gov/about/biography/
+- url: https://ballotpedia.org/Kwame_Raoul
+- url: https://www.naag.org/attorney-general/kwame-raoul/

--- a/data/in/executive/Micah-Beckwith-f3361ebb-630c-4160-9f66-68c7c9eb7419.yml
+++ b/data/in/executive/Micah-Beckwith-f3361ebb-630c-4160-9f66-68c7c9eb7419.yml
@@ -1,0 +1,17 @@
+id: ocd-person/f3361ebb-630c-4160-9f66-68c7c9eb7419
+name: Micah Beckwith
+given_name: Micah
+family_name: Beckwith
+image: https://www.in.gov/lg/images/LG-Headshot-26.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-08'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+links:
+- url: https://www.in.gov/lg/
+sources:
+- url: https://www.in.gov/lg/about-the-office/biography/
+- url: https://ballotpedia.org/Micah_Beckwith

--- a/data/in/executive/Todd-Rokita-b2cb0fa8-b426-4c50-94d8-dedd948175cd.yml
+++ b/data/in/executive/Todd-Rokita-b2cb0fa8-b426-4c50-94d8-dedd948175cd.yml
@@ -1,0 +1,23 @@
+id: ocd-person/b2cb0fa8-b426-4c50-94d8-dedd948175cd
+name: Todd Rokita
+given_name: Todd
+family_name: Rokita
+image: https://www.naag.org/wp-content/uploads/2021/02/ag-IN-Rokita.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2021-01-11'
+  end_date: '2029-01-08'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:in/government
+offices:
+- classification: capitol
+  address: 302 W. Washington St., 5th Floor; Indianapolis, IN 46204
+  voice: 317-232-6201
+  fax: 317-232-7979
+links:
+- url: https://www.in.gov/attorneygeneral/
+sources:
+- url: https://www.in.gov/attorneygeneral/contact-us/
+- url: https://ballotpedia.org/Todd_Rokita
+- url: https://www.naag.org/attorney-general/todd-rokita/

--- a/data/ks/executive/David-Toland-33e1e312-76c0-4d83-81d3-fa07768eab34.yml
+++ b/data/ks/executive/David-Toland-33e1e312-76c0-4d83-81d3-fa07768eab34.yml
@@ -1,0 +1,21 @@
+id: ocd-person/33e1e312-76c0-4d83-81d3-fa07768eab34
+name: David Toland
+given_name: David
+family_name: Toland
+image: https://www.governor.ks.gov/home/showpublishedimage/827/638816867442470000
+party:
+- name: Democratic
+roles:
+- start_date: '2021-01-04'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ks/government
+offices:
+- classification: capitol
+  address: Kansas Statehouse, 300 SW 10th Ave., Ste. 241S; Topeka, KS 66612-1590
+  voice: 785-296-3232
+links:
+- url: https://www.governor.ks.gov/about-the-office/lt-governor-david-toland
+sources:
+- url: https://www.governor.ks.gov/about-the-office/lt-governor-david-toland
+- url: https://ballotpedia.org/David_Toland

--- a/data/ks/executive/Kris-Kobach-10fdb8a1-6fed-43c9-a7ee-289b859b60ab.yml
+++ b/data/ks/executive/Kris-Kobach-10fdb8a1-6fed-43c9-a7ee-289b859b60ab.yml
@@ -1,0 +1,21 @@
+id: ocd-person/10fdb8a1-6fed-43c9-a7ee-289b859b60ab
+name: Kris Kobach
+given_name: Kris
+family_name: Kobach
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-KS-Kobach.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-09'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ks/government
+offices:
+- classification: capitol
+  address: 120 S.W. 10th Ave., 2nd Fl.; Topeka, KS 66612-1597
+  voice: 785-296-2215
+links:
+- url: https://www.ag.ks.gov/
+sources:
+- url: https://ballotpedia.org/Kris_Kobach
+- url: https://www.naag.org/attorney-general/kris-kobach/

--- a/data/ky/executive/Jacqueline-Coleman-9b07a848-b96c-4424-826a-5194b65e43d9.yml
+++ b/data/ky/executive/Jacqueline-Coleman-9b07a848-b96c-4424-826a-5194b65e43d9.yml
@@ -1,0 +1,22 @@
+id: ocd-person/9b07a848-b96c-4424-826a-5194b65e43d9
+name: Jacqueline Coleman
+given_name: Jacqueline
+family_name: Coleman
+image: https://governor.ky.gov/PublishingImages/Lt-Governor-Jacqueline-Coleman-Crop.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-12-10'
+  end_date: '2027-12-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ky/government
+offices:
+- classification: capitol
+  address: 501 High Street, 2nd Floor; Frankfort, KY 40602
+  voice: 502-564-2611
+  fax: 502-564-2517
+links:
+- url: https://governor.ky.gov/about/lt-governor-jacqueline-coleman
+sources:
+- url: https://governor.ky.gov/about/lt-governor-jacqueline-coleman
+- url: https://ballotpedia.org/Jacqueline_Coleman

--- a/data/ky/executive/Russell-Coleman-542cf596-f393-4fcf-b2d6-7439e7726328.yml
+++ b/data/ky/executive/Russell-Coleman-542cf596-f393-4fcf-b2d6-7439e7726328.yml
@@ -1,0 +1,23 @@
+id: ocd-person/542cf596-f393-4fcf-b2d6-7439e7726328
+name: Russell Coleman
+given_name: Russell
+family_name: Coleman
+image: https://www.ag.ky.gov/about/SiteAssets/Pages/Attorney-General/Russell-Coleman-400x500.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2024-01-01'
+  end_date: '2028-01-03'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ky/government
+offices:
+- classification: capitol
+  address: 1024 Capital Center Drive, Suite 200; Frankfort, KY 40601
+  voice: 502-696-5300
+  fax: 502-564-2894
+links:
+- url: https://www.ag.ky.gov/
+sources:
+- url: https://www.ag.ky.gov/about/Pages/Attorney-General.aspx
+- url: https://ballotpedia.org/Russell_Coleman
+- url: https://www.naag.org/attorney-general/russell-coleman/

--- a/data/la/executive/Billy-Nungesser-003d1e83-14f4-4bda-8484-c552e036f421.yml
+++ b/data/la/executive/Billy-Nungesser-003d1e83-14f4-4bda-8484-c552e036f421.yml
@@ -1,0 +1,23 @@
+id: ocd-person/003d1e83-14f4-4bda-8484-c552e036f421
+name: Billy Nungesser
+given_name: Billy
+family_name: Nungesser
+email: ltgov@crt.la.gov
+image: https://www.crt.state.la.us/Assets/LTG/nungesser.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2016-01-11'
+  end_date: '2028-01-10'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:la/government
+offices:
+- classification: capitol
+  address: Capitol Annex Building, 1051 North Third Street; Baton Rouge, LA 70802
+  voice: 225-342-7009
+  fax: 225-342-1949
+links:
+- url: https://www.crt.state.la.us/lt-governor/
+sources:
+- url: https://www.crt.state.la.us/lt-governor/contact/
+- url: https://ballotpedia.org/Billy_Nungesser

--- a/data/la/executive/Liz-Murrill-6beaac02-1e0d-4aee-96d3-9033f9f918e8.yml
+++ b/data/la/executive/Liz-Murrill-6beaac02-1e0d-4aee-96d3-9033f9f918e8.yml
@@ -1,0 +1,22 @@
+id: ocd-person/6beaac02-1e0d-4aee-96d3-9033f9f918e8
+name: Liz Murrill
+given_name: Liz
+family_name: Murrill
+image: https://www.naag.org/wp-content/uploads/2024/02/ag-LA-Murrill-Liz.png
+party:
+- name: Republican
+roles:
+- start_date: '2024-01-08'
+  end_date: '2028-01-10'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:la/government
+offices:
+- classification: capitol
+  address: 1885 North Third Street; Baton Rouge, LA 70802
+  voice: 225-326-6000
+links:
+- url: https://www.aglizmurrill.com/
+sources:
+- url: https://www.aglizmurrill.com/About
+- url: https://ballotpedia.org/Liz_Murrill
+- url: https://www.naag.org/attorney-general/liz-murrill/

--- a/data/ma/executive/Andrea-Campbell-4e8f36fb-9017-4a35-a692-7f09958dcf61.yml
+++ b/data/ma/executive/Andrea-Campbell-4e8f36fb-9017-4a35-a692-7f09958dcf61.yml
@@ -1,0 +1,21 @@
+id: ocd-person/4e8f36fb-9017-4a35-a692-7f09958dcf61
+name: Andrea Joy Campbell
+given_name: Andrea
+family_name: Campbell
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-MA-Campbell.png
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-04'
+  end_date: '2027-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ma/government
+offices:
+- classification: capitol
+  voice: 617-727-2200
+links:
+- url: https://www.mass.gov/orgs/office-of-the-attorney-general
+sources:
+- url: https://www.mass.gov/person/andrea-joy-campbell-attorney-general
+- url: https://ballotpedia.org/Andrea_Joy_Campbell
+- url: https://www.naag.org/attorney-general/andrea-campbell/

--- a/data/ma/executive/Kim-Driscoll-0587c400-b81a-4ced-b560-a4009519076a.yml
+++ b/data/ma/executive/Kim-Driscoll-0587c400-b81a-4ced-b560-a4009519076a.yml
@@ -1,0 +1,20 @@
+id: ocd-person/0587c400-b81a-4ced-b560-a4009519076a
+name: Kim Driscoll
+given_name: Kim
+family_name: Driscoll
+image: https://www.mass.gov/files/2023-01/PRINTFINAL-Shopper-Kim_Driscoll_91R_1.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-05'
+  end_date: '2027-01-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ma/government
+offices:
+- classification: capitol
+  voice: 617-725-4005
+links:
+- url: https://www.mass.gov/person/kim-driscoll-lieutenant-governor
+sources:
+- url: https://www.mass.gov/person/kim-driscoll-lieutenant-governor
+- url: https://ballotpedia.org/Kim_Driscoll

--- a/data/md/executive/Anthony-Brown-1ad81709-e1d6-42bd-86bc-afdec934288c.yml
+++ b/data/md/executive/Anthony-Brown-1ad81709-e1d6-42bd-86bc-afdec934288c.yml
@@ -1,0 +1,22 @@
+id: ocd-person/1ad81709-e1d6-42bd-86bc-afdec934288c
+name: Anthony G. Brown
+given_name: Anthony
+family_name: Brown
+image: https://oag.maryland.gov/our-office/PublishingImages/AttorneyGeneral.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-03'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:md/government
+offices:
+- classification: capitol
+  address: 200 St. Paul Place; Baltimore, MD 21202
+  voice: 410-576-6300
+links:
+- url: https://oag.maryland.gov/
+sources:
+- url: https://oag.maryland.gov/Pages/oag.aspx
+- url: https://ballotpedia.org/Anthony_Brown_(Maryland)
+- url: https://www.naag.org/attorney-general/anthony-brown/

--- a/data/md/executive/Aruna-Miller-27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1.yml
+++ b/data/md/executive/Aruna-Miller-27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1.yml
@@ -1,0 +1,22 @@
+id: ocd-person/27dd7c4f-0e25-4cd0-b849-6830e5ec7fa1
+name: Aruna Miller
+given_name: Aruna
+family_name: Miller
+image: https://governor.maryland.gov/leadership/ltgovernor/PublishingImages/Pages/biography/Lt.%20Governor%20Aruna%20K.%20Miller.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-18'
+  end_date: '2027-01-20'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:md/government
+offices:
+- classification: capitol
+  address: 100 State Circle; Annapolis, MD 21401-1925
+  voice: 410-974-3901
+links:
+- url: https://governor.maryland.gov/leadership/ltgovernor/Pages/default.aspx
+sources:
+- url: https://governor.maryland.gov/leadership/ltgovernor/Pages/biography.aspx
+- url: https://governor.maryland.gov/leadership/ltgovernor/contact-us/Pages/default.aspx
+- url: https://ballotpedia.org/Aruna_Miller

--- a/data/me/executive/Aaron-Frey-530fa17b-8a45-4d39-adb1-e9492081a761.yml
+++ b/data/me/executive/Aaron-Frey-530fa17b-8a45-4d39-adb1-e9492081a761.yml
@@ -1,0 +1,22 @@
+id: ocd-person/530fa17b-8a45-4d39-adb1-e9492081a761
+name: Aaron Frey
+given_name: Aaron
+family_name: Frey
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-ME-Frey-Aaron-2025.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-08'
+  end_date: '2027-01-05'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:me/government
+offices:
+- classification: capitol
+  address: State House Station 6; Augusta, ME 04333
+  voice: 207-626-8800
+links:
+- url: https://www.maine.gov/ag/
+sources:
+- url: https://www.maine.gov/ag/about/message.shtml
+- url: https://ballotpedia.org/Aaron_Frey
+- url: https://www.naag.org/attorney-general/aaron-frey/

--- a/data/mi/executive/Dana-Nessel-d45a5608-2735-4ef3-883b-0ebdabed89e0.yml
+++ b/data/mi/executive/Dana-Nessel-d45a5608-2735-4ef3-883b-0ebdabed89e0.yml
@@ -1,0 +1,21 @@
+id: ocd-person/d45a5608-2735-4ef3-883b-0ebdabed89e0
+name: Dana Nessel
+given_name: Dana
+family_name: Nessel
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-MI-nessel2.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:mi/government
+offices:
+- classification: capitol
+  address: 525 W. Ottawa St.; Lansing, MI 48909-0212
+  voice: 517-373-1110
+links:
+- url: https://www.michigan.gov/ag
+sources:
+- url: https://ballotpedia.org/Dana_Nessel
+- url: https://www.naag.org/attorney-general/dana-nessel/

--- a/data/mi/executive/Garlin-Gilchrist-e077b72e-8c9e-4506-a4b5-1fd83d6f6226.yml
+++ b/data/mi/executive/Garlin-Gilchrist-e077b72e-8c9e-4506-a4b5-1fd83d6f6226.yml
@@ -1,0 +1,21 @@
+id: ocd-person/e077b72e-8c9e-4506-a4b5-1fd83d6f6226
+name: Garlin Gilchrist II
+given_name: Garlin
+family_name: Gilchrist
+image: https://www.michigan.gov/whitmer/-/media/Project/Websites/Whitmer/Images/About/Lt-Governor-Bio/LtGovGilchrist2x.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:mi/government
+offices:
+- classification: capitol
+  address: P.O. Box 30013; Lansing, MI 48909
+  voice: 517-335-7858
+links:
+- url: https://www.michigan.gov/whitmer/ltgov
+sources:
+- url: https://www.michigan.gov/en/whitmer/ltgov
+- url: https://ballotpedia.org/Garlin_Gilchrist_II

--- a/data/mn/executive/Keith-Ellison-46deef0f-6af0-4cb8-b4ac-385aa505df50.yml
+++ b/data/mn/executive/Keith-Ellison-46deef0f-6af0-4cb8-b4ac-385aa505df50.yml
@@ -1,0 +1,22 @@
+id: ocd-person/46deef0f-6af0-4cb8-b4ac-385aa505df50
+name: Keith Ellison
+given_name: Keith
+family_name: Ellison
+image: https://www.ag.state.mn.us/Photos/Keith-Ellison.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:mn/government
+offices:
+- classification: capitol
+  address: Suite 102, State Capital, 75 Dr. Martin Luther King, Jr. Blvd.; Saint Paul, MN 55155
+  voice: 651-296-3353
+links:
+- url: https://www.ag.state.mn.us/
+sources:
+- url: https://www.ag.state.mn.us/Office/AGBio.asp
+- url: https://ballotpedia.org/Keith_Ellison_(Minnesota)
+- url: https://www.naag.org/attorney-general/keith-ellison/

--- a/data/mn/executive/Peggy-Flanagan-d563a09c-876b-4384-a7cc-a15f3d5d064c.yml
+++ b/data/mn/executive/Peggy-Flanagan-d563a09c-876b-4384-a7cc-a15f3d5d064c.yml
@@ -1,0 +1,21 @@
+id: ocd-person/d563a09c-876b-4384-a7cc-a15f3d5d064c
+name: Peggy Flanagan
+given_name: Peggy
+family_name: Flanagan
+image: https://mn.gov/governor/assets/flanagan-bio-thumbnail_tcm1055-653288.png
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:mn/government
+offices:
+- classification: capitol
+  address: 130 State Capitol, 75 Rev Dr. Martin Luther King Jr. Blvd.; St. Paul, MN 55155
+  voice: 651-201-3400
+links:
+- url: https://mn.gov/governor/about-gov/peggyflanagan/
+sources:
+- url: https://mn.gov/governor/about-gov/peggyflanagan/
+- url: https://ballotpedia.org/Peggy_Flanagan

--- a/data/mo/executive/Catherine-Hanaway-c2f94a50-d59c-4c56-abe6-2eebbce40a68.yml
+++ b/data/mo/executive/Catherine-Hanaway-c2f94a50-d59c-4c56-abe6-2eebbce40a68.yml
@@ -1,0 +1,22 @@
+id: ocd-person/c2f94a50-d59c-4c56-abe6-2eebbce40a68
+name: Catherine Hanaway
+given_name: Catherine
+family_name: Hanaway
+image: https://ago.mo.gov/wp-content/uploads/Hanaway-Headshot-230x300.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-09-08'
+  end_date: '2029-01-08'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:mo/government
+offices:
+- classification: capitol
+  address: Supreme Court Building, 207 W. High St.; Jefferson City, MO 65102
+  voice: 573-751-3321
+links:
+- url: https://ago.mo.gov/
+sources:
+- url: https://ago.mo.gov/
+- url: https://ballotpedia.org/Catherine_Hanaway
+- url: https://www.naag.org/attorney-general/catherine-hanaway/

--- a/data/mo/executive/David-Wasinger-43d8764b-a3b7-432a-8750-ae0e9165ecf9.yml
+++ b/data/mo/executive/David-Wasinger-43d8764b-a3b7-432a-8750-ae0e9165ecf9.yml
@@ -1,0 +1,22 @@
+id: ocd-person/43d8764b-a3b7-432a-8750-ae0e9165ecf9
+name: David Wasinger
+given_name: David
+family_name: Wasinger
+email: ltgovinfo@ltgov.mo.gov
+image: https://ltgov.mo.gov/wp-content/uploads/2025/06/cropped-Lt-Gov-photo-scaled-1.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-08'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:mo/government
+offices:
+- classification: capitol
+  address: State Capitol Building, Room 224; Jefferson City, MO 65101
+  voice: 573-751-4727
+links:
+- url: https://ltgov.mo.gov/
+sources:
+- url: https://ltgov.mo.gov/biography/
+- url: https://ballotpedia.org/David_Wasinger

--- a/data/ms/executive/Delbert-Hosemann-c735ee81-f40f-4c16-aa57-e7068d7df10e.yml
+++ b/data/ms/executive/Delbert-Hosemann-c735ee81-f40f-4c16-aa57-e7068d7df10e.yml
@@ -1,0 +1,21 @@
+id: ocd-person/c735ee81-f40f-4c16-aa57-e7068d7df10e
+name: Delbert Hosemann
+given_name: Delbert
+family_name: Hosemann
+email: ltgov@senate.ms.gov
+image: https://ltgovhosemann.ms.gov/wp-content/uploads/2024/10/CDH-Headshot-6.20.22-400x560.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2020-01-09'
+  end_date: '2028-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ms/government
+offices:
+- classification: capitol
+  voice: 601-359-3200
+links:
+- url: https://ltgovhosemann.ms.gov/
+sources:
+- url: https://ltgovhosemann.ms.gov/about-delbert/
+- url: https://ballotpedia.org/Delbert_Hosemann

--- a/data/ms/executive/Lynn-Fitch-3a1d28c1-dd21-40b8-9a79-159441a5c88a.yml
+++ b/data/ms/executive/Lynn-Fitch-3a1d28c1-dd21-40b8-9a79-159441a5c88a.yml
@@ -1,0 +1,22 @@
+id: ocd-person/3a1d28c1-dd21-40b8-9a79-159441a5c88a
+name: Lynn Fitch
+given_name: Lynn
+family_name: Fitch
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-MS-Fitch-2024.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2020-01-09'
+  end_date: '2028-01-06'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ms/government
+offices:
+- classification: capitol
+  address: P.O. Box 220; Jackson, MS 39205
+  voice: 601-359-3680
+links:
+- url: https://www.ago.state.ms.us/
+sources:
+- url: https://attorneygenerallynnfitch.com/about/
+- url: https://ballotpedia.org/Lynn_Fitch
+- url: https://www.naag.org/attorney-general/lynn-fitch/

--- a/data/mt/executive/Austin-Knudsen-6932f017-6867-409a-8321-6cf9dce312ef.yml
+++ b/data/mt/executive/Austin-Knudsen-6932f017-6867-409a-8321-6cf9dce312ef.yml
@@ -1,0 +1,22 @@
+id: ocd-person/6932f017-6867-409a-8321-6cf9dce312ef
+name: Austin Knudsen
+given_name: Austin
+family_name: Knudsen
+image: https://www.naag.org/wp-content/uploads/2021/02/ag-MT-Knudsen.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2021-01-04'
+  end_date: '2029-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:mt/government
+offices:
+- classification: capitol
+  address: Justice Bldg., 215 N. Sanders; Helena, MT 59620-1401
+  voice: 406-444-2026
+links:
+- url: https://dojmt.gov/
+sources:
+- url: https://dojmt.gov/attorney-generals-office/about-austin-knudsen/
+- url: https://ballotpedia.org/Austin_Knudsen
+- url: https://www.naag.org/attorney-general/austin-knudsen/

--- a/data/mt/executive/Kristen-Juras-f4a7fa52-2f69-40f9-b806-7cec241ab27d.yml
+++ b/data/mt/executive/Kristen-Juras-f4a7fa52-2f69-40f9-b806-7cec241ab27d.yml
@@ -1,0 +1,22 @@
+id: ocd-person/f4a7fa52-2f69-40f9-b806-7cec241ab27d
+name: Kristen Juras
+given_name: Kristen
+family_name: Juras
+image: https://governor.mt.gov/_images/portrait_juras.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2021-01-04'
+  end_date: '2029-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:mt/government
+offices:
+- classification: capitol
+  address: P.O. Box 200801; Helena, MT 59620-0801
+  voice: 406-444-3111
+  fax: 406-444-5529
+links:
+- url: https://governor.mt.gov/About/LieutenantGovernor
+sources:
+- url: https://governor.mt.gov/About/LieutenantGovernor
+- url: https://ballotpedia.org/Kristen_Juras

--- a/data/nc/executive/Jeff-Jackson-59ece42c-d325-427b-bd54-96b3625bc43d.yml
+++ b/data/nc/executive/Jeff-Jackson-59ece42c-d325-427b-bd54-96b3625bc43d.yml
@@ -1,0 +1,22 @@
+id: ocd-person/59ece42c-d325-427b-bd54-96b3625bc43d
+name: Jeff Jackson
+given_name: Jeff
+family_name: Jackson
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-NC-Jackson-Jeff-2025.png
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-01'
+  end_date: '2029-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nc/government
+offices:
+- classification: capitol
+  address: Dept. of Justice, P.O. Box 629; Raleigh, NC 27602-0629
+  voice: 919-716-6400
+links:
+- url: https://ncdoj.gov/
+sources:
+- url: https://ncdoj.gov/about-ncdoj/the-attorney-general/
+- url: https://ballotpedia.org/Jeff_Jackson
+- url: https://www.naag.org/attorney-general/jeff-jackson/

--- a/data/nc/executive/Rachel-Hunt-4c3a1120-2dd5-4fbe-a084-e64894e57163.yml
+++ b/data/nc/executive/Rachel-Hunt-4c3a1120-2dd5-4fbe-a084-e64894e57163.yml
@@ -1,0 +1,21 @@
+id: ocd-person/4c3a1120-2dd5-4fbe-a084-e64894e57163
+name: Rachel Hunt
+given_name: Rachel
+family_name: Hunt
+image: https://files.nc.gov/lt-governor/images/2025-02/LG_Headshot_final.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-01'
+  end_date: '2029-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:nc/government
+offices:
+- classification: capitol
+  address: 310 N. Blount Street; Raleigh, NC 27601
+  voice: 919-814-3680
+links:
+- url: https://ltgov.nc.gov/
+sources:
+- url: https://ltgov.nc.gov/
+- url: https://ballotpedia.org/Rachel_Hunt

--- a/data/nd/executive/Drew-Wrigley-b86dfdcd-93e3-40d8-929f-47f1c86813e3.yml
+++ b/data/nd/executive/Drew-Wrigley-b86dfdcd-93e3-40d8-929f-47f1c86813e3.yml
@@ -1,0 +1,22 @@
+id: ocd-person/b86dfdcd-93e3-40d8-929f-47f1c86813e3
+name: Drew Wrigley
+given_name: Drew
+family_name: Wrigley
+image: https://www.naag.org/wp-content/uploads/2022/02/ag-ND-Wrigley-Drew.png
+party:
+- name: Republican
+roles:
+- start_date: '2022-02-09'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nd/government
+offices:
+- classification: capitol
+  address: State Capitol, 600 E. Boulevard Ave.; Bismarck, ND 58505-0040
+  voice: 701-328-2210
+links:
+- url: https://attorneygeneral.nd.gov/
+sources:
+- url: https://attorneygeneral.nd.gov/attorney-generals-office/attorney-general-drew-h-wrigley
+- url: https://ballotpedia.org/Drew_Wrigley
+- url: https://www.naag.org/attorney-general/drew-wrigley/

--- a/data/nd/executive/Michelle-Strinden-a6e733ce-ccdc-425a-bb9b-9010a09c3933.yml
+++ b/data/nd/executive/Michelle-Strinden-a6e733ce-ccdc-425a-bb9b-9010a09c3933.yml
@@ -1,0 +1,21 @@
+id: ocd-person/a6e733ce-ccdc-425a-bb9b-9010a09c3933
+name: Michelle Strinden
+given_name: Michelle
+family_name: Strinden
+image: https://www.governor.nd.gov/sites/www/files/documents/portraits/LtGovMichelleStrinden.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2024-12-15'
+  end_date: '2028-12-15'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:nd/government
+offices:
+- classification: capitol
+  address: 600 East Boulevard Avenue; Bismarck, ND 58505-0100
+  voice: 701-328-2200
+links:
+- url: https://www.governor.nd.gov/lt-governor-michelle-strinden
+sources:
+- url: https://www.governor.nd.gov/lt-governor-michelle-strinden
+- url: https://ballotpedia.org/Michelle_Strinden

--- a/data/ne/executive/Joe-Kelly-74c5deca-9550-45e2-a5dc-c3386623edef.yml
+++ b/data/ne/executive/Joe-Kelly-74c5deca-9550-45e2-a5dc-c3386623edef.yml
@@ -1,0 +1,22 @@
+id: ocd-person/74c5deca-9550-45e2-a5dc-c3386623edef
+name: Joe Kelly
+given_name: Joe
+family_name: Kelly
+image: https://ltgov.nebraska.gov/sites/default/files/img/Lt%20Governor%20Kelly-1.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-05'
+  end_date: '2027-01-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ne/government
+offices:
+- classification: capitol
+  address: P.O. Box 94848; Lincoln, NE 68509-4848
+  voice: 402-471-2244
+  fax: 402-471-6031
+links:
+- url: https://ltgov.nebraska.gov/
+sources:
+- url: https://ltgov.nebraska.gov/about-lt-governor-joe-kelly
+- url: https://ballotpedia.org/Joe_Kelly_(Nebraska)

--- a/data/ne/executive/Mike-Hilgers-3eafc2ab-5448-40ac-9d5f-b317abdbc747.yml
+++ b/data/ne/executive/Mike-Hilgers-3eafc2ab-5448-40ac-9d5f-b317abdbc747.yml
@@ -1,0 +1,22 @@
+id: ocd-person/3eafc2ab-5448-40ac-9d5f-b317abdbc747
+name: Mike Hilgers
+given_name: Mike
+family_name: Hilgers
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-OK-Hilgers.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-05'
+  end_date: '2027-01-07'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ne/government
+offices:
+- classification: capitol
+  address: State Capitol, P.O. Box 98920; Lincoln, NE 68509-8920
+  voice: 402-471-2682
+links:
+- url: https://ago.nebraska.gov/
+sources:
+- url: https://ago.nebraska.gov/about
+- url: https://ballotpedia.org/Mike_Hilgers
+- url: https://www.naag.org/attorney-general/mike-hilgers/

--- a/data/nh/executive/John-Formella-f317bfaf-ded5-4ef7-88e3-02e675b20c17.yml
+++ b/data/nh/executive/John-Formella-f317bfaf-ded5-4ef7-88e3-02e675b20c17.yml
@@ -1,0 +1,21 @@
+id: ocd-person/f317bfaf-ded5-4ef7-88e3-02e675b20c17
+name: John Formella
+given_name: John
+family_name: Formella
+image: https://www.naag.org/wp-content/uploads/2021/04/ag-NH-Formella.png
+party:
+- name: Republican
+roles:
+- start_date: '2021-03-24'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nh/government
+offices:
+- classification: capitol
+  address: 1 Granite Place South; Concord, NH 03301
+  voice: 603-271-3658
+links:
+- url: https://www.doj.nh.gov/
+sources:
+- url: https://ballotpedia.org/John_Formella
+- url: https://www.naag.org/attorney-general/john-formella/
+- url: https://www.nhpr.org/nh-news/2025-03-25/ayotte-declines-to-renew-formellas-term-as-nh-attorney-general-for-now

--- a/data/nj/executive/Dale-Caldwell-45caac41-0f71-4243-99cc-bb18b7b82386.yml
+++ b/data/nj/executive/Dale-Caldwell-45caac41-0f71-4243-99cc-bb18b7b82386.yml
@@ -1,0 +1,20 @@
+id: ocd-person/45caac41-0f71-4243-99cc-bb18b7b82386
+name: Dale Caldwell
+given_name: Dale
+family_name: Caldwell
+image: https://www.nj.gov/governor/library/secondary/ltgov_LGDaleCaldwell_new.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2026-01-20'
+  end_date: '2030-01-15'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+offices:
+- classification: capitol
+  address: P.O. Box 001; Trenton, NJ 08625
+links:
+- url: https://www.nj.gov/governor/admin/ltgovernor/
+sources:
+- url: https://www.nj.gov/governor/admin/ltgovernor/
+- url: https://ballotpedia.org/Dale_Caldwell

--- a/data/nj/executive/Jennifer-Davenport-cf9793dd-4ef2-4db2-807c-4cf8fce4eecb.yml
+++ b/data/nj/executive/Jennifer-Davenport-cf9793dd-4ef2-4db2-807c-4cf8fce4eecb.yml
@@ -1,0 +1,21 @@
+id: ocd-person/cf9793dd-4ef2-4db2-807c-4cf8fce4eecb
+name: Jennifer Davenport
+given_name: Jennifer
+family_name: Davenport
+image: https://www.naag.org/wp-content/uploads/2026/01/ag-NJ-Davenport-Jennifer.png
+party:
+- name: Democratic
+roles:
+- start_date: '2026-02-24'
+  end_date: '2030-01-15'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nj/government
+offices:
+- classification: capitol
+  address: Richard J. Hughes Justice Complex, 25 Market Street, P.O. Box 080; Trenton, NJ 08625
+  voice: 609-292-8740
+links:
+- url: https://www.njoag.gov/
+sources:
+- url: https://ballotpedia.org/Jennifer_Davenport
+- url: https://www.naag.org/attorney-general/jennifer-davenport/

--- a/data/nm/executive/Howie-Morales-56e025c5-7367-4e17-98eb-d7a5cf0b5688.yml
+++ b/data/nm/executive/Howie-Morales-56e025c5-7367-4e17-98eb-d7a5cf0b5688.yml
@@ -1,0 +1,22 @@
+id: ocd-person/56e025c5-7367-4e17-98eb-d7a5cf0b5688
+name: Howie Morales
+given_name: Howie
+family_name: Morales
+image: https://www.lgo.nm.gov/wp-content/uploads/2019/08/lt-gov-howie-morales-headshot.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:nm/government
+offices:
+- classification: capitol
+  address: 490 Old Santa Fe Trail, Room 417; Santa Fe, NM 87501
+  voice: 505-476-2250
+links:
+- url: https://www.lgo.nm.gov/
+sources:
+- url: https://www.lgo.nm.gov/about-the-lt-governor/
+- url: https://www.lgo.nm.gov/contact-form-lt-gov/
+- url: https://ballotpedia.org/Howie_Morales

--- a/data/nm/executive/Raul-Torrez-d52c0e56-76f1-4b81-a62c-2a3dd7abcc4e.yml
+++ b/data/nm/executive/Raul-Torrez-d52c0e56-76f1-4b81-a62c-2a3dd7abcc4e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/d52c0e56-76f1-4b81-a62c-2a3dd7abcc4e
+name: Raúl Torrez
+given_name: Raúl
+family_name: Torrez
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-NM-Torrez.png
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-01'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nm/government
+offices:
+- classification: capitol
+  address: 408 Galisteo Street, Villagra Building; Santa Fe, NM 87501
+  voice: 505-490-4060
+links:
+- url: https://nmdoj.gov/
+sources:
+- url: https://nmdoj.gov/about-the-office/meet-the-attorney-general/
+- url: https://ballotpedia.org/Raul_Torrez
+- url: https://www.naag.org/attorney-general/raul-torrez/

--- a/data/nv/executive/Aaron-Ford-05db3ab9-9801-410f-9d35-2f184df77f8e.yml
+++ b/data/nv/executive/Aaron-Ford-05db3ab9-9801-410f-9d35-2f184df77f8e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/05db3ab9-9801-410f-9d35-2f184df77f8e
+name: Aaron Ford
+given_name: Aaron
+family_name: Ford
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-NV-ford2.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:nv/government
+offices:
+- classification: capitol
+  address: Old Supreme Ct. Bldg., 100 N. Carson St.; Carson City, NV 89701
+  voice: 775-684-1100
+links:
+- url: https://ag.nv.gov/
+sources:
+- url: https://ag.nv.gov/About/AG_Aaron_Ford/
+- url: https://ballotpedia.org/Aaron_Ford_(Nevada)
+- url: https://www.naag.org/attorney-general/aaron-ford/

--- a/data/nv/executive/Stavros-Anthony-e730bc7c-c97e-4428-8bc7-f1e9708cb878.yml
+++ b/data/nv/executive/Stavros-Anthony-e730bc7c-c97e-4428-8bc7-f1e9708cb878.yml
@@ -1,0 +1,22 @@
+id: ocd-person/e730bc7c-c97e-4428-8bc7-f1e9708cb878
+name: Stavros Anthony
+given_name: Stavros
+family_name: Anthony
+image: https://ltgov.nv.gov/uploadedImages/ltgov2022nvgov/content/AboutUs/Stavros%20New%20Headshot.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:nv/government
+offices:
+- classification: capitol
+  address: State Capitol Building, 101 N. Carson Street, Suite #2; Carson City, NV 89701
+  voice: 775-684-7111
+links:
+- url: https://ltgov.nv.gov/
+sources:
+- url: https://ltgov.nv.gov/AboutUs/BiographyStavrosAnthony/
+- url: https://ltgov.nv.gov/Contact/ContactUs/
+- url: https://ballotpedia.org/Stavros_S._Anthony

--- a/data/ny/executive/Antonio-Delgado-6a95f6b7-1eb0-439b-af25-c9b26d19de9e.yml
+++ b/data/ny/executive/Antonio-Delgado-6a95f6b7-1eb0-439b-af25-c9b26d19de9e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/6a95f6b7-1eb0-439b-af25-c9b26d19de9e
+name: Antonio Delgado
+given_name: Antonio
+family_name: Delgado
+email: LGNY@exec.ny.gov
+image: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/LG_Antonio_Delgado_Portrait.jpg/500px-LG_Antonio_Delgado_Portrait.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2022-05-25'
+  end_date: '2027-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ny/government
+offices:
+- classification: capitol
+  voice: 518-402-2292
+links:
+- url: https://www.governor.ny.gov/lt-governor-antonio-delgado
+sources:
+- url: https://www.governor.ny.gov/lt-governor-antonio-delgado
+- url: https://ballotpedia.org/Antonio_Delgado_(New_York)
+- url: https://commons.wikimedia.org/wiki/File:LG_Antonio_Delgado_Portrait.jpg

--- a/data/ny/executive/Letitia-James-a620faf8-81e3-490e-8d26-dbf84c707786.yml
+++ b/data/ny/executive/Letitia-James-a620faf8-81e3-490e-8d26-dbf84c707786.yml
@@ -1,0 +1,22 @@
+id: ocd-person/a620faf8-81e3-490e-8d26-dbf84c707786
+name: Letitia James
+given_name: Letitia
+family_name: James
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-NY-james2.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ny/government
+offices:
+- classification: capitol
+  address: Dept. of Law, The Capitol, 2nd fl.; Albany, NY 12224
+  voice: 518-776-2000
+links:
+- url: https://ag.ny.gov/
+sources:
+- url: https://ag.ny.gov/about/meet-letitia-james
+- url: https://ballotpedia.org/Letitia_James
+- url: https://www.naag.org/attorney-general/letitia-james/

--- a/data/oh/executive/Dave-Yost-b8ac5c3b-66e6-47f4-b8c2-1fd148a1f041.yml
+++ b/data/oh/executive/Dave-Yost-b8ac5c3b-66e6-47f4-b8c2-1fd148a1f041.yml
@@ -1,0 +1,22 @@
+id: ocd-person/b8ac5c3b-66e6-47f4-b8c2-1fd148a1f041
+name: Dave Yost
+given_name: Dave
+family_name: Yost
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-OH-yost.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:oh/government
+offices:
+- classification: capitol
+  address: State Office Tower, 30 E. Broad St.; Columbus, OH 43266-0410
+  voice: 614-466-4320
+links:
+- url: https://www.ohioattorneygeneral.gov/
+sources:
+- url: https://www.ohioattorneygeneral.gov/About-AG/Dave-Yost
+- url: https://ballotpedia.org/Dave_Yost
+- url: https://www.naag.org/attorney-general/dave-yost/

--- a/data/oh/executive/Jim-Tressel-6aef5093-5720-48fd-9997-e4f5451014b4.yml
+++ b/data/oh/executive/Jim-Tressel-6aef5093-5720-48fd-9997-e4f5451014b4.yml
@@ -1,0 +1,21 @@
+id: ocd-person/6aef5093-5720-48fd-9997-e4f5451014b4
+name: Jim Tressel
+given_name: Jim
+family_name: Tressel
+image: https://governor.ohio.gov/wps/wcm/connect/gov/12ebe94c-b50b-41d2-b88f-eafb0b1734e7/Jim+Tressel.jpg?MOD=AJPERES
+party:
+- name: Republican
+roles:
+- start_date: '2025-02-14'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:oh/government
+offices:
+- classification: capitol
+  address: Riffe Center, 30th Floor, 77 South High Street; Columbus, OH 43215-6117
+  voice: 614-644-4357
+links:
+- url: https://governor.ohio.gov/administration/lt-governor
+sources:
+- url: https://governor.ohio.gov/administration/lt-governor
+- url: https://ballotpedia.org/Jim_Tressel

--- a/data/ok/executive/Gentner-Drummond-e55fbb4f-73e3-4ee7-a4c6-6e5ae860d360.yml
+++ b/data/ok/executive/Gentner-Drummond-e55fbb4f-73e3-4ee7-a4c6-6e5ae860d360.yml
@@ -1,0 +1,22 @@
+id: ocd-person/e55fbb4f-73e3-4ee7-a4c6-6e5ae860d360
+name: Gentner Drummond
+given_name: Gentner
+family_name: Drummond
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-OK-Drummond.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-09'
+  end_date: '2027-01-11'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ok/government
+offices:
+- classification: capitol
+  address: 313 NE 21st Street; Oklahoma City, OK 73105
+  voice: 405-521-3921
+links:
+- url: https://oklahoma.gov/oag.html
+sources:
+- url: https://oklahoma.gov/oag.html
+- url: https://ballotpedia.org/Gentner_Drummond
+- url: https://www.naag.org/attorney-general/gentner-drummond/

--- a/data/ok/executive/Matt-Pinnell-c363ab87-72b9-4c52-af58-c5cb2da323d2.yml
+++ b/data/ok/executive/Matt-Pinnell-c363ab87-72b9-4c52-af58-c5cb2da323d2.yml
@@ -1,0 +1,21 @@
+id: ocd-person/c363ab87-72b9-4c52-af58-c5cb2da323d2
+name: Matt Pinnell
+given_name: Matt
+family_name: Pinnell
+image: https://oklahoma.gov/content/dam/ok/en/ltgov/images/photography/Official-LtGovMattPinnell.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-14'
+  end_date: '2027-01-11'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ok/government
+offices:
+- classification: capitol
+  address: 2300 N Lincoln Blvd, Room 117; Oklahoma City, OK 73105
+  voice: 405-521-2161
+links:
+- url: https://oklahoma.gov/ltgovpinnell.html
+sources:
+- url: https://oklahoma.gov/ltgovpinnell.html
+- url: https://ballotpedia.org/Matt_Pinnell

--- a/data/or/executive/Dan-Rayfield-201cf42b-d036-4582-a6ff-f23b3ab3f442.yml
+++ b/data/or/executive/Dan-Rayfield-201cf42b-d036-4582-a6ff-f23b3ab3f442.yml
@@ -1,0 +1,22 @@
+id: ocd-person/201cf42b-d036-4582-a6ff-f23b3ab3f442
+name: Dan Rayfield
+given_name: Dan
+family_name: Rayfield
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-OR-Rayfield-Dan.png
+party:
+- name: Democratic
+roles:
+- start_date: '2024-12-31'
+  end_date: '2029-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:or/government
+offices:
+- classification: capitol
+  address: Justice Bldg., 1162 Court St., NE; Salem, OR 97301
+  voice: 503-378-6002
+links:
+- url: https://www.doj.state.or.us/
+sources:
+- url: https://www.doj.state.or.us/oregon-department-of-justice/office-of-the-attorney-general/attorney-general-dan-rayfield/
+- url: https://ballotpedia.org/Dan_Rayfield
+- url: https://www.naag.org/attorney-general/dan-rayfield/

--- a/data/or/executive/Tobias-Read-73710d6f-5ce6-4015-8b6f-92fa17458afc.yml
+++ b/data/or/executive/Tobias-Read-73710d6f-5ce6-4015-8b6f-92fa17458afc.yml
@@ -1,0 +1,23 @@
+id: ocd-person/73710d6f-5ce6-4015-8b6f-92fa17458afc
+name: Tobias Read
+given_name: Tobias
+family_name: Read
+email: oregon.sos@sos.oregon.gov
+image: https://sos.oregon.gov/PublishingImages/Tobias-Read.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-06'
+  end_date: '2029-01-01'
+  type: secretary of state
+  jurisdiction: ocd-jurisdiction/country:us/state:or/government
+offices:
+- classification: capitol
+  address: 900 Court Street NE, Capitol Room 136; Salem, OR 97301
+  voice: 503-986-1523
+links:
+- url: https://sos.oregon.gov/
+sources:
+- url: https://sos.oregon.gov/Pages/meet-the-secretary.aspx
+- url: https://sos.oregon.gov/Pages/contactus.aspx
+- url: https://ballotpedia.org/Tobias_Read

--- a/data/pa/executive/Austin-Davis-e5de67f9-3e82-4e65-89ce-47aa0772d1f8.yml
+++ b/data/pa/executive/Austin-Davis-e5de67f9-3e82-4e65-89ce-47aa0772d1f8.yml
@@ -1,0 +1,21 @@
+id: ocd-person/e5de67f9-3e82-4e65-89ce-47aa0772d1f8
+name: Austin Davis
+given_name: Austin
+family_name: Davis
+image: https://s7d9.scene7.com/is/image/statepa/LG%20Portrait
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-17'
+  end_date: '2027-01-19'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+offices:
+- classification: capitol
+  address: 200 Main Capitol Building; Harrisburg, PA 17120
+  voice: 717-787-3300
+links:
+- url: https://www.pa.gov/ltgovernor
+sources:
+- url: https://www.pa.gov/ltgovernor
+- url: https://ballotpedia.org/Austin_Davis_(Pennsylvania)

--- a/data/pa/executive/Dave-Sunday-d880fd50-7249-4f5d-b7d4-193a4ae8319e.yml
+++ b/data/pa/executive/Dave-Sunday-d880fd50-7249-4f5d-b7d4-193a4ae8319e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/d880fd50-7249-4f5d-b7d4-193a4ae8319e
+name: Dave Sunday
+given_name: Dave
+family_name: Sunday
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-PA-Sunday-2025.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-21'
+  end_date: '2029-01-16'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:pa/government
+offices:
+- classification: capitol
+  address: Strawberry Square; Harrisburg, PA 17120
+  voice: 717-787-3391
+links:
+- url: https://www.attorneygeneral.gov/
+sources:
+- url: https://www.attorneygeneral.gov/
+- url: https://ballotpedia.org/Dave_Sunday
+- url: https://www.naag.org/attorney-general/dave-sunday/

--- a/data/ri/executive/Peter-Neronha-2c4e5251-d011-436c-8d4e-5142d174813e.yml
+++ b/data/ri/executive/Peter-Neronha-2c4e5251-d011-436c-8d4e-5142d174813e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/2c4e5251-d011-436c-8d4e-5142d174813e
+name: Peter Neronha
+given_name: Peter
+family_name: Neronha
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-RI-neronha2.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-01'
+  end_date: '2027-01-05'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ri/government
+offices:
+- classification: capitol
+  address: 150 S. Main St.; Providence, RI 02903
+  voice: 401-274-4400
+links:
+- url: https://riag.ri.gov/
+sources:
+- url: https://riag.ri.gov/about-our-office/attorney-general-peter-f-neronha
+- url: https://ballotpedia.org/Peter_Neronha
+- url: https://www.naag.org/attorney-general/peter-neronha/

--- a/data/ri/executive/Sabina-Matos-811001df-7f40-4641-9461-fb2dc02bacce.yml
+++ b/data/ri/executive/Sabina-Matos-811001df-7f40-4641-9461-fb2dc02bacce.yml
@@ -1,0 +1,21 @@
+id: ocd-person/811001df-7f40-4641-9461-fb2dc02bacce
+name: Sabina Matos
+given_name: Sabina
+family_name: Matos
+image: https://ltgov.ri.gov/sites/g/files/xkgbur491/files/styles/max_2600x2600/public/2021-05/Sabina-StatePhoto.png
+party:
+- name: Democratic
+roles:
+- start_date: '2021-04-14'
+  end_date: '2027-01-05'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ri/government
+offices:
+- classification: capitol
+  address: 82 Smith Street, Room 116; Providence, RI 02903
+  voice: 401-222-2371
+links:
+- url: https://ltgov.ri.gov/
+sources:
+- url: https://ltgov.ri.gov/about
+- url: https://ballotpedia.org/Sabina_Matos

--- a/data/sc/executive/Alan-Wilson-b9f92b67-9de4-489e-861b-995274f4d20e.yml
+++ b/data/sc/executive/Alan-Wilson-b9f92b67-9de4-489e-861b-995274f4d20e.yml
@@ -1,0 +1,22 @@
+id: ocd-person/b9f92b67-9de4-489e-861b-995274f4d20e
+name: Alan Wilson
+given_name: Alan
+family_name: Wilson
+image: https://www.scag.gov/media/ie5nqrqm/about-meet.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2011-01-12'
+  end_date: '2027-01-13'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
+offices:
+- classification: capitol
+  address: Rembert C. Dennis Office Bldg., P.O. Box 11549; Columbia, SC 29211-1549
+  voice: 803-734-3970
+links:
+- url: https://www.scag.gov/
+sources:
+- url: https://www.scag.gov/about-the-office/meet-the-attorney-general/
+- url: https://ballotpedia.org/Alan_Wilson_(South_Carolina)
+- url: https://www.naag.org/attorney-general/alan-wilson/

--- a/data/sc/executive/Pamela-Evette-f96c83a2-ed1e-4ff6-b5a7-7bb83afdf2df.yml
+++ b/data/sc/executive/Pamela-Evette-f96c83a2-ed1e-4ff6-b5a7-7bb83afdf2df.yml
@@ -1,0 +1,23 @@
+id: ocd-person/f96c83a2-ed1e-4ff6-b5a7-7bb83afdf2df
+name: Pamela Evette
+given_name: Pamela
+family_name: Evette
+image: https://governor.sc.gov/sites/governor/files/Documents/Images/LG%20Headshot%202022.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2019-01-09'
+  end_date: '2027-01-13'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
+offices:
+- classification: capitol
+  address: State House, 1100 Gervais Street; Columbia, SC 29201
+  voice: 803-734-2100
+  fax: 803-734-5167
+links:
+- url: https://governor.sc.gov/lieutenant-governor
+sources:
+- url: https://governor.sc.gov/lieutenant-governor
+- url: https://contactgovernor.my.site.com/constituents/s/contact-the-governor
+- url: https://ballotpedia.org/Pamela_Evette

--- a/data/sd/executive/Marty-Jackley-b305d3f4-6e90-44ab-a228-3ed2933e2989.yml
+++ b/data/sd/executive/Marty-Jackley-b305d3f4-6e90-44ab-a228-3ed2933e2989.yml
@@ -1,0 +1,22 @@
+id: ocd-person/b305d3f4-6e90-44ab-a228-3ed2933e2989
+name: Marty Jackley
+given_name: Marty
+family_name: Jackley
+image: https://www.naag.org/wp-content/uploads/2022/11/ag-SD-Jackley-Marty.png
+party:
+- name: Republican
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:sd/government
+offices:
+- classification: capitol
+  address: 1302 East Highway 14, Suite 1; Pierre, SD 57501-8501
+  voice: 605-773-3215
+links:
+- url: https://atg.sd.gov/
+sources:
+- url: https://atg.sd.gov/OurOffice/bio.aspx
+- url: https://ballotpedia.org/Marty_J._Jackley
+- url: https://www.naag.org/attorney-general/marty-jackley/

--- a/data/sd/executive/Tony-Venhuizen-c8d6a31f-a4e9-454a-a75a-28b668c1b729.yml
+++ b/data/sd/executive/Tony-Venhuizen-c8d6a31f-a4e9-454a-a75a-28b668c1b729.yml
@@ -1,0 +1,22 @@
+id: ocd-person/c8d6a31f-a4e9-454a-a75a-28b668c1b729
+name: Tony Venhuizen
+given_name: Tony
+family_name: Venhuizen
+image: https://governor.sd.gov/img/LtGovTV-photo.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-30'
+  end_date: '2027-01-06'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:sd/government
+offices:
+- classification: capitol
+  address: 500 East Capitol Avenue; Pierre, SD 57501
+  voice: 605-773-3212
+  fax: 605-773-4711
+links:
+- url: https://governor.sd.gov/governor/lt-governor.aspx
+sources:
+- url: https://governor.sd.gov/governor/lt-governor.aspx
+- url: https://ballotpedia.org/Tony_Venhuizen

--- a/data/tn/executive/Jonathan-Skrmetti-8a5fa491-f871-4b57-962e-8db9adf2c8c3.yml
+++ b/data/tn/executive/Jonathan-Skrmetti-8a5fa491-f871-4b57-962e-8db9adf2c8c3.yml
@@ -1,0 +1,21 @@
+id: ocd-person/8a5fa491-f871-4b57-962e-8db9adf2c8c3
+name: Jonathan Skrmetti
+given_name: Jonathan
+family_name: Skrmetti
+image: https://www.naag.org/wp-content/uploads/2022/09/ag-TN-Skrmetti-2025.png
+party:
+- name: Republican
+roles:
+- start_date: '2022-09-01'
+  end_date: '2030-09-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:tn/government
+offices:
+- classification: capitol
+  address: P.O. Box 20207; Nashville, TN 37202
+  voice: 615-741-3491
+links:
+- url: https://www.tn.gov/attorneygeneral.html
+sources:
+- url: https://ballotpedia.org/Jonathan_Skrmetti
+- url: https://www.naag.org/attorney-general/jonathan-skrmetti/

--- a/data/tx/executive/Dan-Patrick-22c1bff3-e936-4398-8d7c-95233e85b5c5.yml
+++ b/data/tx/executive/Dan-Patrick-22c1bff3-e936-4398-8d7c-95233e85b5c5.yml
@@ -1,0 +1,21 @@
+id: ocd-person/22c1bff3-e936-4398-8d7c-95233e85b5c5
+name: Dan Patrick
+given_name: Dan
+family_name: Patrick
+image: https://www.ltgov.state.tx.us/wp-content/uploads/2021/01/dan_patrick_new_2021.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2015-01-20'
+  end_date: '2027-01-19'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
+offices:
+- classification: capitol
+  address: P.O. Box 12068; Austin, TX 78711
+  voice: 512-463-0001
+links:
+- url: https://www.ltgov.texas.gov/
+sources:
+- url: https://www.ltgov.texas.gov/about/
+- url: https://ballotpedia.org/Dan_Patrick

--- a/data/tx/executive/Ken-Paxton-1c1b6320-5ed6-4739-9f53-389b724b0305.yml
+++ b/data/tx/executive/Ken-Paxton-1c1b6320-5ed6-4739-9f53-389b724b0305.yml
@@ -1,0 +1,22 @@
+id: ocd-person/1c1b6320-5ed6-4739-9f53-389b724b0305
+name: Ken Paxton
+given_name: Ken
+family_name: Paxton
+image: https://www.naag.org/wp-content/uploads/2020/09/ag-TX-Paxton.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2015-01-05'
+  end_date: '2027-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:tx/government
+offices:
+- classification: capitol
+  address: Capitol Station, P.O. Box 12548; Austin, TX 78711-2548
+  voice: 512-463-2100
+links:
+- url: https://www.texasattorneygeneral.gov/
+sources:
+- url: https://www.texasattorneygeneral.gov/
+- url: https://ballotpedia.org/Ken_Paxton
+- url: https://www.naag.org/attorney-general/ken-paxton/

--- a/data/ut/executive/Deidre-Henderson-8bae8ef6-d21e-4eba-94e4-2aad97023cbc.yml
+++ b/data/ut/executive/Deidre-Henderson-8bae8ef6-d21e-4eba-94e4-2aad97023cbc.yml
@@ -1,0 +1,21 @@
+id: ocd-person/8bae8ef6-d21e-4eba-94e4-2aad97023cbc
+name: Deidre Henderson
+given_name: Deidre
+family_name: Henderson
+image: https://ltgovernor.utah.gov/wp-content/uploads/Official-portrait-2-scaled-1-728x1024.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2021-01-04'
+  end_date: '2029-01-01'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:ut/government
+offices:
+- classification: capitol
+  address: Utah State Capitol, 350 N. State Street, Suite 200; Salt Lake City, UT 84114-2220
+  voice: 801-538-1041
+links:
+- url: https://ltgovernor.utah.gov/
+sources:
+- url: https://ltgovernor.utah.gov/about-lt-governor-deidre-m-henderson/
+- url: https://ballotpedia.org/Deidre_Henderson

--- a/data/ut/executive/Derek-Brown-34430fff-d52e-4218-a99b-3d2764578bc9.yml
+++ b/data/ut/executive/Derek-Brown-34430fff-d52e-4218-a99b-3d2764578bc9.yml
@@ -1,0 +1,22 @@
+id: ocd-person/34430fff-d52e-4218-a99b-3d2764578bc9
+name: Derek Brown
+given_name: Derek
+family_name: Brown
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-UT-Brown-Derek.png
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-07'
+  end_date: '2029-01-01'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:ut/government
+offices:
+- classification: capitol
+  address: State Capitol, Rm. 236; Salt Lake City, UT 84114-0810
+  voice: 801-538-9600
+links:
+- url: https://attorneygeneral.utah.gov/
+sources:
+- url: https://attorneygeneral.utah.gov/
+- url: https://ballotpedia.org/Derek_Brown_(Utah)
+- url: https://www.naag.org/attorney-general/derek-brown/

--- a/data/va/executive/Ghazala-Hashmi-2ae6c10e-e6d0-4033-927f-0b067b2ba0fc.yml
+++ b/data/va/executive/Ghazala-Hashmi-2ae6c10e-e6d0-4033-927f-0b067b2ba0fc.yml
@@ -1,0 +1,22 @@
+id: ocd-person/2ae6c10e-e6d0-4033-927f-0b067b2ba0fc
+name: Ghazala Hashmi
+given_name: Ghazala
+family_name: Hashmi
+email: Ltgov43@ltgov.virginia.gov
+image: https://www.ltgov.virginia.gov/media/governorvirginiagov/lieutenant-governor/Portrait-LT-Governor-Ghazala-Hashmi.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2026-01-17'
+  end_date: '2030-01-12'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:va/government
+offices:
+- classification: capitol
+  address: P.O. Box 1195; Richmond, VA 23218
+  voice: 804-593-2897
+links:
+- url: https://www.ltgov.virginia.gov/
+sources:
+- url: https://www.ltgov.virginia.gov/about/about-the-lt-gov/
+- url: https://ballotpedia.org/Ghazala_Hashmi

--- a/data/va/executive/Jay-Jones-7ef2fdd9-b55d-4ab4-83ea-17c47c2e5227.yml
+++ b/data/va/executive/Jay-Jones-7ef2fdd9-b55d-4ab4-83ea-17c47c2e5227.yml
@@ -1,0 +1,22 @@
+id: ocd-person/7ef2fdd9-b55d-4ab4-83ea-17c47c2e5227
+name: Jay Jones
+given_name: Jay
+family_name: Jones
+image: https://www.oag.state.va.us/images/Jones-headshot-20260320.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2026-01-17'
+  end_date: '2030-01-12'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:va/government
+offices:
+- classification: capitol
+  address: 202 North Ninth Street; Richmond, VA 23219
+  voice: 804-786-2071
+links:
+- url: https://www.oag.state.va.us/
+sources:
+- url: https://www.oag.state.va.us/our-office/about-the-attorney-general
+- url: https://www.oag.state.va.us/contact-us/contact-info
+- url: https://ballotpedia.org/Jay_Jones_(Virginia)

--- a/data/vt/executive/Charity-Clark-5ff8e24a-93df-4bc3-a669-7ea42d42c59b.yml
+++ b/data/vt/executive/Charity-Clark-5ff8e24a-93df-4bc3-a669-7ea42d42c59b.yml
@@ -1,0 +1,22 @@
+id: ocd-person/5ff8e24a-93df-4bc3-a669-7ea42d42c59b
+name: Charity Clark
+given_name: Charity
+family_name: Clark
+image: https://ago.vermont.gov/sites/ago/files/inline-images/Charity%20R%20Clark%20headshot.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-05'
+  end_date: '2027-01-14'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:vt/government
+offices:
+- classification: capitol
+  address: 109 State St.; Montpelier, VT 05609-1001
+  voice: 802-828-3173
+links:
+- url: https://ago.vermont.gov/
+sources:
+- url: https://ago.vermont.gov/about-attorney-generals-office
+- url: https://ballotpedia.org/Charity_Clark
+- url: https://www.naag.org/attorney-general/charity-clark/

--- a/data/vt/executive/John-Rodgers-2cb218ea-52a4-4d1f-9732-217940ba260e.yml
+++ b/data/vt/executive/John-Rodgers-2cb218ea-52a4-4d1f-9732-217940ba260e.yml
@@ -1,0 +1,21 @@
+id: ocd-person/2cb218ea-52a4-4d1f-9732-217940ba260e
+name: John Rodgers
+given_name: John
+family_name: Rodgers
+image: https://ltgov.vermont.gov/sites/gray/files/inline-images/John%20Rodgers%20002_0.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-09'
+  end_date: '2027-01-07'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:vt/government
+offices:
+- classification: capitol
+  address: 115 State Street; Montpelier, VT 05633
+  voice: 802-828-2226
+links:
+- url: https://ltgov.vermont.gov/
+sources:
+- url: https://ltgov.vermont.gov/about/john-rodgers
+- url: https://ballotpedia.org/John_Rodgers_(Vermont)

--- a/data/wa/executive/Denny-Heck-b1789e29-3532-4554-9ee1-853497224a85.yml
+++ b/data/wa/executive/Denny-Heck-b1789e29-3532-4554-9ee1-853497224a85.yml
@@ -1,0 +1,22 @@
+id: ocd-person/b1789e29-3532-4554-9ee1-853497224a85
+name: Denny Heck
+given_name: Denny
+family_name: Heck
+email: ltgov@ltgov.wa.gov
+image: https://images.squarespace-cdn.com/content/v1/5d70140860791400013fe3ce/2bb4d89d-3bb3-45dd-896a-5f984bdd1d4e/Lt.+Gov+Heck+headshot_updated.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2021-01-11'
+  end_date: '2029-01-08'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:wa/government
+offices:
+- classification: capitol
+  address: 220 Legislative Building, 416 Sid Snyder Ave. S.W.; Olympia, WA 98504
+  voice: 360-786-7700
+links:
+- url: https://www.ltgov.wa.gov/
+sources:
+- url: https://www.ltgov.wa.gov/aboutdenny
+- url: https://ballotpedia.org/Denny_Heck

--- a/data/wa/executive/Nick-Brown-4816d75e-eac4-4ff8-8270-fb79324b93c8.yml
+++ b/data/wa/executive/Nick-Brown-4816d75e-eac4-4ff8-8270-fb79324b93c8.yml
@@ -1,0 +1,22 @@
+id: ocd-person/4816d75e-eac4-4ff8-8270-fb79324b93c8
+name: Nick Brown
+given_name: Nick
+family_name: Brown
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-WA-Brown-Nick.png
+party:
+- name: Democratic
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-08'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:wa/government
+offices:
+- classification: capitol
+  address: 1125 Washington St. SE, P.O. Box 40100; Olympia, WA 98504-0100
+  voice: 360-753-6200
+links:
+- url: https://www.atg.wa.gov/
+sources:
+- url: https://www.atg.wa.gov/about-nick-brown
+- url: https://ballotpedia.org/Nick_Brown_(Washington)
+- url: https://www.naag.org/attorney-general/nick-brown/

--- a/data/wi/executive/Josh-Kaul-21c76f44-b31e-4300-b8d1-bb8d4b93bc51.yml
+++ b/data/wi/executive/Josh-Kaul-21c76f44-b31e-4300-b8d1-bb8d4b93bc51.yml
@@ -1,0 +1,22 @@
+id: ocd-person/21c76f44-b31e-4300-b8d1-bb8d4b93bc51
+name: Josh Kaul
+given_name: Josh
+family_name: Kaul
+image: https://www.wisdoj.gov/PublishingImages/josh-kaul-headshot.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2019-01-07'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:wi/government
+offices:
+- classification: capitol
+  address: State Capitol, Room 114 East, P.O. Box 7857; Madison, WI 53707-7857
+  voice: 608-266-1221
+links:
+- url: https://www.wisdoj.gov/
+sources:
+- url: https://www.wisdoj.gov/Pages/AboutUs/leadership.aspx
+- url: https://ballotpedia.org/Josh_Kaul
+- url: https://www.naag.org/attorney-general/josh-kaul/

--- a/data/wi/executive/Sara-Rodriguez-827a69f2-8b85-4a72-ac01-14be2c08aa6c.yml
+++ b/data/wi/executive/Sara-Rodriguez-827a69f2-8b85-4a72-ac01-14be2c08aa6c.yml
@@ -1,0 +1,21 @@
+id: ocd-person/827a69f2-8b85-4a72-ac01-14be2c08aa6c
+name: Sara Rodriguez
+given_name: Sara
+family_name: Rodriguez
+image: https://evers.wi.gov/ltgov/PublishingImages/Pages/default/230207%20LG%20Sara%20Rodriguez%20Portrait%20Second%2002.jpg
+party:
+- name: Democratic
+roles:
+- start_date: '2023-01-02'
+  end_date: '2027-01-04'
+  type: lt_governor
+  jurisdiction: ocd-jurisdiction/country:us/state:wi/government
+offices:
+- classification: capitol
+  address: 19 East Capitol; Madison, WI 53702
+  voice: 608-266-3516
+links:
+- url: https://evers.wi.gov/ltgov/Pages/default.aspx
+sources:
+- url: https://evers.wi.gov/ltgov/Pages/default.aspx
+- url: https://ballotpedia.org/Sara_Rodriguez

--- a/data/wv/executive/John-McCuskey-0788d53c-8461-4f0f-ba32-07f626cb45e1.yml
+++ b/data/wv/executive/John-McCuskey-0788d53c-8461-4f0f-ba32-07f626cb45e1.yml
@@ -1,0 +1,21 @@
+id: ocd-person/0788d53c-8461-4f0f-ba32-07f626cb45e1
+name: John B. McCuskey
+given_name: John
+family_name: McCuskey
+image: https://www.naag.org/wp-content/uploads/2025/01/ag-WA-McCusker.png
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-15'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:wv/government
+offices:
+- classification: capitol
+  address: State Capitol, 1900 Kanawha Blvd., E.; Charleston, WV 25305
+  voice: 304-558-2021
+links:
+- url: https://ago.wv.gov/
+sources:
+- url: https://ballotpedia.org/John_B._McCuskey
+- url: https://www.naag.org/attorney-general/j-b-mccuskey/

--- a/data/wv/executive/Patrick-Morrisey-cf5ab5dc-33c4-4d93-a810-f42cd6f98f5d.yml
+++ b/data/wv/executive/Patrick-Morrisey-cf5ab5dc-33c4-4d93-a810-f42cd6f98f5d.yml
@@ -1,0 +1,22 @@
+id: ocd-person/cf5ab5dc-33c4-4d93-a810-f42cd6f98f5d
+name: Patrick Morrisey
+given_name: Patrick
+family_name: Morrisey
+image: https://governor.wv.gov/sites/default/files/2024-12/morrissey.jpg
+party:
+- name: Republican
+roles:
+- start_date: '2025-01-13'
+  end_date: '2029-01-15'
+  type: governor
+  jurisdiction: ocd-jurisdiction/country:us/state:wv/government
+offices:
+- classification: capitol
+  address: State Capitol, 1900 Kanawha Blvd. E; Charleston, WV 25305
+  voice: 304-558-2000
+  fax: 304-558-3588
+links:
+- url: https://governor.wv.gov/
+sources:
+- url: https://governor.wv.gov/
+- url: https://ballotpedia.org/Patrick_Morrisey

--- a/data/wy/executive/Keith-Kautz-d2a01d75-b8ff-4c5b-8e8e-38803e9502b4.yml
+++ b/data/wy/executive/Keith-Kautz-d2a01d75-b8ff-4c5b-8e8e-38803e9502b4.yml
@@ -1,0 +1,21 @@
+id: ocd-person/d2a01d75-b8ff-4c5b-8e8e-38803e9502b4
+name: Keith G. Kautz
+given_name: Keith
+family_name: Kautz
+image: https://www.naag.org/wp-content/uploads/2025/07/ag-WY-Kautz-Keith-2025.png
+party:
+- name: Republican
+roles:
+- start_date: '2025-07-07'
+  end_date: '2027-01-04'
+  type: attorney general
+  jurisdiction: ocd-jurisdiction/country:us/state:wy/government
+offices:
+- classification: capitol
+  address: State Capitol Building; Cheyenne, WY 82002
+  voice: 307-777-7841
+links:
+- url: https://ag.wyo.gov/
+sources:
+- url: https://ballotpedia.org/Keith_G._Kautz
+- url: https://www.naag.org/attorney-general/keith-g-kautz/


### PR DESCRIPTION
## Summary

- **Keith G. Kautz** (Attorney General) — new UUID generated

Wyoming does not have a lieutenant governor. The AG is appointed by the governor, not elected.

## Sources

All data sourced from Ballotpedia and NAAG.