### PR TITLE
Fix broken image URL for PA Rep. Brad Roae

### DIFF
--- a/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
+++ b/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
@@ -5,7 +5,7 @@ family_name: Roae
 birth_date: 1967-04-06
 gender: Male
 email: broae@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1083.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1083.jpg
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
## Summary
- Updates Brad Roae's image URL from the deprecated `legis.state.pa.us` domain to the new official PA General Assembly domain `palegis.us`.
- The old domain now 301-redirects to the new site; the existing image URL no longer resolves directly.

Surfaced via internal data quality tooling.

**Old:** `https://www.legis.state.pa.us/images/members/200/1083.jpg?1703415645672`
**New:** `https://www.palegis.us/resources/images/members/300/1083.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (~134KB)
- [x] `palegis.us` is the official PA General Assembly site (already referenced elsewhere in this file's `links` and `sources`)