### PR TITLE
Add Goodlettsville TN mayor; restore Homewood IL village president

### DIFF
--- a/data/il/municipalities/Rich-Hofeld-709b1a57-548f-4aff-9181-49a6468db6ae.yml
+++ b/data/il/municipalities/Rich-Hofeld-709b1a57-548f-4aff-9181-49a6468db6ae.yml
@@ -4,7 +4,7 @@ given_name: Rich
 family_name: Hofeld
 email: generalinfo@homewoodil.gov
 roles:
-- end_date: '2029-05-01'
+- end_date: 2029-05-01
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:il/place:homewood/government
 offices:

--- a/data/il/municipalities/Rich-Hofeld-709b1a57-548f-4aff-9181-49a6468db6ae.yml
+++ b/data/il/municipalities/Rich-Hofeld-709b1a57-548f-4aff-9181-49a6468db6ae.yml
@@ -4,12 +4,16 @@ given_name: Rich
 family_name: Hofeld
 email: generalinfo@homewoodil.gov
 roles:
-- end_date: 2021-04-06
+- end_date: '2029-05-01'
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:il/place:homewood/government
 offices:
 - classification: primary
   address: 2020 Chestnut Road;Homewood, IL 60430
   voice: 708-206-3377
+  fax: 708-206-3496
+links:
+- url: https://www.village.homewood.il.us/government-departments/mayor-trustees
 sources:
 - url: https://www.village.homewood.il.us/Home/Components/StaffDirectory/StaffDirectory/36/156
+- url: https://www.hfchronicle.com/2025/04/02/election-2025-hofeld-team-holds-onto-homewood-board-challengers-encouraged-by-first-efforts/

--- a/data/tn/municipalities.yml
+++ b/data/tn/municipalities.yml
@@ -46,3 +46,5 @@
   id: ocd-jurisdiction/country:us/state:tn/place:germantown/government
 - name: Rogersville
   id: ocd-jurisdiction/country:us/state:tn/place:rogersville/government
+- name: Goodlettsville
+  id: ocd-jurisdiction/country:us/state:tn/place:goodlettsville/government

--- a/data/tn/municipalities/Rusty-Tinnin-6b9ef152-4a2c-4d4a-af2c-e7e2002a3fc6.yml
+++ b/data/tn/municipalities/Rusty-Tinnin-6b9ef152-4a2c-4d4a-af2c-e7e2002a3fc6.yml
@@ -4,7 +4,7 @@ given_name: Rusty
 family_name: Tinnin
 email: rtinnin@goodlettsville.gov
 roles:
-- end_date: '2026-11-03'
+- end_date: 2026-11-03
   type: mayor
   jurisdiction: ocd-jurisdiction/country:us/state:tn/place:goodlettsville/government
 offices:

--- a/data/tn/municipalities/Rusty-Tinnin-6b9ef152-4a2c-4d4a-af2c-e7e2002a3fc6.yml
+++ b/data/tn/municipalities/Rusty-Tinnin-6b9ef152-4a2c-4d4a-af2c-e7e2002a3fc6.yml
@@ -1,0 +1,18 @@
+id: ocd-person/6b9ef152-4a2c-4d4a-af2c-e7e2002a3fc6
+name: Rusty Tinnin
+given_name: Rusty
+family_name: Tinnin
+email: rtinnin@goodlettsville.gov
+roles:
+- end_date: '2026-11-03'
+  type: mayor
+  jurisdiction: ocd-jurisdiction/country:us/state:tn/place:goodlettsville/government
+offices:
+- classification: primary
+  address: 105 S. Main St.;Goodlettsville, TN 37072
+  voice: 615-300-7878
+links:
+- url: https://www.goodlettsville.gov/61/Board-of-Commissioners
+sources:
+- url: https://www.goodlettsville.gov/61/Board-of-Commissioners
+- url: https://www.goodlettsville.gov/directory.aspx?EID=118


### PR DESCRIPTION
Two municipal records, both verified against official government sources.

### Goodlettsville, TN — new
Rusty Tinnin, mayor. Goodlettsville is a commission-manager city; the five commissioners elect the mayor from among themselves. The [Board of Commissioners page](https://www.goodlettsville.gov/61/Board-of-Commissioners) lists his term as expiring 11/2026, so `end_date` is `2026-11-03` (Tennessee general election day). Address, phone `615-300-7878`, and `rtinnin@goodlettsville.gov` all confirmed on goodlettsville.gov.

This adds a new `place:goodlettsville` entry to `data/tn/municipalities.yml` — the state registry had no entry for the city.

### Homewood, IL — restored from `retired/`
Rich Hofeld was retired at `2021-04-06`, but that appears to have been a mistake: he has served as Homewood's village president continuously since 1997 and was [re-elected to an eighth term on 2025-04-01](https://www.hfchronicle.com/2025/04/02/election-2025-hofeld-team-holds-onto-homewood-board-challengers-encouraged-by-first-efforts/) with roughly 74% of the vote.

Moved back to `data/il/municipalities/` under his original `ocd-person` id rather than minting a new one, with `end_date` extended to `2029-05-01` (Illinois consolidated election April 2029, seated at the first May board meeting) and the fax number added from the village directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)