### PR TITLE
GA: add 2026 special-election members — Sen. Adrienne White Carden (SD-7), Rep. Alvin Payton Jr. (HD-177)

### DIFF
--- a/data/ga/legislature/Adrienne-White-Carden-136ab749-d80f-4939-b21a-6d537b5c4dac.yml
+++ b/data/ga/legislature/Adrienne-White-Carden-136ab749-d80f-4939-b21a-6d537b5c4dac.yml
@@ -1,0 +1,31 @@
+id: ocd-person/136ab749-d80f-4939-b21a-6d537b5c4dac
+name: Adrienne White Carden
+given_name: Adrienne
+family_name: Carden
+gender: Female
+party:
+- name: Democratic
+roles:
+- start_date: 2026-06-26
+  type: upper
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  district: '7'
+links:
+- url: https://www.legis.ga.gov/members/senate
+  note: HTML members list page
+- url: https://www.legis.ga.gov/members/senate/5097
+  note: HTML member detail page
+other_names:
+- name: Adrienne White
+- name: Adrienne Carden
+- name: A. Carden
+- name: Carden, A.
+- name: CARDEN, 7TH
+sources:
+- url: https://www.legis.ga.gov/api/document/docs/default-source/bios/carden-adrienne-white-5097.pdf
+  note: Georgia Senate official biography
+- url: https://senatepress.net/sen-adrienne-white-carden-officially-sworn-in-as-georgia-state-senator.html
+  note: Georgia Senate Press Office swearing-in announcement
+- url: https://roughdraftatlanta.com/2026/06/29/adrienne-carden-sworn-in/
+- url: https://capitol-beat.org/2026/06/new-state-senator-fills-vacancy-restores-senate-to-capacity/
+- url: https://en.wikipedia.org/wiki/Adrienne_White

--- a/data/ga/legislature/Alvin-Payton-6346ec2a-a7d7-49a3-ad7d-658456ad2086.yml
+++ b/data/ga/legislature/Alvin-Payton-6346ec2a-a7d7-49a3-ad7d-658456ad2086.yml
@@ -1,0 +1,26 @@
+id: ocd-person/6346ec2a-a7d7-49a3-ad7d-658456ad2086
+name: Alvin Payton Jr.
+given_name: Alvin
+family_name: Payton
+gender: Male
+party:
+- name: Democratic
+roles:
+- start_date: 2026-06-16
+  type: lower
+  jurisdiction: ocd-jurisdiction/country:us/state:ga/government
+  district: '177'
+links:
+- url: https://www.legis.ga.gov/members/house
+  note: HTML members list page
+other_names:
+- name: Alvin Payton
+- name: A. Payton
+- name: Payton, A.
+- name: PAYTON, 177TH
+sources:
+- url: https://www.wctv.tv/2026/06/10/alvin-payton-jr-wins-runoff-election-georgia-house-rep-district-177/
+  note: special-election runoff result
+- url: https://www.wtxl.com/news/local-news/in-your-neighborhood/lowndes-county/alvin-payton-jr-wins-district-177-special-election-runoff-in-lowndes-county
+  note: special-election runoff result
+- url: https://ballotpedia.org/Alvin_Payton_Jr.


### PR DESCRIPTION
Adds two Georgia legislators seated via 2026 special elections and currently absent from the dataset (upper shows 54/56 rows, lower 179/180):

**Sen. Adrienne White Carden (D, Senate District 7).** Won the June 16 special election to succeed Nabilah Parkes; sworn in 2026-06-26, restoring the Senate to its full 56 members.
- https://www.legis.ga.gov/api/document/docs/default-source/bios/carden-adrienne-white-5097.pdf (official Senate bio)
- https://senatepress.net/sen-adrienne-white-carden-officially-sworn-in-as-georgia-state-senator.html
- https://roughdraftatlanta.com/2026/06/29/adrienne-carden-sworn-in/

**Rep. Alvin Payton Jr. (D, House District 177).** Won the June 9 special-election runoff to succeed Dexter Sharper; seated 2026-06-16.
- https://www.wctv.tv/2026/06/10/alvin-payton-jr-wins-runoff-election-georgia-house-rep-district-177/
- https://www.wtxl.com/news/local-news/in-your-neighborhood/lowndes-county/alvin-payton-jr-wins-district-177-special-election-runoff-in-lowndes-county

**Deliberately not included:** Senate District 12 (Edward Brown, won the May 19 special election to succeed Freddie Powell Sims) is also filled, but no primary source for his swearing-in date could be confirmed — several official-adjacent rosters still lag. Happy to follow up when a citable date exists.

Refs openstates/issues#1391 (this PR resolves districts 7 and 177; SD-12 remains open).
