### PR TITLE
Fix broken image URL for FL Rep. Brad Yeager

### DIFF
--- a/data/fl/legislature/Bradford-Troy-Brad-Yeager-8d746fc8-370b-4d12-bcf8-3dd4a4061707.yml
+++ b/data/fl/legislature/Bradford-Troy-Brad-Yeager-8d746fc8-370b-4d12-bcf8-3dd4a4061707.yml
@@ -4,7 +4,7 @@ given_name: Brad
 family_name: Yeager
 gender: Male
 email: brad.yeager@flhouse.gov
-image: https://myfloridahouse.gov//FileStores/Web/Imaging/Member/4882.jpg
+image: https://www.flhouse.gov/FileStores/Web/Imaging/Member/4882.jpg
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
## Summary
- Updates Brad Yeager's image URL. The old URL on `myfloridahouse.gov` (which also had a stray double-slash in the path) no longer serves images — requests to `/FileStores/Web/Imaging/Member/...` return an HTML page instead of the JPEG.
- Replaces it with the same path on the current official `flhouse.gov` domain, which is already used in this file's `links` and `sources`.

Surfaced via internal data quality tooling.

**Old:** `https://myfloridahouse.gov//FileStores/Web/Imaging/Member/4882.jpg`
**New:** `https://www.flhouse.gov/FileStores/Web/Imaging/Member/4882.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (208×279 JPEG, ~70KB)
- [x] Verified old URL returns `text/html` (97KB error page) — both with and without the duplicated slash