### PR TITLE
Fix broken image URL for CA Asm. Blanca Pacheco

### DIFF
--- a/data/ca/legislature/Blanca-Pacheco-f2ba8154-6bf3-4e5e-af05-9412e2a189f2.yml
+++ b/data/ca/legislature/Blanca-Pacheco-f2ba8154-6bf3-4e5e-af05-9412e2a189f2.yml
@@ -5,7 +5,7 @@ family_name: Pacheco
 birth_date: 1974-04-17
 gender: Female
 email: assemblymember.pacheco@assembly.ca.gov
-image: https://www.assembly.ca.gov/sites/assembly.ca.gov/files/memberphotos/pachecho_007_11-30-22_resized.jpg
+image: https://pacheco.asmdc.org/sites/pacheco.asmdc.org/files/inline-images/Pachecho-007-11-30-22.jpg
 party:
 - name: Democratic
 roles:


### PR DESCRIPTION
## Summary
- Updates Blanca Pacheco's image URL. The old `assembly.ca.gov/sites/assembly.ca.gov/files/memberphotos/pachecho_007_11-30-22_resized.jpg` URL returns **404** — the assembly.ca.gov memberphotos directory no longer hosts this file.
- Replaces it with the headshot served directly from her official Assembly District 64 site at `pacheco.asmdc.org`, which is already referenced in this file's `links` and `sources`.

Surfaced via internal data quality tooling.

**Old:** `https://www.assembly.ca.gov/sites/assembly.ca.gov/files/memberphotos/pachecho_007_11-30-22_resized.jpg`
**New:** `https://pacheco.asmdc.org/sites/pacheco.asmdc.org/files/inline-images/Pachecho-007-11-30-22.jpg`

(Note: the upstream filename retains the "Pachecho" typo — preserving as-published.)

## Test plan
- [x] Verified new URL returns HTTP 200 with `image/jpeg` content (~4.76MB)
- [x] Verified old URL returns 404
- [x] Sourced directly from `<img src="...">` on her official `a64.asmdc.org/biography` profile page