### PR TITLE
Fix SC legislators showing simultaneous House and Senate service

### DIFF
--- a/data/sc/legislature/Jason-Elliott-3d40ff3f-ddbf-4611-a366-9be7d55b9247.yml
+++ b/data/sc/legislature/Jason-Elliott-3d40ff3f-ddbf-4611-a366-9be7d55b9247.yml
@@ -15,11 +15,6 @@ roles:
   district: '6'
 - start_date: 2016-11-14
   end_date: 2024-11-10
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
-  district: '6'
-- start_date: 2016-11-14
-  end_date: 2024-11-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   district: '22'

--- a/data/sc/legislature/Matthew-W-Matt-Leber-1bf0b19d-9fa1-474a-99f2-16e7835064cf.yml
+++ b/data/sc/legislature/Matthew-W-Matt-Leber-1bf0b19d-9fa1-474a-99f2-16e7835064cf.yml
@@ -15,11 +15,6 @@ roles:
   district: '41'
 - start_date: 2022-11-14
   end_date: 2024-11-10
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
-  district: '41'
-- start_date: 2022-11-14
-  end_date: 2024-11-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   district: '116'

--- a/data/sc/legislature/Russell-L-Ott-458d191f-6584-4548-b464-a3a24cda3cf3.yml
+++ b/data/sc/legislature/Russell-L-Ott-458d191f-6584-4548-b464-a3a24cda3cf3.yml
@@ -14,11 +14,6 @@ roles:
   district: '26'
 - start_date: 2013-10-29
   end_date: 2024-11-10
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
-  district: '26'
-- start_date: 2013-10-29
-  end_date: 2024-11-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   district: '93'

--- a/data/sc/retired/Roger-A-Nutt-46debaf0-1a2a-4816-bc4e-ddaa74b4bed0.yml
+++ b/data/sc/retired/Roger-A-Nutt-46debaf0-1a2a-4816-bc4e-ddaa74b4bed0.yml
@@ -16,11 +16,6 @@ roles:
   end_date: 2026-01-24
 - start_date: 2020-11-09
   end_date: 2024-11-10
-  type: upper
-  jurisdiction: ocd-jurisdiction/country:us/state:sc/government
-  district: '12'
-- start_date: 2020-11-09
-  end_date: 2024-11-10
   type: lower
   jurisdiction: ocd-jurisdiction/country:us/state:sc/government
   district: '34'


### PR DESCRIPTION
## Summary
Four SC legislators had a duplicate \`upper\` role entry with the exact same start/end dates as their real \`lower\`-chamber term, making it look like they held both seats at once:

| Person | Bogus duplicate entry | Real term (verified) |
|---|---|---|
| Jason Elliott | upper/6, 2016-11-14–2024-11-10 | lower/22, 2016-11-14–2024-11-10 |
| Matt Leber | upper/41, 2022-11-14–2024-11-10 | lower/116, 2022-11-14–2024-11-10 |
| Russell Ott | upper/26, 2013-10-29–2024-11-10 | lower/93, 2013-10-29–2024-11-10 |
| Roger Nutt | upper/12, 2020-11-09–2024-11-10 | lower/34, 2020-11-09–2024-11-10 |

Cross-checked each against Wikipedia — all four were in the House only for that span, then moved to the Senate on the date their existing (kept) upper-chamber role already starts. Removed the bogus duplicate upper entries; the correct lower-chamber and current/historical upper entries are untouched.

## Verification
- \`os-people lint sc\` — no new errors (pre-existing unrelated warnings only).

Fixes openstates/issues#1330