### PR TITLE
Add duplicate person CI guard

### DIFF
--- a/.github/scripts/check_duplicate_people.py
+++ b/.github/scripts/check_duplicate_people.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+
+PERSON_DIRS = ("executive", "legislature", "municipalities", "retired")
+
+
+def normalize(value: object) -> str:
+    """Normalize names for duplicate comparisons."""
+    return " ".join(str(value or "").casefold().split())
+
+
+def person_files(data_dir: Path, state: str) -> list[Path]:
+    """Return all person YAML files for a state, excluding committees."""
+    state_dir = data_dir / state
+    files: list[Path] = []
+    for person_dir in PERSON_DIRS:
+        directory = state_dir / person_dir
+        if directory.exists():
+            files.extend(sorted(directory.glob("*.yml")))
+            files.extend(sorted(directory.glob("*.yaml")))
+    return files
+
+
+def person_file_state(data_dir: Path, path: Path) -> str | None:
+    """Return a changed person file's state, or None when the path should be ignored."""
+    if path.is_absolute():
+        try:
+            path = path.relative_to(Path.cwd())
+        except ValueError:
+            return None
+
+    parts = path.parts
+    data_parts = data_dir.parts
+    if len(parts) != len(data_parts) + 3:
+        return None
+    if parts[:len(data_parts)] != data_parts:
+        return None
+    if parts[len(data_parts) + 1] not in PERSON_DIRS:
+        return None
+    if path.suffix not in (".yml", ".yaml"):
+        return None
+    return parts[len(data_parts)]
+
+
+def check_state(data_dir: Path, state: str) -> dict[tuple[str, str], list[Path]]:
+    """Find duplicate person files in one state by normalized given and family name."""
+    people: dict[tuple[str, str], list[Path]] = defaultdict(list)
+
+    for path in person_files(data_dir, state):
+        with path.open() as file:
+            record = yaml.safe_load(file) or {}
+
+        given_name = normalize(record.get("given_name"))
+        family_name = normalize(record.get("family_name"))
+        if not given_name or not family_name:
+            continue
+
+        people[(given_name, family_name)].append(path)
+
+    return {
+        key: paths
+        for key, paths in sorted(people.items())
+        if len(paths) > 1
+    }
+
+
+def changed_person_files(data_dir: Path, changed_files: list[str]) -> dict[str, set[Path]]:
+    """Group changed person files by state for CI-scoped duplicate checks."""
+    changed_by_state: dict[str, set[Path]] = defaultdict(set)
+    for changed_file in changed_files:
+        path = Path(changed_file)
+        state = person_file_state(data_dir, path)
+        if state is None or not path.exists():
+            continue
+        changed_by_state[state].add(path)
+    return changed_by_state
+
+
+def main() -> int:
+    """Run either a full-state duplicate scan or a changed-file-scoped CI scan."""
+    parser = argparse.ArgumentParser(
+        description="Fail if person files have duplicate given_name and family_name in the same state."
+    )
+    parser.add_argument("states", nargs="*", help="state abbreviations to check, e.g. ar ma")
+    parser.add_argument("--data-dir", default="data", type=Path)
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        help="limit failures to duplicate groups containing one of these changed person files",
+    )
+    args = parser.parse_args()
+
+    found_duplicates = False
+    changed_by_state = changed_person_files(args.data_dir, args.changed_files or [])
+
+    if args.changed_files is not None:
+        if not changed_by_state:
+            print("No changed person files to check")
+            return 0
+
+        # Existing historical duplicate groups are allowed unless this change touches one of them.
+        for state, changed_paths in sorted(changed_by_state.items()):
+            duplicates = check_state(args.data_dir, state)
+            for (given_name, family_name), paths in duplicates.items():
+                if not changed_paths.intersection(paths):
+                    continue
+                found_duplicates = True
+                print(f"{state}: changed file violates duplicate person rule for given_name={given_name!r}, family_name={family_name!r}")
+                for path in paths:
+                    marker = " (changed)" if path in changed_paths else ""
+                    print(f"  - {path}{marker}")
+    else:
+        if not args.states:
+            parser.error("provide states to check, or use --changed-files")
+
+        for state in sorted(set(args.states)):
+            duplicates = check_state(args.data_dir, state)
+            for (given_name, family_name), paths in duplicates.items():
+                found_duplicates = True
+                print(f"{state}: duplicate person records for given_name={given_name!r}, family_name={family_name!r}")
+                for path in paths:
+                    print(f"  - {path}")
+
+    if found_duplicates:
+        print(
+            "\nDuplicate person records found. A person is considered duplicate when "
+            "given_name and family_name match within the same state. In CI, only duplicate "
+            "groups containing changed person files fail.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -11,6 +11,7 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - ".github/workflows/lint-yaml.yml"
+      - ".github/scripts/check_duplicate_people.py"
   pull_request:
     branches:
       - main
@@ -21,6 +22,7 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - ".github/workflows/lint-yaml.yml"
+      - ".github/scripts/check_duplicate_people.py"
 
 jobs:
   lint:
@@ -34,6 +36,8 @@ jobs:
       id: changed-dirs
       with:
         dir_names: 'true'
+    - uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.5
+      id: changed-files
     - name: Yaml file linting
       run: |
         docker run --rm \
@@ -77,6 +81,11 @@ jobs:
             echo "$dir contains changes, but ignored for linting people"
           fi
         done
+    - name: check duplicate people selectively
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        poetry run python .github/scripts/check_duplicate_people.py --changed-files ${ALL_CHANGED_FILES}
     - name: lint committees selectively
       env:
         OS_PEOPLE_DIRECTORY: ${{ env.GITHUB_WORKSPACE }}

--- a/data/duplicates.md
+++ b/data/duplicates.md
@@ -1,0 +1,1460 @@
+# Duplicate people to fix
+
+Generated from `.github/scripts/check_duplicate_people.py` duplicate identity rule: within a state, two person files are duplicates when normalized `given_name` and `family_name` match.
+
+- States with duplicates: `52`
+- Duplicate name groups: `429`
+- Files involved: `866`
+
+Resolution convention: when a duplicate group is fixed, move the whole group under a `## Resolved` section at the bottom with the resolving PR number. This keeps unresolved groups easy to scan while preserving cleanup history for coordination.
+
+## ak
+
+- `kevin` `meyer`
+  - `data/ak/retired/Kevin-Meyer-d3a387fa-c0b9-4022-a8b4-a26ebc9e7fa3.yml`
+  - `data/ak/retired/Kevin-Meyer-ef900e86-8c72-426a-8a78-1d47e5122367.yml`
+- `mike` `dunleavy`
+  - `data/ak/executive/Mike-Dunleavy-80f0f5f8-976d-427b-b980-ce3a23a23e84.yml`
+  - `data/ak/retired/Mike-Dunleavy-d4aca12d-41ed-411d-a25a-feb29b688c06.yml`
+
+## al
+
+- `jack` `williams`
+  - `data/al/legislature/Jack-W-Williams-a7e333c5-03f2-4343-9981-956bcc1ea38e.yml`
+  - `data/al/retired/Jack-Williams-e383fc29-5212-42d3-bc76-46dd93bf3e6f.yml`
+- `john` `merrill`
+  - `data/al/executive/John-Merrill-6a69be8a-7d2c-4291-9d18-a03b7fdfd29d.yml`
+  - `data/al/retired/John-Merrill-5c06e1c9-7b24-4796-94de-eea8651a83f7.yml`
+- `mack` `butler`
+  - `data/al/legislature/Mack-Butler-5071243c-3e2d-4acb-ac8d-0d3a8af3eb8a.yml`
+  - `data/al/retired/Mack-Butler-76f9d6ad-f147-4913-b011-3f52e1105f77.yml`
+- `steve` `marshall`
+  - `data/al/executive/Steve-Marshall-3636b6ed-56b0-44bb-97b8-dee266b6d9c8.yml`
+  - `data/al/executive/Steve-Marshall-e6931735-4601-485b-b62d-c88b01a5c93a.yml`
+
+## ar
+
+- `ashley` `hudson`
+  - `data/ar/legislature/Ashley-Hudson-0e0e799b-70de-4472-b289-4a0c2aba3a26.yml`
+  - `data/ar/retired/Ashley-Hudson-1099474b-8219-43f8-a71e-1ff9bd1efe5f.yml`
+- `brian` `evans`
+  - `data/ar/legislature/Brian-S-Evans-a1614a7c-f5f0-4fe1-a2b1-c8390e4bf106.yml`
+  - `data/ar/retired/Brian-S-Evans-844b8ab2-d68c-4aa6-9b98-647b2c380e0a.yml`
+- `bryan` `king`
+  - `data/ar/legislature/Bryan-King-ac9a90a0-dfba-4bf0-a07d-ca2232b21a90.yml`
+  - `data/ar/retired/Bryan-King-a89e0832-a0ed-4b5f-98b1-21f74833dd60.yml`
+- `carol` `dalby`
+  - `data/ar/legislature/Carol-Dalby-247b430e-d46a-474a-87bc-24d03c636fd8.yml`
+  - `data/ar/retired/Carol-Dalby-495926c5-ea19-4140-9c7b-2a67cc5cdc50.yml`
+- `clarke` `tucker`
+  - `data/ar/legislature/Clarke-Tucker-cdb599f1-f956-430d-9ba2-87ce18d3fd53.yml`
+  - `data/ar/retired/Clarke-Tucker-27859771-43ae-4b7b-b33c-832f4e294d6f.yml`
+- `clint` `penzo`
+  - `data/ar/legislature/Clint-Penzo-6c773215-c5d7-4039-bcb2-d2abe9053e39.yml`
+  - `data/ar/retired/Clint-Penzo-73f7d9f8-e8fc-448d-939e-683dd0d49669.yml`
+- `danny` `watson`
+  - `data/ar/retired/Danny-Watson-4e317d99-bb6f-45ea-a9fc-802b463edce6.yml`
+  - `data/ar/retired/Danny-Watson-6dbac93f-c202-42a6-bd91-87baf5c1bb86.yml`
+- `dave` `wallace`
+  - `data/ar/legislature/David-Wallace-f009d442-b840-4308-b48e-f38591e5d0d4.yml`
+  - `data/ar/retired/Dave-Wallace-01055e2b-ca1d-48a0-9351-ca596bf812de.yml`
+- `gary` `stubblefield`
+  - `data/ar/retired/Gary-Stubblefield-616dd7e2-7ff0-4577-9857-c395a31008d8.yml`
+  - `data/ar/retired/Gary-Stubblefield-b4087806-94ad-43fd-b4a1-31a4f923bf2f.yml`
+- `george b.` `mcgill`
+  - `data/ar/retired/George-B-McGill-3e9324f3-ad4a-4c41-8925-e2b8a41760d8.yml`
+  - `data/ar/retired/George-B-McGill-b9437b92-b4d8-46ad-b647-3afa508b502d.yml`
+- `grant` `hodges`
+  - `data/ar/retired/Grant-Hodges-62260ac2-8904-4532-9eb8-a5c13b6eddc1.yml`
+  - `data/ar/retired/Grant-Hodges-fffc4c69-eca0-47c2-81b0-1f7c7a60f07f.yml`
+- `greg` `hines`
+  - `data/ar/municipalities/Greg-Hines-4a61afcc-83c3-459d-8e03-03bfbb68a5c8.yml`
+  - `data/ar/retired/Greg-Hines-913ca0fb-8255-4973-9b96-f65abdbe8a4a.yml`
+- `jay` `richardson`
+  - `data/ar/legislature/Jay-Richardson-65961429-87cb-4c8c-b9c9-006622ea63c7.yml`
+  - `data/ar/retired/Jay-Richardson-2e8688ce-44eb-4d59-8cd1-ce47a4582fa9.yml`
+- `jimmy` `hickey`
+  - `data/ar/legislature/Jimmy-Hickey-Jr-c083823a-b0f6-43dd-87b9-f1f398b84a00.yml`
+  - `data/ar/retired/Jimmy-Hickey-Jr-58934086-405c-4944-a679-d2631b596af9.yml`
+- `jon` `eubanks`
+  - `data/ar/legislature/Jon-S-Eubanks-3220c1b9-f133-47fa-8ef9-9944493fbb2c.yml`
+  - `data/ar/retired/Jon-S-Eubanks-d6eb5613-d3b5-4cdc-80c4-22c2b5e031d0.yml`
+- `josh` `miller`
+  - `data/ar/retired/Josh-Miller-ad87b082-c8f3-4ad3-9051-4f765b4836b6.yml`
+  - `data/ar/retired/Josh-Miller-c3c73d2f-7c05-4f6a-99d2-e3500dce2c76.yml`
+- `justin` `gonzales`
+  - `data/ar/legislature/Justin-Gonzales-96dbbbb4-8a04-42bc-a553-e178d47ce838.yml`
+  - `data/ar/retired/Justin-Gonzales-71773db4-6549-42b9-a88b-a76990ae4e99.yml`
+- `keith` `brooks`
+  - `data/ar/legislature/Keith-Brooks-d4c881c3-3d11-4cc4-a40d-64d3d0e11c60.yml`
+  - `data/ar/retired/Keith-Brooks-421c662e-d0d6-41af-b440-4aa59260a606.yml`
+- `lane` `jean`
+  - `data/ar/legislature/Lane-Jean-e04b2e49-1a8c-46e5-b9fc-c23d35e10393.yml`
+  - `data/ar/retired/Lane-Jean-b68672f5-0505-420c-bd07-3ab440c3c9c8.yml`
+- `lee` `johnson`
+  - `data/ar/legislature/Lee-Johnson-4a794d08-4a71-424a-a17d-d35af3c979ae.yml`
+  - `data/ar/retired/Lee-Johnson-3e79119d-2d88-484c-b20e-0f47213a42f0.yml`
+- `les` `eaves`
+  - `data/ar/legislature/Les-D-Eaves-7d85c10d-346f-4c4f-a4e5-470799f7b21c.yml`
+  - `data/ar/retired/Les-Eaves-e0974602-c00a-4a98-9377-a2ed444d5acd.yml`
+- `leslie` `rutledge`
+  - `data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml`
+  - `data/ar/executive/Leslie-Rutledge-4c6b83dc-b4d7-4202-aee3-76fdd2d6575e.yml`
+- `rick` `mcclure`
+  - `data/ar/legislature/Rick-McClure-9b76655d-a7c5-474d-8a35-5a30e8bf9d3a.yml`
+  - `data/ar/retired/Rick-McClure-bcd154e4-75dc-4b86-9605-dac8ada6cf6b.yml`
+- `ricky` `hill`
+  - `data/ar/legislature/Ricky-Hill-faf89935-181a-4d19-9e4b-dce4657d4d3a.yml`
+  - `data/ar/retired/Ricky-Hill-24a31239-d467-46e5-931a-c1faea5fd5d1.yml`
+- `ron` `mcnair`
+  - `data/ar/legislature/Ron-McNair-c45493e9-afbd-4f5e-bb69-e6caed58936a.yml`
+  - `data/ar/retired/Ron-McNair-dd44b7ab-309f-4cdd-810a-1446d4171f35.yml`
+- `sonia` `barker`
+  - `data/ar/legislature/Sonia-Eubanks-Barker-bd3c22f6-b1b5-4089-b03b-f8198ca843a2.yml`
+  - `data/ar/retired/Sonia-Eubanks-Barker-ca6b1551-7881-419c-bc8b-176a3fb66ac4.yml`
+- `stephanie` `flowers`
+  - `data/ar/legislature/Stephanie-Flowers-536c6536-294f-499b-a261-120a685297f0.yml`
+  - `data/ar/retired/Stephanie-Flowers-8d8f904b-b0e6-4b48-8945-313ab3e3cd59.yml`
+- `tim` `griffin`
+  - `data/ar/executive/Tim-Griffin-48067475-c8df-4956-8390-efd0b389af34.yml`
+  - `data/ar/executive/Tim-Griffin-99f67d4f-c181-46a8-b7a9-4b45ada32c50.yml`
+- `tony` `furman`
+  - `data/ar/legislature/Tony-Furman-55779b79-fd86-4991-882f-05819d80a87d.yml`
+  - `data/ar/retired/Tony-Furman-29f5644d-c2f0-47a1-af09-90d778bccd7b.yml`
+
+## az
+
+- `anthony` `kern`
+  - `data/az/retired/Anthony-Kern-82385dc6-0d39-4d02-aa6d-95dbc2534972.yml`
+  - `data/az/retired/Anthony-Kern-f4ea36ef-3e74-4753-be45-43d3029a8a0d.yml`
+  - `data/az/retired/Anthony-T-Kern-5053d803-8513-47ed-9ad1-d49c1b12f012.yml`
+- `catherine` `miranda`
+  - `data/az/legislature/Catherine-Miranda-6241112b-910b-4ad8-9c0d-9caad318874f.yml`
+  - `data/az/retired/Catherine-Miranda-cab32a4c-9f0f-445b-b8d2-a80a937ec87a.yml`
+- `david` `gowan`
+  - `data/az/legislature/David-Gowan-51520de4-0e87-475b-91d2-99aa18addf72.yml`
+  - `data/az/retired/David-Gowan-96ec9994-949d-47bd-8b20-79dec573323f.yml`
+- `jerry` `weiers`
+  - `data/az/retired/Jerry-Weiers-5d724fe6-d337-4eae-820a-37ce92dd363c.yml`
+  - `data/az/retired/Jerry-Weiers-6f8b10da-5b02-4732-94ab-873957fb0a3f.yml`
+  - `data/az/retired/Jerry-Weiers-c3ecc534-9335-4bb4-99ec-c9fc6d056399.yml`
+- `john` `giles`
+  - `data/az/retired/John-Giles-5c1097a1-137c-422f-9906-99b9c9503687.yml`
+  - `data/az/retired/John-Giles-5efe53bd-0f33-4ade-a121-271d2da9381b.yml`
+- `justin` `olson`
+  - `data/az/legislature/Justin-Olson-448cb969-a498-4826-ad1e-c443fe9b8057.yml`
+  - `data/az/retired/Justin-Olson-7eb206d9-c5b3-441e-93c2-8b2ba8110a32.yml`
+- `katie` `hobbs`
+  - `data/az/executive/Katie-Hobbs-6e522a2a-e7b7-4713-a40f-c897e4341a87.yml`
+  - `data/az/retired/Katie-Hobbs-b2e74e17-c184-4a98-921f-0683e513de6c.yml`
+  - `data/az/retired/Katie-Hobbs-cd668109-5466-4c61-96cf-f5448ea118bd.yml`
+- `kevin` `hartke`
+  - `data/az/municipalities/Kevin-Hartke-2f98bb5d-6401-4717-9a6e-3b879b82eb47.yml`
+  - `data/az/retired/Kevin-Hartke-52e15d8f-2819-4c1a-aeaa-04abde69d2d7.yml`
+- `lela` `alston`
+  - `data/az/legislature/Lela-Alston-030638cb-5fcd-4637-8c59-c129e28db988.yml`
+  - `data/az/retired/Lela-Alston-7bb65fd8-141d-49f5-a37d-98f92d6b522d.yml`
+- `martin` `quezada`
+  - `data/az/retired/Martin-J-Quezada-705bec87-a9ff-455b-a63f-ec3108e64f57.yml`
+  - `data/az/retired/Martin-Quezada-63396e5e-c77d-4f2c-b700-ff240eea75f5.yml`
+- `regina` `cobb`
+  - `data/az/retired/Regina-Cobb-55cdd789-761a-415a-8a35-c83306e1e4fc.yml`
+  - `data/az/retired/Regina-E-Cobb-c1216de5-2070-43b3-8398-7cf074dbf336.yml`
+- `reginald` `bolding`
+  - `data/az/retired/Reginald-Bolding-97d71f2f-9518-43fa-8076-5a78809563ff.yml`
+  - `data/az/retired/Reginald-Bolding-Jr-e7896fe6-b6a8-4fee-99d2-efb539262b7d.yml`
+- `rosanna` `gabaldón`
+  - `data/az/legislature/Rosanna-Gabaldn-6de57177-1b9e-4864-bb87-97c528842030.yml`
+  - `data/az/retired/Rosanna-Gabaldn-6910a81f-2b36-450a-ae79-b7387862ff05.yml`
+- `sarah` `liguori`
+  - `data/az/legislature/Sarah-Liguori-99f91f84-b1db-4a48-897a-4f87593357ea.yml`
+  - `data/az/retired/Sarah-Liguori-f62fec81-65ec-4893-aa8a-ea6b7c8b8df8.yml`
+- `shawnna` `bolick`
+  - `data/az/legislature/Shawnna-Bolick-355be281-2f88-4108-b894-62c54b67fba3.yml`
+  - `data/az/retired/Shawnna-Bolick-33c76d31-65d6-4072-9d30-c1b292a7bb52.yml`
+- `t.j.` `shope`
+  - `data/az/legislature/Thomas-R-Shope-bde26535-68ee-4eef-bbc8-bfa8a4380015.yml`
+  - `data/az/retired/TJ-Shope-ac99bf33-0875-4723-836c-286476d8725f.yml`
+- `warren` `petersen`
+  - `data/az/legislature/Warren-Petersen-66e496a4-a407-4af1-add3-ef6899b89807.yml`
+  - `data/az/retired/Warren-Petersen-1bbf0d07-d4d6-4654-b330-8d7f6542e258.yml`
+
+## ca
+
+- `aja` `brown`
+  - `data/ca/retired/Aja-Brown-2bb63001-991e-4262-9b5f-111ad2f33881.yml`
+  - `data/ca/retired/Aja-Brown-7451e00b-d236-492e-8049-224cc4b600f2.yml`
+- `bill` `zimmerman`
+  - `data/ca/municipalities/Bill-Zimmerman-3990341b-18c1-4974-b9f1-4e4c35e8b2e2.yml`
+  - `data/ca/retired/Bill-Zimmerman-bb6e1e33-cab7-4a3c-949e-a5ded8b3dce4.yml`
+- `blanca` `pacheco`
+  - `data/ca/legislature/Blanca-Pacheco-f2ba8154-6bf3-4e5e-af05-9412e2a189f2.yml`
+  - `data/ca/retired/Blanca-Pacheco-5af955d4-de39-4032-81f6-2e8f735780e3.yml`
+- `cameron` `smyth`
+  - `data/ca/municipalities/Cameron-Smyth-16e1cf9c-fde6-4a0a-bfbe-8bea180eca63.yml`
+  - `data/ca/retired/Cameron-Smyth-0cc78336-41e4-4699-837d-8e12b7b7ffaa.yml`
+  - `data/ca/retired/Cameron-Smyth-882872bc-9b00-4bc0-9046-c8e5c8ad7488.yml`
+- `carol` `dutra-vernaci`
+  - `data/ca/municipalities/Carol-Dutra-Vernaci-611c6cfe-bc70-4f7e-bca1-b0a48579a132.yml`
+  - `data/ca/retired/Carol-Dutra-Vernaci-40737603-029c-4a1b-a295-c7a73450b4c4.yml`
+- `chris` `rogers`
+  - `data/ca/legislature/Chris-Rogers-84a80bdb-37d5-4f52-8f55-e116fb97ca58.yml`
+  - `data/ca/municipalities/Chris-Rogers-40141964-f8cb-4270-a013-c483902a09ee.yml`
+- `darrell` `steinberg`
+  - `data/ca/retired/Darrell-Steinberg-9a11af5e-84e1-445b-b1db-5f9a431e9dc2.yml`
+  - `data/ca/retired/Darrell-Steinberg-b16c60c3-a356-48c5-88b9-29adaa61cabf.yml`
+- `ellen` `kamei`
+  - `data/ca/municipalities/Ellen-Kamei-6650db22-2b43-43f5-833e-7ebbcb4d119f.yml`
+  - `data/ca/retired/Ellen-Kamei-452427e0-1e49-4896-a624-8c6a69b69707.yml`
+- `fred` `smith`
+  - `data/ca/retired/Fred-Smith-a84ec045-cd5b-4fd5-b3ed-b995051a1b32.yml`
+  - `data/ca/retired/Fred-Smith-bd739820-92a9-4e19-905e-25dea37e2d29.yml`
+- `heidi` `harmon`
+  - `data/ca/retired/Heidi-Harmon-3d7703c6-e657-4d05-b7e3-5e1e25b03821.yml`
+  - `data/ca/retired/Heidi-Harmon-7b4b7067-c6de-4cb1-bed2-810a3208450c.yml`
+- `joe` `vinatieri`
+  - `data/ca/municipalities/Joe-Vinatieri-a21dba70-98c4-423b-98d5-663a490c3940.yml`
+  - `data/ca/retired/Joe-Vinatieri-3ab695b7-a4f3-4b14-9742-3b2023daff2f.yml`
+- `keith l.` `mashburn`
+  - `data/ca/retired/Keith-L-Mashburn-30a05a33-33f2-4c49-9f01-8c7f53c56d0b.yml`
+  - `data/ca/retired/Keith-L-Mashburn-620b158c-0118-4da8-8153-5e91e5b40f24.yml`
+- `kevin` `mccarty`
+  - `data/ca/municipalities/Kevin-McCarty-8b3e796b-da8d-43a0-82f8-464f139a2758.yml`
+  - `data/ca/retired/Kevin-McCarty-723bd312-e1c3-490c-9a8c-65388f834092.yml`
+- `l. dennis` `michael`
+  - `data/ca/municipalities/L-Dennis-Michael-f2d123d9-dbf7-497f-b9ba-d2c4271c1a2f.yml`
+  - `data/ca/retired/L-Dennis-Michael-41e4c4fa-defb-4a97-b431-6512e3de0939.yml`
+- `larry` `klein`
+  - `data/ca/municipalities/Larry-Klein-a1f5352b-ce24-4d32-9a4d-34741d047b1a.yml`
+  - `data/ca/retired/Larry-Klein-39f44874-07b8-4a5c-a3fc-e42c27d535d9.yml`
+- `mary` `salas`
+  - `data/ca/retired/Mary-Salas-d9305e9b-4ceb-42e8-bcb1-75cb77d81dac.yml`
+  - `data/ca/retired/Mary-Salas-eae08829-2f0b-4b6b-a305-a01b2fda7048.yml`
+- `maryann` `edwards`
+  - `data/ca/retired/Maryann-Edwards-08de737a-6043-4b60-bbe4-f1b43a450e51.yml`
+  - `data/ca/retired/Maryann-Edwards-0fed44d2-48db-4fcf-8d3d-4ed6b5247cd4.yml`
+- `roger` `niello`
+  - `data/ca/legislature/Roger-W-Niello-ee85bc79-20ee-4046-905e-ad797995fa41.yml`
+  - `data/ca/retired/Roger-Niello-917e90ed-3ac1-4ee9-a143-789ad0cf5e72.yml`
+- `shirley` `weber`
+  - `data/ca/executive/Shirley-Weber-c8e67d27-47c2-4565-8e29-79bc78ae9495.yml`
+  - `data/ca/retired/Shirley-N-Weber-71cfb6c2-577a-4813-8bdf-a1083314c491.yml`
+- `susan m.` `landry`
+  - `data/ca/retired/Susan-M-Landry-1c4e63bd-84a8-4196-9395-4a20efe21d7f.yml`
+  - `data/ca/retired/Susan-M-Landry-f7853ff4-5f48-49cf-a644-9ee037391e05.yml`
+- `tim` `mcgallian`
+  - `data/ca/retired/Tim-McGallian-8838356e-a58a-4830-9423-85a994d98cb8.yml`
+  - `data/ca/retired/Tim-McGallian-cc2b6524-896e-4eb0-926f-b1bab5603795.yml`
+
+## co
+
+- `dafna` `michaelson jenet`
+  - `data/co/retired/Dafna-Michaelson-Jenet-3818c80e-ca06-40d5-be21-ae570f6a21b5.yml`
+  - `data/co/retired/Dafna-Michaelson-Jenet-a37712a4-bcbe-4179-83c7-ab0574fccedc.yml`
+- `janice` `rich`
+  - `data/co/legislature/Janice-Rich-2372415a-2aea-4423-8a3a-bed2d40493a6.yml`
+  - `data/co/retired/Janice-Rich-45efea89-1f3a-497d-8963-37d9f9d1281f.yml`
+- `jeni` `arndt`
+  - `data/co/municipalities/Jeni-Arndt-a5d3543a-a959-4e35-937d-a82fa5ebb479.yml`
+  - `data/co/retired/Jeni-James-Arndt-e058cefb-c8bb-4251-947a-f0af071dfe02.yml`
+- `joseph` `salazar`
+  - `data/co/retired/Joseph-A-Salazar-2a7df723-73e9-431c-94a2-a646bfcd1e0c.yml`
+  - `data/co/retired/Joseph-Salazar-47348619-f5e3-494f-bf03-f6a6248e28ef.yml`
+- `julie` `mccluskie`
+  - `data/co/legislature/Julie-McCluskie-53facaaf-5673-4c76-b15a-6b5061965ae1.yml`
+  - `data/co/retired/Julie-McCluskie-fd2cb73e-2c46-4009-932b-d235f24fc442.yml`
+- `leroy` `garcia`
+  - `data/co/retired/Leroy-Garcia-6aa0113f-e293-4be5-b0e2-715581e84878.yml`
+  - `data/co/retired/Leroy-M-Garcia-ce857cd8-6a5f-4bf7-8faa-58a4a858e253.yml`
+- `michael` `johnston`
+  - `data/co/municipalities/Mike-Johnston-3b5c8213-a8a7-474b-903f-f5d67e75c4bc.yml`
+  - `data/co/retired/Michael-Johnston-e34bdf69-f45e-4fcd-8ece-f3e942b7b40b.yml`
+- `perry` `will`
+  - `data/co/retired/Perry-Will-221d86f6-e78f-4381-8826-e48451a8a97f.yml`
+  - `data/co/retired/Perry-Will-c4686ac9-e2d6-454a-b101-d33b9f32255f.yml`
+- `tom` `sullivan`
+  - `data/co/legislature/Tom-Sullivan-dc9056b8-fb9c-4a66-99b8-210acce64bff.yml`
+  - `data/co/retired/Tom-Sullivan-7a09a2fa-0249-4751-8dd1-caa100395438.yml`
+- `tony` `exum`
+  - `data/co/legislature/Tony-Exum-473bd095-778d-4418-8e61-96a2b8005c8e.yml`
+  - `data/co/retired/Tony-Exum-a7c5f656-26d8-4ad1-bef4-24bb2d667964.yml`
+
+## ct
+
+- `aundré` `bumgardner`
+  - `data/ct/legislature/Aundre-Bumgardner-32ad6577-b1ee-411f-9dca-e40e06226703.yml`
+  - `data/ct/retired/Aundr-Bumgardner-1af3c171-f7f9-4843-8a06-25960ac20bc6.yml`
+- `brenda l.` `kupchick`
+  - `data/ct/municipalities/Brenda-L-Kupchick-d799c3ad-6665-45be-b4d8-6784ad72849a.yml`
+  - `data/ct/retired/Brenda-L-Kupchick-d9f16dc8-f123-451a-a1cf-191706553a25.yml`
+- `james` `maroney`
+  - `data/ct/legislature/James-J-Maroney-f37ce303-e106-4972-b453-4287b7915762.yml`
+  - `data/ct/retired/James-Maroney-71aa6702-6b26-45d5-8101-e30a6b36b6b2.yml`
+- `len` `suzio`
+  - `data/ct/retired/Len-Suzio-Jr-dfa7d6da-abfd-48b2-b6fc-ea76a31cd616.yml`
+  - `data/ct/retired/Len-Suzio-f07d1ea1-34a5-4a50-ab43-c77a7843eabe.yml`
+- `marilyn` `moore`
+  - `data/ct/retired/Marilyn-Moore-8d113751-6123-4181-a3a7-eb5c3c9e70e5.yml`
+  - `data/ct/retired/Marilyn-V-Moore-41d83b98-d5ab-48db-b847-3a3e08194b4c.yml`
+- `stephanie` `thomas`
+  - `data/ct/executive/Stephanie-Thomas-e54205b6-c824-4f64-9a68-301d01318457.yml`
+  - `data/ct/retired/Stephanie-Thomas-ea5497d0-5a3b-4dcc-9d13-5d50a586cf2b.yml`
+
+## dc
+
+- `robert` `white`
+  - `data/dc/legislature/Robert-C-White-Jr-07b9c384-a232-40d5-b445-61db9e4bb65b.yml`
+  - `data/dc/retired/Robert-White-039d6153-d791-42ff-9fb1-3326c4565c53.yml`
+
+## de
+
+- `earl g.` `jaques`
+  - `data/de/retired/Earl-G-Jaques-5ed571c2-c769-4a1e-8ea9-8c5c77d4cf73.yml`
+  - `data/de/retired/Earl-G-Jaques-Jr-107bd04c-d4e1-4b41-86f2-bfd8dbcdabf3.yml`
+
+## fl
+
+- `anne` `gerwig`
+  - `data/fl/legislature/Anne-Gerwig-ad877adf-e8f2-4f31-bdd2-38a6aaf74884.yml`
+  - `data/fl/municipalities/Anne-Gerwig-4be11847-f457-4852-bcfd-bd6b2c62c448.yml`
+- `bobby` `powell`
+  - `data/fl/retired/Bobby-Powell-1f25e279-3bd4-423b-8d2d-c2d09154540d.yml`
+  - `data/fl/retired/Bobby-Powell-efe6dfff-38e5-4a7f-822e-8cb4cfba7e71.yml`
+- `bruce` `antone`
+  - `data/fl/legislature/Bruce-Hadley-Antone-617888c1-3369-49cd-a264-18ab663d2e8a.yml`
+  - `data/fl/retired/Bruce-Antone-46ab1d9a-c958-4fa8-b26d-512195838adb.yml`
+- `bryan` `nelson`
+  - `data/fl/retired/Bryan-Nelson-98d5c583-a6d0-45b4-93ca-864ce2ad6028.yml`
+  - `data/fl/retired/Bryan-Nelson-c9b86ba5-1c9e-4d70-a047-31c1eacda961.yml`
+- `cord` `byrd`
+  - `data/fl/executive/Cord-Byrd-bf19e4db-85d0-4b4e-a980-e30d84905d8a.yml`
+  - `data/fl/retired/Cord-Byrd-52b678b9-cb9c-4e65-bd81-32bc7c2bdf0c.yml`
+- `daphne` `campbell`
+  - `data/fl/retired/Daphne-Campbell-d344349d-157c-46cd-9b54-90ecdaf764e5.yml`
+  - `data/fl/retired/Daphne-D-Campbell-4197ba56-4123-411b-b9a8-5f6213511b06.yml`
+- `heather` `fitzenhagen`
+  - `data/fl/retired/Heather-Dawes-Fitzenhagen-86feda61-2f70-4018-bc3a-2500807a3d64.yml`
+  - `data/fl/retired/Heather-Fitzenhagen-737bedf7-ea9c-4177-bfd9-98e3b72af927.yml`
+- `holly` `raschein`
+  - `data/fl/retired/Holly-Merrill-Raschein-5e7307f2-2223-45f2-9ab2-f21bbe19ae4d.yml`
+  - `data/fl/retired/Holly-Raschein-788fd221-0fed-4b4f-a646-da55bb57625d.yml`
+- `jason` `brodeur`
+  - `data/fl/legislature/Jason-Brodeur-b1525f57-c2db-407e-bca9-66675cc4d3ff.yml`
+  - `data/fl/retired/Jason-Brodeur-cd669d62-d957-4a41-b7e7-9fe2bd6a94ab.yml`
+  - `data/fl/retired/Jason-T-Brodeur-c82b28f1-75b1-44b4-b224-d85efe2bd3ec.yml`
+- `jay` `trumbull`
+  - `data/fl/legislature/Jay-Trumbull-29c38853-2773-45d3-bc17-0979def1ab54.yml`
+  - `data/fl/retired/Jay-Trumbull-423a0d95-471e-4da5-853c-3cd55a29498c.yml`
+- `jeff` `clemens`
+  - `data/fl/retired/Clemens-Jeff-a5324bcf-40f6-4dac-af52-a9d37e666b5f.yml`
+  - `data/fl/retired/Jeff-Clemens-89b85b1c-d734-4ecf-9d09-f61c5bece4d6.yml`
+- `jennifer` `bradley`
+  - `data/fl/legislature/Jennifer-Bradley-68e0a17f-338b-497b-ba07-1f74e9623f1d.yml`
+  - `data/fl/retired/Jennifer-Bradley-4fa3d065-c48d-46a7-9dca-ab85fad5c5f8.yml`
+- `joe` `negron`
+  - `data/fl/retired/Joe-Negron-401f6e59-730d-45c5-900c-f4cc73468fb4.yml`
+  - `data/fl/retired/Joe-Negron-826d9906-3894-49ea-a397-ebb7b8fb489e.yml`
+- `john` `rees`
+  - `data/fl/municipalities/John-Rees-9425b1d1-9155-442a-805f-45ec65b66f56.yml`
+  - `data/fl/retired/John-Rees-b72eb120-6327-400e-b5e0-71c83a15c810.yml`
+- `kathleen` `passidomo`
+  - `data/fl/legislature/Kathleen-Passidomo-ae123d54-1076-49b2-84f9-2897b7d60ebd.yml`
+  - `data/fl/retired/Kathleen-C-Passidomo-d360a7bc-12c0-48ba-896e-0c01d306d2dd.yml`
+- `kaylee` `tuck`
+  - `data/fl/legislature/Kaylee-Tuck-43356d29-3396-423e-9286-f7bd1e52ebde.yml`
+  - `data/fl/retired/Kaylee-Tuck-7bf7d958-fabd-430b-9326-97586b0c0880.yml`
+- `kelly` `skidmore`
+  - `data/fl/legislature/Kelly-Skidmore-8eff1a19-557d-4a5d-8a3b-c77015a7babe.yml`
+  - `data/fl/retired/Kelly-Skidmore-232b7507-aca7-41d0-8efd-95276b13081a.yml`
+- `lawrence` `mcclure`
+  - `data/fl/legislature/Lawrence-McClure-56263ea0-3c5c-45cb-998d-ac7cf8db5446.yml`
+  - `data/fl/retired/Lawrence-McClure-879b8e36-473e-4e72-b1c2-f95be96f1cc0.yml`
+- `linda` `chaney`
+  - `data/fl/legislature/Linda-Chaney-7d59a4fe-d0f1-43a8-93b4-bcd3b7fe5b4e.yml`
+  - `data/fl/retired/Linda-Chaney-02a076d1-b8da-4eb5-8fde-1dc0408cc36a.yml`
+- `mike` `beltran`
+  - `data/fl/retired/Mike-Beltran-4f45bda8-a133-43a3-aa11-6c80833a7521.yml`
+  - `data/fl/retired/Mike-Beltran-5cd475cc-449f-481e-9e65-97f3a2352556.yml`
+- `mike` `giallombardo`
+  - `data/fl/legislature/Mike-Giallombardo-9a44c892-cd4a-452b-88cb-435e8ece8d82.yml`
+  - `data/fl/retired/Mike-Giallombardo-4815dd20-5f86-4af4-a8a5-44878855e734.yml`
+- `randy` `fine`
+  - `data/fl/retired/Randy-Fine-24414448-9244-4c72-bf3f-1930103b746d.yml`
+  - `data/fl/retired/Randy-Fine-4f34e436-9669-41ba-8469-eff589b84943.yml`
+- `rick` `kriseman`
+  - `data/fl/retired/Rick-Kriseman-18a7fdec-d2a6-42ff-9efa-dc5c98b698e9.yml`
+  - `data/fl/retired/Rick-Kriseman-19812604-9a24-4f98-a697-07dc2bd5a885.yml`
+- `rosalind` `osgood`
+  - `data/fl/legislature/Rosalind-Osgood-3194701f-dfa8-40e9-9081-56aa20c63f6e.yml`
+  - `data/fl/retired/Rosalind-Osgood-ba43e456-b4d3-408d-aeba-d4b7482dacd0.yml`
+- `shelly` `petrolia`
+  - `data/fl/municipalities/Shelly-Petrolia-b488f0f6-6eae-4692-ab6b-1174ba4db708.yml`
+  - `data/fl/retired/Shelly-Petrolia-a1f473a5-5c79-45a4-9c92-cc0b58875c73.yml`
+- `thad` `altman`
+  - `data/fl/retired/Thad-Altman-24c94be4-a2b4-4efc-b3cd-4ef4b8bc4224.yml`
+  - `data/fl/retired/Thad-Altman-8ae6fdaf-d47d-46a8-b69c-118459f23ecd.yml`
+- `tim` `pospichal`
+  - `data/fl/retired/Tim-Pospichal-1eb9840d-381f-4d8a-a519-b1f08db85cd8.yml`
+  - `data/fl/retired/Tim-Pospichal-b1f95762-0dca-49e2-9c0c-269d7f77787c.yml`
+- `tracie` `davis`
+  - `data/fl/legislature/Tracie-Davis-03362949-948c-415d-a5b6-f99e8fbc6495.yml`
+  - `data/fl/retired/Tracie-Davis-f98f9fd7-e1e7-4c5b-aa2f-b6096c39cfd3.yml`
+- `tracy` `upchurch`
+  - `data/fl/retired/Tracy-Upchurch-3cc073f5-b233-4818-bba4-47fc42aef4a9.yml`
+  - `data/fl/retired/Tracy-Upchurch-6e94b96d-61e8-45ca-b615-21df0dfd0a27.yml`
+- `wyman` `duggan`
+  - `data/fl/legislature/Wyman-Duggan-17ae3cd7-1aa0-44b4-baab-ed839b6776a6.yml`
+  - `data/fl/retired/Wyman-Duggan-0cce8972-cfe4-44c3-90d2-65596f073d15.yml`
+
+## ga
+
+- `brad` `raffensperger`
+  - `data/ga/executive/Brad-Raffensperger-02e75ac0-4350-4305-980e-8dc0462c5cc1.yml`
+  - `data/ga/retired/Brad-Raffensperger-1e5d1b04-a659-45b4-9c43-0945df52b1a3.yml`
+- `derrick` `jackson`
+  - `data/ga/legislature/Derrick-Jackson-9046fcb2-f3eb-4233-bd92-32c94e60f9df.yml`
+  - `data/ga/retired/Derrick-Jackson-9c6d1032-c14f-4b57-90df-eaa1273cc336.yml`
+- `doug` `stoner`
+  - `data/ga/retired/Doug-Stoner-1bb829c7-7da3-4e9e-87f4-0f3a9b72bf8a.yml`
+  - `data/ga/retired/Doug-Stoner-52457c0b-9f25-469e-958c-30327af42ee1.yml`
+- `hardie` `davis`
+  - `data/ga/retired/Hardie-Davis-37cb3792-8cbd-466c-9fb6-b71176b05955.yml`
+  - `data/ga/retired/Hardie-Davis-Jr-659265e0-be6b-4a02-8a56-b61aa967fda4.yml`
+- `scott` `hilton`
+  - `data/ga/legislature/Scott-Hilton-91abe321-5ea4-4f17-b8d8-573d7cb913e6.yml`
+  - `data/ga/retired/Scott-Hilton-f80db73b-f8c4-48e0-ac57-9b22912f40c0.yml`
+- `van` `johnson`
+  - `data/ga/municipalities/Van-Johnson-7037800c-02c2-4ce2-bd71-9ec5f1d8b817.yml`
+  - `data/ga/municipalities/Van-R-Johnson-II-31ddbce1-fe21-4dc6-a741-47a145ff3148.yml`
+
+## hi
+
+- `carol` `fukunaga`
+  - `data/hi/legislature/Carol-Fukunaga-ca85a087-4a1f-450b-9386-11c13eb8c280.yml`
+  - `data/hi/retired/Carol-Fukunaga-4376a049-b7c6-411b-ae73-c7e5532f1bca.yml`
+- `james kunane` `tokioka`
+  - `data/hi/retired/James-Kunane-Tokioka-c2096cdc-d6cd-4d6a-98eb-4276e0389386.yml`
+  - `data/hi/retired/James-Kunane-Tokioka-d9351eed-1650-4caf-b96f-3683f91c0633.yml`
+- `josh` `green`
+  - `data/hi/executive/Josh-Green-c7e5e0d4-7a5d-42dc-a3cc-d7b54b1dc51b.yml`
+  - `data/hi/retired/Josh-Green-342ddd0b-d580-4790-8aa1-3ffceed3cecc.yml`
+- `linda` `ichiyama`
+  - `data/hi/legislature/Linda-Ichiyama-546ef7bf-9015-4a09-b8d3-f37fd87ed97f.yml`
+  - `data/hi/retired/Linda-Ichiyama-f263427a-454f-46b6-ba94-2e05fe82e802.yml`
+- `mike` `gabbard`
+  - `data/hi/legislature/Mike-Gabbard-9f87e7d6-a307-45ab-b384-96a8599dab56.yml`
+  - `data/hi/retired/Mike-Gabbard-926b2548-5882-4163-9dcd-317ff923698d.yml`
+- `richard` `creagan`
+  - `data/hi/retired/Richard-Creagan-0e1a9a28-2ae6-428b-a64c-c4dd2994e35a.yml`
+  - `data/hi/retired/Richard-P-Creagan-b8877741-38eb-417e-be87-7a7ae5baa984.yml`
+- `sam` `kong`
+  - `data/hi/legislature/Sam-Satoru-Kong-cbf4fe33-42cf-41c2-b689-5e4c0ff150f6.yml`
+  - `data/hi/retired/Sam-Kong-ba497986-3d54-48f6-85c2-fa1a87b17a1e.yml`
+
+## ia
+
+- `amy` `nielsen`
+  - `data/ia/legislature/Amy-Nielsen-0ed1d7f1-1471-4055-b674-582bf19c28b3.yml`
+  - `data/ia/retired/Amy-Nielsen-14aced68-fa51-4bb7-8f79-ae7996e55fa2.yml`
+- `anne` `osmundson`
+  - `data/ia/retired/Anne-Osmundson-5afd80c1-3f96-4ccc-92b1-19bc26d72f4e.yml`
+  - `data/ia/retired/Anne-Osmundson-f7c967d7-bd1b-4cd6-aa35-dfbf0966b382.yml`
+- `bob` `kressig`
+  - `data/ia/legislature/Bob-Kressig-bdd055a7-677f-4df3-ba42-72c09d75a2ad.yml`
+  - `data/ia/retired/Bob-Kressig-5f79b082-fcb1-431d-98ad-27150167210d.yml`
+- `bobby` `kaufmann`
+  - `data/ia/legislature/Bobby-Kaufmann-657c7d2d-2444-4809-93fb-d1701d77f528.yml`
+  - `data/ia/retired/Bobby-Kaufmann-96b02859-9182-4192-8e4c-e8be15cb4002.yml`
+- `brian` `lohse`
+  - `data/ia/legislature/Brian-K-Lohse-e0d66082-fd49-47ff-acd7-2f8106bc9837.yml`
+  - `data/ia/retired/Brian-K-Lohse-076d9aaa-b357-4f27-aa57-05bb3c8f2075.yml`
+- `charlie` `mcclintock`
+  - `data/ia/legislature/Charlie-McClintock-006bcadf-1173-4661-a28e-25fbf1a5c423.yml`
+  - `data/ia/retired/Charlie-McClintock-dc57bea2-1861-4006-bc0a-bcc9eb4d2826.yml`
+- `cherielynn` `westrich`
+  - `data/ia/legislature/Cherielynn-Westrich-f4803b48-80d4-43aa-86cd-fe78d268e77a.yml`
+  - `data/ia/retired/Cherielynn-Westrich-5ef366c0-449c-4bfe-9631-275cd0a894d0.yml`
+- `cindy` `winckler`
+  - `data/ia/legislature/Cindy-Winckler-84279bc7-04df-475e-8d6f-9f9703c73101.yml`
+  - `data/ia/retired/Cindy-Winckler-70a12248-3bd4-4bd9-9028-004fb34f3191.yml`
+- `dave` `jacoby`
+  - `data/ia/legislature/David-Jacoby-55c46119-e6fa-4b22-ade6-18990aeacf0c.yml`
+  - `data/ia/retired/Dave-Jacoby-4c535bc4-4b3c-4def-9332-700a1ebb5c6a.yml`
+- `dawn` `driscoll`
+  - `data/ia/legislature/Dawn-Driscoll-fe90f2b2-0892-4abd-9d6d-4b2ac1dae632.yml`
+  - `data/ia/retired/Dawn-Driscoll-20af7fbf-7d15-402a-bf78-b5b2cd7edec3.yml`
+- `dennis` `guth`
+  - `data/ia/legislature/Dennis-Guth-1e11235a-f4c8-4124-9f3a-3bb7a219636d.yml`
+  - `data/ia/retired/Dennis-Guth-306bac58-f624-4f62-80e9-16fa1d172396.yml`
+- `eddie` `andrews`
+  - `data/ia/legislature/Eddie-Andrews-258e0f31-d71a-42b5-98ff-3f2263f95f65.yml`
+  - `data/ia/retired/Eddie-Andrews-93b7c1cc-9339-4236-920b-596d61547df4.yml`
+- `eric` `giddens`
+  - `data/ia/retired/Eric-Giddens-5d41736d-437f-4b53-a9a2-5ebc1d088e35.yml`
+  - `data/ia/retired/Eric-Giddens-83a23151-4c51-4466-954c-c27005186f54.yml`
+- `eric` `gjerde`
+  - `data/ia/legislature/Eric-J-Gjerde-8e424b53-9531-4b76-bd44-a8008f34b539.yml`
+  - `data/ia/retired/Eric-Gjerde-bcc8455f-8ea2-49ff-a778-5ff5c812cea9.yml`
+- `heather` `matson`
+  - `data/ia/legislature/Heather-Matson-ba713234-dc5e-4646-9f74-c25d84f648cc.yml`
+  - `data/ia/retired/Heather-Matson-79d03429-b53d-472b-bd89-18b4b273a973.yml`
+- `herman` `quirmbach`
+  - `data/ia/legislature/Herman-C-Quirmbach-d3b3bc8e-ab0c-4ee2-ba3d-de78040274af.yml`
+  - `data/ia/retired/Herman-C-Quirmbach-f1658c80-10e7-4309-a9f5-9be524ccae68.yml`
+- `jennifer` `konfrst`
+  - `data/ia/legislature/Jennifer-Konfrst-522b14b8-b82f-4336-a7fb-a0f782d5509a.yml`
+  - `data/ia/retired/Jennifer-Konfrst-f8a5dfc0-e8e0-4f38-a29f-4e3d3ddf87cb.yml`
+- `john` `forbes`
+  - `data/ia/retired/John-Forbes-0695ec27-a347-429b-8f47-ed8fcc2dfcf9.yml`
+  - `data/ia/retired/John-Forbes-2f46318a-682d-40b2-a7f5-793a6014939c.yml`
+- `jon` `dunwell`
+  - `data/ia/legislature/Jon-Dunwell-7a97018b-eb0e-46cf-8bd8-26520ff0d1e0.yml`
+  - `data/ia/retired/Jon-Dunwell-273104f3-ad0c-484e-b4ad-22e08809c146.yml`
+- `lindsay` `james`
+  - `data/ia/legislature/Lindsay-James-2f43be90-4912-41fa-acf3-735e3a9ef557.yml`
+  - `data/ia/retired/Lindsay-James-5d24f3bc-b000-4283-bf2d-4b279610da00.yml`
+- `ross` `wilburn`
+  - `data/ia/legislature/Ross-Wilburn-068a7290-ab67-4ff5-abe5-8e23a7715097.yml`
+  - `data/ia/retired/Ross-Wilburn-4c300623-1add-49f4-a8e3-2356d78d188f.yml`
+- `shannon` `latham`
+  - `data/ia/legislature/Shannon-Latham-90ea16da-2e10-470e-a004-a5e2688e6331.yml`
+  - `data/ia/retired/Shannon-Latham-15a5304e-8fa9-410e-8c95-19b7a4ede1b4.yml`
+
+## id
+
+- `christy` `perry`
+  - `data/id/retired/Christy-Perry-4eb7f9b3-8cba-4041-aef3-b41efba9cd63.yml`
+  - `data/id/retired/Christy-Perry-7d210a5b-d725-430b-944f-55f3cfb1c0ba.yml`
+- `daniel` `johnson`
+  - `data/id/municipalities/Daniel-Johnson-97b7bc48-08b6-4b68-9330-dbb591779635.yml`
+  - `data/id/retired/Dan-G-Johnson-50aa3753-ad43-4fe4-b58e-1c107b0db944.yml`
+- `jeff` `thompson`
+  - `data/id/retired/Jeff-Thompson-06d76e92-9a46-4e4f-b15f-0a1131a0296f.yml`
+  - `data/id/retired/Jeff-Thompson-7e518268-126e-4661-bc5e-0390fc3e06df.yml`
+- `jim` `patrick`
+  - `data/id/retired/Jim-L-Patrick-54d254b5-070b-4aad-9cdb-a38c60ff39ea.yml`
+  - `data/id/retired/Jim-Patrick-eee10503-d086-48f4-9b9a-6c5b3694840c.yml`
+- `lawerence` `denney`
+  - `data/id/retired/Lawerence-Denney-5704ac44-e3e6-4da6-b5d6-5ba7de015620.yml`
+  - `data/id/retired/Lawerence-Denney-66ed85af-de58-4af0-822d-6f268606d52c.yml`
+- `mathew` `erpelding`
+  - `data/id/retired/Mathew-W-Erpelding-6979490b-4a7e-41a3-b884-a359a34fae1e.yml`
+  - `data/id/retired/Mathew-W-Mat-Erpelding-1903ff33-9ae0-4c0f-98b5-84a9e79cdcec.yml`
+- `phil` `hart`
+  - `data/id/legislature/Phil-Hart-202344ed-fa6e-4d6d-b746-516abb5c962d.yml`
+  - `data/id/retired/Phil-Hart-013a5528-b35c-4c65-990a-bbb9edb98d4c.yml`
+
+## il
+
+- `daniel` `biss`
+  - `data/il/municipalities/Daniel-Biss-c15bcf05-635e-4c9e-95e1-5f52d5a5dd47.yml`
+  - `data/il/retired/Daniel-Biss-800445ad-7249-40dd-8544-7570d3366bba.yml`
+- `george` `van dusen`
+  - `data/il/municipalities/George-Van-Dusen-7ef9fe40-704a-4ccd-8edf-e25d425ee3f7.yml`
+  - `data/il/retired/George-Van-Dusen-132f9cc6-0d0e-4fd1-b411-c0366335b86d.yml`
+- `kevin` `burns`
+  - `data/il/municipalities/Kevin-Burns-5e9eff58-9a43-484a-9ae0-c77732f19884.yml`
+  - `data/il/retired/Kevin-Burns-d7d6036e-139d-4c40-9cd2-621ef9ff2bca.yml`
+- `kimberly` `du buclet`
+  - `data/il/legislature/Kimberly-du-Buclet-3b2af944-b2b7-4b13-87db-1c8cdd45de3c.yml`
+  - `data/il/retired/Kimberly-du-Buclet-c114c642-0e7d-46a3-bcc6-05ea966904ad.yml`
+- `mary` `alexander-basta`
+  - `data/il/municipalities/Mary--Alexander-Basta-c35566d3-e116-467f-b0d0-2ffb0d300208.yml`
+  - `data/il/retired/Mary-Alexander-Basta-4220ba19-3410-4a0a-a331-6400d2640801.yml`
+- `mary` `edly-allen`
+  - `data/il/legislature/Mary-Edly-Allen-1a1cd310-b42c-4da3-b9ac-6278b1e95a02.yml`
+  - `data/il/retired/Mary-Edly-Allen-4961384a-0200-48da-a027-5b8a21103c37.yml`
+- `thaddeus` `jones`
+  - `data/il/legislature/Thaddeus-Jones-a38c9ab5-48b6-417c-baf1-bae5e8f3b7c0.yml`
+  - `data/il/municipalities/Thaddeus-Jones-373f5136-b0ed-4f7e-a04d-02eb355672a2.yml`
+- `wayne` `rosenthal`
+  - `data/il/legislature/Wayne-A-Rosenthal-5a23473f-1af0-4f7d-8b08-cb287d93db6f.yml`
+  - `data/il/retired/Wayne-Rosenthal-002fb74d-0879-4be4-947e-6914148b073f.yml`
+
+## in
+
+- `connie` `lawson`
+  - `data/in/retired/Connie-Lawson-81fd1ddd-e2ff-4c20-bd91-e8fea723153b.yml`
+  - `data/in/retired/Connie-Lawson-8382a68a-7cd7-4d7c-8ad3-69a38567f0c3.yml`
+- `earl` `harris`
+  - `data/in/legislature/Earl-Harris-e0aaea95-033f-49d8-9be6-3875fc3b8efe.yml`
+  - `data/in/retired/Earl-L-Harris-060f70bc-34fb-4e21-ab9b-48a5eca0d33b.yml`
+
+## ks
+
+- `brandon` `whipple`
+  - `data/ks/retired/Brandon-Whipple-99d17def-cb5e-426a-bbec-3a04a8b42166.yml`
+  - `data/ks/retired/Brandon-Whipple-a3bc67f4-8f74-4e64-b405-9dfe0c6ef45f.yml`
+- `brandon` `woodard`
+  - `data/ks/legislature/Brandon-Woodard-c56cf970-39c2-4821-8723-a85dfe09cd6b.yml`
+  - `data/ks/retired/Brandon-Woodard-7e82e21f-443a-4d81-b4a8-c41af07913b1.yml`
+- `dan` `goddard`
+  - `data/ks/legislature/Dan-Goddard-2d7cf122-fd6c-406c-a158-de6c61ff0afa.yml`
+  - `data/ks/retired/Dan-Goddard-804bbf3c-f3b3-4666-a50a-d55f3716f741.yml`
+- `laura` `kelly`
+  - `data/ks/executive/Laura-Kelly-2654d836-700f-464d-a0dd-81cb0bd77b9e.yml`
+  - `data/ks/retired/Laura-Kelly-2a1eea1d-1624-4146-a322-a69f8d02e7f4.yml`
+- `mike` `thompson`
+  - `data/ks/legislature/Mike-Thompson-97943c08-7d1f-400e-b71d-7a20e939b1d9.yml`
+  - `data/ks/retired/Mike-Thompson-3a3759b4-7380-4ea8-acdf-bec3f61929c5.yml`
+- `ron` `ryckman`
+  - `data/ks/legislature/Ronald-Ryckman-43caafd7-9177-40f4-b515-0681ef5930f3.yml`
+  - `data/ks/retired/Ron-Ryckman-d0726d0a-4a9e-44e1-992e-8e1addd330ce.yml`
+- `scott` `schwab`
+  - `data/ks/executive/Scott-Schwab-5ef16835-fd08-407d-abaf-0407a665ada1.yml`
+  - `data/ks/retired/Scott-Schwab-6a7ea31f-d4d3-4259-a518-4162aaddea54.yml`
+- `usha` `reddi`
+  - `data/ks/retired/Usha-Reddi-0db9f5c4-ab64-4f99-90db-cce297e57167.yml`
+  - `data/ks/retired/Usha-Reddi-5f39e157-4b1e-4a21-bc24-ec7c142db356.yml`
+
+## la
+
+- `cameron` `henry`
+  - `data/la/legislature/J-Cameron-Henry-Jr-684d1cc7-cce3-4545-a6ab-d689c7c56105.yml`
+  - `data/la/retired/Cameron-Henry-7ab1d262-f01a-483c-866f-eeec5fc3de38.yml`
+- `john bel` `edwards`
+  - `data/la/retired/John-Bel-Edwards-149f1e2a-4cda-4433-a95b-2aa968d4aef2.yml`
+  - `data/la/retired/John-Bel-Edwards-52134ed5-805e-4ab0-8d97-547580f054a8.yml`
+- `mike` `johnson`
+  - `data/la/legislature/Michael-T-Johnson-0e901294-3718-49df-9922-0ac4503acee2.yml`
+  - `data/la/retired/Johnson-Mike-207bac55-0252-40f6-82ae-d47ad0b1d264.yml`
+- `regina` `barrow`
+  - `data/la/legislature/Regina-Ashford-Barrow-8710f3da-9aea-41a9-acd2-181377cc6ae7.yml`
+  - `data/la/retired/Regina-Barrow-bcfc9c78-88c4-452d-9038-19272892cc1c.yml`
+- `sharon weston` `broome`
+  - `data/la/retired/Sharon-Weston-Broome-1526d628-9a5d-455e-ade8-802b5e8efc85.yml`
+  - `data/la/retired/Sharon-Weston-Broome-6ff6d27f-e20c-4de9-a0d1-55378ba18a2b.yml`
+- `troy` `hebert`
+  - `data/la/legislature/Troy-Hebert-ba2902d5-5a0e-4e71-b396-6e85358511de.yml`
+  - `data/la/retired/Troy-Hebert-2eccfbd6-9ee9-4cad-9cd0-a3c75bf06bb1.yml`
+
+## ma
+
+- `aaron` `michlewitz`
+  - `data/ma/legislature/Aaron-Michlewitz-4183f327-e2a6-4b1a-9d23-161da1b5e261.yml`
+  - `data/ma/retired/Aaron-M-Michlewitz-9d25e0a4-81f7-4b0f-9c9c-87cf84b1fc91.yml`
+- `adrian` `madaro`
+  - `data/ma/legislature/Adrian-Madaro-f8772f1e-29f7-42e2-8a8c-ab4005153b05.yml`
+  - `data/ma/retired/Adrian-Madaro-cf3448cf-989e-43d1-a003-48ec8dbf6281.yml`
+- `andrea` `campbell`
+  - `data/ma/executive/Andrea-Campbell-4e8f36fb-9017-4a35-a692-7f09958dcf61.yml`
+  - `data/ma/executive/Andrea-Joy-Campbell-cda44699-dbdd-4486-882f-552e573325c6.yml`
+- `angelo` `puppolo`
+  - `data/ma/legislature/Angelo-J-Puppolo-Jr-8302648f-4ed2-454e-ad1e-d7389e25b8dc.yml`
+  - `data/ma/retired/Angelo-J-Puppolo-Jr-53918ad0-5fc9-46cd-ae86-d1fe4300efb3.yml`
+- `barbara` `l'italien`
+  - `data/ma/retired/Barbara-A-LItalien-44d678cb-ac3c-4f3d-a665-ea7cf6c6273d.yml`
+  - `data/ma/retired/Barbara-LItalien-330d78ce-5492-4d8f-80d3-845dad4fa641.yml`
+- `daniel` `cullinane`
+  - `data/ma/retired/Daniel-Cullinane-2247ed2c-6931-432e-86b2-5eaec873300b.yml`
+  - `data/ma/retired/Daniel-Cullinane-2c809d40-ca4d-47e4-bfe5-14eaa37ecf43.yml`
+- `david j.` `narkewicz`
+  - `data/ma/retired/David-J-Narkewicz-1602c8e0-d2d4-48ed-9c49-5e9c09cad12d.yml`
+  - `data/ma/retired/David-J-Narkewicz-3b9c87d8-244a-4bac-94ec-3da8fad95de7.yml`
+- `harold` `naughton`
+  - `data/ma/retired/Harold-P-Naughton-Jr-33017dde-3525-43ff-8c3a-fb44a4a9d833.yml`
+  - `data/ma/retired/Harold-P-Naughton-Jr-9a42cd75-9298-4aee-b940-10e8c4feb634.yml`
+- `james` `lyons`
+  - `data/ma/retired/James-J-Lyons-Jr-0991e0b6-5748-45a5-829c-5aa3bf851993.yml`
+  - `data/ma/retired/James-J-Lyons-Jr-c86cc627-0708-45f8-98b8-f951e435234b.yml`
+- `john` `keenan`
+  - `data/ma/legislature/John-F-Keenan-7be04e69-85c6-44e4-a933-88c59c0675a5.yml`
+  - `data/ma/retired/John-D-Keenan-c34ee04a-0af8-4d1c-bd70-40265770fc02.yml`
+- `john` `lawn`
+  - `data/ma/legislature/John-J-Lawn-Jr-1ea6937d-a39e-41e2-92fb-47c2966cd52e.yml`
+  - `data/ma/retired/John-J-Lawn-4d955a7b-082e-46d3-9687-1f3634cd28d0.yml`
+- `leonard` `mirra`
+  - `data/ma/retired/Leonard-Mirra-06d8e7f7-fc49-4dcf-bf23-33d36a6dcb38.yml`
+  - `data/ma/retired/Leonard-Mirra-a7f48a11-ca12-440b-a8e3-622548c92694.yml`
+- `martin` `walsh`
+  - `data/ma/retired/Martin-J-Walsh-c4aff440-4796-49f2-836e-b2715a3834ba.yml`
+  - `data/ma/retired/Martin-J-Walsh-c5d2b098-b520-48a3-956e-98710ac0baec.yml`
+- `paul` `brodeur`
+  - `data/ma/retired/Paul-A-Brodeur-dc686187-37f3-45d8-84bd-5ff42924b448.yml`
+  - `data/ma/retired/Paul-Brodeur-771bc657-03b1-41fc-b8f4-008a98a94361.yml`
+- `paul` `schmid`
+  - `data/ma/retired/Paul-A-Schmid-4029179a-0be9-44d8-9644-4a5446c13c44.yml`
+  - `data/ma/retired/Paul-A-Schmid-III-51c2533b-95e0-45c5-9100-0c6d68efb192.yml`
+- `paul` `tucker`
+  - `data/ma/retired/Paul-Tucker-3bd33dbb-8eee-4da3-a3e6-47a326d28dad.yml`
+  - `data/ma/retired/Paul-Tucker-4246ee2e-3e90-40c2-ae05-76bf836889ee.yml`
+- `thomas` `golden`
+  - `data/ma/retired/Thomas-A-Golden-Jr-bfc246c3-e697-472e-8a54-890f599f2cec.yml`
+  - `data/ma/retired/Thomas-A-Golden-Jr-c51da7d7-aaf6-4621-a544-6910d5113fc2.yml`
+
+## md
+
+- `barbara` `robinson`
+  - `data/md/retired/Barbara-A-Robinson-cf149010-43b2-487a-9d40-07d5d4354969.yml`
+  - `data/md/retired/Barbara-Robinson-0728c86e-8fca-4d87-bdfb-f735ed99e88c.yml`
+- `jill` `carter`
+  - `data/md/retired/Jill-P-Carter-d2a4d2c5-192b-4545-bd00-58024b65e7b4.yml`
+  - `data/md/retired/Jill-P-Carter-ec8f0c98-4f08-451b-b641-1c24814d0c17.yml`
+- `jon` `cardin`
+  - `data/md/legislature/Jon-S-Cardin-13771198-ddf4-4dfd-80f1-b4069ec55914.yml`
+  - `data/md/retired/Jon-S-Cardin-7ffd25b4-46f7-42fb-8346-fb3fc88059e3.yml`
+- `joseph` `boteler`
+  - `data/md/retired/Joseph-C-Boteler-III-849b2ad5-f22a-4d8b-aaf5-d079b01e5916.yml`
+  - `data/md/retired/Joseph-C-Boteler-III-cd091ba3-849a-438d-8e3e-f97b396bdd97.yml`
+- `mary-dulany` `james`
+  - `data/md/legislature/Mary-Dulany-James-72a5c405-0523-4ea4-9029-024c49d76cb3.yml`
+  - `data/md/retired/Mary-Dulany-James-c0832fae-fa24-4cd4-a104-a2f09fae8c77.yml`
+- `melony` `griffith`
+  - `data/md/retired/Melony-G-Griffith-ab4ed24e-32f8-4f09-8f58-890ce6946504.yml`
+  - `data/md/retired/Melony-Griffith-e79608fa-7921-49f2-ba2e-d10f70008a5b.yml`
+- `veronica` `turner`
+  - `data/md/legislature/Veronica-Turner-b982cab0-0d2e-46ae-8e22-51f68e7aac82.yml`
+  - `data/md/retired/Veronica-L-Turner-ce1f293b-747f-4f90-a4e6-49acb235712e.yml`
+
+## me
+
+- `anne-marie` `mastraccio`
+  - `data/me/legislature/Anne-Marie-Mastraccio-56960ccd-b154-42ae-9fb3-c323e07c23b1.yml`
+  - `data/me/retired/Anne-Marie-Mastraccio-d432631f-c2ec-40e2-afbb-3f55cf6a7b64.yml`
+- `david` `burns`
+  - `data/me/retired/David-C-Burns-542ce5fc-9caf-4667-a1fb-0d988ed8d621.yml`
+  - `data/me/retired/David-R-Burns-1cf9e55c-7fed-4903-a5b4-969866bfadff.yml`
+- `eric` `brakey`
+  - `data/me/retired/Eric-Brakey-d24ac656-4b2e-416f-83ce-b5f32e3d5825.yml`
+  - `data/me/retired/Eric-L-Brakey-ce76aa12-2996-4720-9f89-b4fd6af3c4cc.yml`
+- `larry` `dunphy`
+  - `data/me/retired/Larry-C-Dunphy-62fbaabc-63da-4026-849c-3d2e444ea444.yml`
+  - `data/me/retired/Larry-C-Dunphy-80e659b4-0182-4ce6-8d2e-1ddb9de5422c.yml`
+- `linda` `sanborn`
+  - `data/me/retired/Linda-F-Sanborn-83638647-de1c-45d5-bc4c-549c82e1aac7.yml`
+  - `data/me/retired/Linda-Sanborn-ad8f214d-08a9-4ee6-818b-fa829287de4b.yml`
+- `lydia` `blume`
+  - `data/me/retired/Lydia-Blume-7b64ca81-856c-4edc-b4d9-fb36a8a4d24c.yml`
+  - `data/me/retired/Lydia-C-Blume-9fc89f91-5eb8-428b-97e0-1833fb687300.yml`
+- `margaret` `craven`
+  - `data/me/retired/Margaret-Craven-0b6d7994-8ba7-48cc-aaaf-b1210c3d3f2e.yml`
+  - `data/me/retired/Margaret-M-Craven-f9f8dc08-3d31-400a-a165-ca3c95cb3bbb.yml`
+- `michael` `willette`
+  - `data/me/retired/Michael-J-Willette-076750df-d16a-4e40-84b1-32203a1f4d87.yml`
+  - `data/me/retired/Michael-James-Willette-beb61c7f-4641-4ada-9527-c998c6f6c0c5.yml`
+- `paul` `davis`
+  - `data/me/retired/Paul-T-Davis-Sr-0dd8bc2b-7237-4f5c-955a-478c7fb57654.yml`
+  - `data/me/retired/Paul-T-Davis-bd258c94-db3f-419f-83c1-707886c98ff5.yml`
+- `pinny` `beebe-center`
+  - `data/me/legislature/Anne-Beebe-Center-db11e611-94a4-4451-8486-f941a532789d.yml`
+  - `data/me/retired/Pinny-Beebe-Center-283a0d7c-98df-40fd-8fdf-44d7e0378e6b.yml`
+- `shenna` `bellows`
+  - `data/me/executive/Shenna-Bellows-a641743d-e1c1-4bb6-bba0-ad1f143dbf20.yml`
+  - `data/me/retired/Shenna-L-Bellows-57f42a08-7404-484b-8885-05d10679cab7.yml`
+- `troy` `jackson`
+  - `data/me/retired/Troy-D-Jackson-78ccbb5e-2908-43c7-b609-5ed18f8ff685.yml`
+  - `data/me/retired/Troy-Dale-Jackson-af7f267b-60b4-4e6f-8e33-7ad4e70e0979.yml`
+
+## mi
+
+- `andy` `schor`
+  - `data/mi/retired/Andy-Schor-2d8a99e3-3864-48eb-8352-5d3a64184b8d.yml`
+  - `data/mi/retired/Andy-Schor-537630fb-30fc-4bc1-93be-97e465625184.yml`
+- `david` `anderson`
+  - `data/mi/municipalities/David-Anderson-29fb6f78-497d-4775-b1f9-8b0be6be371e.yml`
+  - `data/mi/retired/David-Anderson-df15c153-b52f-458f-8b71-f868c8bda3ac.yml`
+- `david` `knezek`
+  - `data/mi/retired/David-Knezek-457cee8a-fc19-4d73-9b58-41cb06cd1194.yml`
+  - `data/mi/retired/David-Knezek-bc665a6c-14a9-4e4d-a8b4-e3743da91dd4.yml`
+- `gretchen` `whitmer`
+  - `data/mi/executive/Gretchen-Whitmer-9b425a88-36ae-439c-b2f9-8da167b9ff27.yml`
+  - `data/mi/retired/Gretchen-Whitmer-28c5d139-0c87-49da-b868-0d0b160e463a.yml`
+- `jim` `runestad`
+  - `data/mi/legislature/Jim-Runestad-e0a8928d-8ccc-4e1e-9ca5-d7f50642ff91.yml`
+  - `data/mi/retired/Jim-Runestad-15eed21e-264a-48bc-a990-978bebb4e36a.yml`
+- `john` `bizon`
+  - `data/mi/retired/John-Bizon-1278c5a5-ac6e-491b-9f84-311e46812fa8.yml`
+  - `data/mi/retired/John-Dr-Bizon-3c1b73ef-2ecb-4fe9-93c1-f457bd515949.yml`
+- `mark s.` `meadows`
+  - `data/mi/retired/Mark-Meadows-bf6037c3-af53-4de5-bb60-7e60be227d67.yml`
+  - `data/mi/retired/Mark-S-Meadows-aad0fad7-d397-40b2-98b0-fbcd8438636b.yml`
+- `michael` `webber`
+  - `data/mi/legislature/Michael-Webber-be2c96ad-1304-4c25-8cab-2c8ec5d6475f.yml`
+  - `data/mi/retired/Michael-Webber-80e3da2e-46db-468c-8d19-0bf8535ea10b.yml`
+- `michele` `hoitenga`
+  - `data/mi/legislature/Michele-Hoitenga-0c9a2c44-5a9a-44cd-8470-5dad5c7b2c53.yml`
+  - `data/mi/retired/Michele-Hoitenga-a228a84e-8f2e-49f6-b38a-ab8ce2bbf177.yml`
+- `mike` `harris`
+  - `data/mi/legislature/Mike-Harris-a93eaebe-bdac-4292-a28f-6a3b04efd191.yml`
+  - `data/mi/retired/Mike-Harris-73f715f3-eb5d-46c8-8dc0-b034f84060ab.yml`
+- `mike` `mueller`
+  - `data/mi/legislature/Mike-Mueller-bdbada04-5616-4e9c-91db-f709e24d43f3.yml`
+  - `data/mi/retired/Mike-Mueller-02fd81f5-6105-4b97-b865-d21946eb8c02.yml`
+- `mike` `shirkey`
+  - `data/mi/retired/Michael-Shirkey-422664f9-725c-4d9b-9835-10ede639dbd1.yml`
+  - `data/mi/retired/Mike-Shirkey-e0135597-4e92-4777-aa3b-0013286075a4.yml`
+- `nate` `shannon`
+  - `data/mi/retired/Nate-Shannon-47409ebc-de08-42f1-b6d6-47ec083904c0.yml`
+  - `data/mi/retired/Nate-Shannon-af52f259-fe60-4903-98b8-739a114a8deb.yml`
+- `pauline` `wendzel`
+  - `data/mi/legislature/Pauline-Wendzel-f749bf7e-46bc-482d-ac6e-60288f3b722e.yml`
+  - `data/mi/retired/Pauline-Wendzel-262428ec-422f-42ec-a206-51dfe2bba93a.yml`
+- `sheldon` `neeley`
+  - `data/mi/retired/Sheldon-Neeley-98ce9311-8f46-4572-9866-80a7eceeb746.yml`
+  - `data/mi/retired/Sheldon-Neeley-ce87d244-de67-4e85-8358-5a791543743a.yml`
+- `vicki` `barnett`
+  - `data/mi/retired/Vicki-Barnett-4f9a6234-b9bd-452a-824a-11a1c262cf45.yml`
+  - `data/mi/retired/Vicki-Barnett-b96080c0-cf2d-4803-a6a6-3d31229f595d.yml`
+- `william e.` `hosler`
+  - `data/mi/retired/William-E-Hosler-1d022505-bc32-407b-a639-e313ab80ba82.yml`
+  - `data/mi/retired/William-E-Hosler-b5e7a6b4-9f49-445d-8250-aa6d0b38ca2b.yml`
+
+## mn
+
+- `alice` `mann`
+  - `data/mn/legislature/Alice-Mann-c5f2a744-0a3e-481f-9224-e4d5a58b9c9d.yml`
+  - `data/mn/retired/Alice-Mann-00ac39dc-6cee-4f9b-b740-e513bb485122.yml`
+- `brad` `tabke`
+  - `data/mn/legislature/Brad-Tabke-05f634e6-f8d3-4983-9604-dfc8dddc574e.yml`
+  - `data/mn/retired/Brad-Tabke-769f1153-4288-413a-91e6-49d38a3e7c57.yml`
+- `jeff` `brand`
+  - `data/mn/retired/Jeff-Brand-6864cbde-4569-4710-90ef-a492a1d560db.yml`
+  - `data/mn/retired/Jeff-Brand-9bf2790e-2c31-4464-872f-869bc387312e.yml`
+- `kaohly` `her`
+  - `data/mn/municipalities/Kaohly-Her-79caa971-9111-4dd9-8eb5-cf896c56a0b7.yml`
+  - `data/mn/retired/Kaohly-Her-92da7ead-83b1-4d16-9acd-c403152fa0b0.yml`
+- `paul` `anderson`
+  - `data/mn/legislature/Paul-Anderson-ab35dde5-226a-4427-9344-c74d8291a75f.yml`
+  - `data/mn/retired/Paul-T-Anderson-86e4040d-cfb6-4345-b1e6-9816f33da8f2.yml`
+- `steve` `simon`
+  - `data/mn/executive/Steve-Simon-029aa632-cefd-431d-bba0-e2ed611b2151.yml`
+  - `data/mn/retired/Steve-Simon-622a885e-63a3-4d9f-853b-3c8598b81d39.yml`
+- `torrey` `westrom`
+  - `data/mn/legislature/Torrey-N-Westrom-1c19414e-994b-46d4-8971-432ed482ca39.yml`
+  - `data/mn/retired/Torrey-Westrom-af972763-4704-4ee9-95e8-fdca5ae58807.yml`
+
+## mo
+
+- `adam` `schwadron`
+  - `data/mo/retired/Adam-Schwadron-0035304c-e314-4d57-8fc8-addf19b16111.yml`
+  - `data/mo/retired/Adam-Schwadron-c9efc84d-7adb-462d-9e86-b545fe52f6ae.yml`
+- `bennie` `cook`
+  - `data/mo/legislature/Bennie-Cook-9c485ac1-4ad5-4466-9392-a9014827ef56.yml`
+  - `data/mo/retired/Bennie-Cook-5effdbcd-6045-436c-8f70-a67131c27ac4.yml`
+- `bill` `hardwick`
+  - `data/mo/legislature/Bill-Hardwick-6b7c5c9c-05ba-4a2e-8f23-117edbf2969b.yml`
+  - `data/mo/retired/Bill-Hardwick-b71be68e-7289-4744-bacf-0e98bf375f0d.yml`
+- `curtis` `trent`
+  - `data/mo/legislature/Curtis-Trent-c5e38dee-7f82-4795-a134-b984b6878458.yml`
+  - `data/mo/retired/Curtis-Trent-a4977829-21d4-4668-ae6e-16a3d0f444ec.yml`
+- `david` `smith`
+  - `data/mo/legislature/David-Tyson-Smith-c509449e-070c-462c-810e-f14315c9df42.yml`
+  - `data/mo/retired/David-T-Smith-c8f4ccf3-c7c4-4e71-8226-6ee92bdf501e.yml`
+- `deb` `lavender`
+  - `data/mo/retired/Deb-Lavender-3135abbd-6e12-4847-9b19-e2a57337724a.yml`
+  - `data/mo/retired/Deb-Lavender-c92b2810-9dcd-41e9-9d3b-7c65e1e36011.yml`
+- `josh` `hurlbert`
+  - `data/mo/legislature/Josh-Hurlbert-1da3a25b-64fa-48d4-8441-e1dca4526f7f.yml`
+  - `data/mo/retired/Josh-Hurlbert-08e6cc95-8f83-4e3f-a9d4-1b22d12d23b6.yml`
+- `ken` `mcclure`
+  - `data/mo/retired/Ken-McClure-081663c7-ed2f-4449-9dd1-a183b59b6d5a.yml`
+  - `data/mo/retired/Ken-McClure-13389263-ac97-486d-8b33-b9303dd00c1d.yml`
+- `mark` `matthiesen`
+  - `data/mo/legislature/Mark-Matthiesen-661f49f4-e075-491e-aad8-4dde65ecb6df.yml`
+  - `data/mo/retired/Mark-Matthiesen-f7a7b094-3b7f-470c-aed3-9e9bc60f68b5.yml`
+- `mary elizabeth` `coleman`
+  - `data/mo/legislature/Mary-Elizabeth-Coleman-f1d83642-4aa6-4fea-80f1-4c3f422c63ed.yml`
+  - `data/mo/retired/Mary-Elizabeth-Coleman-54d1ac92-5c3c-4f59-91c4-fbfd23d3eb0f.yml`
+- `mike` `parson`
+  - `data/mo/executive/Mike-Parson-49049354-68cd-45da-849f-b8ddbc629bab.yml`
+  - `data/mo/retired/Mike-Parson-843925dc-0356-4f50-a85a-ad14b48ff5f4.yml`
+- `nick` `schroer`
+  - `data/mo/legislature/Nick-Schroer-ecbee637-2b07-4028-acb3-b82df2edb42a.yml`
+  - `data/mo/retired/Nick-Schroer-7ec31266-6738-481f-aaf9-c89ff8a7965b.yml`
+- `rusty` `black`
+  - `data/mo/legislature/Rusty-Black-bb98b6a0-ba5f-45f8-ad14-b798515fa8a0.yml`
+  - `data/mo/retired/Rusty-Black-c46e8275-c962-4530-af84-563236b03e37.yml`
+- `stephen` `webber`
+  - `data/mo/legislature/Stephen-Webber-63dea1c8-8916-4ca8-8821-223a7fef95a9.yml`
+  - `data/mo/retired/Stephen-Webber-385fd852-bd78-4f3c-8a3d-9fb2233297e0.yml`
+- `tim` `pogue`
+  - `data/mo/retired/Tim-Pogue-5864121e-922b-4cb1-9cec-50c341f3932c.yml`
+  - `data/mo/retired/Tim-Pogue-833d2dfd-6861-411a-a199-37d65ed551e7.yml`
+- `tommie` `pierson`
+  - `data/mo/retired/Tommie-Pierson-Jr-0cecb203-76c8-4a17-b033-c9a5b8c6f2a4.yml`
+  - `data/mo/retired/Tommie-Pierson-a1282b7f-98d8-4a28-83f3-aedb24cae924.yml`
+- `tracy` `mccreery`
+  - `data/mo/legislature/Tracy-McCreery-802c155f-8979-418f-b13b-b75de93caf31.yml`
+  - `data/mo/retired/Tracy-McCreery-704c5c98-77bc-47e7-9df5-10b5c5ecb4ec.yml`
+- `travis` `fitzwater`
+  - `data/mo/legislature/Travis-Fitzwater-c9758b3c-066c-40b4-9d40-a93880fda67a.yml`
+  - `data/mo/retired/Travis-Fitzwater-0889a1d5-7416-4391-b235-6c7772dc5ce2.yml`
+
+## ms
+
+- `billy` `hewes`
+  - `data/ms/municipalities/Billy-Hewes-b11cb160-9e88-41de-87e4-fa5f294a664e.yml`
+  - `data/ms/retired/Billy-Hewes-d93e26a4-4b01-4a1b-93ec-cdd3b6b17f17.yml`
+- `kelvin` `butler`
+  - `data/ms/retired/Kelvin-Butler-02de97f6-5b78-4211-9d7d-92d5a4c7375e.yml`
+  - `data/ms/retired/Kelvin-E-Butler-20df1611-31cf-4300-9ffe-669f792434aa.yml`
+- `michael` `watson`
+  - `data/ms/executive/Michael-Watson-a9b2b93d-b993-4a20-af9e-3e9e2c9cd770.yml`
+  - `data/ms/retired/Michael-Watson-d7615aed-6496-4efd-91db-d25ca1c9d965.yml`
+- `toby` `barker`
+  - `data/ms/municipalities/Toby-Barker-87b6da5a-92a6-426a-9279-3589d2778fc3.yml`
+  - `data/ms/retired/Toby-Barker-d786f79d-2401-405d-af3c-fee4cb91af66.yml`
+- `walter` `michel`
+  - `data/ms/legislature/J-Walter-Michel-61c65e25-07c9-445c-8cef-1e6d53cbbfb3.yml`
+  - `data/ms/retired/Walter-Michel-f4aa52fd-c29d-4db0-90f6-3d2610fe19a3.yml`
+
+## mt
+
+- `daniel` `zolnikov`
+  - `data/mt/legislature/Daniel-Zolnikov-afffd4a2-fd6b-4cc5-8eff-8aa1f696db3a.yml`
+  - `data/mt/retired/Daniel-Zolnikov-8d10ea79-663e-4f1e-8d8d-019b8b8ec948.yml`
+- `forrest` `mandeville`
+  - `data/mt/legislature/Forrest-Mandeville-40c484e9-cba9-4fd5-8f99-7bcaf25fc4ac.yml`
+  - `data/mt/retired/Forrest-Mandeville-df07018c-c8d6-4b38-9856-bfbde4429409.yml`
+- `kelly` `mccarthy`
+  - `data/mt/retired/Kelly-McCarthy-2b168dc8-9282-4a66-8072-10705e299323.yml`
+  - `data/mt/retired/Kelly-Mccarthy-5b97f82c-ef27-40c6-8037-5cfe18534905.yml`
+
+## nc
+
+- `ben` `moss`
+  - `data/nc/legislature/Ben-T-Moss-Jr-fdc7d25a-085c-4100-b5f4-a8ae51979292.yml`
+  - `data/nc/retired/Ben-T-Moss-Jr-cd5c9c5e-fe42-4110-886a-8fc2b50e98ee.yml`
+- `gale` `adcock`
+  - `data/nc/legislature/Gale-Adcock-1ba9c7a6-3a28-47ec-9704-6f3437463845.yml`
+  - `data/nc/retired/Gale-Adcock-bf4bb2bf-abd4-4b0c-b3a1-721a98f82fbd.yml`
+- `graig` `meyer`
+  - `data/nc/retired/Graig-Meyer-dea063a9-3548-4ec7-b226-a126d2eea0b2.yml`
+  - `data/nc/retired/Graig-R-Meyer-730906aa-0f36-4d9e-a0bd-6c3c06b51645.yml`
+- `kandie` `smith`
+  - `data/nc/legislature/Kandie-D-Smith-5afbb4dc-a121-414a-b600-53af0936beb8.yml`
+  - `data/nc/retired/Kandie-D-Smith-84982a59-9454-4528-b0b1-cd5a01c09bf5.yml`
+- `tricia` `cotham`
+  - `data/nc/legislature/Tricia-Ann-Cotham-6045737f-cc7a-4cf5-b7e6-12419deed77b.yml`
+  - `data/nc/retired/Tricia-Ann-Cotham-ed627d49-21cf-49e8-871e-ae7052764eb9.yml`
+
+## nd
+
+- `george j.` `keiser`
+  - `data/nd/retired/George-J-Keiser-5db91a7e-928c-40f4-aa90-62ae2c45a23b.yml`
+  - `data/nd/retired/George-J-Keiser-9894fad1-e089-4e11-8863-6dd34361f49e.yml`
+- `jim` `roers`
+  - `data/nd/retired/Jim-P-Roers-22f8f645-3aeb-4918-b026-1182683144de.yml`
+  - `data/nd/retired/Jim-Roers-abe021f1-e5f4-4f5c-be00-56224a1ba203.yml`
+- `michael` `howe`
+  - `data/nd/executive/Michael-Howe-31c83885-ce7e-4b8f-ac6d-bf310c12acb8.yml`
+  - `data/nd/retired/Michael-Howe-7d98fdaa-e045-4953-8865-e7c812c0390a.yml`
+
+## ne
+
+- `danielle` `conrad`
+  - `data/ne/legislature/Danielle-Conrad-bf280e36-3547-4d6a-b5aa-d6c32bb5547a.yml`
+  - `data/ne/retired/Danielle-Conrad-950eb956-e493-451e-a446-4faa11d9641e.yml`
+- `merv` `riepe`
+  - `data/ne/legislature/Merv-Riepe-3c015cf9-e3de-42cf-a364-64607ecc70ce.yml`
+  - `data/ne/retired/Merv-Riepe-8a0290ef-475b-4394-994e-d5fcc08970e8.yml`
+
+## nh
+
+- `benjamin` `baroody`
+  - `data/nh/retired/Benjamin-C-Baroody-018987e5-d731-41ed-8cce-b3266df24b64.yml`
+  - `data/nh/retired/Benjamin-C-Baroody-7e50ab19-481f-4813-a748-27a4ab6de306.yml`
+- `chuck` `grassie`
+  - `data/nh/retired/Chuck-Grassie-8ee07d33-9189-4bfe-b1a1-e15c79fd1114.yml`
+  - `data/nh/retired/Chuck-W-Grassie-152fbcf7-564b-483f-b6b3-aa3f0cae47ee.yml`
+- `chuck` `morse`
+  - `data/nh/retired/Chuck-W-Morse-72b8f708-a22d-477d-9c55-e5d14b8308a6.yml`
+  - `data/nh/retired/Chuck-W-Morse-f1987686-85f9-4eb2-a3ab-25268676ce7e.yml`
+- `dan` `mcguire`
+  - `data/nh/legislature/Dan-McGuire-f67d5fcc-0dac-4bf0-b1ab-b63f73162d0b.yml`
+  - `data/nh/retired/Dan-McGuire-cf5aa19f-0023-4a3a-bd88-ec423bf19ea5.yml`
+- `daniel` `eaton`
+  - `data/nh/retired/Daniel-A-Eaton-566f423e-75f7-474c-b57f-7e53bffcd411.yml`
+  - `data/nh/retired/Daniel-A-Eaton-58818151-3b11-41f9-87ac-0fc7d51ffc6c.yml`
+- `david` `welch`
+  - `data/nh/retired/David-A-Welch-718467b7-182a-426d-a100-68a244184533.yml`
+  - `data/nh/retired/David-A-Welch-b8201b25-9bdd-45d3-819d-5bae4c670ad0.yml`
+- `donovan` `fenton`
+  - `data/nh/legislature/Donovan-Fenton-8e013e93-3dd2-4530-a42f-d9ba62ea5f04.yml`
+  - `data/nh/retired/Donovan-Fenton-34b5aacc-cc43-49c8-af70-c692639b2e4a.yml`
+- `fenton` `groen`
+  - `data/nh/retired/Fenton-Groen-1396a02f-8c77-4f09-b9c7-10f2070721bd.yml`
+  - `data/nh/retired/Fenton-L-Groen-9a5bfca1-f35f-4050-93d4-0abedb8ba436.yml`
+- `fred` `doucette`
+  - `data/nh/retired/Fred-Doucette-b544733a-d241-4568-88c2-7521cb67bf04.yml`
+  - `data/nh/retired/Fred-G-Doucette-db4ec0a8-f70c-4510-ae01-c9050646a503.yml`
+- `gary` `daniels`
+  - `data/nh/retired/Gary-L-Daniels-281c916b-4280-41ff-9ee1-ba183d838536.yml`
+  - `data/nh/retired/Gary-L-Daniels-4c8ac73e-dca4-48ca-b50c-25d0d41425bc.yml`
+- `john` `graham`
+  - `data/nh/retired/John-A-Graham-05a586d8-4c39-4578-95f6-7aaa30b3c67c.yml`
+  - `data/nh/retired/John-A-Graham-f8c301d4-e3bd-4839-8159-40bba675b68f.yml`
+- `john` `reagan`
+  - `data/nh/retired/John-M-Reagan-6fae3b68-faa2-4965-834d-94a8e28de553.yml`
+  - `data/nh/retired/John-Reagan-f516d40a-3676-4437-8285-a931d7c2885b.yml`
+- `katherine` `prudhomme-o'brien`
+  - `data/nh/legislature/Katherine-J-Prudhomme-OBrien-a0a8c9d8-1f27-4d28-a249-8a5856ea5c05.yml`
+  - `data/nh/retired/Katherine-Prudhomme-OBrien-92c01f02-b619-495b-b3a5-4d089c044cb4.yml`
+- `keith` `murphy`
+  - `data/nh/legislature/Keith-R-Murphy-7ec573c3-d961-4d08-a71c-d239490b5c1a.yml`
+  - `data/nh/retired/Keith-Murphy-f5a60d8c-c900-4e53-9095-b9fdfeb7f506.yml`
+- `latha` `mangipudi`
+  - `data/nh/retired/Latha-D-Mangipudi-4f71f9e1-ce78-46d3-9665-00dd404a0f1b.yml`
+  - `data/nh/retired/Latha-Mangipudi-1a33f5ef-fe58-44dd-98dc-d496a1e76275.yml`
+- `linda` `harriott-gathright`
+  - `data/nh/legislature/Linda-C-Harriott-Gathright-1e2b57f6-dbb9-4069-a71b-d40828c80cfa.yml`
+  - `data/nh/retired/Linda-Harriott-Gathright-ed01f9a8-0365-4c84-89ca-fea490faf27b.yml`
+- `linda` `massimilla`
+  - `data/nh/retired/Linda-A-Massimilla-c018f667-a248-4b79-b8be-63740191e1ff.yml`
+  - `data/nh/retired/Linda-Massimilla-884bc06a-e0a0-488b-be42-162f6d763b8e.yml`
+- `lorrie` `carey`
+  - `data/nh/retired/Lorrie-J-Carey-2b100e9f-2721-4836-ae23-32a4172f1f87.yml`
+  - `data/nh/retired/Lorrie-J-Carey-c1f83f4d-e410-4642-b973-0ec4cd924ab4.yml`
+- `mark` `vallone`
+  - `data/nh/legislature/Mark-A-Vallone-248ddc70-c3e0-4ec2-94ff-1d1de0d0e9fc.yml`
+  - `data/nh/retired/Mark-Vallone-208012dd-f741-412c-9727-d7e8aa0fe8b0.yml`
+- `mary` `griffin`
+  - `data/nh/retired/Mary-E-Griffin-347fa364-852b-49c9-9610-99a813965a69.yml`
+  - `data/nh/retired/Mary-E-Griffin-9f1eb082-5364-4c35-8b9a-32eb4b355296.yml`
+- `norman` `silber`
+  - `data/nh/retired/Norman-J-Silber-2f3c984e-640c-49ec-aba9-4928db0e9edc.yml`
+  - `data/nh/retired/Norman-Silber-93ce2392-c7cf-46cc-97bd-2cc0a1bca111.yml`
+- `phyllis` `katsakiores`
+  - `data/nh/legislature/Phyllis-M-Katsakiores-19404ada-b556-4609-9814-f19db9c0a0ad.yml`
+  - `data/nh/retired/Phyllis-M-Katsakiores-a90280ce-b44d-4f0a-a496-bbb9b1cd5f29.yml`
+- `ralph` `boehm`
+  - `data/nh/legislature/Ralph-G-Boehm-ac6ce16b-a462-4727-8e4b-724c7c19e58c.yml`
+  - `data/nh/retired/Ralph-G-Boehm-094453b5-f953-4bed-b813-62359f625036.yml`
+- `robert` `cushing`
+  - `data/nh/retired/Robert-R-Cushing-ce5ff509-d3f5-46df-8cae-2310ac2b5aa2.yml`
+  - `data/nh/retired/Robert-Renny-Cushing-cdb3279c-243a-4ca0-8e83-fcb10a975736.yml`
+- `robert` `theberge`
+  - `data/nh/retired/Robert-L-Theberge-7127cb81-a4d0-46c2-a25e-e9f1e770cf31.yml`
+  - `data/nh/retired/Robert-L-Theberge-994345f8-cb25-4ff7-a6d3-ce88a0800ec1.yml`
+- `skip` `rollins`
+  - `data/nh/legislature/Skip-A-Rollins-31d4d765-be08-4393-8e9a-21444cf8b411.yml`
+  - `data/nh/retired/Skip-Rollins-bb0d8c96-c276-49a7-8ab4-02d45410f959.yml`
+- `steve` `shurtleff`
+  - `data/nh/retired/Stephen-J-Shurtleff-5faefb6a-67fa-47ea-907a-8f4f545862be.yml`
+  - `data/nh/retired/Steve-J-Shurtleff-8572ae91-584f-45b3-8882-b33fa9588de2.yml`
+- `susan` `almy`
+  - `data/nh/legislature/Susan-W-Almy-e13283b4-defe-4f4e-8e67-4d89b8e3790c.yml`
+  - `data/nh/retired/Susan-W-Almy-856da428-f5e9-4fa4-92c7-d08575cae4a2.yml`
+- `susan` `delemus`
+  - `data/nh/retired/Susan-C-DeLemus-0d0e2536-4b7b-49ad-823c-e636099eef9a.yml`
+  - `data/nh/retired/Susan-C-DeLemus-0e3a4612-9179-4659-a512-86322f4ff0ef.yml`
+- `ted` `rokas`
+  - `data/nh/retired/Ted-Rokas-c148c301-5a02-4711-b27f-167fc111b832.yml`
+  - `data/nh/retired/Ted-V-Rokas-88ea3db4-12b1-4a76-97c7-f03528b2569c.yml`
+- `william` `gannon`
+  - `data/nh/retired/William-Gannon-4c202b3f-19f5-4e07-b034-653e361ee361.yml`
+  - `data/nh/retired/William-M-Gannon-54ccbeac-d705-44d1-856b-01a8b4efec83.yml`
+
+## nj
+
+- `jon` `bramnick`
+  - `data/nj/legislature/Jon-M-Bramnick-08a758f9-92fb-4e59-ac8f-edc75aaf3390.yml`
+  - `data/nj/retired/Jon-M-Bramnick-f201aae9-beef-450e-82c4-68e50aa241fa.yml`
+
+## nm
+
+- `rodolpho` `martinez`
+  - `data/nm/retired/Rodolpho-Rudy-S-Martinez-3cf00e3d-4d32-4813-9b28-6c06f477ecb6.yml`
+  - `data/nm/retired/Rodolpho-S-Martinez-437d0428-411e-4afa-b9b2-5a0d2b7ba511.yml`
+
+## nv
+
+- `ellen` `spiegel`
+  - `data/nv/retired/Ellen-B-Spiegel-c5ef702d-5e04-400d-9924-839b74608370.yml`
+  - `data/nv/retired/Ellen-B-Spiegel-de3a576a-63ed-4a42-a780-f633d5ca3cf0.yml`
+- `heidi` `gansert`
+  - `data/nv/retired/Heidi-S-Gansert-61ba1ce5-9bcd-462d-9c31-045106ae744e.yml`
+  - `data/nv/retired/Heidi-Seevers-Gansert-a9c5b02b-6b3c-42ab-9085-104a6f673f00.yml`
+- `keith` `pickard`
+  - `data/nv/retired/Keith-F-Pickard-08269c01-28ee-4862-ab45-9ea9bbd4f0a4.yml`
+  - `data/nv/retired/Keith-Pickard-1b3b55a8-ba25-408a-bae7-183e43cffa0e.yml`
+- `shea` `backus`
+  - `data/nv/legislature/Shea-Backus-1fa69460-c910-4cf1-acfb-1d44c342e658.yml`
+  - `data/nv/retired/Shea-Backus-9c694eea-ad2d-4678-99c4-1ebba457a857.yml`
+- `skip` `daly`
+  - `data/nv/legislature/Skip-Daly-a0553b6f-7142-4321-9e3a-c089447d3a78.yml`
+  - `data/nv/retired/Richard-Daly-7e1c5e59-cf07-416e-a1d7-a6fd34762671.yml`
+  - `data/nv/retired/Skip-Daly-3c8ae405-5bc3-4bf5-bb90-eca7fcd67ffd.yml`
+
+## ny
+
+- `alec` `brook-krasny`
+  - `data/ny/legislature/Alec-Brook-Krasny-69640dce-9d99-45a3-83b5-cbdc1dc2f2e5.yml`
+  - `data/ny/retired/Alec-Brook-Krasny-9b2bff3a-c7ec-458e-94ad-a2ae4bfaeba5.yml`
+- `brian` `curran`
+  - `data/ny/retired/Brian-Curran-01f6baef-d2d4-41b0-af8b-fefcbd478bf1.yml`
+  - `data/ny/retired/Brian-Curran-5d0016e7-6394-4abc-81b9-226723acd5c7.yml`
+- `chad` `lupinacci`
+  - `data/ny/retired/Chad-Lupinacci-00ed036d-a539-4c31-8d7d-7c29c5c589cc.yml`
+  - `data/ny/retired/Chad-Lupinacci-921298e0-bb0e-4a02-bbd5-e7ae90d089c6.yml`
+  - `data/ny/retired/Chad-Lupinacci-c01c55f8-5b02-45c8-a585-fbce32ab13e9.yml`
+- `dan` `stec`
+  - `data/ny/legislature/Daniel-G-Stec-7bb8c8bc-0238-4fd2-8dff-e5f2b2aaa92a.yml`
+  - `data/ny/retired/Dan-Stec-eccc0711-76bd-4312-af2c-a2036f960333.yml`
+- `dean` `murray`
+  - `data/ny/legislature/Dean-Murray-8ff653e0-5aa6-4692-ac54-25ed36e32f97.yml`
+  - `data/ny/retired/Dean-Murray-869e7026-c395-43b4-a026-da6e834abdad.yml`
+- `eric` `adams`
+  - `data/ny/retired/Eric-Adams-0847e238-52cf-454b-87c5-864560de56f7.yml`
+  - `data/ny/retired/Eric-Adams-7346f0ad-6d6f-41da-b816-d1394bd4f555.yml`
+- `helene` `weinstein`
+  - `data/ny/retired/Helene-E-Weinstein-d796d2c5-66a3-44b6-9ef8-39beeebce9b7.yml`
+  - `data/ny/retired/Helene-Weinstein-06610649-ee0c-4c67-a1ea-b1fd5042f09b.yml`
+- `jack` `martins`
+  - `data/ny/legislature/Jack-M-Martins-7f031836-0a9e-46d2-bcab-7cc6a14848df.yml`
+  - `data/ny/retired/Jack-M-Martins-2a7dc723-92be-47d8-8462-e346b4394842.yml`
+- `jamaal` `bailey`
+  - `data/ny/legislature/Jamaal-T-Bailey-6872ad9e-fcba-426f-a9ef-b4495dba17f5.yml`
+  - `data/ny/retired/Jamaal-Bailey-5116a858-d504-4cfb-bfb1-a8881b0a9451.yml`
+- `luis` `sepúlveda`
+  - `data/ny/legislature/Luis-R-Seplveda-1e5af6bc-1643-4cfd-b4c1-8b2e86b02c2d.yml`
+  - `data/ny/retired/Luis-Sepulveda-55cd565f-8f75-4d4c-842a-c9fdf8597a6d.yml`
+- `mike` `spano`
+  - `data/ny/retired/Mike-Spano-211acd0f-ce3d-4bfd-a771-011000d0481a.yml`
+  - `data/ny/retired/Mike-Spano-4c279513-6979-4605-9f0f-d9a312e6a999.yml`
+- `sean` `ryan`
+  - `data/ny/retired/Sean-M-Ryan-6913e7e0-3ad5-4593-a2b0-dc31e974cdf6.yml`
+  - `data/ny/retired/Sean-Ryan-3bcad7b1-387d-42bf-8233-ce88bd671b50.yml`
+- `zohran` `mamdani`
+  - `data/ny/municipalities/Zohran-Mamdani-0986ce6e-b580-46ef-85c3-86c2d049857a.yml`
+  - `data/ny/retired/Zohran-Mamdani-7bf43536-ab00-4cce-84c2-e2cc1c418d9c.yml`
+
+## oh
+
+- `al` `landis`
+  - `data/oh/legislature/Al-Landis-debec71d-fcfb-4422-9c9e-c6a8709cbb3a.yml`
+  - `data/oh/retired/Al-Landis-2ddf0efa-75c0-45ea-a1ed-9cdf2a47a4bb.yml`
+- `andrew` `ginther`
+  - `data/oh/municipalities/Andrew-Ginther-531c8974-f317-44f6-9cd0-b0b0a0f73729.yml`
+  - `data/oh/retired/Andrew-Ginther-6f15b2b9-fc1f-4119-8827-66c75169ecc6.yml`
+- `frank` `larose`
+  - `data/oh/executive/Frank-LaRose-eaeed96a-2f5c-43f2-aef4-fa3432d33451.yml`
+  - `data/oh/retired/Frank-LaRose-56038e50-64a7-40b8-a748-a772003e6c24.yml`
+- `kyle` `koehler`
+  - `data/oh/legislature/Kyle-Koehler-f2e79c7c-7e3a-496d-8f87-d43b62eb54a5.yml`
+  - `data/oh/retired/Kyle-Koehler-9578948b-5af3-46fd-9567-8438c67fa148.yml`
+- `mark` `romanchuk`
+  - `data/oh/legislature/Mark-Romanchuk-2ae62dc8-e902-4a8e-99b7-182477c50bc3.yml`
+  - `data/oh/retired/Mark-J-Romanchuk-257a1a5f-8888-49e4-a652-69db47e75832.yml`
+- `niraj` `antani`
+  - `data/oh/retired/Niraj-Antani-5c7158e0-2f04-4021-8947-50d1d4cd5cae.yml`
+  - `data/oh/retired/Niraj-J-Antani-61a15c05-6623-49f8-a421-3d56a29eed23.yml`
+- `sandra` `williams`
+  - `data/oh/retired/Sandra-Williams-925ef313-4409-48dd-b1be-d37c6077b0af.yml`
+  - `data/oh/retired/Sandra-Williams-efe05fc4-5f09-42cf-80b9-51bca7c62f1b.yml`
+- `sean` `o'brien`
+  - `data/oh/retired/Sean-OBrien-49ef2e8f-c4fb-4113-ba9d-d645afc7a479.yml`
+  - `data/oh/retired/Sean-OBrien-a0a3005d-fb90-46cc-9c3b-59d40398a863.yml`
+- `steven` `arndt`
+  - `data/oh/retired/Steven-Arndt-965dc59e-80bf-41e4-9711-8999f45bdf0c.yml`
+  - `data/oh/retired/Steven-M-Arndt-193ef670-8329-47fc-bb7f-536ee4d5d09e.yml`
+- `tom` `patton`
+  - `data/oh/legislature/Thomas-F-Patton-a57f6c78-ac58-4f7d-870e-0d8052984cd9.yml`
+  - `data/oh/retired/Tom-Patton-1956dfd2-6203-4d3c-aecc-7c957dd5f114.yml`
+- `william` `coley`
+  - `data/oh/retired/Bill-Coley-a988a4a6-21b1-4051-ad70-356db84869a1.yml`
+  - `data/oh/retired/William-P-Coley-II-b7e9da77-eede-4662-bfc9-21651a275aa5.yml`
+
+## ok
+
+- `david` `holt`
+  - `data/ok/municipalities/David-Holt-4581d8a7-2800-4212-bed1-806b1118ec86.yml`
+  - `data/ok/retired/David-Holt-2182d996-9d2e-48ea-bd58-35c5befb7a9e.yml`
+  - `data/ok/retired/David-Holt-43cc0ab4-b8ad-4563-99d4-a69f9b616fb1.yml`
+- `john` `montgomery`
+  - `data/ok/retired/John-Michael-Montgomery-749f91d3-e8a4-466b-aa3a-2572ae91988f.yml`
+  - `data/ok/retired/John-Montgomery-bc5f44c1-951c-4dc1-b5cb-98b96b538b5d.yml`
+
+## or
+
+- `ted` `wheeler`
+  - `data/or/retired/Ted-Wheeler-5eb15e9d-6fe9-432c-82a0-257148be4f4d.yml`
+  - `data/or/retired/Ted-Wheeler-6bee340b-6271-41d0-b996-0a72aeb51415.yml`
+- `tina` `kotek`
+  - `data/or/executive/Tina-Kotek-c136922d-c34a-4b53-a56b-2201b139d469.yml`
+  - `data/or/retired/Tina-Kotek-818b4cd1-9ced-461e-9c59-8b5e6ed858cf.yml`
+
+## pa
+
+- `cherelle` `parker`
+  - `data/pa/municipalities/Cherelle-Parker-5aff4d4d-e7e2-4ac8-8ae0-8c03934fc62d.yml`
+  - `data/pa/retired/Cherelle-L-Parker-97b067bb-ba59-4a33-8a6e-d5cca0099ecb.yml`
+- `dianne` `herrin`
+  - `data/pa/retired/Dianne-Herrin-3f50fb6a-ea48-4ae9-92a6-1eb8f2d15b19.yml`
+  - `data/pa/retired/Dianne-Herrin-f8859e63-a26c-4fca-b4dd-51074c40f447.yml`
+- `josh` `shapiro`
+  - `data/pa/executive/Josh-Shapiro-ac7497c7-0a0d-495f-98ce-75dedbfeb0c7.yml`
+  - `data/pa/retired/Josh-Shapiro-0aa38ee7-e429-4d67-9dc6-0220117ef1b9.yml`
+- `ron` `strouse`
+  - `data/pa/retired/Ron--Strouse-95614a26-8466-4948-85d9-3e02b455d67b.yml`
+  - `data/pa/retired/Ron-Strouse-9039e317-cc46-4d15-b636-595ee7ba71a1.yml`
+- `roni` `green`
+  - `data/pa/legislature/G-Roni-Green-c3ad9b17-c8f5-450e-9aaa-f002e1414bd5.yml`
+  - `data/pa/retired/G-Roni-Green-895e8c64-08d3-4ae1-969a-351145256676.yml`
+
+## pr
+
+- `josé` `pérez cordero`
+  - `data/pr/legislature/Jos-J-Prez-Cordero-65f91ca5-2401-4bd4-b146-79b08b12fad6.yml`
+  - `data/pr/retired/Jos-J-Prez-Cordero-49054128-56f7-4c06-ad4c-74e13c62be28.yml`
+- `migdalia` `gonzález`
+  - `data/pr/retired/Migdalia-Gonzalez-a5036514-440a-4db9-a089-349caea8ca73.yml`
+  - `data/pr/retired/Migdalia-Gonzlez-8b62caa9-ef8b-44ff-872c-030c6e33096c.yml`
+
+## ri
+
+- `gregg` `amore`
+  - `data/ri/executive/Gregg-Amore-18b9f6aa-ba50-4c0a-953c-fba2720ef2a6.yml`
+  - `data/ri/retired/Gregg-Amore-2c07b2e1-9f17-4b9e-af12-ead475429999.yml`
+
+## sc
+
+- `guynn` `savage`
+  - `data/sc/municipalities/Guynn-Savage-aff1c4d2-ddc3-4f7f-bd84-f3fa3161126e.yml`
+  - `data/sc/municipalities/Guynn-Savage-b4e21b4c-ea16-4ca0-ae7b-7cc834c80bc0.yml`
+- `luke` `rankin`
+  - `data/sc/legislature/Luke-A-Rankin-27fb6caf-f757-44a3-8973-6ce72aacd7e2.yml`
+  - `data/sc/legislature/Luke-Rankin-94b1b04a-1be7-4128-b7ac-0c3b299b7d53.yml`
+
+## sd
+
+- `bruce` `rampelberg`
+  - `data/sd/retired/Bruce-E-Rampelberg-bcfa1997-0219-47da-9ac2-7298faea5398.yml`
+  - `data/sd/retired/Rampelberg-Bruce-4ddf243d-8b56-4f21-b655-9f13297e465f.yml`
+- `burt` `tulson`
+  - `data/sd/retired/Burt-E-Tulson-76c34b23-57cf-4c62-8114-7bd89180e4ab.yml`
+  - `data/sd/retired/Burt-Tulson-923b72f8-13cb-4e4e-9b96-b33c457fca17.yml`
+- `craig` `tieszen`
+  - `data/sd/retired/Craig-Tieszen-5bf1fe4c-25a4-4a7a-b85b-54470c23fa88.yml`
+  - `data/sd/retired/Tieszen-Craig-38c95291-8e01-4e5b-96be-a2977894c36a.yml`
+- `dan` `ahlers`
+  - `data/sd/retired/Dan-Ahlers-62f2fade-5ca5-461b-ad1f-e08d01af65d0.yml`
+  - `data/sd/retired/Dan-P-Ahlers-ddba83be-9a8b-4d24-a1db-62c7301d1c71.yml`
+- `david` `johnson`
+  - `data/sd/retired/David-Johnson-5d7e12d0-3fe0-41ef-a32e-43767d99b97b.yml`
+  - `data/sd/retired/David-L-Johnson-19b6f18f-5afe-411f-a791-ed81213eafd0.yml`
+- `dean` `wink`
+  - `data/sd/retired/Dean-A-Wink-2de0c972-4ac8-48eb-8754-23f214079b40.yml`
+  - `data/sd/retired/Dean-Wink-1a428591-a0bf-4955-adb0-a8f118e76fc5.yml`
+- `fred` `romkema`
+  - `data/sd/retired/Fred-W-Romkema-4f653dcb-145c-4479-90ac-cb1016dc8581.yml`
+  - `data/sd/retired/Romkema-Fred-27d6c066-1871-4459-8c41-872791730f92.yml`
+- `jean` `hunhoff`
+  - `data/sd/retired/Hunhoff-Jean-dcd05ac1-1d62-47c2-8421-5a2da8b93536.yml`
+  - `data/sd/retired/Jean-M-Hunhoff-c80f69e1-70f3-4ee8-b74b-53f532db335b.yml`
+- `julie` `frye-mueller`
+  - `data/sd/retired/Julie-A-Frye-Mueller-ba5d7a37-c0f2-42fe-b262-685623f0be32.yml`
+  - `data/sd/retired/Julie-Frye-Mueller-014e29e7-d4db-4800-adf3-17d12a114454.yml`
+- `karen` `soli`
+  - `data/sd/retired/Karen-L-Soli-6f9c73d2-5873-44b6-b6f1-a7142a75adaf.yml`
+  - `data/sd/retired/Karen-Soli-947fb182-7242-4ece-b83e-61e89a88f8a0.yml`
+- `kristi` `noem`
+  - `data/sd/retired/Kristi-Noem-8e08e266-1113-4cce-9c78-a8ee68332a74.yml`
+  - `data/sd/retired/Kristi-Noem-e76e3662-0567-4615-9142-655989f08ff4.yml`
+- `kyle` `schoenfish`
+  - `data/sd/legislature/Kyle-R-Schoenfish-bd74c8bf-cc11-4bfc-a721-269a01a6ccb1.yml`
+  - `data/sd/retired/Kyle-Schoenfish-38a7ca91-fc3b-4ddf-94e4-eef20bc3bb79.yml`
+- `larry` `tidemann`
+  - `data/sd/retired/Larry-J-Tidemann-9c0c3e49-c7db-4ad1-8bb5-be861c3a7a7c.yml`
+  - `data/sd/retired/Larry-Tidemann-ecbedda7-00f6-41ad-8190-a6f09483b9f0.yml`
+- `mark` `willadsen`
+  - `data/sd/retired/Mark-K-Willadsen-04468e3c-2c34-4c42-a007-c551cee0b5a1.yml`
+  - `data/sd/retired/Mark-Willadsen-ce233e8e-a3dc-4c28-a5b5-e40d271a4156.yml`
+- `mary` `duvall`
+  - `data/sd/retired/Mary-Duvall-df0dfab0-9fb0-415d-a892-8929f4e0cf2c.yml`
+  - `data/sd/retired/Mary-K-Duvall-a804ddc2-54cd-411b-b536-ecda7cfabc26.yml`
+- `ried` `holien`
+  - `data/sd/retired/Holien-Ried-a5625668-7b2f-4c5c-a7cc-3fa941a78e44.yml`
+  - `data/sd/retired/Ried-S-Holien-3fcb0cab-1359-4fc4-b777-65f8ba3a357a.yml`
+- `tim` `goodwin`
+  - `data/sd/legislature/Tim-Goodwin-e12868fa-61b7-4ad5-9f68-bcfca817057d.yml`
+  - `data/sd/retired/Tim-Goodwin-4b767162-f103-449a-a19d-4e08304a10b6.yml`
+
+## tn
+
+- `andy` `berke`
+  - `data/tn/retired/Andy-Berke--67cedf87-0c2a-474e-80d7-b5e00b8bc7a0.yml`
+  - `data/tn/retired/Andy-Berke-6e5d5734-beb1-4381-809d-08c6859c3ce3.yml`
+- `joe` `pitts`
+  - `data/tn/retired/Joe-Pitts-273de6b0-a4bc-4446-b186-fa15ef29976e.yml`
+  - `data/tn/retired/Joe-Pitts-5ad978f9-94c7-4263-9e70-bfcb4384ec0e.yml`
+- `kevin` `brooks`
+  - `data/tn/retired/Kevin-Brooks-a77f1dbe-8a0b-48c8-af73-c4b45a2ad865.yml`
+  - `data/tn/retired/Kevin-Brooks-eb0e4e6d-5f9c-40fb-b722-8a4a9a6a9f50.yml`
+- `lee` `harris`
+  - `data/tn/retired/Lee-Harris-56a9f86a-cd6a-4f03-8901-7b4b8a18b3e4.yml`
+  - `data/tn/retired/Lee-Harris-daa066d8-1712-44f9-a0db-2b60c0687b21.yml`
+
+## tx
+
+- `dee` `margo`
+  - `data/tx/retired/Dee-Margo-9249daf1-eee3-42c9-803a-398f7152be16.yml`
+  - `data/tx/retired/Dee-Margo-9eb36b84-b390-4415-a2bb-3581016c00f7.yml`
+- `don` `mclaughlin`
+  - `data/tx/legislature/Don-McLaughlin-0941f4bf-2ac8-48d0-8675-191514e06850.yml`
+  - `data/tx/retired/Don-Mclaughlin-3a72c076-5393-4c45-bcba-4daba56e8ece.yml`
+- `eddie` `lucio`
+  - `data/tx/retired/Eddie-Lucio-III-2afa7f91-6f62-403c-b37b-d0ff135b6b58.yml`
+  - `data/tx/retired/Eduardo-A-Eddie-Lucio-Jr-cc490cb2-b29c-4989-8cc3-574ae04bf1d7.yml`
+- `eric` `johnson`
+  - `data/tx/municipalities/Eric-Johnson-9b26a8d9-1ccb-4c21-8b68-193aafb04c3f.yml`
+  - `data/tx/retired/Eric-Johnson-c6dc85d6-09ed-4aee-955f-a5c3a6a94435.yml`
+- `george` `fuller`
+  - `data/tx/municipalities/George-Fuller-550916c8-3f08-4638-a1d9-6df145d77502.yml`
+  - `data/tx/retired/George-Fuller-f036e155-ba93-4214-9990-acdd05d836c3.yml`
+- `ginger` `nelson`
+  - `data/tx/municipalities/Ginger-Nelson-67a2ab27-4a5c-48d5-8f1f-03c3f6c148a3.yml`
+  - `data/tx/retired/Ginger-Nelson-b239eaef-a67a-4877-b467-25229fc0a2ca.yml`
+- `jane` `nelson`
+  - `data/tx/executive/Jane-Nelson-ff63d52e-ec3f-4749-9b96-8e8323cd655f.yml`
+  - `data/tx/retired/Jane-Nelson-dd120c8b-e0c8-4907-b982-8653f4208c80.yml`
+- `jeff` `williams`
+  - `data/tx/retired/Jeff-Williams-7c8ab5a6-9a3b-4238-897c-5436f7d4d1c8.yml`
+  - `data/tx/retired/Jeff-Williams-8d83f049-20a7-4d56-942d-befcf943f95c.yml`
+- `jim` `jarratt`
+  - `data/tx/municipalities/Jim-Jarratt-30fd13ea-62bf-489a-a0f4-d3b01ced174c.yml`
+  - `data/tx/retired/Jim-Jarratt-ff8e668d-02eb-43ae-ad66-65274d9d3a5e.yml`
+- `john` `lujan`
+  - `data/tx/legislature/John-Lujan-fbd66d9f-2a93-4cbf-b75d-b51cb01e955e.yml`
+  - `data/tx/retired/Lujan-John-ed08c61f-905c-4887-b99b-368d7c398e75.yml`
+- `john` `whitmire`
+  - `data/tx/municipalities/John-Whitmire-92d60f74-2fed-11ef-9454-0242ac120002.yml`
+  - `data/tx/retired/John-Whitmire-54ac2dae-47ea-4f0b-8ce9-594c1c58b423.yml`
+- `kirk` `watson`
+  - `data/tx/municipalities/Kirk-Watson-603db6b7-89e7-488f-ac09-0da68b3dbce4.yml`
+  - `data/tx/municipalities/Kirk-Watson-b01406d8-8d24-4fc9-887f-d169b220a5dc.yml`
+- `paul` `voelker`
+  - `data/tx/retired/Paul-Voelker-3364d8d7-e44e-4f46-ae34-87ccf265a849.yml`
+  - `data/tx/retired/Paul-Voelker-bd4e8b87-ce6b-4ae4-aa36-e5f81bc207ff.yml`
+- `pete` `flores`
+  - `data/tx/legislature/Pete-Flores-682e8ef8-8fc1-4490-a04d-63a7c6d92185.yml`
+  - `data/tx/retired/Pete-Flores-7a497d46-5c50-4bf4-9be7-26fcf13aa659.yml`
+- `ron` `nirenberg`
+  - `data/tx/municipalities/Ron-Nirenberg--1dedd1e4-bd05-4fde-b688-2145b7070bee.yml`
+  - `data/tx/retired/Ron-Nirenberg-4ba1ad17-03f6-4b23-86b0-d270700b077b.yml`
+- `scott` `lemay`
+  - `data/tx/municipalities/Scott-LeMay-0db1d663-6487-47c6-97b9-a1a5a4bcccd6.yml`
+  - `data/tx/retired/Scott-LeMay-343fbe64-4ab7-4e6a-9e66-a94bbfd1e8c1.yml`
+- `sylvester` `turner`
+  - `data/tx/retired/Sylvester-Turner-163ed457-a95b-4671-ade7-1afe27eaf7d5.yml`
+  - `data/tx/retired/Sylvester-Turner-cd267f00-f049-46f6-99d0-f61498605663.yml`
+
+## us
+
+- `marlin` `stutzman`
+  - `data/us/legislature/Marlin-Stutzman-75da3666-5cb1-4849-a995-dedc76db6cf5.yml`
+  - `data/us/retired/Marlin-Stutzman-21f03982-e598-4407-a0c6-3451f62afcf9.yml`
+
+## ut
+
+- `derrin` `owens`
+  - `data/ut/legislature/Derrin-R-Owens-ef1c9af3-b4f9-4eeb-b63d-a22f01c84262.yml`
+  - `data/ut/retired/Derrin-Owens-003f2796-d3b3-411b-b55c-0ee1c29210e4.yml`
+- `don` `ipson`
+  - `data/ut/legislature/Don-L-Ipson-cbfab19e-80f2-4edc-ae55-08f9e03a6d2f.yml`
+  - `data/ut/retired/Don-L-Ipson-dc1f963b-a45d-418e-9005-48c9dea8fb93.yml`
+- `kim` `coleman`
+  - `data/ut/retired/Kim-Coleman-3adca5e3-7bac-4051-aab6-ed97de9508bd.yml`
+  - `data/ut/retired/Kim-F-Coleman-53895be7-c7bb-482d-b812-f710b41282ce.yml`
+- `spencer` `cox`
+  - `data/ut/executive/Spencer-Cox-52dd3ff2-e7a2-458e-b8f1-797fdab69e4a.yml`
+  - `data/ut/retired/Spencer-J-Cox-9902bd44-c106-401d-bf97-88719ab8dd50.yml`
+
+## va
+
+- `bill` `desteph`
+  - `data/va/legislature/Bill-R-DeSteph-Jr-ec14a514-ce1c-4fba-b053-fcf133793445.yml`
+  - `data/va/retired/Bill-R-DeSteph-Jr-1c1e24bb-4e9c-43f7-a51f-96bcefda35c8.yml`
+- `kelly` `burk`
+  - `data/va/municipalities/Kelly-Burk-a9ea71a8-57b1-41c8-b5a7-4ba4c74a1e8b.yml`
+  - `data/va/retired/Kelly-Burk-8e9dd82f-2935-4b29-8928-25fe6921935f.yml`
+- `lionell` `spruill`
+  - `data/va/retired/Lionell-Spruill-Sr-3321a69e-2055-4673-bf1b-47feec15f9cc.yml`
+  - `data/va/retired/Lionell-Spruill-Sr-bd1e992b-4c13-4e7f-bba5-120709c93810.yml`
+- `mary katherine` `greenlaw`
+  - `data/va/municipalities/Mary-Katherine-Greenlaw-9fd042ae-f16c-4f87-a3c5-3dd0d229a6ea.yml`
+  - `data/va/retired/Mary-Katherine-Greenlaw-e87774db-d5cf-4166-868c-9ef2b53efec4.yml`
+- `ralph` `northam`
+  - `data/va/retired/Ralph-Northam-dd95825c-d102-4418-beb8-24ca8c54a22c.yml`
+  - `data/va/retired/Ralph-S-Northam-8214605b-76b4-4ee9-aed5-54e3347b3131.yml`
+- `scott` `surovell`
+  - `data/va/legislature/Scott-A-Surovell-50a6c704-2ba7-4ecc-a24c-8f55b400709b.yml`
+  - `data/va/retired/Scott-A-Surovell-db0733fb-d920-4772-a20a-6da372b452d3.yml`
+
+## vt
+
+- `christopher` `pearson`
+  - `data/vt/retired/Christopher-A-Pearson-44656e87-18e9-4049-89f8-5dc26628ef6c.yml`
+  - `data/vt/retired/Christopher-A-Pearson-48d31a41-0a4a-4fd4-997c-220b93c28881.yml`
+- `david` `ainsworth`
+  - `data/vt/retired/David-Ainsworth-34b05847-9606-47cc-8939-bcdebd1e7791.yml`
+  - `data/vt/retired/David-M-Ainsworth-0062fcbd-f9a1-4f3d-b227-6a4269b99a01.yml`
+- `james` `carroll`
+  - `data/vt/retired/James-Carroll-439f6541-dcf9-4661-9088-fa7dd39734be.yml`
+  - `data/vt/retired/Jim-Carroll-e0dc51a6-8a81-4140-8693-15106fd1a000.yml`
+- `martine` `gulick`
+  - `data/vt/legislature/Martine-Gulick-a1812863-f6a9-4ce2-8131-d701923dd507.yml`
+  - `data/vt/retired/Martine-L-Gulick-ae0ecb9d-9899-484c-b634-2fd85a77eb9d.yml`
+- `phil` `scott`
+  - `data/vt/executive/Phil-Scott-f3e613ff-3cd6-4b2c-b268-f6460d029f05.yml`
+  - `data/vt/retired/Phil-B-Scott-575d9ad9-9340-407a-8824-e009f91061f9.yml`
+- `sarah` `copeland hanzas`
+  - `data/vt/executive/Sarah-L-Copeland-Hanzas-19d6cf01-f77c-4db7-8765-af838a00bc75.yml`
+  - `data/vt/retired/Sarah-Copeland-Hanzas-389f6327-715a-47b2-b833-9869bb69074f.yml`
+
+## wa
+
+- `greg` `wheeler`
+  - `data/wa/municipalities/Greg-Wheeler-ed4c031e-8156-4961-a5b6-3af89b8e26bd.yml`
+  - `data/wa/retired/Greg-Wheeler-70ac7a50-81d6-414e-be8b-83b4a7d0c703.yml`
+- `liam` `olsen`
+  - `data/wa/retired/Liam-Olsen-172915df-d82a-449f-b7b4-4c055074208c.yml`
+  - `data/wa/retired/Liam-Olsen-d2c6c36e-094e-4ff5-928c-faa4b2b20d9b.yml`
+- `lynne` `robinson`
+  - `data/wa/retired/Lynne-Robinson-47b556ec-3584-41d6-ab99-ea85018812e4.yml`
+  - `data/wa/retired/Lynne-Robinson-ffefec62-d4ed-4263-a0cc-c0c221c9bcc0.yml`
+- `monica` `stonier`
+  - `data/wa/legislature/Monica-Jurado-Stonier-fabb9834-0e6d-476b-ba0f-50d4ecf74a43.yml`
+  - `data/wa/retired/Monica-Stonier-9e740364-9ccf-4f3c-b2df-0ea498dd9118.yml`
+- `steve` `hobbs`
+  - `data/wa/executive/Steve-Hobbs-4a203502-87b1-49f6-8cf2-8cbf4dedb954.yml`
+  - `data/wa/retired/Steve-Hobbs-14816361-a653-4221-9673-416581c9d97d.yml`
+
+## wi
+
+- `cory` `mason`
+  - `data/wi/retired/Cory-Mason-b58e5901-e3b6-49e1-869c-2849757ff889.yml`
+  - `data/wi/retired/Cory-Mason-f05c5fab-a7f1-46df-9c9d-49c967704190.yml`
+- `eric` `genrich`
+  - `data/wi/retired/Eric-Genrich-14d120bb-5f9d-449b-a0f6-060ba5b6d232.yml`
+  - `data/wi/retired/Eric-Genrich-7faa8a79-f7a0-40cc-aa14-84a21867344f.yml`
+- `lori` `palmeri`
+  - `data/wi/legislature/Lori-Palmeri-aef40b88-72b7-4001-b336-9210a55a2bde.yml`
+  - `data/wi/retired/Lori-Palmeri-426da80f-c348-46fd-a601-819c3a3a37ea.yml`
+- `satya` `rhodes-conway`
+  - `data/wi/municipalities/Satya-Rhodes-Conway-0537e2fe-8e96-4d05-8023-e747c92e4ad1.yml`
+  - `data/wi/retired/Satya-Rhodes-Conway-74c20321-4989-488b-adac-ba3a6cf8ca52.yml`
+
+## wv
+
+- `jeff` `campbell`
+  - `data/wv/legislature/Jeff-Campbell-81cad520-b015-42c8-b533-64a9e4596197.yml`
+  - `data/wv/retired/Jeff-Campbell-3d8e0acc-c57d-450e-aacf-3b4a656e213d.yml`
+
+## wy
+
+- `chuck` `gray`
+  - `data/wy/executive/Chuck-Gray-fc4a66ba-5fc1-47e2-8e8a-4fec762c7af6.yml`
+  - `data/wy/retired/Chuck-Gray-11bc0b6a-d71c-4d2f-83e2-8209be24e2d9.yml`
+- `dan` `laursen`
+  - `data/wy/legislature/Dan-Laursen-982cdb50-2a81-47b4-97e8-cf80b92d1412.yml`
+  - `data/wy/retired/Dan-Laursen-f3ae6a07-a963-47fb-87af-c6dda696f6be.yml`
+- `david` `northrup`
+  - `data/wy/retired/David-Northrup-b6a82760-a924-4d26-bcce-1b8a8c0fccf2.yml`
+  - `data/wy/retired/David-Northrup-d7089cdb-4701-4777-82ea-b17217194aad.yml`
+- `edward` `buchanan`
+  - `data/wy/retired/Edward-Buchanan-30b24955-fd52-42da-878b-6a33873e9d1a.yml`
+  - `data/wy/retired/Edward-Buchanan-a00fbae0-ff30-4b08-a442-64a6f0d98581.yml`
+- `eric` `barlow`
+  - `data/wy/legislature/Eric-Barlow-afa67bb0-3191-4dce-94ab-ddb3a9e7475c.yml`
+  - `data/wy/retired/Eric-Barlow-d54d2b39-7361-46f7-b4be-b5f4cb11f7b3.yml`


### PR DESCRIPTION
## Summary

- Add a duplicate-person checker for person YAML records.
- Wire the checker into the existing selective YAML lint workflow.
- Add `data/duplicates.md` as a generated backlog of existing duplicate groups.

## Behavior

The duplicate rule is scoped by state: two person files are considered duplicates when normalized `given_name` and `family_name` match in the same state.

The workflow only fails duplicate groups that include a changed person file. This lets existing historical duplicates remain as cleanup backlog while preventing newly added or modified duplicate person records from landing.

## Validation

- `python3 .github/scripts/check_duplicate_people.py ar` fails and reports existing Arkansas duplicate groups.
- `python3 .github/scripts/check_duplicate_people.py --changed-files data/ar/executive/Leslie-Rutledge-29e6b6e2-82fc-48f8-9177-96b1ec30a2a6.yml` fails because the changed file is in a duplicate group.
- `python3 .github/scripts/check_duplicate_people.py --changed-files data/ky/executive/Jacqueline-Coleman-9b07a848-b96c-4b2b-86ba-5194b65e43d9.yml` passes.
- `python3 -m py_compile .github/scripts/check_duplicate_people.py`
- `git diff --check`
