### PR TITLE
Fix CA Chris Rogers given_name, clean up duplicates.md

### DIFF
--- a/data/ca/legislature/Chris-Rogers-84a80bdb-37d5-4f52-8f55-e116fb97ca58.yml
+++ b/data/ca/legislature/Chris-Rogers-84a80bdb-37d5-4f52-8f55-e116fb97ca58.yml
@@ -1,6 +1,6 @@
 id: ocd-person/84a80bdb-37d5-4f52-8f55-e116fb97ca58
 name: Chris Rogers
-given_name: Christopher
+given_name: Chris
 family_name: Rogers
 birth_date: 1987-09-16
 gender: Male
@@ -37,10 +37,10 @@ links:
 - url: https://a02.asmdc.org/
 - url: https://www.assembly.ca.gov/assemblymembers/02
 other_names:
-- name: Chris Rogers
 - name: C. Rogers
 - name: C.J. Rogers
 - name: Rogers, C.
+- name: Christopher John Rogers
 sources:
 - url: https://a02.asmdc.org
 - url: https://ballotpedia.org/Chris_Rogers_(California)

--- a/duplicates.md
+++ b/duplicates.md
@@ -197,9 +197,6 @@ Resolution convention: when a duplicate group is fixed, move the whole group und
 - `carol` `dutra-vernaci`
   - `data/ca/municipalities/Carol-Dutra-Vernaci-611c6cfe-bc70-4f7e-bca1-b0a48579a132.yml`
   - `data/ca/retired/Carol-Dutra-Vernaci-40737603-029c-4a1b-a295-c7a73450b4c4.yml`
-- `chris` `rogers`
-  - `data/ca/legislature/Chris-Rogers-84a80bdb-37d5-4f52-8f55-e116fb97ca58.yml`
-  - `data/ca/municipalities/Chris-Rogers-40141964-f8cb-4270-a013-c483902a09ee.yml`
 - `darrell` `steinberg`
   - `data/ca/retired/Darrell-Steinberg-9a11af5e-84e1-445b-b1db-5f9a431e9dc2.yml`
   - `data/ca/retired/Darrell-Steinberg-b16c60c3-a356-48c5-88b9-29adaa61cabf.yml`
@@ -1455,4 +1452,4 @@ Resolution convention: when a duplicate group is fixed, move the whole group und
 - `ne` `danielle` `conrad`: consolidated retired (950eb956) into legislature (bf280e36), deleted retired file
 - `nh` `katherine` `prudhomme-o'brien`: consolidated retired (92c01f02) into legislature (a0a8c9d8), deleted retired file
 - `oh` `kyle` `koehler`: consolidated retired (9578948b) into legislature (f2e79c7c), deleted retired file
-- `ca` `chris` `rogers`: two distinct people (state legislator vs mayor); changed legislator given_name to `Christopher`, added `Chris Rogers` to other_names
+- `ca` `chris` `rogers`: same person (Santa Rosa mayor 2020-2022 -> CA Assembly District 2 since 2024); mayor role/office/sources already consolidated into legislature file; corrected given_name back to `Chris` (was mistakenly set to `Christopher`)


### PR DESCRIPTION
Follows up on #4001 

Chris Rogers (CA Assembly District 2) was incorrectly set to given_name: Christopher in #4001 — his legal name is Chris (Christopher John Rogers). Corrected given_name back to Chris and added Christopher John Rogers to other_names.

Also cleaned up a stale duplicates.md entry referencing the already-deleted municipalities file.

Flagged by contributor review on #4001 