### PR TITLE
Add Ben Albritton's missing FL Senate District 26 start date

### DIFF
--- a/data/fl/legislature/Ben-Albritton-5c81dfe7-1cec-45e8-8044-6d9cd324f2e8.yml
+++ b/data/fl/legislature/Ben-Albritton-5c81dfe7-1cec-45e8-8044-6d9cd324f2e8.yml
@@ -17,7 +17,8 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '56'
-- end_date: 2023-02-10
+- start_date: 2018-11-06
+  end_date: 2023-02-10
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '26'


### PR DESCRIPTION
## Summary
His Senate District 26 role had an `end_date` (2023-02-10) but no `start_date` at all.

## Date
`start_date: 2018-11-06` — he assumed office this date, succeeding Denise Grimsley. He served until 2022 redistricting renumbered the seat to District 27 (already correctly dated in the roster).

## Source
https://ballotpedia.org/Ben_Albritton