### PR TITLE
mi: correct Rep. Tonya Myers Phillips's name (MI House district 7)

### DIFF
--- a/data/mi/legislature/Tonya-Myers-Phillips-787d9bda-d4dd-47fe-aaf0-348c505211e4.yml
+++ b/data/mi/legislature/Tonya-Myers-Phillips-787d9bda-d4dd-47fe-aaf0-348c505211e4.yml
@@ -1,7 +1,7 @@
 id: ocd-person/787d9bda-d4dd-47fe-aaf0-348c505211e4
-name: Tonya Phillips
+name: Tonya Myers Phillips
 given_name: Tonya
-family_name: Phillips
+family_name: Myers Phillips
 birth_date: 1977-03-18
 gender: Female
 email: tonyamyersphillips@house.mi.gov
@@ -26,6 +26,8 @@ other_names:
 - name: Phillips, T.
 - name: T. Phillips
 - name: T.M. Phillips
+- name: Myers-Phillips
+- name: Tonya Phillips
 sources:
 - url: https://ballotpedia.org/Tonya_Myers_Phillips
 - url: https://en.wikipedia.org/wiki/Tonya_Myers_Phillips


### PR DESCRIPTION
The record for MI House district 7 reads **Tonya Phillips**, dropping "Myers".

Every source already in the file says otherwise:

- her legislative email — `tonyamyersphillips@house.mi.gov`
- her photo — `Tonya_Myers_Phillips_20241022_115414.png`
- the `sources` / `links` entries — `ballotpedia.org/Tonya_Myers_Phillips`, `en.wikipedia.org/wiki/Tonya_Myers_Phillips`, `housedems.com/tonya-myers-phillips`
- the existing `T.M. Phillips` alias, which already hints at the middle name

### Why it matters beyond the spelling

The Michigan House journal writes her as **Myers-Phillips**, which matches neither `name`, `family_name`, nor any `other_names` entry — so vote records naming her resolve to nobody.

In our own OpenStates database that is **680 vote rows between 2025-01-08 and 2026-07-03** that resolve to no person, more than any other unmatched name in Michigan. The visible symptom is roll calls quietly one vote short, which reads as an absence rather than as an error.

### The change

- `name` and `family_name` corrected to the documented form
- two aliases added: `Myers-Phillips` (as the journal writes it) and `Tonya Phillips` (so the previous form keeps resolving)
- file renamed to match the naming convention

Her `ocd-person` id is unchanged, so this corrects the existing identity rather than creating a second one.

### Verification

Loaded into a copy of the OpenStates schema and queried with `resolve_person()`'s own predicate (`name` / `other_names.name` / `family_name`, case-insensitive, restricted to MI legislative memberships):

| lookup | people matched |
|---|---|
| `Myers-Phillips` | 1 |
| `Tonya Phillips` | 1 |
| `Tonya Myers Phillips` | 1 |
| `Phillips` (bare) | 0 |

Each form resolves to exactly this one person, and no lookup was made ambiguous. `os-people lint mi` passes.