### PR TITLE
Add official X/Twitter handles for 14 US senators

### DIFF
--- a/data/us/legislature/Adam-B-Schiff-c5a3238c-f36a-5b17-af62-ca6dcce0b91d.yml
+++ b/data/us/legislature/Adam-B-Schiff-c5a3238c-f36a-5b17-af62-ca6dcce0b91d.yml
@@ -107,6 +107,8 @@ other_names:
 - name: A.B. Schiff
 - name: Adam B. Schiff
 - name: Schiff, A.
+ids:
+  twitter: SenAdamSchiff
 other_identifiers:
 - scheme: ballotpedia
   identifier: Adam Schiff

--- a/data/us/legislature/Andy-Kim-62227c11-1ad4-5395-b233-f1f526efc5b4.yml
+++ b/data/us/legislature/Andy-Kim-62227c11-1ad4-5395-b233-f1f526efc5b4.yml
@@ -55,6 +55,8 @@ other_names:
 - name: A. Kim
 - name: A.N. Kim
 - name: Kim, A.
+ids:
+  twitter: senatorandykim
 other_identifiers:
 - scheme: ballotpedia
   identifier: Andrew Kim (New Jersey)

--- a/data/us/legislature/Angela-Alsobrooks-93f7b243-f3e6-4fec-b65a-42f7a19939e3.yml
+++ b/data/us/legislature/Angela-Alsobrooks-93f7b243-f3e6-4fec-b65a-42f7a19939e3.yml
@@ -38,6 +38,8 @@ other_names:
 - name: A. Alsobrooks
 - name: A.D. Alsobrooks
 - name: Alsobrooks, A.
+ids:
+  twitter: Sen_Alsobrooks
 other_identifiers:
 - scheme: bioguide
   identifier: A000382

--- a/data/us/legislature/Ashley-Moody-cb582ab6-6a5a-4578-9e44-620c9a6a1f4c.yml
+++ b/data/us/legislature/Ashley-Moody-cb582ab6-6a5a-4578-9e44-620c9a6a1f4c.yml
@@ -46,6 +46,8 @@ other_names:
 - name: A. Moody
 - name: A.B. Moody
 - name: Moody, A.
+ids:
+  twitter: SenAshleyMoody
 other_identifiers:
 - scheme: bioguide
   identifier: M001244

--- a/data/us/legislature/Bernie-Moreno-a9a4d048-36e2-4f72-a764-5c361593a0d3.yml
+++ b/data/us/legislature/Bernie-Moreno-a9a4d048-36e2-4f72-a764-5c361593a0d3.yml
@@ -34,6 +34,8 @@ other_names:
 - name: B. Moreno
 - name: B.F. Moreno
 - name: Moreno, B.
+ids:
+  twitter: berniemoreno
 other_identifiers:
 - scheme: bioguide
   identifier: M001242

--- a/data/us/legislature/Dave-McCormick-c7b45762-ba65-46cd-a8db-cddfe0521cba.yml
+++ b/data/us/legislature/Dave-McCormick-c7b45762-ba65-46cd-a8db-cddfe0521cba.yml
@@ -45,6 +45,8 @@ other_names:
 - name: D.H. McCormick
 - name: David H. McCormick
 - name: McCormick, D.
+ids:
+  twitter: SenMcCormickPA
 other_identifiers:
 - scheme: bioguide
   identifier: M001243

--- a/data/us/legislature/Eric-Schmitt-999df51b-9318-55b9-b0f6-d738ffc1d62d.yml
+++ b/data/us/legislature/Eric-Schmitt-999df51b-9318-55b9-b0f6-d738ffc1d62d.yml
@@ -45,6 +45,8 @@ other_names:
 - name: E.S. Schmitt
 - name: Eric S. Schmitt
 - name: Schmitt, E.
+ids:
+  twitter: SenEricSchmitt
 other_identifiers:
 - scheme: ballotpedia
   identifier: Eric Schmitt

--- a/data/us/legislature/Jim-Justice-2f9a1274-1a6a-4a78-b253-01ec02f20eee.yml
+++ b/data/us/legislature/Jim-Justice-2f9a1274-1a6a-4a78-b253-01ec02f20eee.yml
@@ -31,6 +31,8 @@ other_names:
 - name: J.C. Justice
 - name: James C. Justice
 - name: Justice, J.
+ids:
+  twitter: JimJustice_WV
 other_identifiers:
 - scheme: bioguide
   identifier: J000312

--- a/data/us/legislature/John-Fetterman-6f500f52-75ce-5cf0-afc6-5be71f0921d2.yml
+++ b/data/us/legislature/John-Fetterman-6f500f52-75ce-5cf0-afc6-5be71f0921d2.yml
@@ -47,6 +47,8 @@ other_names:
 - name: Fetterman, J.
 - name: J. Fetterman
 - name: J.K. Fetterman
+ids:
+  twitter: SenFettermanPA
 other_identifiers:
 - scheme: ballotpedia
   identifier: John Fetterman

--- a/data/us/legislature/Jon-Husted-caec878c-2749-45e6-99a3-9bf077bf07e7.yml
+++ b/data/us/legislature/Jon-Husted-caec878c-2749-45e6-99a3-9bf077bf07e7.yml
@@ -36,6 +36,8 @@ other_names:
 - name: Husted, J.
 - name: J. Husted
 - name: J.A. Husted
+ids:
+  twitter: SenJonHusted
 other_identifiers:
 - scheme: bioguide
   identifier: H001104

--- a/data/us/legislature/Katie-Boyd-Britt-7bf077d8-e8b9-503e-b9c2-d18b55951e93.yml
+++ b/data/us/legislature/Katie-Boyd-Britt-7bf077d8-e8b9-503e-b9c2-d18b55951e93.yml
@@ -51,6 +51,8 @@ other_names:
 - name: K. Britt
 - name: K.B. Britt
 - name: Katie Boyd Britt
+ids:
+  twitter: SenKatieBritt
 other_identifiers:
 - scheme: ballotpedia
   identifier: Katie Britt

--- a/data/us/legislature/Pete-Ricketts-e1b9405a-e695-5bc5-b3b0-6cdc1415f53c.yml
+++ b/data/us/legislature/Pete-Ricketts-e1b9405a-e695-5bc5-b3b0-6cdc1415f53c.yml
@@ -45,6 +45,8 @@ other_names:
 - name: J.P. Ricketts
 - name: P. Ricketts
 - name: Ricketts, P.
+ids:
+  twitter: SenatorRicketts
 other_identifiers:
 - scheme: ballotpedia
   identifier: Pete Ricketts

--- a/data/us/legislature/Tim-Kaine-4d537f5f-04fd-578a-a8d2-61dd4972e758.yml
+++ b/data/us/legislature/Tim-Kaine-4d537f5f-04fd-578a-a8d2-61dd4972e758.yml
@@ -59,6 +59,7 @@ other_names:
 - name: T.M. Kaine
 - name: Timothy M. Kaine
 ids:
+  twitter: SenTimKaine
   youtube: UC27LgTZlUnBQoNEQFZdn9LA
   facebook: SenatorKaine
 other_identifiers:

--- a/data/us/legislature/Tim-Sheehy-db5da3bd-3690-4c44-9c86-1c66752503c9.yml
+++ b/data/us/legislature/Tim-Sheehy-db5da3bd-3690-4c44-9c86-1c66752503c9.yml
@@ -44,6 +44,8 @@ other_names:
 - name: Sheehy, T.
 - name: T. Sheehy
 - name: T.P. Sheehy
+ids:
+  twitter: TimSheehyMT
 other_identifiers:
 - scheme: bioguide
   identifier: S001232


### PR DESCRIPTION
## Summary
- 14 US senators had no `twitter` id despite running active official X accounts.
- Handles were cross-checked against each senator's own `*.senate.gov` site rather than copied verbatim from the issue — two of the issue's listed handles were stale/wrong: Andy Kim (issue: `AndyKimNJ`, a leftover from his House days → actual: `senatorandykim`) and Eric Schmitt (issue: `eric_schmitt` → actual official: `SenEricSchmitt`). Alsobrooks and Husted's issue-listed handles were campaign accounts, not their official Senate ones (`AlsobrooksForMD`→`Sen_Alsobrooks`, `JonHusted`→`SenJonHusted`).
- Tim Kaine already had an `ids:` block (youtube/facebook); added `twitter` into it rather than creating a duplicate block.

## Verification
- `os-people lint us` — no new errors.
- Each handle confirmed via a link-out on the senator's official senate.gov page.

Fixes openstates/issues#1343