### PR TITLE
Fix broken image URL for PA Rep. Bob Merski

### DIFF
--- a/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
+++ b/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
@@ -5,7 +5,7 @@ family_name: Merski
 birth_date: 1975-05-14
 gender: Male
 email: rmerski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1822.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1822.jpg
 party:
 - name: Democratic
 roles:


### PR DESCRIPTION
## Summary
- Updates Bob Merski's image URL from the deprecated `legis.state.pa.us` domain to the new official PA General Assembly domain `palegis.us`.
- The old domain now 301-redirects to the new site; the existing image URL no longer resolves directly.

Surfaced via internal data quality tooling.

**Old:** `https://www.legis.state.pa.us/images/members/200/1822.jpg?1703415645672`
**New:** `https://www.palegis.us/resources/images/members/300/1822.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (~85KB)
- [x] `palegis.us` is the official PA General Assembly site