### PR TITLE
IL: move Sen. Paul Jacobs to Senate District 59; add Rep. Scott Doody (HD-118)

### DIFF
--- a/data/il/legislature/Paul-Jacobs-2febe0de-8b57-43c9-b8cd-a5363af4eae3.yml
+++ b/data/il/legislature/Paul-Jacobs-2febe0de-8b57-43c9-b8cd-a5363af4eae3.yml
@@ -8,7 +8,12 @@ image: https://cdn.ilga.gov/assets/img/members/{0E151A06-57C8-4261-9577-278F5DD4
 party:
 - name: Republican
 roles:
+- start_date: 2026-06-17
+  type: upper
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  district: '59'
 - start_date: 2023-01-11
+  end_date: 2026-06-17
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:il/government
   district: '118'
@@ -53,3 +58,9 @@ sources:
 - url: https://www.ilga.gov/house/Rep.asp?GA=103&MemberID=3191
 - url: https://www.ilga.gov/house/Rep.asp?GA=104&MemberID=3394
 - url: https://www.ilga.gov/house/Rep.asp?MemberID=3394
+- url: https://ilsenategop.org/2026/06/23/paul-jacobs-appointed-as-state-senator-for-illinois-59th-senate-district/
+  note: appointment to Senate District 59
+- url: https://www.kfvs12.com/2026/06/18/republican-partys-59th-legislative-district-committee-selects-paul-jacobs-fill-senate-vacancy/
+  note: appointment to Senate District 59
+- url: https://www.ilga.gov/Senate/Members
+  note: Senate members list showing District 59

--- a/data/il/legislature/Scott-Doody-2c12b171-8ec1-4c34-aa78-96a20944a3b3.yml
+++ b/data/il/legislature/Scott-Doody-2c12b171-8ec1-4c34-aa78-96a20944a3b3.yml
@@ -1,0 +1,23 @@
+id: ocd-person/2c12b171-8ec1-4c34-aa78-96a20944a3b3
+name: Scott Doody
+given_name: Scott
+family_name: Doody
+gender: Male
+party:
+- name: Republican
+roles:
+- start_date: 2026-06-25
+  type: lower
+  jurisdiction: ocd-jurisdiction/country:us/state:il/government
+  district: '118'
+other_names:
+- name: S. Doody
+- name: Doody, S.
+- name: Doody, Scott
+sources:
+- url: https://www.ilga.gov/House/Members
+  note: House members list showing District 118
+- url: https://www.wsiu.org/politics-elections/2026-06-25/scott-doody-sworn-in-as-state-representative-for-118th-district
+- url: https://www.wpsdlocal6.com/news/doody-appointed-to-fill-illinois-house-vacancy/article_7a4a4ce5-0221-46e8-acc7-27dd2173f1d8.html
+- url: https://en.wikipedia.org/wiki/Scott_Doody
+- url: https://ballotpedia.org/Scott_Doody


### PR DESCRIPTION
Two changes that resolve the Senate District 59 gap and the resulting House District 118 staleness:

**Paul Jacobs → Senate District 59.** Appointed 2026-06-17 by the 59th Legislative District Republican Committee to serve the remainder of retired Sen. Dale Fowler's term (104th GA). His open lower/118 role gains `end_date: 2026-06-17` and an upper/59 role is added. ilga.gov's Senate members list shows him seated for the 59th.
- https://ilsenategop.org/2026/06/23/paul-jacobs-appointed-as-state-senator-for-illinois-59th-senate-district/
- https://www.kfvs12.com/2026/06/18/republican-partys-59th-legislative-district-committee-selects-paul-jacobs-fill-senate-vacancy/

**Scott Doody (R) added at House District 118.** Appointed 2026-06-25 to fill the vacancy Jacobs's move created; shown on ilga.gov's House members list.
- https://www.wsiu.org/politics-elections/2026-06-25/scott-doody-sworn-in-as-state-representative-for-118th-district
- https://www.wpsdlocal6.com/news/doody-appointed-to-fill-illinois-house-vacancy/article_7a4a4ce5-0221-46e8-acc7-27dd2173f1d8.html

Fixes openstates/issues#1390.
