### PR TITLE
Fix Deon Tedder (SC): 2020-2024 term mistagged as Senate, was House

### DIFF
--- a/data/sc/legislature/Deon-T-Tedder-4f07a054-384b-4fc7-b60a-f5848ea514d4.yml
+++ b/data/sc/legislature/Deon-T-Tedder-4f07a054-384b-4fc7-b60a-f5848ea514d4.yml
@@ -15,10 +15,6 @@ roles:
   district: '42'
 - start_date: 2020-11-09
   end_date: 2024-01-08
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
-  district: '42'
-- end_date: 2023-11-06
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   district: '109'


### PR DESCRIPTION
## Summary
- \`Deon-T-Tedder-4f07a054-384b-4fc7-b60a-f5848ea514d4.yml\` had a role from 2020-11-09 to 2024-01-08 tagged \`type: upper, district: '42'\` (Senate) — overlapping his real Senate start (2024-01-09) by over 3 years — plus a stray second lower/district-109 entry for the same span with only an \`end_date\` (2023-11-06) and no \`start_date\`.
- Per [Wikipedia](https://en.wikipedia.org/wiki/Deon_Tedder), he served in the SC House (district 109) 2020-11-09 through his Senate swearing-in 2024-01-09. Retagged the 2020-2024 entry as \`lower/109\` and removed the redundant stub entry.

## Verification
- \`os-people lint sc\` — no new errors (pre-existing unrelated warnings only).
- Ran the deterministic role-date overlap checker from \`user/akost/backend-improvements\` (\`.github/scripts/check_role_dates.py\`, not merged to main yet) scoped to this file — clean, no findings.

Fixes openstates/issues#1325