### PR TITLE
Fix broken image URL for CO Rep. Brandi Bradley

### DIFF
--- a/data/co/legislature/Brandi-Bradley-5a396024-8dcf-438c-beca-a730e972d9d8.yml
+++ b/data/co/legislature/Brandi-Bradley-5a396024-8dcf-438c-beca-a730e972d9d8.yml
@@ -4,7 +4,7 @@ given_name: Brandi
 family_name: Bradley
 gender: Female
 email: brandi.bradley.house@coleg.gov
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2023b_bradley%2Cbrandi.jpg?itok=gkSqfLu8
+image: https://leg.colorado.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMnhUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--f00bc156e1af4f5ddf1b991b5f96817a5221767c/Bradley,%20Brandi.jpg
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
## Summary
- Updates Brandi Bradley's image URL. The old Drupal-style URL on `leg.colorado.gov/sites/default/files/...` 301-redirects to `content.leg.colorado.gov/...` which returns **404** — the Colorado legislature site has migrated to a Rails Active Storage backend.
- The new URL is the stable signed-blob URL referenced directly from her official profile page at https://leg.colorado.gov/legislators/brandi-bradley. The signed token has no expiration (`exp: null`); each request 302-redirects to a freshly-minted presigned S3 URL behind it.

Surfaced via internal data quality tooling.

**Old:** `http://leg.colorado.gov/sites/default/files/styles/width_300/public/2023b_bradley%2Cbrandi.jpg?itok=gkSqfLu8`
**New:** `https://leg.colorado.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMi...--f00bc156e1af4f5ddf1b991b5f96817a5221767c/Bradley,%20Brandi.jpg`

### Alternative considered
There is also a properly-thumbnailed image (~15KB, 300×420) hosted on Squarespace at `https://images.squarespace-cdn.com/content/v1/5fbb03fe5d27c00d59715528/9537e1b1-f937-432a-82bf-4c8a1a1d92f4/Brandi+Bradley.jpg`. Went with the official state source for stability — campaign/personal sites churn, but the legislature site won't. Happy to switch if maintainers prefer the smaller thumbnailed version.

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (3000×4200 JPEG, ~2.16MB)
- [x] Verified the signed token has no expiration (decoded payload: `{"exp":null,"pur":"blob_id"}`)
- [x] Verified new URL is sourced directly from `<img src="...">` on her official `leg.colorado.gov/legislators/brandi-bradley` profile page