### PR TITLE
Fix Wyoming Governor Mark Gordon's office address (currently shows Puerto Rico's La Fortaleza)

### DIFF
--- a/data/wy/executive/Mark-Gordon-d832b435-0a83-49ba-abd8-6ce265eb52ef.yml
+++ b/data/wy/executive/Mark-Gordon-d832b435-0a83-49ba-abd8-6ce265eb52ef.yml
@@ -13,9 +13,9 @@ roles:
   jurisdiction: ocd-jurisdiction/country:us/state:wy/government
 offices:
 - classification: capitol
-  address: La Fortaleza; P.O. Box 9020082; San Juan, PR 00902-0082
-  voice: 787-721-2400
-  fax: 787-721-5072
+  address: State Capitol; 200 West 24th Street; Cheyenne, WY 82002
+  voice: 307-777-7434
+  fax: 307-632-3909
 links:
 - url: https://governor.wyo.gov/
 ids:


### PR DESCRIPTION
## Summary

The capitol office block in Wyoming Governor Mark Gordon's file currently
contains the mailing address, phone, and fax of **La Fortaleza — the office
of the Governor of Puerto Rico** — rather than the Wyoming Governor's office.
This looks like a copy/paste mix-up, since the Puerto Rico governor's file
(`data/pr/executive/Jenniffer-Gonzalez-Colon-2ec9fa1f-8254-4602-a5cd-14f849c2d5e9.yml`)
currently has no `offices` block at all.

Previous (incorrect) data:

- Address: `La Fortaleza; P.O. Box 9020082; San Juan, PR 00902-0082`
- Voice: `787-721-2400` (a Puerto Rico 787 area code)
- Fax: `787-721-5072`

## Fix

Replaced the office block with the Wyoming Governor's actual contact
information, as published on the office's official contact page
(https://governor.wyo.gov/contact/governor, retrieved 2026-08-31):

- Address: `State Capitol; 200 West 24th Street; Cheyenne, WY 82002`
- Voice: `307-777-7434`
- Fax: `307-632-3909`

## Notes

- No other fields in the file were changed.
- The displaced La Fortaleza contact information may belong in the Puerto
  Rico governor's file, but I have left that file untouched in this PR to
  keep the change minimal; happy to add it there if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
