### PR TITLE
Migrate all active PA legislator images to palegis.us domain

### DIFF
--- a/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
+++ b/data/pa/legislature/Aaron-Bernstine-844f3ed7-03df-420f-81bd-3f547c12e61e.yml
@@ -5,7 +5,7 @@ family_name: Bernstine
 birth_date: 1984-07-02
 gender: Male
 email: abernstine@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1742.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1742.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
+++ b/data/pa/legislature/Abby-Major-db196239-5fca-4218-82ee-ce1f6cf03ec4.yml
@@ -4,7 +4,7 @@ given_name: Abby
 family_name: Major
 gender: Female
 email: amajor@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1926.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1926.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Abigail-Salisbury-4bc74848-3896-4a0a-9310-970458f48d1a.yml
+++ b/data/pa/legislature/Abigail-Salisbury-4bc74848-3896-4a0a-9310-970458f48d1a.yml
@@ -5,7 +5,7 @@ family_name: Salisbury
 birth_date: 1982-04-07
 gender: Female
 email: repsalisbury@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2012.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2012.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Aerion-Abney-1b5abb1e-0028-49a3-ae86-cfb90296c796.yml
+++ b/data/pa/legislature/Aerion-Abney-1b5abb1e-0028-49a3-ae86-cfb90296c796.yml
@@ -5,7 +5,7 @@ family_name: Abney
 birth_date: 1988-05-23
 gender: Male
 email: aabney@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1933.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1933.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Alec-J-Ryncavage-be809fa5-6ef4-4071-bb94-ed10fb051f69.yml
+++ b/data/pa/legislature/Alec-J-Ryncavage-be809fa5-6ef4-4071-bb94-ed10fb051f69.yml
@@ -5,7 +5,7 @@ family_name: Ryncavage
 birth_date: 2001-03-27
 gender: Male
 email: aryncavage@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1967.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1967.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Amanda-M-Cappelletti-77755456-0f2a-4bbd-ac96-03d83398d6fc.yml
+++ b/data/pa/legislature/Amanda-M-Cappelletti-77755456-0f2a-4bbd-ac96-03d83398d6fc.yml
@@ -5,7 +5,7 @@ family_name: Cappelletti
 birth_date: 1986-12-09
 gender: Female
 email: cappelletti@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1923.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1923.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Amen-Brown-a41016aa-660f-4af7-afcd-ef182e544533.yml
+++ b/data/pa/legislature/Amen-Brown-a41016aa-660f-4af7-afcd-ef182e544533.yml
@@ -4,7 +4,7 @@ given_name: Amen
 family_name: Brown
 gender: Male
 email: repbrown@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1919.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1919.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Andrew-Kuzma-0d86d77b-ff68-4182-be53-09ff196b8174.yml
+++ b/data/pa/legislature/Andrew-Kuzma-0d86d77b-ff68-4182-be53-09ff196b8174.yml
@@ -4,7 +4,7 @@ given_name: Andrew
 family_name: Kuzma
 gender: Male
 email: akuzma@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1946.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1946.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
+++ b/data/pa/legislature/Anita-Astorino-Kulik-999d1ffd-b893-4aac-9fbb-ae43b3039038.yml
@@ -5,7 +5,7 @@ family_name: Kulik
 birth_date: 1964-05-05
 gender: Female
 email: akulik@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1744.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1744.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ann-Flood-e00e0f63-7058-46a4-8b63-f31dc804c614.yml
+++ b/data/pa/legislature/Ann-Flood-e00e0f63-7058-46a4-8b63-f31dc804c614.yml
@@ -4,7 +4,7 @@ given_name: Ann
 family_name: Flood
 gender: Female
 email: aflood@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1910.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1910.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Anthony-A-Bellmon-57be936d-802b-4d09-b95e-2a5354cb9984.yml
+++ b/data/pa/legislature/Anthony-A-Bellmon-57be936d-802b-4d09-b95e-2a5354cb9984.yml
@@ -5,7 +5,7 @@ family_name: Bellmon
 birth_date: 1990-04-12
 gender: Male
 email: repbellmon@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1984.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1984.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Anthony-H-Williams-fe79a0f0-7dfd-442a-8b79-f8792613a4de.yml
+++ b/data/pa/legislature/Anthony-H-Williams-fe79a0f0-7dfd-442a-8b79-f8792613a4de.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1957-02-28
 gender: Male
 email: williams@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/153.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/153.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Art-Haywood-ea712eba-1da5-45e2-8d9f-022e8307a614.yml
+++ b/data/pa/legislature/Art-Haywood-ea712eba-1da5-45e2-8d9f-022e8307a614.yml
@@ -5,7 +5,7 @@ family_name: Haywood
 birth_date: 1957-01-28
 gender: Male
 email: senatorhaywood@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1689.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1689.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Arvind-Venkat-f4e98ad8-2ee6-45e4-8594-0deaaa51190e.yml
+++ b/data/pa/legislature/Arvind-Venkat-f4e98ad8-2ee6-45e4-8594-0deaaa51190e.yml
@@ -5,7 +5,7 @@ family_name: Venkat
 birth_date: 1974-06-06
 gender: Male
 email: repvenkat@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1944.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1944.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
+++ b/data/pa/legislature/Barbara-Gleim-48c5b966-eef2-456a-8ca0-f47d584e7883.yml
@@ -5,7 +5,7 @@ family_name: Gleim
 birth_date: 1964-05-20
 gender: Female
 email: bgleim@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1864.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1864.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ben-Waxman-1f2c3093-8ce7-41f7-8df0-6cd14ddd354b.yml
+++ b/data/pa/legislature/Ben-Waxman-1f2c3093-8ce7-41f7-8df0-6cd14ddd354b.yml
@@ -5,7 +5,7 @@ family_name: Waxman
 birth_date: 1985-02-09
 gender: Male
 email: repwaxman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1981.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1981.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
+++ b/data/pa/legislature/Benjamin-V-Sanchez-b64463e2-41f6-4d58-a725-03db71798c1c.yml
@@ -5,7 +5,7 @@ family_name: Sanchez
 birth_date: 1975-03-11
 gender: Male
 email: repsanchez@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1849.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1849.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
+++ b/data/pa/legislature/Brad-Roae-979ea568-4c43-41bd-ba1e-4c2da172bb82.yml
@@ -5,7 +5,7 @@ family_name: Roae
 birth_date: 1967-04-06
 gender: Male
 email: broae@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1083.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1083.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
+++ b/data/pa/legislature/Brandon-J-Markosek-9aea39f8-1503-4fea-9440-1e0e9c2f8fa3.yml
@@ -4,7 +4,7 @@ given_name: Brandon
 family_name: Markosek
 gender: Male
 email: repmarkosek@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1825.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1825.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
+++ b/data/pa/legislature/Brett-R-Miller-1a6e36d3-ff44-4e21-bb9d-397a56482b34.yml
@@ -5,7 +5,7 @@ family_name: Miller
 birth_date: 1961-07-22
 gender: Male
 email: bmiller@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1699.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1699.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Brian-Munroe-0f035e7e-d035-4d8c-bc5b-876ba70452cc.yml
+++ b/data/pa/legislature/Brian-Munroe-0f035e7e-d035-4d8c-bc5b-876ba70452cc.yml
@@ -5,7 +5,7 @@ family_name: Munroe
 birth_date: 1974-01-25
 gender: Male
 email: repmunroe@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1972.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1972.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Brian-Smith-ac7d02d3-9bb7-4cc1-8cee-4283094fe604.yml
+++ b/data/pa/legislature/Brian-Smith-ac7d02d3-9bb7-4cc1-8cee-4283094fe604.yml
@@ -4,7 +4,7 @@ given_name: Brian
 family_name: Smith
 gender: Male
 email: bsmith@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1902.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1902.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
+++ b/data/pa/legislature/Bridget-M-Kosierowski-e5149ed2-f2bb-4054-8064-e2331ffaf1c0.yml
@@ -4,7 +4,7 @@ given_name: Bridget
 family_name: Kosierowski
 gender: Female
 email: repkosierowski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1866.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1866.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
+++ b/data/pa/legislature/Bryan-Cutler-fd5d0580-766c-482c-a12f-e4689e0bcf30.yml
@@ -5,7 +5,7 @@ family_name: Cutler
 birth_date: 1975-04-02
 gender: Male
 email: bcutler@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1105.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1105.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
+++ b/data/pa/legislature/Bud-Cook-9b9857aa-5fad-4678-a4f9-7e40bc642f64.yml
@@ -5,7 +5,7 @@ family_name: Cook
 birth_date: 1956-06-29
 gender: Male
 email: bcook@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1745.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1745.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Camera-Bartolotta-66b8c0a7-f8be-4acd-aafb-29ca02fcde65.yml
+++ b/data/pa/legislature/Camera-Bartolotta-66b8c0a7-f8be-4acd-aafb-29ca02fcde65.yml
@@ -5,7 +5,7 @@ family_name: Bartolotta
 birth_date: 1963-12-04
 gender: Female
 email: cbartolotta@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1698.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1698.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
+++ b/data/pa/legislature/Carl-Walker-Metzgar-462fc474-e481-436e-b47a-7bbde2de3e3a.yml
@@ -5,7 +5,7 @@ family_name: Metzgar
 birth_date: 1981-10-01
 gender: Male
 email: cmetzgar@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1174.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1174.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
+++ b/data/pa/legislature/Carol-Hill-Evans-cafbffed-be4d-4e5b-9d99-9aec024675e2.yml
@@ -5,7 +5,7 @@ family_name: Hill-Evans
 birth_date: 1949-11-21
 gender: Female
 email: chill-evans@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1749.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1749.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Carol-Kazeem-05f5a4fa-4a1e-4242-8664-eca508f36a3c.yml
+++ b/data/pa/legislature/Carol-Kazeem-05f5a4fa-4a1e-4242-8664-eca508f36a3c.yml
@@ -4,7 +4,7 @@ given_name: Carol
 family_name: Kazeem
 gender: Female
 email: repkazeem@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1976.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1976.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Carolyn-T-Comitta-91c58c1d-de9d-471b-8178-f6ef89c1286b.yml
+++ b/data/pa/legislature/Carolyn-T-Comitta-91c58c1d-de9d-471b-8178-f6ef89c1286b.yml
@@ -5,7 +5,7 @@ family_name: Comitta
 birth_date: 1952-04-27
 gender: Female
 email: senatorcomitta@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1790.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1790.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Charity-Grimm-Krupa-d5bd036c-03f5-4111-b770-15cb2dbe3278.yml
+++ b/data/pa/legislature/Charity-Grimm-Krupa-d5bd036c-03f5-4111-b770-15cb2dbe3278.yml
@@ -4,7 +4,7 @@ given_name: Charity
 family_name: Krupa
 gender: Female
 email: ckrupa@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1949.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1949.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Chris-Pielli-d83a0679-02c9-469b-89ed-11f9b46166c5.yml
+++ b/data/pa/legislature/Chris-Pielli-d83a0679-02c9-469b-89ed-11f9b46166c5.yml
@@ -5,7 +5,7 @@ family_name: Pielli
 birth_date: 1966-01-20
 gender: Male
 email: reppielli@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1975.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1975.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
+++ b/data/pa/legislature/Christina-D-Sappey-43d9c3c2-aeec-416c-859d-ad90600bbe0e.yml
@@ -5,7 +5,7 @@ family_name: Sappey
 birth_date: 1962-08-31
 gender: Female
 email: repsappey@pahouse.com
-image: https://www.legis.state.pa.us/images/members/200/1852.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1852.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Christine-M-Tartaglione-f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd.yml
+++ b/data/pa/legislature/Christine-M-Tartaglione-f3b4fe8c-05f9-4610-81ef-354c0fcb0cdd.yml
@@ -5,7 +5,7 @@ family_name: Tartaglione
 birth_date: 1960-09-21
 gender: Female
 email: tartaglione@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/277.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/277.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Christopher-Gebhard-965b26f8-5a4a-4458-a327-a25d89605e65.yml
+++ b/data/pa/legislature/Christopher-Gebhard-965b26f8-5a4a-4458-a327-a25d89605e65.yml
@@ -4,7 +4,7 @@ given_name: Chris
 family_name: Gebhard
 gender: Male
 email: cgebhard@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1928.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1928.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
+++ b/data/pa/legislature/Christopher-M-Rabb-e6a8e555-0d65-4a1f-9673-56ad1e3c7855.yml
@@ -5,7 +5,7 @@ family_name: Rabb
 birth_date: 1970-02-21
 gender: Male
 email: reprabb@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1760.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1760.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
+++ b/data/pa/legislature/Clint-Owlett-626de4be-b2f3-4a37-bbbc-ede598381d6b.yml
@@ -4,7 +4,7 @@ given_name: Clint
 family_name: Owlett
 gender: Male
 email: cowlett@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1796.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1796.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
+++ b/data/pa/legislature/Craig-T-Staats-bb324f66-3a5c-4e90-9c75-d142cce81c92.yml
@@ -5,7 +5,7 @@ family_name: Staats
 birth_date: 1961-02-04
 gender: Male
 email: cstaats@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1707.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1707.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Craig-Williams-e17c51da-556e-4afe-aad4-137ee3a0881e.yml
+++ b/data/pa/legislature/Craig-Williams-e17c51da-556e-4afe-aad4-137ee3a0881e.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1965-11-07
 gender: Male
 email: craig.williams@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1916.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1916.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Cris-Dush-402d7e3b-1935-47fa-8124-61490037d016.yml
+++ b/data/pa/legislature/Cris-Dush-402d7e3b-1935-47fa-8124-61490037d016.yml
@@ -5,7 +5,7 @@ family_name: Dush
 birth_date: 1961-03-01
 gender: Male
 email: cdush@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1687.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1687.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dallas-Kephart-70d0ff46-746e-47a0-8c5f-cbe73dbf72ce.yml
+++ b/data/pa/legislature/Dallas-Kephart-70d0ff46-746e-47a0-8c5f-cbe73dbf72ce.yml
@@ -4,7 +4,7 @@ given_name: Dallas
 family_name: Kephart
 gender: Male
 email: dkephart@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1952.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1952.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
+++ b/data/pa/legislature/Dan-Frankel-96667f6d-d967-4f6a-9cd9-23bf480a98c1.yml
@@ -5,7 +5,7 @@ family_name: Frankel
 birth_date: 1956-04-11
 gender: Male
 email: repfrankel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/84.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/84.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
+++ b/data/pa/legislature/Dan-K-Williams-8cb5e285-fdd9-4c63-b7c7-480bf9e477e1.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1956-09-23
 gender: Male
 email: dwilliams@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1837.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1837.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
+++ b/data/pa/legislature/Dan-Moul-f4071288-fa18-48bb-99f1-41abd60d215e.yml
@@ -5,7 +5,7 @@ family_name: Moul
 birth_date: 1950-10-10
 gender: Male
 email: dmoul@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1101.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1101.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dane-Watro-d4de5cc2-b3b9-49a0-9f20-62c6f4f6a052.yml
+++ b/data/pa/legislature/Dane-Watro-d4de5cc2-b3b9-49a0-9f20-62c6f4f6a052.yml
@@ -4,7 +4,7 @@ given_name: Dane
 family_name: Watro
 gender: Male
 email: dwatro@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1964.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1964.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
+++ b/data/pa/legislature/Daniel-J-Deasy-2608882d-9ae2-4522-b8b2-83d905913d3f.yml
@@ -5,7 +5,7 @@ family_name: Deasy
 birth_date: 1966-08-01
 gender: Male
 email: ddeasy@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1166.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1166.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Daniel-Laughlin-431a823e-0268-4921-a62d-5f698211e706.yml
+++ b/data/pa/legislature/Daniel-Laughlin-431a823e-0268-4921-a62d-5f698211e706.yml
@@ -4,7 +4,7 @@ given_name: Dan
 family_name: Laughlin
 gender: Male
 email: dlaughlin@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1766.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1766.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
+++ b/data/pa/legislature/Danielle-Friel-Otten-6678bcaf-292f-408a-aa36-90ed8bc8fd08.yml
@@ -5,7 +5,7 @@ family_name: Otten
 birth_date: 1977-07-25
 gender: Female
 email: repotten@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1850.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1850.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
+++ b/data/pa/legislature/Danilo-Burgos-a2579707-5a31-4f4b-a9ed-49847d35eae6.yml
@@ -5,7 +5,7 @@ family_name: Burgos
 birth_date: 1978-01-19
 gender: Male
 email: dburgos@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1863.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1863.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Darisha-K-Parker-943fdd89-fe0a-43f6-8077-82cd252bdeb2.yml
+++ b/data/pa/legislature/Darisha-K-Parker-943fdd89-fe0a-43f6-8077-82cd252bdeb2.yml
@@ -4,7 +4,7 @@ given_name: Darisha
 family_name: Parker
 gender: Female
 email: repparker@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1920.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1920.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
+++ b/data/pa/legislature/Dave-Delloso-c05046a6-87dd-4956-a172-cad035960391.yml
@@ -5,7 +5,7 @@ family_name: Delloso
 birth_date: 1965-06-18
 gender: Male
 email: repdelloso@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1853.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1853.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Dave-Madsen-4a0c9e5e-07cc-4b4b-a47a-22be60d1623e.yml
+++ b/data/pa/legislature/Dave-Madsen-4a0c9e5e-07cc-4b4b-a47a-22be60d1623e.yml
@@ -4,7 +4,7 @@ given_name: Dave
 family_name: Madsen
 gender: Male
 email: repmadsen@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1959.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1959.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/David-G-Argall-2a2df3c1-9ede-46b7-8d73-896b1e317aff.yml
+++ b/data/pa/legislature/David-G-Argall-2a2df3c1-9ede-46b7-8d73-896b1e317aff.yml
@@ -5,7 +5,7 @@ family_name: Argall
 birth_date: 1958-11-21
 gender: Male
 email: dargall@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/69.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/69.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
+++ b/data/pa/legislature/David-H-Zimmerman-2fbada46-9c48-4be5-a49f-e1ca0af132ed.yml
@@ -5,7 +5,7 @@ family_name: Zimmerman
 birth_date: 1956-04-13
 gender: Male
 email: dzimmerman@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1711.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1711.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
+++ b/data/pa/legislature/David-M-Maloney-fb4a0115-dd63-4e25-8d36-0ea6afc55faf.yml
@@ -5,7 +5,7 @@ family_name: Maloney
 birth_date: 1960-08-25
 gender: Male
 email: dmaloney@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1226.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1226.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
+++ b/data/pa/legislature/David-Rowe-c88ccd9a-3378-4284-9dc6-767a4826526e.yml
@@ -5,7 +5,7 @@ family_name: Rowe
 birth_date: 1991-02-10
 gender: Male
 email: drowe@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1871.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1871.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
+++ b/data/pa/legislature/Dawn-W-Keefer-2a13f9df-b7e6-4281-82e4-f7263b6fa12e.yml
@@ -5,7 +5,7 @@ family_name: Keefer
 birth_date: 1972-10-06
 gender: Female
 email: dkeefer@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1748.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1748.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Devlin-Robinson-5271803b-8b46-449c-bf89-44f7d09c6cd2.yml
+++ b/data/pa/legislature/Devlin-Robinson-5271803b-8b46-449c-bf89-44f7d09c6cd2.yml
@@ -4,7 +4,7 @@ given_name: Devlin
 family_name: Robinson
 gender: Male
 email: drobinson@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1924.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1924.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Donna-Scheuren-5913495d-53f8-4c39-8507-650cfe51c08b.yml
+++ b/data/pa/legislature/Donna-Scheuren-5913495d-53f8-4c39-8507-650cfe51c08b.yml
@@ -4,7 +4,7 @@ given_name: Donna
 family_name: Scheuren
 gender: Female
 email: dscheuren@pahousegop.gov
-image: https://www.legis.state.pa.us/images/members/200/1973.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1973.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Doug-Mastriano-cda65f80-13e8-463c-88fa-6f5569a599bf.yml
+++ b/data/pa/legislature/Doug-Mastriano-cda65f80-13e8-463c-88fa-6f5569a599bf.yml
@@ -5,7 +5,7 @@ family_name: Mastriano
 birth_date: 1964-01-02
 gender: Male
 email: dmastriano@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1869.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1869.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
+++ b/data/pa/legislature/Doyle-Heffley-885e9a2a-c18b-4f68-b5d0-0b867ec3268d.yml
@@ -5,7 +5,7 @@ family_name: Heffley
 birth_date: 1970-02-24
 gender: Male
 email: dheffley@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1211.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1211.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
+++ b/data/pa/legislature/Ed-Neilson-3d3d4070-dadd-4382-9d40-be2892745773.yml
@@ -5,7 +5,7 @@ family_name: Neilson
 birth_date: 1963-08-23
 gender: Male
 email: repneilson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1615.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1615.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
+++ b/data/pa/legislature/Eddie-Day-Pashinski-c1cb6f95-37c8-4e25-802e-80387e70ad74.yml
@@ -5,7 +5,7 @@ family_name: Pashinski
 birth_date: 1945-07-02
 gender: Male
 email: reppashinski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1112.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1112.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Elder-A-Vogel-8a2a9b56-cdfa-45e0-a26e-b45b547a2eae.yml
+++ b/data/pa/legislature/Elder-A-Vogel-8a2a9b56-cdfa-45e0-a26e-b45b547a2eae.yml
@@ -5,7 +5,7 @@ family_name: Vogel
 birth_date: 1956-07-09
 gender: Male
 email: evogel@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1189.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1189.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
+++ b/data/pa/legislature/Elizabeth-Fiedler-90d95881-f6ae-4b29-af31-31a8821b8a7c.yml
@@ -5,7 +5,7 @@ family_name: Fiedler
 birth_date: 1980-07-18
 gender: Female
 email: repfiedler@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1861.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1861.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Emily-Kinkead-875b1add-2803-4cc3-964b-0e351ed6ca1c.yml
+++ b/data/pa/legislature/Emily-Kinkead-875b1add-2803-4cc3-964b-0e351ed6ca1c.yml
@@ -5,7 +5,7 @@ family_name: Kinkead
 birth_date: 1987-06-04
 gender: Female
 email: repkinkead@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1896.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1896.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
+++ b/data/pa/legislature/Eric-Davanzo-80abce94-a517-4357-a70d-cbc791aa34a1.yml
@@ -4,7 +4,7 @@ given_name: Eric
 family_name: Davanzo
 gender: Male
 email: edavanzo@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1875.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1875.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
+++ b/data/pa/legislature/Eric-R-Nelson-0910d394-3c42-48ee-aea7-6d4c0c144130.yml
@@ -5,7 +5,7 @@ family_name: Nelson
 birth_date: 1968-12-19
 gender: Male
 email: enelson@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1738.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1738.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Frank-A-Farry-611d3c65-f30f-4dde-8f80-7db4ec405a36.yml
+++ b/data/pa/legislature/Frank-A-Farry-611d3c65-f30f-4dde-8f80-7db4ec405a36.yml
@@ -5,7 +5,7 @@ family_name: Farry
 birth_date: 1972-12-31
 gender: Male
 email: ffarry@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1169.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1169.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
+++ b/data/pa/legislature/Frank-Burns-a60da669-bae3-4e1d-a241-370a7ad2c769.yml
@@ -5,7 +5,7 @@ family_name: Burns
 birth_date: 1975-10-21
 gender: Male
 email: repburns@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1163.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1163.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/G-Roni-Green-c3ad9b17-c8f5-450e-9aaa-f002e1414bd5.yml
+++ b/data/pa/legislature/G-Roni-Green-c3ad9b17-c8f5-450e-9aaa-f002e1414bd5.yml
@@ -5,7 +5,7 @@ family_name: Green
 birth_date: 1959-06-09
 gender: Female
 email: repgreen@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1874.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1874.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
+++ b/data/pa/legislature/Gary-Day-3088ff8e-d2d9-46b9-8ea3-bd35af9438c2.yml
@@ -5,7 +5,7 @@ family_name: Day
 birth_date: 1967-01-18
 gender: Male
 email: gday@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1190.jpg
+image: https://www.palegis.us/resources/images/members/300/1190.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Gene-Yaw-18127660-d04e-43c2-b931-084f0c87142c.yml
+++ b/data/pa/legislature/Gene-Yaw-18127660-d04e-43c2-b931-084f0c87142c.yml
@@ -5,7 +5,7 @@ family_name: Yaw
 birth_date: 1943-02-26
 gender: Male
 email: gyaw@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1186.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1186.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Gina-H-Curry-4c88ce64-4ba6-4f5e-a22f-86bf6a0d5b7f.yml
+++ b/data/pa/legislature/Gina-H-Curry-4c88ce64-4ba6-4f5e-a22f-86bf6a0d5b7f.yml
@@ -5,7 +5,7 @@ family_name: Curry
 birth_date: 1972-10-23
 gender: Female
 email: repcurry@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1932.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1932.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
+++ b/data/pa/legislature/Greg-Rothman-3e99b4f3-2efa-4330-b0b9-fb273b1322ea.yml
@@ -5,7 +5,7 @@ family_name: Rothman
 birth_date: 1966-12-10
 gender: Male
 email: grothman@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1733.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1733.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Greg-Scott-969ce6cb-ddcb-4347-b69d-2019cfbd6e18.yml
+++ b/data/pa/legislature/Greg-Scott-969ce6cb-ddcb-4347-b69d-2019cfbd6e18.yml
@@ -4,7 +4,7 @@ given_name: Greg
 family_name: Scott
 gender: Male
 email: repscott@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1950.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1950.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
+++ b/data/pa/legislature/Greg-Vitali-7a1f510f-12e0-4018-b6da-556b404399be.yml
@@ -5,7 +5,7 @@ family_name: Vitali
 birth_date: 1956-06-04
 gender: Male
 email: gvitali@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/210.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/210.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Heather-Boyd-d5f1bbaf-5daf-4266-9b18-16042f49db1b.yml
+++ b/data/pa/legislature/Heather-Boyd-d5f1bbaf-5daf-4266-9b18-16042f49db1b.yml
@@ -4,7 +4,7 @@ given_name: Heather
 family_name: Boyd
 gender: Female
 email: hboyd@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2015.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2015.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ismail-Smith-Wade-El-fefff26b-b89a-4400-b633-99e5aa09523b.yml
+++ b/data/pa/legislature/Ismail-Smith-Wade-El-fefff26b-b89a-4400-b633-99e5aa09523b.yml
@@ -4,7 +4,7 @@ given_name: Izzy
 family_name: Smith-Wade-El
 gender: Male
 email: repsmithwadeel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1948.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1948.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
+++ b/data/pa/legislature/Jack-Rader-abca93cc-5058-473c-93bc-c8e099c7fa20.yml
@@ -5,7 +5,7 @@ family_name: Rader
 birth_date: 1954-02-10
 gender: Male
 email: jrader@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1703.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1703.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jacob-D-Banta-4657c161-af68-44a8-bd60-8b8e88e702d1.yml
+++ b/data/pa/legislature/Jacob-D-Banta-4657c161-af68-44a8-bd60-8b8e88e702d1.yml
@@ -4,7 +4,7 @@ given_name: Jake
 family_name: Banta
 gender: Male
 email: jbanta@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1937.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1937.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
+++ b/data/pa/legislature/James-B-Struzzi-4a24dcc2-5619-4bb1-acb3-bf7a7d08e6b1.yml
@@ -5,7 +5,7 @@ family_name: Struzzi
 birth_date: 1967-09-23
 gender: Male
 email: jstruzzi@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1835.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1835.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jamie-Barton-82938e14-97ce-44f0-942f-5bd2d7c532ba.yml
+++ b/data/pa/legislature/Jamie-Barton-82938e14-97ce-44f0-942f-5bd2d7c532ba.yml
@@ -4,7 +4,7 @@ given_name: Jamie
 family_name: Barton
 gender: Male
 email: jbarton@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1968.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1968.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jamie-L-Flick-e396f514-a357-404f-bdb9-1ba33d97d0a7.yml
+++ b/data/pa/legislature/Jamie-L-Flick-e396f514-a357-404f-bdb9-1ba33d97d0a7.yml
@@ -4,7 +4,7 @@ given_name: Jamie
 family_name: Flick
 gender: Male
 email: jflick@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1954.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1954.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
+++ b/data/pa/legislature/Jared-G-Solomon-6b6602c0-8b45-4e1e-89ba-1782da5d67c6.yml
@@ -5,7 +5,7 @@ family_name: Solomon
 birth_date: 1978-11-18
 gender: Male
 email: jsolomon@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1761.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1761.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jarrett-Coleman-ecd51b53-a59b-4b92-b203-c1d24f748cb1.yml
+++ b/data/pa/legislature/Jarrett-Coleman-ecd51b53-a59b-4b92-b203-c1d24f748cb1.yml
@@ -4,7 +4,7 @@ given_name: Jarrett
 family_name: Coleman
 gender: Male
 email: jcoleman@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/2008.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2008.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
+++ b/data/pa/legislature/Jason-Dawkins-4a2176cc-292b-4d19-aff6-8b4c4b460ba0.yml
@@ -5,7 +5,7 @@ family_name: Dawkins
 birth_date: 1984-03-25
 gender: Male
 email: jdawkins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1685.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1685.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
+++ b/data/pa/legislature/Jason-Ortitay-1871b5c7-35c4-4d32-9e09-9febf8ba3f66.yml
@@ -5,7 +5,7 @@ family_name: Ortitay
 birth_date: 1983-03-14
 gender: Male
 email: jortitay@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1701.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1701.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jay-Costa-ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0.yml
+++ b/data/pa/legislature/Jay-Costa-ee6b52c3-d92c-4cd6-a6ea-6869a8c93df0.yml
@@ -5,7 +5,7 @@ family_name: Costa
 birth_date: 1957-11-17
 gender: Male
 email: costa@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/254.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/254.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
+++ b/data/pa/legislature/Jeanne-McNeill-ddd14a2f-ebef-4918-bf91-578b71c085e4.yml
@@ -5,7 +5,7 @@ family_name: McNeill
 birth_date: 1960-08-09
 gender: Female
 email: jmcneill@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1793.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1793.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
+++ b/data/pa/legislature/Jennifer-OMara-7c8e87fe-1c8e-4736-a03c-35cf729b80e9.yml
@@ -5,7 +5,7 @@ family_name: O'Mara
 birth_date: 1989-11-12
 gender: Female
 email: repomara@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1855.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1855.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
+++ b/data/pa/legislature/Jesse-Topper-865dbfc4-e6ec-400e-bd5c-257f9a947519.yml
@@ -5,7 +5,7 @@ family_name: Topper
 birth_date: 1981-09-19
 gender: Male
 email: jtopper@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1681.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1681.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jessica-Benham-8b6409e9-8ab6-4222-b6f3-fb8f33800c95.yml
+++ b/data/pa/legislature/Jessica-Benham-8b6409e9-8ab6-4222-b6f3-fb8f33800c95.yml
@@ -5,7 +5,7 @@ family_name: Benham
 birth_date: 1990-12-13
 gender: Female
 email: repbenham@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1899.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1899.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jill-N-Cooper-6ae972c8-aff3-4886-a7d7-bd2cc5e40a38.yml
+++ b/data/pa/legislature/Jill-N-Cooper-6ae972c8-aff3-4886-a7d7-bd2cc5e40a38.yml
@@ -4,7 +4,7 @@ given_name: Jill
 family_name: Cooper
 gender: Female
 email: jcooper@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1951.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1951.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jim-Haddock-3b91abb8-4b49-4fa2-85ed-beea4919bccc.yml
+++ b/data/pa/legislature/Jim-Haddock-3b91abb8-4b49-4fa2-85ed-beea4919bccc.yml
@@ -4,7 +4,7 @@ given_name: Jim
 family_name: Haddock
 gender: Male
 email: rephaddock@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1966.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1966.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
+++ b/data/pa/legislature/Jim-Rigby-343e541b-fbd3-4622-bf42-7843494b1714.yml
@@ -4,7 +4,7 @@ given_name: Jim
 family_name: Rigby
 gender: Male
 email: jrigby@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1836.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1836.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
+++ b/data/pa/legislature/Joanna-E-McClinton-1951ae06-881a-4c43-9635-224878c3ecb5.yml
@@ -5,7 +5,7 @@ family_name: McClinton
 birth_date: 1982-08-19
 gender: Female
 email: repmcclinton@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1734.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1734.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joanne-Stehr-6e7b8baa-4fa3-404e-b8f8-bab3077221b7.yml
+++ b/data/pa/legislature/Joanne-Stehr-6e7b8baa-4fa3-404e-b8f8-bab3077221b7.yml
@@ -4,7 +4,7 @@ given_name: Joanne
 family_name: Stehr
 gender: Female
 email: jstehr@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1961.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1961.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
+++ b/data/pa/legislature/Joe-Ciresi-c9521d0e-56ca-40d2-b9bc-7a1f1be639bc.yml
@@ -5,7 +5,7 @@ family_name: Ciresi
 birth_date: 1970-09-15
 gender: Male
 email: jciresi@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1847.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1847.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
+++ b/data/pa/legislature/Joe-Emrick-0e873ea0-c8a2-4fbb-a408-de0c5bd36de9.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Emrick
 gender: Male
 email: jemrick@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1207.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1207.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Hamm-acc00fca-50e5-46f7-8676-d502ecfc94ac.yml
+++ b/data/pa/legislature/Joe-Hamm-acc00fca-50e5-46f7-8676-d502ecfc94ac.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Hamm
 gender: Male
 email: jhamm@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1904.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1904.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Hogan-b1beaa5c-93d2-479e-9408-47c7687cd212.yml
+++ b/data/pa/legislature/Joe-Hogan-b1beaa5c-93d2-479e-9408-47c7687cd212.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Hogan
 gender: Male
 email: jhogan@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1971.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1971.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Kerwin-8a7494a6-3d82-432b-a5c2-6dc46d192611.yml
+++ b/data/pa/legislature/Joe-Kerwin-8a7494a6-3d82-432b-a5c2-6dc46d192611.yml
@@ -5,7 +5,7 @@ family_name: Kerwin
 birth_date: 1993-01-20
 gender: Male
 email: jkerwin@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1907.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1907.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-McAndrew-d31e549e-2c3d-4ea3-850b-5285955c3c2f.yml
+++ b/data/pa/legislature/Joe-McAndrew-d31e549e-2c3d-4ea3-850b-5285955c3c2f.yml
@@ -5,7 +5,7 @@ family_name: McAndrew
 birth_date: 1990-08-01
 gender: Male
 email: repmcandrew@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2011.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2011.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joe-Pittman-722f324f-db47-4ce2-9cbc-93f29ae38158.yml
+++ b/data/pa/legislature/Joe-Pittman-722f324f-db47-4ce2-9cbc-93f29ae38158.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: Pittman
 birth_date: 1977-03-31
 gender: Male
-image: https://www.legis.state.pa.us/images/members/200/1870.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1870.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
+++ b/data/pa/legislature/Joe-Webster-676410b6-c3aa-4c17-856f-7d896e6fbc83.yml
@@ -5,7 +5,7 @@ family_name: Webster
 birth_date: 1958-03-23
 gender: Male
 email: repwebster@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1848.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1848.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Johanny-Cepeda-Freytiz-8d5ab463-45d5-4cf0-9c65-85820c08e506.yml
+++ b/data/pa/legislature/Johanny-Cepeda-Freytiz-8d5ab463-45d5-4cf0-9c65-85820c08e506.yml
@@ -5,7 +5,7 @@ family_name: Cepeda-Freytiz
 birth_date: 1973-08-31
 gender: Female
 email: repcepedafreytiz@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1969.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1969.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
+++ b/data/pa/legislature/John-A-Lawrence-8c1966e4-80f4-4a98-bf55-b1de0b9705b3.yml
@@ -5,7 +5,7 @@ family_name: Lawrence
 birth_date: 1978-06-15
 gender: Male
 email: jlawrenc@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1215.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1215.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/John-A-Schlegel-b6a10f6b-3f2e-42df-adf9-7184222af2c2.yml
+++ b/data/pa/legislature/John-A-Schlegel-b6a10f6b-3f2e-42df-adf9-7184222af2c2.yml
@@ -4,7 +4,7 @@ given_name: John
 family_name: Schlegel
 gender: Male
 email: jschlegel@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1958.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1958.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/John-I-Kane-c45052c1-f3e4-485e-a3d2-f346fa51839b.yml
+++ b/data/pa/legislature/John-I-Kane-c45052c1-f3e4-485e-a3d2-f346fa51839b.yml
@@ -5,7 +5,7 @@ family_name: Kane
 birth_date: 1960-11-12
 gender: Male
 email: kane@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1925.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1925.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
+++ b/data/pa/legislature/Jonathan-Fritz-23a2b079-dc91-49b0-b08e-f3ae80fba11f.yml
@@ -5,7 +5,7 @@ family_name: Fritz
 birth_date: 1976-11-30
 gender: Male
 email: jfritz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1752.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1752.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
+++ b/data/pa/legislature/Jordan-A-Harris-2313ce98-7ac4-44b9-a61d-5b128338a405.yml
@@ -5,7 +5,7 @@ family_name: Harris
 birth_date: 1984-05-12
 gender: Male
 email: repharris@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1633.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1633.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Jose-Giral-d390f1ac-1f16-478a-9e0d-462c9ed79818.yml
+++ b/data/pa/legislature/Jose-Giral-d390f1ac-1f16-478a-9e0d-462c9ed79818.yml
@@ -4,7 +4,7 @@ given_name: "Jos\xE9"
 family_name: Giral
 gender: Male
 email: repgiral@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1980.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1980.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
+++ b/data/pa/legislature/Joseph-C-Hohenstein-99728978-f905-406c-8b52-f2912f374602.yml
@@ -5,7 +5,7 @@ family_name: Hohenstein
 birth_date: 1967-06-24
 gender: Male
 email: jhohenstein@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1858.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1858.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Joseph-DOrsie-b698d343-137d-423b-a102-c471f1fd1768.yml
+++ b/data/pa/legislature/Joseph-DOrsie-b698d343-137d-423b-a102-c471f1fd1768.yml
@@ -4,7 +4,7 @@ given_name: Joe
 family_name: D'Orsie
 gender: Male
 email: jdorsie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1947.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1947.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
+++ b/data/pa/legislature/Joshua-D-Kail-fbb14b8a-8940-4679-9ed8-3ec48096a3a2.yml
@@ -5,7 +5,7 @@ family_name: Kail
 birth_date: 1986-03-29
 gender: Male
 email: jkail@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1823.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1823.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Judith-L-Schwank-35362d6e-d00a-4cf1-806d-b4f2f2a55f72.yml
+++ b/data/pa/legislature/Judith-L-Schwank-35362d6e-d00a-4cf1-806d-b4f2f2a55f72.yml
@@ -4,7 +4,7 @@ given_name: Judy
 family_name: Schwank
 gender: Female
 email: senatorschwank@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1234.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1234.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Judy-Ward-b6ed7151-9ea4-4828-b639-785f9e358eb1.yml
+++ b/data/pa/legislature/Judy-Ward-b6ed7151-9ea4-4828-b639-785f9e358eb1.yml
@@ -4,7 +4,7 @@ given_name: Judy
 family_name: Ward
 gender: Female
 email: jward@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1683.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1683.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Justin-C-Fleming-98b96b05-81eb-4871-a81b-2e03c0b92267.yml
+++ b/data/pa/legislature/Justin-C-Fleming-98b96b05-81eb-4871-a81b-2e03c0b92267.yml
@@ -5,7 +5,7 @@ family_name: Fleming
 birth_date: 1980-07-05
 gender: Male
 email: repfleming@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1960.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1960.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
+++ b/data/pa/legislature/Kate-A-Klunk-08283fbe-18bc-4daf-972c-617d1e35d746.yml
@@ -5,7 +5,7 @@ family_name: Klunk
 birth_date: 1982-06-04
 gender: Female
 email: kklunk@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1694.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1694.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
+++ b/data/pa/legislature/Kathleen-C-Tomlinson-26925ace-f614-409d-80a2-9b6a42e7ddb5.yml
@@ -5,7 +5,7 @@ family_name: Tomlinson
 birth_date: 1988-09-29
 gender: Female
 email: ktomlinson@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1876.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1876.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
+++ b/data/pa/legislature/Kathy-L-Rapp-36348b5e-47fe-404a-b6c3-99359115846c.yml
@@ -5,7 +5,7 @@ family_name: Rapp
 birth_date: 1951-02-23
 gender: Female
 email: klrapp@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1028.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1028.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Katie-J-Muth-ade3ef98-a98c-4448-a974-ec4e0eede98f.yml
+++ b/data/pa/legislature/Katie-J-Muth-ade3ef98-a98c-4448-a974-ec4e0eede98f.yml
@@ -5,7 +5,7 @@ family_name: Muth
 birth_date: 1983-09-20
 gender: Female
 email: senatormuth@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1802.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1802.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
+++ b/data/pa/legislature/Keith-J-Greiner-dcd0037e-7833-416d-9523-5f25802bd43a.yml
@@ -5,7 +5,7 @@ family_name: Greiner
 birth_date: 1965-05-02
 gender: Male
 email: kgreiner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1632.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1632.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
+++ b/data/pa/legislature/Kerry-A-Benninghoff-5a5a7a42-bc5e-4a07-aee1-d1a01e810385.yml
@@ -5,7 +5,7 @@ family_name: Benninghoff
 birth_date: 1962-01-14
 gender: Male
 email: kbenning@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/215.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/215.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kim-L-Ward-c48a0179-5770-410d-ba97-bdbc05d20786.yml
+++ b/data/pa/legislature/Kim-L-Ward-c48a0179-5770-410d-ba97-bdbc05d20786.yml
@@ -4,7 +4,7 @@ given_name: Kim
 family_name: Ward
 gender: Female
 email: kward@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1188.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1188.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
+++ b/data/pa/legislature/Kristin-Hill-cb724e4a-0e5e-4ebd-ac0c-f3dfda73aef6.yml
@@ -5,7 +5,7 @@ family_name: Phillips-Hill
 birth_date: 1965-12-02
 gender: Female
 email: senatorkristin@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1801.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1801.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kristin-Marcell-f1c8d8ab-0220-4b1e-96d0-6e0ae0b6df87.yml
+++ b/data/pa/legislature/Kristin-Marcell-f1c8d8ab-0220-4b1e-96d0-6e0ae0b6df87.yml
@@ -5,7 +5,7 @@ family_name: Marcell
 birth_date: 1977-12-14
 gender: Female
 email: kmarcell@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1979.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1979.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
+++ b/data/pa/legislature/Kristine-C-Howard-f451e90b-e93a-4768-a294-67d1ff000396.yml
@@ -5,7 +5,7 @@ family_name: Howard
 birth_date: 1961-06-07
 gender: Female
 email: khoward@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1856.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1856.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kyle-Donahue-009be4f2-d613-4353-8126-6b5642d868bc.yml
+++ b/data/pa/legislature/Kyle-Donahue-009be4f2-d613-4353-8126-6b5642d868bc.yml
@@ -5,7 +5,7 @@ family_name: Donahue
 birth_date: 1986-02-23
 gender: Male
 email: repdonahue@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1963.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1963.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
+++ b/data/pa/legislature/Kyle-J-Mullins-625784c9-4cd0-417c-9c44-1acd53b34307.yml
@@ -4,7 +4,7 @@ given_name: Kyle
 family_name: Mullins
 gender: Male
 email: repmullins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1844.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1844.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/LaTasha-D-Mayes-526967db-cef3-4f64-a380-1377f5c6f1fe.yml
+++ b/data/pa/legislature/LaTasha-D-Mayes-526967db-cef3-4f64-a380-1377f5c6f1fe.yml
@@ -4,7 +4,7 @@ given_name: La'Tasha
 family_name: Mayes
 gender: Female
 email: repmayes@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1941.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1941.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
+++ b/data/pa/legislature/Leanne-Krueger-Braneky-8187ecb2-3e4b-4ba0-819e-a7cfb4b9ac93.yml
@@ -5,7 +5,7 @@ family_name: Krueger
 birth_date: 1977-02-14
 gender: Female
 email: repkrueger@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1735.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1735.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Leslie-Rossi-71bb086e-11d9-496d-b274-91d7a8b85eaf.yml
+++ b/data/pa/legislature/Leslie-Rossi-71bb086e-11d9-496d-b274-91d7a8b85eaf.yml
@@ -4,7 +4,7 @@ given_name: Leslie
 family_name: Rossi
 gender: Female
 email: lrossi@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1927.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1927.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Lindsay-Powell-b7c8d063-8db4-4cdf-a159-a0b064b7cae5.yml
+++ b/data/pa/legislature/Lindsay-Powell-b7c8d063-8db4-4cdf-a159-a0b064b7cae5.yml
@@ -4,7 +4,7 @@ given_name: Lindsay
 family_name: Powell
 gender: Female
 email: reppowell@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/2016.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2016.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Lindsey-Williams-bc64322a-faaf-4b33-b6c2-cf5059f4121c.yml
+++ b/data/pa/legislature/Lindsey-Williams-bc64322a-faaf-4b33-b6c2-cf5059f4121c.yml
@@ -5,7 +5,7 @@ family_name: Williams
 birth_date: 1983-08-27
 gender: Female
 email: senatorlindseywilliams@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1803.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1803.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Lisa-A-Borowski-d927a6f9-9878-4375-ac7d-9996e8968c9d.yml
+++ b/data/pa/legislature/Lisa-A-Borowski-d927a6f9-9878-4375-ac7d-9996e8968c9d.yml
@@ -4,7 +4,7 @@ given_name: Lisa
 family_name: Borowski
 gender: Female
 email: repborowski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1977.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1977.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Lisa-Baker-aa421a2c-4203-45b7-9766-8826c02a659d.yml
+++ b/data/pa/legislature/Lisa-Baker-aa421a2c-4203-45b7-9766-8826c02a659d.yml
@@ -4,7 +4,7 @@ given_name: Lisa
 family_name: Baker
 gender: Female
 email: lbaker@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1077.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1077.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Lisa-M-Boscola-de81d407-bc84-48e6-9796-4a56be984cbd.yml
+++ b/data/pa/legislature/Lisa-M-Boscola-de81d407-bc84-48e6-9796-4a56be984cbd.yml
@@ -5,7 +5,7 @@ family_name: Boscola
 birth_date: 1962-04-06
 gender: Female
 email: boscola@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/179.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/179.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
+++ b/data/pa/legislature/Liz-Hanbidge-0aa9e1d6-4552-4ad4-b660-e2f3cc17b7dd.yml
@@ -4,7 +4,7 @@ given_name: Liz
 family_name: Hanbidge
 gender: Female
 email: lhanbidge@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1834.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1834.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Lynda-Schlegel-Culver-02117eb4-a7b3-4095-831b-1857910660fb.yml
+++ b/data/pa/legislature/Lynda-Schlegel-Culver-02117eb4-a7b3-4095-831b-1857910660fb.yml
@@ -5,7 +5,7 @@ family_name: Culver
 birth_date: 1969-05-28
 gender: Female
 email: lculver@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1202.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1202.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
+++ b/data/pa/legislature/Malcolm-Kenyatta-96711736-a47d-4bd6-bcc3-92297ec01516.yml
@@ -5,7 +5,7 @@ family_name: Kenyatta
 birth_date: 1990-07-30
 gender: Male
 email: mkenyatta@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1860.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1860.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Mandy-Steele-63f8d7ea-b621-48b7-a326-4e2a732a521c.yml
+++ b/data/pa/legislature/Mandy-Steele-63f8d7ea-b621-48b7-a326-4e2a732a521c.yml
@@ -4,7 +4,7 @@ given_name: Mandy
 family_name: Steele
 gender: Female
 email: repsteele@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1945.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1945.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Manuel-Guzman-d26c016b-27e5-4171-849b-94773178023d.yml
+++ b/data/pa/legislature/Manuel-Guzman-d26c016b-27e5-4171-849b-94773178023d.yml
@@ -5,7 +5,7 @@ family_name: Guzman
 birth_date: 1988-03-28
 gender: Male
 email: repguzman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1908.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1908.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
+++ b/data/pa/legislature/Marci-Mustello-dc7a449c-43cf-4522-b2a3-efb4707907c4.yml
@@ -5,7 +5,7 @@ family_name: Mustello
 birth_date: 1970-07-25
 gender: Female
 email: mmustello@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1868.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1868.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Maria-Collett-323c52e8-f841-4a0b-a49e-91103949fbc8.yml
+++ b/data/pa/legislature/Maria-Collett-323c52e8-f841-4a0b-a49e-91103949fbc8.yml
@@ -5,7 +5,7 @@ family_name: Collett
 birth_date: 1974-07-21
 gender: Female
 email: senatorcollett@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1799.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1799.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
+++ b/data/pa/legislature/Mark-M-Gillen-cd92c819-d5aa-4df3-ba96-2315dbdf4555.yml
@@ -5,7 +5,7 @@ family_name: Gillen
 birth_date: 1955-11-06
 gender: Male
 email: mgillen@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1209.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1209.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Marla-Brown-68e26db9-10ba-414b-9d06-440dd1fd3f10.yml
+++ b/data/pa/legislature/Marla-Brown-68e26db9-10ba-414b-9d06-440dd1fd3f10.yml
@@ -4,7 +4,7 @@ given_name: Marla
 family_name: Brown
 gender: Female
 email: mbrown@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1938.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1938.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
+++ b/data/pa/legislature/Martin-T-Causer-171af8ac-41e0-4047-be38-654cc912053b.yml
@@ -4,7 +4,7 @@ given_name: Marty
 family_name: Causer
 gender: Male
 email: mcauser@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/982.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/982.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
+++ b/data/pa/legislature/Martina-A-White-93435394-e853-45f2-9e88-65399b3f9042.yml
@@ -5,7 +5,7 @@ family_name: White
 birth_date: 1988-07-07
 gender: Female
 email: mwhite@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1732.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1732.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Marty-Flynn-7061c75d-7eeb-40aa-841e-8121edba5d8a.yml
+++ b/data/pa/legislature/Marty-Flynn-7061c75d-7eeb-40aa-841e-8121edba5d8a.yml
@@ -5,7 +5,7 @@ family_name: Flynn
 birth_date: 1975-09-18
 gender: Male
 email: flynn@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1626.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1626.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
+++ b/data/pa/legislature/Mary-Jo-Daley-2b9c199b-dd4e-477a-a5d0-849180c956a0.yml
@@ -5,7 +5,7 @@ family_name: Daley
 birth_date: 1949-09-16
 gender: Female
 email: repmaryjodaley@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1622.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1622.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
+++ b/data/pa/legislature/MaryLouise-Isaacson-ac9d319c-4df3-489a-890e-f7daba8c4bda.yml
@@ -5,7 +5,7 @@ family_name: Isaacson
 birth_date: 1970-11-15
 gender: Female
 email: misaacson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1857.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1857.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
+++ b/data/pa/legislature/Matthew-D-Bradford-a15da78b-2475-4606-854f-7477dfc4233d.yml
@@ -5,7 +5,7 @@ family_name: Bradford
 birth_date: 1975-05-23
 gender: Male
 email: repbradford@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1161.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1161.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
+++ b/data/pa/legislature/Maureen-E-Madden-8ec333cd-97c4-4f5a-92de-13bf8cbc0020.yml
@@ -5,7 +5,7 @@ family_name: Madden
 birth_date: 1959-12-13
 gender: Female
 email: repmadden@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1753.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1753.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Melissa-Cerrato-610a353c-8973-48ea-a4d4-dac21efc3422.yml
+++ b/data/pa/legislature/Melissa-Cerrato-610a353c-8973-48ea-a4d4-dac21efc3422.yml
@@ -4,7 +4,7 @@ given_name: Missy
 family_name: Cerrato
 gender: Female
 email: repcerrato@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1974.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1974.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
+++ b/data/pa/legislature/Melissa-L-Shusterman-2cb7688e-e8ea-431e-9f56-34ee9a9a3ecc.yml
@@ -5,7 +5,7 @@ family_name: Shusterman
 birth_date: 1967-09-08
 gender: Female
 email: repshusterman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1851.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1851.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Michael-A-Stender-ef4ff98e-baba-4655-b24f-66ec5933fcb0.yml
+++ b/data/pa/legislature/Michael-A-Stender-ef4ff98e-baba-4655-b24f-66ec5933fcb0.yml
@@ -4,7 +4,7 @@ given_name: Michael
 family_name: Stender
 gender: Male
 email: mstender@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/2014.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2014.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
+++ b/data/pa/legislature/Michael-H-Schlossberg-fc1f0752-9166-4d7f-987a-ec15b8bf4048.yml
@@ -5,7 +5,7 @@ family_name: Schlossberg
 birth_date: 1983-05-15
 gender: Male
 email: repschlossberg@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1649.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1649.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Michele-Brooks-406baa79-8352-4fa4-a1fa-70cc55e34406.yml
+++ b/data/pa/legislature/Michele-Brooks-406baa79-8352-4fa4-a1fa-70cc55e34406.yml
@@ -5,7 +5,7 @@ family_name: Brooks
 birth_date: 1964-04-04
 gender: Female
 email: mbrooks@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1087.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1087.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mike-Armanini-32c83f92-2bcc-4c2f-bcd0-8b367af29e28.yml
+++ b/data/pa/legislature/Mike-Armanini-32c83f92-2bcc-4c2f-bcd0-8b367af29e28.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Armanini
 gender: Male
 email: marmanini@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1903.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1903.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
+++ b/data/pa/legislature/Mike-Jones-ce5d2c01-e29c-4eac-b06b-208d8c302dff.yml
@@ -4,7 +4,7 @@ given_name: Mike
 family_name: Jones
 gender: Male
 email: mjones@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1842.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1842.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Milou-Mackenzie-b4559406-2139-4c7c-9ce9-7a2a604a8a95.yml
+++ b/data/pa/legislature/Milou-Mackenzie-b4559406-2139-4c7c-9ce9-7a2a604a8a95.yml
@@ -4,7 +4,7 @@ given_name: Milou
 family_name: Mackenzie
 gender: Female
 email: mmackenzie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1909.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1909.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
+++ b/data/pa/legislature/Mindy-Fee-f5b2ec4d-1d69-483a-a6ec-143d50ad395b.yml
@@ -5,7 +5,7 @@ family_name: Fee
 birth_date: 1965-04-16
 gender: Female
 email: mfee@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1625.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1625.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
+++ b/data/pa/legislature/Morgan-Cephas-05326e52-202a-46cd-bbbe-cc8d01d9a44b.yml
@@ -5,7 +5,7 @@ family_name: Cephas
 birth_date: 1984-08-30
 gender: Female
 email: mcephas@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1759.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1759.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Nancy-Guenst-d18ccbd7-270a-46c2-8bbd-a19ea82d0e51.yml
+++ b/data/pa/legislature/Nancy-Guenst-d18ccbd7-270a-46c2-8bbd-a19ea82d0e51.yml
@@ -4,7 +4,7 @@ given_name: Nancy
 family_name: Guenst
 gender: Female
 email: repguenst@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1913.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1913.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Napoleon-J-Nelson-94e57e39-e58d-4374-9506-ece1a01e0ebd.yml
+++ b/data/pa/legislature/Napoleon-J-Nelson-94e57e39-e58d-4374-9506-ece1a01e0ebd.yml
@@ -4,7 +4,7 @@ given_name: Napoleon
 family_name: Nelson
 gender: Male
 email: repnelson@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1914.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1914.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
+++ b/data/pa/legislature/Natalie-Mihalek-c5e053dd-a874-4a51-a071-661a20db33ab.yml
@@ -4,7 +4,7 @@ given_name: Natalie
 family_name: Mihalek
 gender: Female
 email: nmihalek@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1830.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1830.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Nick-Miller-a160699d-cc7d-4ed7-b486-57008ee0e642.yml
+++ b/data/pa/legislature/Nick-Miller-a160699d-cc7d-4ed7-b486-57008ee0e642.yml
@@ -4,7 +4,7 @@ given_name: Nick
 family_name: Miller
 gender: Male
 email: miller@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/2009.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/2009.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Nick-Pisciottano-c9f6833a-470e-480f-b3ad-d91c887aa4f9.yml
+++ b/data/pa/legislature/Nick-Pisciottano-c9f6833a-470e-480f-b3ad-d91c887aa4f9.yml
@@ -5,7 +5,7 @@ family_name: Pisciottano
 birth_date: 1990-01-12
 gender: Male
 email: nick.pisciottano@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1900.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1900.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Nikil-Saval-6f172bc8-50b0-4dd3-aed6-b5fd48b70eeb.yml
+++ b/data/pa/legislature/Nikil-Saval-6f172bc8-50b0-4dd3-aed6-b5fd48b70eeb.yml
@@ -5,7 +5,7 @@ family_name: Saval
 birth_date: 1982-12-27
 gender: Male
 email: saval@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1921.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1921.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
+++ b/data/pa/legislature/Parke-Wentling-8f7a2783-e165-4bf2-aead-113d98dd7dd2.yml
@@ -5,7 +5,7 @@ family_name: Wentling
 birth_date: 1972-05-14
 gender: Male
 email: pwentling@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1709.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1709.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Pat-Gallagher-36e7e815-87a3-4c58-baae-71f210e48114.yml
+++ b/data/pa/legislature/Pat-Gallagher-36e7e815-87a3-4c58-baae-71f210e48114.yml
@@ -5,7 +5,7 @@ family_name: Gallagher
 birth_date: 1974-04-21
 gender: Male
 email: repgallagher@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1978.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1978.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
+++ b/data/pa/legislature/Patrick-J-Harkins-c4a1a8f4-cb29-4700-8235-b103fcb40279.yml
@@ -5,7 +5,7 @@ family_name: Harkins
 birth_date: 1963-12-22
 gender: Male
 email: pharkins@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1081.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1081.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Patrick-J-Stefano-14106428-709f-4018-8881-5c31ee078ff8.yml
+++ b/data/pa/legislature/Patrick-J-Stefano-14106428-709f-4018-8881-5c31ee078ff8.yml
@@ -4,7 +4,7 @@ given_name: Pat
 family_name: Stefano
 gender: Male
 email: pstefano@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1697.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1697.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Patty-Kim-b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29.yml
+++ b/data/pa/legislature/Patty-Kim-b5ff17d0-36e8-4f29-8c9b-e51bb9b3ea29.yml
@@ -5,7 +5,7 @@ family_name: Kim
 birth_date: 1973-07-29
 gender: Female
 email: patty.kim@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1636.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1636.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Paul-Friel-494797a5-3d84-414a-9c8c-caaadd621cdd.yml
+++ b/data/pa/legislature/Paul-Friel-494797a5-3d84-414a-9c8c-caaadd621cdd.yml
@@ -4,7 +4,7 @@ given_name: Paul
 family_name: Friel
 gender: Male
 email: repfriel@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1942.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1942.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Paul-Takac-dd35ae63-5dee-4f87-b64e-65907b8adaba.yml
+++ b/data/pa/legislature/Paul-Takac-dd35ae63-5dee-4f87-b64e-65907b8adaba.yml
@@ -4,7 +4,7 @@ given_name: Paul
 family_name: Takac
 gender: Male
 email: reptakac@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1953.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1953.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Perry-A-Stambaugh-eb33e206-fb08-40bc-8b9b-1d9a72fcb8fc.yml
+++ b/data/pa/legislature/Perry-A-Stambaugh-eb33e206-fb08-40bc-8b9b-1d9a72fcb8fc.yml
@@ -5,7 +5,7 @@ family_name: Stambaugh
 birth_date: 1960-03-08
 gender: Male
 email: pstambaugh@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1905.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1905.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
+++ b/data/pa/legislature/Perry-S-Warren-e2bc8bc4-33ab-46dd-8f67-da218949efb6.yml
@@ -5,7 +5,7 @@ family_name: Warren
 birth_date: 1963-07-23
 gender: Male
 email: repwarren@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1743.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1743.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
+++ b/data/pa/legislature/Peter-Schweyer-63936c68-ec65-40a9-9a68-0d956939404a.yml
@@ -5,7 +5,7 @@ family_name: Schweyer
 birth_date: 1978-07-26
 gender: Male
 email: repschweyer@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1706.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1706.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
+++ b/data/pa/legislature/R-Lee-James-b29f8685-d054-4c6c-a8ad-d64f80bd840f.yml
@@ -5,7 +5,7 @@ family_name: James
 birth_date: 1948-11-20
 gender: Male
 email: rljames@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1634.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1634.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Regina-G-Young-a737f4d4-5b45-469b-8d51-98c7aa78183a.yml
+++ b/data/pa/legislature/Regina-G-Young-a737f4d4-5b45-469b-8d51-98c7aa78183a.yml
@@ -5,7 +5,7 @@ family_name: Young
 birth_date: 1973-08-23
 gender: Female
 email: repyoung@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1917.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1917.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
+++ b/data/pa/legislature/Rich-Irvin-ff2471f3-f3ff-4a46-8ca7-be5094f0dfdc.yml
@@ -5,7 +5,7 @@ family_name: Irvin
 birth_date: 1971-07-07
 gender: Male
 email: rirvin@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1691.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1691.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
+++ b/data/pa/legislature/Rick-Krajewski-42ffbed1-2284-4018-a60f-b5bfa3f35833.yml
@@ -5,7 +5,7 @@ family_name: Krajewski
 birth_date: 1991-06-21
 gender: Male
 email: repkrajewski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1918.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1918.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
+++ b/data/pa/legislature/Rob-W-Kauffman-17e1e676-8e83-4883-8cf5-4c8ddcce076e.yml
@@ -5,7 +5,7 @@ family_name: Kauffman
 birth_date: 1974-08-27
 gender: Male
 email: rkauffma@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1022.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1022.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
+++ b/data/pa/legislature/Robert-E-Merski-bd4c3d05-059a-4084-b8f8-e8598e4eb955.yml
@@ -5,7 +5,7 @@ family_name: Merski
 birth_date: 1975-05-14
 gender: Male
 email: rmerski@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1822.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1822.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
+++ b/data/pa/legislature/Robert-F-Matzie-a7b2e50f-90a6-4f35-b1fb-c33406dc4277.yml
@@ -5,7 +5,7 @@ family_name: Matzie
 birth_date: 1968-09-22
 gender: Male
 email: rmatzie@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1173.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1173.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
+++ b/data/pa/legislature/Robert-Freeman-13bfe11c-06e2-4a1d-844d-d195ef18dc06.yml
@@ -5,7 +5,7 @@ family_name: Freeman
 birth_date: 1956-03-09
 gender: Male
 email: rfreeman@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/136.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/136.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Robert-Leadbeter-1d775faf-9231-420a-b62e-979bb6a1fc78.yml
+++ b/data/pa/legislature/Robert-Leadbeter-1d775faf-9231-420a-b62e-979bb6a1fc78.yml
@@ -4,7 +4,7 @@ given_name: Robert
 family_name: Leadbeter
 gender: Male
 email: rleadbeter@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1962.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1962.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Rosemary-M-Brown-3e2840e6-f904-43be-911e-235b906458a5.yml
+++ b/data/pa/legislature/Rosemary-M-Brown-3e2840e6-f904-43be-911e-235b906458a5.yml
@@ -5,7 +5,7 @@ family_name: Brown
 birth_date: 1970-11-20
 gender: Female
 email: rbrown@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1200.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1200.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
+++ b/data/pa/legislature/Russ-Diamond-5348e28d-bbbe-493f-8f77-a509cb315abe.yml
@@ -5,7 +5,7 @@ family_name: Diamond
 birth_date: 1963-07-26
 gender: Male
 email: rdiamond@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1686.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1686.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
+++ b/data/pa/legislature/Ryan-A-Bizzarro-32370423-acb8-4a8e-8336-67af5ed32bb9.yml
@@ -5,7 +5,7 @@ family_name: Bizzarro
 birth_date: 1985-11-13
 gender: Male
 email: repbizzarro@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1619.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1619.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
+++ b/data/pa/legislature/Ryan-Warner-0d747b7a-0a5a-42cf-8bb6-1eb0fa69090f.yml
@@ -4,7 +4,7 @@ given_name: Ryan
 family_name: Warner
 gender: Male
 email: rwarner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1708.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1708.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
+++ b/data/pa/legislature/Scott-Conklin-97b012cd-5cd7-4039-a9ae-fed936aabe37.yml
@@ -5,7 +5,7 @@ family_name: Conklin
 birth_date: 1958-10-07
 gender: Male
 email: sconklin@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1096.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1096.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Scott-E-Hutchinson-5d3e2203-b11c-4471-8f35-5106c30263ec.yml
+++ b/data/pa/legislature/Scott-E-Hutchinson-5d3e2203-b11c-4471-8f35-5106c30263ec.yml
@@ -5,7 +5,7 @@ family_name: Hutchinson
 birth_date: 1961-08-19
 gender: Male
 email: shutchinson@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1629.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1629.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Scott-Martin-c2fcd2dc-22f8-4ec2-b70a-439bc6d60802.yml
+++ b/data/pa/legislature/Scott-Martin-c2fcd2dc-22f8-4ec2-b70a-439bc6d60802.yml
@@ -4,7 +4,7 @@ given_name: Scott
 family_name: Martin
 gender: Male
 email: smartin@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1763.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1763.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Sharif-Street-b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a.yml
+++ b/data/pa/legislature/Sharif-Street-b0d20b05-428a-4e3a-bda1-bbba5c3cfd6a.yml
@@ -5,7 +5,7 @@ family_name: Street
 birth_date: 1974-03-29
 gender: Male
 email: street@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1767.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1767.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Shelby-Labs-7c0b9792-8ece-4ae8-b0f3-f5d4b79ff9f1.yml
+++ b/data/pa/legislature/Shelby-Labs-7c0b9792-8ece-4ae8-b0f3-f5d4b79ff9f1.yml
@@ -4,7 +4,7 @@ given_name: Shelby
 family_name: Labs
 gender: Female
 email: slabs@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1911.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1911.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
+++ b/data/pa/legislature/Sheryl-M-Delozier-9e4954ab-971c-4620-9f9d-ebb68311e3f1.yml
@@ -4,7 +4,7 @@ given_name: Sheryl
 family_name: Delozier
 gender: Female
 email: sdelozie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1167.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1167.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
+++ b/data/pa/legislature/Stephanie-Borowicz-bccfe530-42ce-47b0-aadf-ae863b37cf9a.yml
@@ -5,7 +5,7 @@ family_name: Borowicz
 birth_date: 1977-03-23
 gender: Female
 email: sborowicz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1838.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1838.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
+++ b/data/pa/legislature/Steve-Samuelson-34472dfb-dae9-4db4-8901-088457d74904.yml
@@ -5,7 +5,7 @@ family_name: Samuelson
 birth_date: 1960-09-21
 gender: Male
 email: ssamuels@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/80.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/80.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
+++ b/data/pa/legislature/Steven-C-Mentzer-4463dd94-6a9d-41bd-830f-0d03e192f896.yml
@@ -5,7 +5,7 @@ family_name: Mentzer
 birth_date: 1956-10-24
 gender: Male
 email: smentzer@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1642.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1642.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Steven-J-Santarsiero-91f290d0-3405-4091-bb16-822a97f45af5.yml
+++ b/data/pa/legislature/Steven-J-Santarsiero-91f290d0-3405-4091-bb16-822a97f45af5.yml
@@ -5,7 +5,7 @@ family_name: Santarsiero
 birth_date: 1965-02-13
 gender: Male
 email: senatorsantarsiero@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1179.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1179.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
+++ b/data/pa/legislature/Steven-R-Malagari-fa1e1564-0a13-4b26-8416-098b39627df7.yml
@@ -5,7 +5,7 @@ family_name: Malagari
 birth_date: 1983-10-17
 gender: Male
 email: repmalagari@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1832.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1832.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tarah-Probst-8caab7df-f601-45f0-9be5-35d94175e766.yml
+++ b/data/pa/legislature/Tarah-Probst-8caab7df-f601-45f0-9be5-35d94175e766.yml
@@ -4,7 +4,7 @@ given_name: Tarah
 family_name: Probst
 gender: Female
 email: repprobst@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1982.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1982.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tarik-Khan-6fa30029-d933-4f6d-b0fb-343a0c82772c.yml
+++ b/data/pa/legislature/Tarik-Khan-6fa30029-d933-4f6d-b0fb-343a0c82772c.yml
@@ -5,7 +5,7 @@ family_name: Khan
 birth_date: 1978-10-14
 gender: Male
 email: reptarik@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1983.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1983.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Thomas-H-Kutz-932682ef-c7da-4383-8c50-58879fba0ca6.yml
+++ b/data/pa/legislature/Thomas-H-Kutz-932682ef-c7da-4383-8c50-58879fba0ca6.yml
@@ -4,7 +4,7 @@ given_name: Thomas
 family_name: Kutz
 gender: Male
 email: tkutz@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1955.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1955.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
+++ b/data/pa/legislature/Thomas-L-Mehaffie-bda0ab75-036f-49bd-9dd5-cfc9c55eec02.yml
@@ -5,7 +5,7 @@ family_name: Mehaffie
 birth_date: 1971-02-22
 gender: Male
 email: tmehaffie@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1751.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1751.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tim-Brennan-de68158e-3cc9-4651-b3a1-71f5e77b7dab.yml
+++ b/data/pa/legislature/Tim-Brennan-de68158e-3cc9-4651-b3a1-71f5e77b7dab.yml
@@ -4,7 +4,7 @@ given_name: Tim
 family_name: Brennan
 gender: Male
 email: repbrennan@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1943.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1943.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
+++ b/data/pa/legislature/Tim-Briggs-5c752a95-ba5d-4f1f-81aa-6cb1c7875581.yml
@@ -5,7 +5,7 @@ family_name: Briggs
 birth_date: 1970-01-03
 gender: Male
 email: repbriggs@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1159.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1159.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tim-Twardzik-686cdc9c-8133-4c1b-a7f0-34b420884559.yml
+++ b/data/pa/legislature/Tim-Twardzik-686cdc9c-8133-4c1b-a7f0-34b420884559.yml
@@ -4,7 +4,7 @@ given_name: Tim
 family_name: Twardzik
 gender: Male
 email: ttwardzik@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1906.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1906.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
+++ b/data/pa/legislature/Timothy-J-ONeal-2c5551d6-71a8-4099-b1a4-a30721320869.yml
@@ -5,7 +5,7 @@ family_name: O'Neal
 birth_date: 1980-11-28
 gender: Male
 email: toneal@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1797.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1797.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Timothy-P-Kearney-f9f2479f-0c37-47d1-a4eb-666146e2856f.yml
+++ b/data/pa/legislature/Timothy-P-Kearney-f9f2479f-0c37-47d1-a4eb-666146e2856f.yml
@@ -5,7 +5,7 @@ family_name: Kearney
 birth_date: 1960-11-22
 gender: Male
 email: senatorkearney@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1800.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1800.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
+++ b/data/pa/legislature/Timothy-R-Bonner-105c6361-0cb6-46f4-9222-ff0ffb727d29.yml
@@ -5,7 +5,7 @@ family_name: Bonner
 birth_date: 1950-06-07
 gender: Male
 email: tbonner@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1877.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1877.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
+++ b/data/pa/legislature/Tina-M-Davis-f9a1f1ab-9538-424c-87f1-65e2a4f4bfc7.yml
@@ -5,7 +5,7 @@ family_name: Davis
 birth_date: 1960-04-21
 gender: Female
 email: repdavis@pahouse.net
-image: https://www.legis.state.pa.us/images/members/200/1204.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1204.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
+++ b/data/pa/legislature/Tina-Pickett-8e174923-d514-4240-b6cd-cbb7927410ba.yml
@@ -5,7 +5,7 @@ family_name: Pickett
 birth_date: 1943-05-28
 gender: Female
 email: tpickett@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/97.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/97.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tom-Jones-7f6b3c0e-4446-4243-ae49-d2d33ab30273.yml
+++ b/data/pa/legislature/Tom-Jones-7f6b3c0e-4446-4243-ae49-d2d33ab30273.yml
@@ -4,7 +4,7 @@ given_name: Tom
 family_name: Jones
 gender: Male
 email: tjones@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1957.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1957.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Tracy-Pennycuick-d9ad47a6-7e74-45f2-93a5-1b7e40ad36db.yml
+++ b/data/pa/legislature/Tracy-Pennycuick-d9ad47a6-7e74-45f2-93a5-1b7e40ad36db.yml
@@ -4,7 +4,7 @@ given_name: Tracy
 family_name: Pennycuick
 gender: Female
 email: tpennycuick@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1912.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1912.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
+++ b/data/pa/legislature/Valerie-S-Gaydos-590df273-5587-46bd-98dc-f3943cd1ddd8.yml
@@ -5,7 +5,7 @@ family_name: Gaydos
 birth_date: 1967-07-03
 gender: Female
 email: vgaydos@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1831.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1831.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Vincent-J-Hughes-53a598e0-3595-4b19-8f65-4a538bdc7a74.yml
+++ b/data/pa/legislature/Vincent-J-Hughes-53a598e0-3595-4b19-8f65-4a538bdc7a74.yml
@@ -5,7 +5,7 @@ family_name: Hughes
 birth_date: 1956-10-26
 gender: Male
 email: hughes@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/152.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/152.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Wayne-D-Fontana-b93e4f38-764f-4e95-bd51-4d40dba0aaa4.yml
+++ b/data/pa/legislature/Wayne-D-Fontana-b93e4f38-764f-4e95-bd51-4d40dba0aaa4.yml
@@ -5,7 +5,7 @@ family_name: Fontana
 birth_date: 1950-03-12
 gender: Male
 email: fontana@pasenate.com
-image: https://www.legis.state.pa.us/images/members/200/1041.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1041.jpg
 party:
 - name: Democratic
 roles:

--- a/data/pa/legislature/Wayne-Langerholc-7b3a6244-335b-4407-957d-b7d6b6ab1d97.yml
+++ b/data/pa/legislature/Wayne-Langerholc-7b3a6244-335b-4407-957d-b7d6b6ab1d97.yml
@@ -4,7 +4,7 @@ given_name: Wayne
 family_name: Langerholc
 gender: Male
 email: wlangerholc@pasen.gov
-image: https://www.legis.state.pa.us/images/members/200/1764.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1764.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Wendy-Fink-1300735f-1441-4861-b20f-c1fa3e222c08.yml
+++ b/data/pa/legislature/Wendy-Fink-1300735f-1441-4861-b20f-c1fa3e222c08.yml
@@ -4,7 +4,7 @@ given_name: Wendy
 family_name: Fink
 gender: Female
 email: wfink@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1956.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1956.jpg
 party:
 - name: Republican
 roles:

--- a/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
+++ b/data/pa/legislature/Zachary-Mako-c3b27985-614c-434d-b3c0-3e032fad4d6c.yml
@@ -5,7 +5,7 @@ family_name: Mako
 birth_date: 1988-12-17
 gender: Male
 email: zmako@pahousegop.com
-image: https://www.legis.state.pa.us/images/members/200/1758.jpg?1703415645672
+image: https://www.palegis.us/resources/images/members/300/1758.jpg
 party:
 - name: Republican
 roles:


### PR DESCRIPTION
## Summary

The `legis.state.pa.us` domain has been deprecated. Image URLs of the form `https://www.legis.state.pa.us/images/members/200/<id>.jpg` 301-redirect, and the legacy Drupal-style image endpoint no longer resolves directly. The PA General Assembly's new official domain is `palegis.us` (already referenced throughout this repo's PA `links` and `sources` sections, and used for at least one already-migrated PA record in `data/pa/legislature/`).

This PR mechanically migrates all **225 active** PA legislator records that still reference the old domain.

### Transformation
- `https://www.legis.state.pa.us/images/members/200/<id>.jpg?<cache-buster>` → `https://www.palegis.us/resources/images/members/300/<id>.jpg`
- The member ID is preserved unchanged
- Width path changes from `/200/` to `/300/` because that's the path the new site serves these at
- Cache-buster query string (`?1703415645672` on most, omitted on one) is dropped — palegis.us doesn't require it

### Scope
- **In scope:** all 225 files under `data/pa/legislature/` that referenced the old URL pattern
- **Out of scope:** ~218 files under `data/pa/retired/` that have the same pattern. Some retired members may have been removed from the new PA system entirely; those need per-record verification rather than blind find/replace. Happy to file a follow-up PR for retired records once those are individually checked.

### Companion individual PRs
Earlier today I opened individual PRs for a handful of these same legislators (#3685, #3689, #3690, #3691) before identifying the broader pattern. Those can be closed in favor of this consolidated PR — or merged first; this PR is a clean find/replace and should rebase cleanly either way.

Surfaced via internal data quality tooling.

## Test plan
- [x] Verified the find/replace touched exactly 225 files, all matching `data/pa/legislature/*.yml`
- [x] Confirmed no remaining references to `legis.state.pa.us/images/members` in `data/pa/legislature/`
- [x] Sample-verified 10 random migrated URLs — all return HTTP 200 with `image/jpeg` content (~70-140KB each)
- [x] Spot-checked diff to confirm only the `image:` line changes per file