### PR TITLE
Fix broken image URL for CO Rep. Bob Marshall

### DIFF
--- a/data/co/legislature/Bob-Marshall-ade56d2d-41d7-436d-b76b-85051f036c7a.yml
+++ b/data/co/legislature/Bob-Marshall-ade56d2d-41d7-436d-b76b-85051f036c7a.yml
@@ -4,7 +4,7 @@ given_name: Bob
 family_name: Marshall
 gender: Male
 email: bob.marshall.house@coleg.gov
-image: http://leg.colorado.gov/sites/default/files/styles/width_300/public/2023b_marshall%2C%20bob.jpg?itok=5ohSNQXK
+image: https://leg.colorado.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM1pUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--18c815634a34450ae6caf0855eeb0406ea4582cc/Marshall,%20Bob.jpg
 party:
 - name: Democratic
 roles:


### PR DESCRIPTION
## Summary
- Updates Bob Marshall's image URL. The old Drupal-style URL on `leg.colorado.gov/sites/default/files/...` 301-redirects to `content.leg.colorado.gov/...` which returns **404** — the Colorado legislature site has migrated to a Rails Active Storage backend.
- The new URL is the stable signed-blob URL referenced directly from his official profile page at https://leg.colorado.gov/legislators/bob-marshall. The signed token has no expiration (`exp: null`).

Surfaced via internal data quality tooling.

**Old:** `http://leg.colorado.gov/sites/default/files/styles/width_300/public/2023b_marshall%2C%20bob.jpg?itok=5ohSNQXK`
**New:** `https://leg.colorado.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMi...--18c815634a34450ae6caf0855eeb0406ea4582cc/Marshall,%20Bob.jpg`

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (3000×4200 JPEG, ~1.9MB)
- [x] Sourced directly from `<img src="...">` on his official `leg.colorado.gov/legislators/bob-marshall` profile page