### PR TITLE
Fix broken image URL for PA Rep. Abby Major

### DIFF
--- a/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
+++ b/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
@@ -4,7 +4,7 @@ given_name: Abby
 family_name: Major
 gender: Female
 email: amajor@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1926.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1926.jpg
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
## Summary
- Updates Abby Major's image URL from the deprecated `legis.state.pa.us` domain to the new official PA General Assembly domain `palegis.us`.
- The old domain now 301-redirects to the new site; the existing image URL no longer resolves directly.

Surfaced via internal data quality tooling.

**Old:** `https://www.legis.state.pa.us/images/members/200/1926.jpg?1703415645672`
**New:** `https://www.palegis.us/resources/images/members/300/1926.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content type
- [x] Verified `palegis.us` is the official PA General Assembly site (already referenced elsewhere in this file's `links` section)