### PR TITLE
Fix broken image URL for PA Rep. Bob Freeman

### DIFF
--- a/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
+++ b/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
@@ -5,7 +5,7 @@ family_name: Freeman
 birth_date: 1956-03-09
 gender: Male
 email: rfreeman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/136.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/136.jpg
 party:
 - name: Democratic
 roles:


### PR DESCRIPTION
## Summary
- Updates Bob Freeman's image URL from the deprecated `legis.state.pa.us` domain to the new official PA General Assembly domain `palegis.us`.
- The old domain now 301-redirects to the new site; the existing image URL no longer resolves directly.

Surfaced via internal data quality tooling.

**Old:** `https://www.legis.state.pa.us/images/members/200/136.jpg?1703415645672`
**New:** `https://www.palegis.us/resources/images/members/300/136.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (~102KB)
- [x] `palegis.us` is the official PA General Assembly site