### PR TITLE
Add Ralph Massullo's missing FL House District 34 start date

### DIFF
--- a/data/fl/legislature/Ralph-E-Massullo-MD-6d1623ae-0b24-4007-9c0f-af352ea22180.yml
+++ b/data/fl/legislature/Ralph-E-Massullo-MD-6d1623ae-0b24-4007-9c0f-af352ea22180.yml
@@ -18,7 +18,8 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '23'
   end_date: 2024-11-19
-- end_date: 2022-11-08
+- start_date: 2016-11-08
+  end_date: 2022-11-08
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:fl/government
   district: '34'


### PR DESCRIPTION
## Summary
His House District 34 role had an `end_date` (2022-11-08) but no `start_date` at all.

## Date
`start_date: 2016-11-08` — first elected unopposed in 2016, re-elected 2018 and 2020, served until 2022 redistricting renumbered the seat to District 23 (already correctly dated in the roster).

## Source
https://ballotpedia.org/Ralph_Massullo_Jr.