### PR TITLE
MO: update vacancy dates for lower 95, 110, 114, 149, 160 to 2026-11-04

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -60,19 +60,19 @@ mo:
   vacancies:
   - chamber: lower
     district: '95'
-    vacant_until: 2026-08-15
+    vacant_until: 2026-11-04
   - chamber: lower
     district: '110'
-    vacant_until: 2026-08-15
+    vacant_until: 2026-11-04
   - chamber: lower
     district: '114'
-    vacant_until: 2026-08-15
+    vacant_until: 2026-11-04
   - chamber: lower
     district: '149'
-    vacant_until: 2026-08-15
+    vacant_until: 2026-11-04
   - chamber: lower
     district: '160'
-    vacant_until: 2026-08-15
+    vacant_until: 2026-11-04
   - chamber: upper
     district: '10'
     vacant_until: 2027-02-03


### PR DESCRIPTION
Problem: The 5 Missouri lower chamber districts (95, 110, 114, 149, 160) had vacancy expiry dates set to 2026-08-15 (Missouri primary election date). Once that date passed, lint started erroring with "missing legislator" for all 5 districts.

Fix: Updated vacant_until to 2026-11-04 for all 5 districts. The seats remain vacant until after the general election on November 3, 2026. Verified all 5 districts are genuinely vacant on Ballotpedia before making the change.