### PR TITLE
Add Joe Gruters's missing FL Senate District 23 start date

### DIFF
--- a/data/fl/legislature/Joe-Gruters-24b4458a-bc61-42f8-805a-6bc43edf6acb.yml
+++ b/data/fl/legislature/Joe-Gruters-24b4458a-bc61-42f8-805a-6bc43edf6acb.yml
@@ -17,7 +17,8 @@ roles:
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '73'
-- end_date: 2022-11-08
+- start_date: 2018-11-06
+  end_date: 2022-11-08
   type: upper
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '23'


### PR DESCRIPTION
## Summary
His Senate District 23 role had an `end_date` (2022-11-08) but no `start_date` at all.

## Date
`start_date: 2018-11-06` — a special election following Greg Steube's resignation to run for Congress. He served until 2022 redistricting renumbered the seat to District 22 (already correctly dated in the roster).

## Source
https://ballotpedia.org/Joe_Gruters