### PR TITLE
Fix broken image URL for NY Sen. Bill Weber

### DIFF
--- a/data/ny/legislature/Bill-Weber-8285be34-48a9-4bbe-b231-f8e5f40df301.yml
+++ b/data/ny/legislature/Bill-Weber-8285be34-48a9-4bbe-b231-f8e5f40df301.yml
@@ -5,7 +5,7 @@ family_name: Weber
 birth_date: 1969-10-01
 gender: Male
 email: weber@nysenate.gov
-image: https://www.nysenate.gov/sites/default/files/styles/160x160/public/01-10-23_weber-hs-1.jpg?itok=aW-g6Y4y
+image: https://www.nysenate.gov/sites/default/files/styles/senator_hero/public/01-10-23_weber-hs-02.jpg
 party:
 - name: Republican/Conservative
 roles:


### PR DESCRIPTION
## Summary
- Updates Bill Weber's image URL. The old `nysenate.gov` Drupal-style URL with the `160x160` style and `?itok=` token no longer resolves.
- Replaces with the `senator_hero` style URL on the same `nysenate.gov` path, which is the current published headshot.

Surfaced via internal data quality tooling.

**Old:** `https://www.nysenate.gov/sites/default/files/styles/160x160/public/01-10-23_weber-hs-1.jpg?itok=aW-g6Y4y`
**New:** `https://www.nysenate.gov/sites/default/files/styles/senator_hero/public/01-10-23_weber-hs-02.jpg`

## Test plan
- [x] Visually confirmed via the official `nysenate.gov/senators/bill-weber` profile page