### PR TITLE
Fix stale Assembly headshot for NY Sen. Patricia Fahy

### DIFF
--- a/data/ny/legislature/Patricia-Fahy-a3e0c7bc-45f6-4a6b-a092-1c124c149a6d.yml
+++ b/data/ny/legislature/Patricia-Fahy-a3e0c7bc-45f6-4a6b-a092-1c124c149a6d.yml
@@ -4,7 +4,7 @@ given_name: Pat
 family_name: Fahy
 gender: Female
 email: fahy@nysenate.gov
-image: https://assembly.state.ny.us/write/upload/member_files/109/headshot/109.jpg?hst=1660074584
+image: https://www.nysenate.gov/sites/default/files/2025/01/23/01-17-25-fahy-hs-021r_final-1.jpg
 party:
 - name: Democratic
 roles:


### PR DESCRIPTION
## Summary
- Patricia Fahy's `image` field pointed at her own outdated NY Assembly (lower, district 109) headshot from `assembly.state.ny.us`, last updated 2022.
- She moved to the NY Senate (upper, district 46) on 2025-01-01; swapped the image to her current official `nysenate.gov` headshot.

## Verification
- Confirmed her current NY Senate profile photo via nysenate.gov/senators/patricia-fahy.
- New image URL returns `HTTP 200 image/jpeg`.
- `os-people lint ny` shows no new errors for this file.

Fixes openstates/issues#1364