### PR TITLE
lint: report only role-date findings a change introduces

### DIFF
--- a/.claude/agents/people-merge.md
+++ b/.claude/agents/people-merge.md
@@ -32,8 +32,11 @@ accomplish the following:
       input if necessary.
     - If the @resolve-lint subagent succeeds, merge the resolved branch into the "auto merge branch" you created
 - Check out your "auto merge branch" and run the lint command to ensure that no lint issues remain for any jurisdiction
-- **Before pushing**, run `uv run python .github/scripts/check_role_dates.py --data-dir data --changed-files
-  $(git diff --name-only origin/main...HEAD -- data)`. PR #4038's review found that the bot has shipped role-date bugs
+- **Before pushing**, run `uv run python .github/scripts/check_role_dates.py --changed-files
+  $(git diff --name-only origin/main...HEAD -- data) --base-ref origin/main`. Pass `--base-ref` every time: without
+  it the check reports every long-standing problem in every file the merge touches, none of which is yours to fix,
+  and its closing `note:` line counts exactly those pre-existing findings — leave them alone. PR #4038's review
+  found that the bot has shipped role-date bugs
   that are only visible once several jurisdictions' branches are bundled together — see the "Checking for known
   openstates-bot role-date bugs" section of `resolve-lint.md` for the specific incidents. A non-zero exit means a
   dangling/duplicate role entry slipped through; a "shared end_date" warning means two or more of the jurisdictions

--- a/.claude/agents/resolve-lint.md
+++ b/.claude/agents/resolve-lint.md
@@ -26,6 +26,28 @@ Where the `nc` part of the branch name indicates North Carolina. Changes in this
 If the lint command returns exit code 0, then linting passes and there are no issues. Some output like "no active roles"
 is not a problem as long as linting returns exit code 0.
 
+## Scope: fix what the branch introduced, nothing else
+
+`check_role_dates.py` and `check_duplicate_people.py` both take `--base-ref`, and with it they report only
+findings that are absent from the base revision. This exists because these branches are mostly reformatting: the
+bot rewrites `'2019-01-14'` as `2019-01-14` and re-sorts `links:`, changing no data, and the checks used to fail
+such a branch over every long-standing problem in every file it happened to touch. A repo-wide run of the role-date
+check reports over eight thousand findings, so almost any touched file carries some.
+
+Always pass `--base-ref`. When a run ends with a line like:
+
+```
+note: 14 role-date finding(s) in these files already exist at <base> and are not this change's to fix.
+```
+
+that count is pre-existing data, deliberately not listed, and **out of scope for this branch**. Do not go fix it
+here, do not widen the branch to clean it up, and do not report it as an outstanding issue on the pull request. If
+the underlying data looks genuinely wrong, raise it separately rather than enlarging a routine update. Only the
+findings printed above that note were introduced by the branch, and only those are yours to resolve.
+
+The same applies to `os-people lint`: run it on the base revision too if you are unsure whether an error is the
+branch's doing. An error that reproduces on the base is not this branch's to fix.
+
 ## Checking for known openstates-bot role-date bugs
 
 Investigation of PR #4038 (`auto-merge-2026-08-27`) found that the automated `automatic-legislators-updates-*`
@@ -43,7 +65,10 @@ wrong) and were only caught by a human reviewer clicking through sources on the 
 
 Before working any branch, run:
 
-`uv run python .github/scripts/check_role_dates.py --data-dir data --changed-files <files this branch changed>`
+`uv run python .github/scripts/check_role_dates.py --changed-files <files this branch changed> --base-ref <base>`
+
+where `<base>` is the commit the branch is based on (`git merge-base HEAD origin/main`). CI passes the pull
+request's base SHA the same way. See "Scope" below for why the base ref matters and what its `note:` line means.
 
 This catches dangling/duplicate role entries deterministically (no web access needed — a role with `end_date` before
 its own `start_date`, or two roles with identical type/jurisdiction/district/start_date, is never valid) and exits
@@ -204,4 +229,9 @@ Instead, actively verify identity before deciding either way:
    the resolution in `duplicates.md` with the sources you used.
 3. Only conclude "two distinct people" when a source explicitly distinguishes them (e.g. two different birth dates, or
    a bio that clearly describes separate individuals) — record that source in `duplicates.md` too.
-4. Re-run the lint and `check_duplicate_people.py` commands to confirm the resolution.
+4. Re-run the lint and `check_duplicate_people.py` commands to confirm the resolution. Run the duplicate check
+   as `uv run python .github/scripts/check_duplicate_people.py --changed-files <files this branch changed>
+   --base-ref <base>`: a pair whose two files both already carried these names at the base revision is
+   pre-existing history, reported as a `note:` count and not this branch's to resolve. The pairs that fail are the
+   ones this branch created, such as a brand-new file for a person who already has one (NH PR #4074 added a second
+   Gary Daniels file while moving the existing one to `retired/`).

--- a/.github/scripts/check_duplicate_people.py
+++ b/.github/scripts/check_duplicate_people.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python3
+"""Fail when person files duplicate a given_name/family_name within one state.
+
+Scoped for CI: a duplicate group only fails when the change under review created
+it. A group whose every member already carried those names at the base revision
+is pre-existing history, and the change that merely reformats one of its files
+is not the one that introduced it - see check_role_dates.py's module docstring
+for the same reasoning applied to role dates.
+"""
+
 from __future__ import annotations
 
 import argparse
+import shutil
+import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -67,6 +78,44 @@ def check_state(data_dir: Path, state: str) -> dict[tuple[str, str], list[Path]]
     return {key: paths for key, paths in sorted(people.items()) if len(paths) > 1}
 
 
+def name_at_base(base_ref: str, path: Path) -> tuple[str, str] | None:
+    """Return (given_name, family_name) for path at base_ref, or None if absent.
+
+    None also covers an unreadable or unparseable base revision: the group is
+    then treated as new and reported, rather than silently dropped.
+    """
+    git = shutil.which("git") or "git"
+    # Fixed argv, no shell: base_ref and path are a git ref and a repo path
+    # supplied by the caller (CI passes the event's base SHA), not free text.
+    result = subprocess.run(  # noqa: S603
+        [git, "show", f"{base_ref}:{path.as_posix()}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        record = yaml.safe_load(result.stdout) or {}
+    except yaml.YAMLError:
+        return None
+    return normalize(record.get("given_name")), normalize(record.get("family_name"))
+
+
+def group_predates_change(
+    base_ref: str, names: tuple[str, str], paths: list[Path]
+) -> bool:
+    """True if this duplicate group already existed at base_ref.
+
+    A group exists at base when every member file was already there under these
+    same names: that is enough to conclude the duplicate is pre-existing, and it
+    reads only the group's own files rather than the whole state at base. A file
+    the change adds, or renames onto a name that collides, has no such base entry
+    and makes the group new.
+    """
+    return all(name_at_base(base_ref, path) == names for path in paths)
+
+
 def changed_person_files(
     data_dir: Path, changed_files: list[str]
 ) -> dict[str, set[Path]]:
@@ -79,6 +128,39 @@ def changed_person_files(
             continue
         changed_by_state[state].add(path)
     return changed_by_state
+
+
+def report_changed_duplicates(
+    data_dir: Path,
+    changed_by_state: dict[str, set[Path]],
+    base_ref: str | None,
+) -> tuple[bool, int]:
+    """Print duplicate groups this change introduced; count the ones it inherited.
+
+    Historical duplicate groups are allowed unless this change touches one of
+    them, and - given a base ref - unless this change is what created it.
+    """
+    found_duplicates = False
+    preexisting = 0
+    for state, changed_paths in sorted(changed_by_state.items()):
+        duplicates = check_state(data_dir, state)
+        for (given_name, family_name), paths in duplicates.items():
+            if not changed_paths.intersection(paths):
+                continue
+            if base_ref and group_predates_change(
+                base_ref, (given_name, family_name), paths
+            ):
+                preexisting += 1
+                continue
+            found_duplicates = True
+            print(
+                f"{state}: changed file violates duplicate person rule for "
+                f"given_name={given_name!r}, family_name={family_name!r}"
+            )
+            for path in paths:
+                marker = " (changed)" if path in changed_paths else ""
+                print(f"  - {path}{marker}")
+    return found_duplicates, preexisting
 
 
 def main() -> int:
@@ -101,31 +183,27 @@ def main() -> int:
             "changed person files"
         ),
     )
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "git ref the change is based on. Duplicate groups that already "
+            "exist at this ref are reported as a pre-existing count instead of "
+            "failing, so a change is only asked to answer for what it introduced."
+        ),
+    )
     args = parser.parse_args()
 
     found_duplicates = False
+    preexisting = 0
     changed_by_state = changed_person_files(args.data_dir, args.changed_files or [])
 
     if args.changed_files is not None:
         if not changed_by_state:
             print("No changed person files to check")
             return 0
-
-        # Existing historical duplicate groups are allowed unless this change
-        # touches one of them.
-        for state, changed_paths in sorted(changed_by_state.items()):
-            duplicates = check_state(args.data_dir, state)
-            for (given_name, family_name), paths in duplicates.items():
-                if not changed_paths.intersection(paths):
-                    continue
-                found_duplicates = True
-                print(
-                    f"{state}: changed file violates duplicate person rule for "
-                    f"given_name={given_name!r}, family_name={family_name!r}"
-                )
-                for path in paths:
-                    marker = " (changed)" if path in changed_paths else ""
-                    print(f"  - {path}{marker}")
+        found_duplicates, preexisting = report_changed_duplicates(
+            args.data_dir, changed_by_state, args.base_ref
+        )
     else:
         if not args.states:
             parser.error("provide states to check, or use --changed-files")
@@ -140,6 +218,13 @@ def main() -> int:
                 )
                 for path in paths:
                     print(f"  - {path}")
+
+    if preexisting:
+        print(
+            f"note: {preexisting} duplicate person group(s) touched by this "
+            f"change already exist at {args.base_ref} and are not this "
+            "change's to fix."
+        )
 
     if found_duplicates:
         print(

--- a/.github/scripts/check_role_dates.py
+++ b/.github/scripts/check_role_dates.py
@@ -221,14 +221,20 @@ def find_shared_end_dates(
 
     Even within one change, a date already on file for both people is not a batch
     date this change invented; --base-ref filters those out (see module docstring).
+
+    Placeholder end_dates are skipped: data/us uses 2100-01-01 to mean "no known
+    end", so every congressional file added shares it, and none of them describes
+    a resignation at all.
     """
+    # ~10 years out, in days so a leap day can't make this raise.
+    horizon = str(datetime.date.today() + datetime.timedelta(days=3653))
     by_date: dict[str, dict[str, tuple[str, Path]]] = defaultdict(dict)
     for path, record in records.items():
         person = str(record.get("id") or path)
         name = _person_name(record)
         for role in record.get("roles") or []:
             end = role.get("end_date")
-            if end:
+            if end and str(end) < horizon:
                 by_date[str(end)][person] = (name, path)
     return {
         date: sorted(people.values(), key=lambda entry: str(entry[1]))

--- a/.github/scripts/check_role_dates.py
+++ b/.github/scripts/check_role_dates.py
@@ -54,15 +54,28 @@ neither one is a schema violation:
 8. A person filed under `executive/` whose every role has already ended: e.g. DE's
    John Carney was still in `executive/` with his governor role's `end_date` in the
    past, well after Matt Meyer's inauguration - he belonged in `retired/`.
+
+Every check above describes a *bot mistake being introduced*, so the check only
+reports a finding the change under review actually introduced. Given `--base-ref`,
+the same analysis runs twice - once over the base revision of the changed files,
+once over the working-tree revision - and only findings absent from the base are
+reported. Without that, a PR that merely reformats or re-sorts a file (the bot
+rewrites `'2019-01-14'` as `2019-01-14` and re-sorts `links:`, changing no data)
+inherits every long-standing problem in every file it happens to touch, and its
+author is asked to fix history they did not write. Pre-existing findings are
+counted in a single summary line instead, and never block.
 """
 
 from __future__ import annotations
 
 import argparse
 import datetime
+import shutil
+import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import NamedTuple
 
 import yaml
 
@@ -135,7 +148,15 @@ def check_missing_start_date(record: dict) -> list[str]:
     ]
 
 
-def find_stale_executive_persons(files: list[Path]) -> list[tuple[str, Path, str]]:
+def _person_name(record: dict) -> str:
+    given = record.get("given_name", "")
+    family = record.get("family_name", "")
+    return f"{given} {family}".strip()
+
+
+def find_stale_executive_persons(
+    records: dict[Path, dict],
+) -> list[tuple[str, Path, str]]:
     """Flag executive/ files whose every role has already ended.
 
     Catches DE's John Carney: still filed under executive/ with his governor
@@ -144,24 +165,20 @@ def find_stale_executive_persons(files: list[Path]) -> list[tuple[str, Path, str
     """
     today = str(datetime.date.today())
     flagged: list[tuple[str, Path, str]] = []
-    for path in files:
+    for path, record in records.items():
         if "executive" not in path.parts:
             continue
-        with path.open() as f:
-            record = yaml.safe_load(f) or {}
         roles = record.get("roles") or []
         end_dates = [str(r["end_date"]) for r in roles if r.get("end_date")]
         if roles and end_dates and max(end_dates) < today:
-            given = record.get("given_name", "")
-            family = record.get("family_name", "")
-            flagged.append((f"{given} {family}".strip(), path, max(end_dates)))
+            flagged.append((_person_name(record), path, max(end_dates)))
     return flagged
 
 
 def find_same_seat_retirements(
-    files: list[Path],
+    records: dict[Path, dict],
 ) -> dict[tuple, list[tuple[str, Path]]]:
-    """Group newly-added end_dates by (jurisdiction, type, district) among files.
+    """Group ended roles by (jurisdiction, type, district) among the given files.
 
     Catches issue #1389: a multi-seat district (e.g. a state House district electing
     two members) had both incumbents retired in the same batch because a news item
@@ -169,21 +186,28 @@ def find_same_seat_retirements(
     seat number is normal for a multi-seat district; two people sharing a seat number
     *both being retired in the same change* is the smell - it means the district
     number was matched instead of the departing person's name/identity.
+
+    One person legitimately holds the same seat across consecutive terms, which is
+    two ended roles for one seat in one file and not this bug at all, so each person
+    counts once per seat.
     """
-    by_seat: dict[tuple, list[tuple[str, Path]]] = defaultdict(list)
-    for path in files:
-        with path.open() as f:
-            record = yaml.safe_load(f) or {}
-        name = f"{record.get('given_name', '')} {record.get('family_name', '')}".strip()
+    by_seat: dict[tuple, dict[str, tuple[str, Path]]] = defaultdict(dict)
+    for path, record in records.items():
+        person = str(record.get("id") or path)
+        name = _person_name(record)
         for role in record.get("roles") or []:
             if role.get("end_date"):
                 key = (role.get("jurisdiction"), role.get("type"), role.get("district"))
-                by_seat[key].append((name, path))
-    return {seat: entries for seat, entries in by_seat.items() if len(entries) > 1}
+                by_seat[key][person] = (name, path)
+    return {
+        seat: sorted(people.values(), key=lambda entry: str(entry[1]))
+        for seat, people in by_seat.items()
+        if len(people) > 1
+    }
 
 
 def find_shared_end_dates(
-    files: list[Path],
+    records: dict[Path, dict],
 ) -> dict[str, list[tuple[str, Path]]]:
     """Group role end_dates by date, among only the given (changed) files.
 
@@ -194,17 +218,23 @@ def find_shared_end_dates(
     people retired in the same batch under one shared date - only shows up when
     comparing people who changed together, e.g. in one people-merge run that
     bundles several jurisdictions' bot branches.
+
+    Even within one change, a date already on file for both people is not a batch
+    date this change invented; --base-ref filters those out (see module docstring).
     """
-    by_date: dict[str, list[tuple[str, Path]]] = defaultdict(list)
-    for path in files:
-        with path.open() as f:
-            record = yaml.safe_load(f) or {}
-        name = f"{record.get('given_name', '')} {record.get('family_name', '')}".strip()
+    by_date: dict[str, dict[str, tuple[str, Path]]] = defaultdict(dict)
+    for path, record in records.items():
+        person = str(record.get("id") or path)
+        name = _person_name(record)
         for role in record.get("roles") or []:
             end = role.get("end_date")
             if end:
-                by_date[str(end)].append((name, path))
-    return {date: entries for date, entries in by_date.items() if len(entries) > 1}
+                by_date[str(end)][person] = (name, path)
+    return {
+        date: sorted(people.values(), key=lambda entry: str(entry[1]))
+        for date, people in by_date.items()
+        if len(people) > 1
+    }
 
 
 def _normalized(s: str) -> str:
@@ -298,7 +328,7 @@ def _given_name_token(name: str, family: str) -> str | None:
 
 
 def find_repurposed_identities(
-    files: list[Path],
+    records: dict[Path, dict],
 ) -> list[tuple[Path, str, str]]:
     """Flag other_names entries that look like a *different* person's name.
 
@@ -310,9 +340,7 @@ def find_repurposed_identities(
     different person's identity left behind in the file, not a legitimate alias.
     """
     flagged: list[tuple[Path, str, str]] = []
-    for path in files:
-        with path.open() as f:
-            record = yaml.safe_load(f) or {}
+    for path, record in records.items():
         given = (record.get("given_name") or "").strip()
         family = (record.get("family_name") or "").strip()
         if not given or not family:
@@ -334,55 +362,140 @@ def find_repurposed_identities(
     return flagged
 
 
-def print_changed_file_warnings(integrity_targets: list[Path]) -> None:
-    """Print the warning-level (non-blocking) checks that only make sense when
-    scoped to a batch of changed files - see find_shared_end_dates' docstring."""
-    shared = find_shared_end_dates(integrity_targets)
-    for date, entries in sorted(shared.items()):
+def load_record(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_records(paths: list[Path]) -> dict[Path, dict]:
+    return {path: load_record(path) for path in paths}
+
+
+def load_base_records(base_ref: str, paths: list[Path]) -> dict[Path, dict]:
+    """Load each path as it exists at base_ref, skipping files added by the change.
+
+    A file the change adds has no base revision, so every finding in it is new and
+    correctly reported. An unreadable base revision is treated the same way: the
+    check falls back to reporting the finding rather than silently dropping it.
+    """
+    git = shutil.which("git") or "git"
+    records: dict[Path, dict] = {}
+    for path in paths:
+        # Fixed argv, no shell: base_ref and path are a git ref and a repo path
+        # supplied by the caller (CI passes the event's base SHA), not free text.
+        result = subprocess.run(  # noqa: S603
+            [git, "show", f"{base_ref}:{path.as_posix()}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            continue
+        records[path] = yaml.safe_load(result.stdout) or {}
+    return records
+
+
+class Finding(NamedTuple):
+    """One reported problem, plus a key identifying it across revisions.
+
+    The key must not change when a file is only reformatted, so dates go into it
+    as strings: the bot rewrites `'2019-01-14'` as `2019-01-14`, which YAML loads
+    as a str in one revision and a datetime.date in the other.
+    """
+
+    key: tuple
+    message: str
+    blocking: bool
+
+
+def batch_findings(records: dict[Path, dict]) -> list[Finding]:
+    """The warning-level (non-blocking) checks that only make sense when scoped to a
+    batch of changed files - see find_shared_end_dates' docstring."""
+    findings: list[Finding] = []
+
+    for date, entries in sorted(find_shared_end_dates(records).items()):
         names = ", ".join(f"{name} ({path})" for name, path in entries)
-        print(
-            f"warning: {len(entries)} people have a role end_date of {date}: "
-            f"{names}\n"
-            "  Verify each person's effective date individually against their "
-            "own source - a shared date across unrelated people is often a "
-            "batch/announcement date rather than each person's real one."
+        findings.append(
+            Finding(
+                ("shared-end-date", date, tuple(str(path) for _, path in entries)),
+                f"warning: {len(entries)} people have a role end_date of {date}: "
+                f"{names}\n"
+                "  Verify each person's effective date individually against their "
+                "own source - a shared date across unrelated people is often a "
+                "batch/announcement date rather than each person's real one.",
+                False,
+            )
         )
 
-    same_seat = find_same_seat_retirements(integrity_targets)
+    same_seat = find_same_seat_retirements(records)
     for (jurisdiction, rtype, district), entries in sorted(
         same_seat.items(), key=lambda kv: str(kv[0])
     ):
         names = ", ".join(f"{name} ({path})" for name, path in entries)
-        print(
-            f"warning: {len(entries)} people retired for the same seat "
-            f"(jurisdiction={jurisdiction!r}, type={rtype!r}, "
-            f"district={district!r}): {names}\n"
-            "  A multi-seat district can legitimately have two incumbents, "
-            "but both being retired in the same change is a sign the "
-            "district number was matched instead of the departing "
-            "person's name - verify each one individually against a "
-            "source naming them specifically before retiring more than "
-            "one incumbent of the same seat at once."
+        findings.append(
+            Finding(
+                (
+                    "same-seat",
+                    str(jurisdiction),
+                    str(rtype),
+                    str(district),
+                    tuple(str(path) for _, path in entries),
+                ),
+                f"warning: {len(entries)} people retired for the same seat "
+                f"(jurisdiction={jurisdiction!r}, type={rtype!r}, "
+                f"district={district!r}): {names}\n"
+                "  A multi-seat district can legitimately have two incumbents, "
+                "but both being retired in the same change is a sign the "
+                "district number was matched instead of the departing "
+                "person's name - verify each one individually against a "
+                "source naming them specifically before retiring more than "
+                "one incumbent of the same seat at once.",
+                False,
+            )
         )
 
-    stale = find_stale_executive_persons(integrity_targets)
+    stale = find_stale_executive_persons(records)
     for name, path, last_end_date in sorted(stale, key=lambda s: str(s[1])):
-        print(
-            f"warning: {path} lists {name} under executive/ but their most "
-            f"recent role ended {last_end_date}, which is in the past - "
-            "consider moving this file to retired/ (see openstates/people#4045)."
+        findings.append(
+            Finding(
+                ("stale-executive", str(path)),
+                f"warning: {path} lists {name} under executive/ but their most "
+                f"recent role ended {last_end_date}, which is in the past - "
+                "consider moving this file to retired/ (see openstates/people#4045).",
+                False,
+            )
         )
 
-    repurposed = find_repurposed_identities(integrity_targets)
+    repurposed = find_repurposed_identities(records)
     for path, other_name, given in sorted(repurposed, key=lambda r: str(r[0])):
-        print(
-            f"warning: {path} lists other_name {other_name!r}, a different given "
-            f"name than this file's own {given!r} but sharing its family name - "
-            "possible repurposed identity (see openstates/issues#4040). Verify "
-            f"whether {other_name!r} is a distinct person (e.g. predecessor in "
-            "the same seat) who needs their own retired/ file with their own "
-            "service history, rather than an alias of the current occupant."
+        findings.append(
+            Finding(
+                ("repurposed-identity", str(path), other_name),
+                f"warning: {path} lists other_name {other_name!r}, a different given "
+                f"name than this file's own {given!r} but sharing its family name - "
+                "possible repurposed identity (see openstates/issues#4040). Verify "
+                f"whether {other_name!r} is a distinct person (e.g. predecessor in "
+                "the same seat) who needs their own retired/ file with their own "
+                "service history, rather than an alias of the current occupant.",
+                False,
+            )
         )
+
+    return findings
+
+
+def collect_findings(records: dict[Path, dict], batch: bool) -> list[Finding]:
+    """Every finding in one revision of the files, as comparable Finding keys."""
+    findings: list[Finding] = []
+    for path, record in sorted(records.items(), key=lambda kv: str(kv[0])):
+        problems = check_role_integrity(record) + check_missing_start_date(record)
+        findings.extend(
+            Finding(("role", str(path), problem), f"{path}: {problem}", True)
+            for problem in problems
+        )
+    if batch:
+        findings.extend(batch_findings(records))
+    return findings
 
 
 def main() -> int:
@@ -400,9 +513,18 @@ def main() -> int:
         nargs="*",
         help="limit the integrity check to these changed person files",
     )
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "git ref the change is based on. Findings that already exist at this "
+            "ref are reported as a pre-existing count instead of blocking, so a "
+            "change is only asked to answer for what it introduced."
+        ),
+    )
     args = parser.parse_args()
 
-    if args.changed_files is not None:
+    scoped = args.changed_files is not None
+    if scoped:
         integrity_targets = [
             Path(f)
             for f in args.changed_files
@@ -414,26 +536,32 @@ def main() -> int:
     else:
         integrity_targets = person_files(args.data_dir)
 
-    found_problems = False
+    # Batch checks are scoped to changed files only - see find_shared_end_dates'
+    # docstring for why comparing against the whole repo is the wrong check (a seat
+    # like a US House district has had many genuinely-unrelated retirees over the
+    # decades; only a single batch of changed files makes a shared date/seat
+    # meaningful).
+    findings = collect_findings(load_records(integrity_targets), batch=scoped)
 
-    for path in integrity_targets:
-        with path.open() as f:
-            record = yaml.safe_load(f) or {}
-        for problem in check_role_integrity(record):
-            found_problems = True
-            print(f"{path}: {problem}")
-        for problem in check_missing_start_date(record):
-            found_problems = True
-            print(f"{path}: {problem}")
+    preexisting = 0
+    if args.base_ref:
+        base_records = load_base_records(args.base_ref, integrity_targets)
+        base_keys = {f.key for f in collect_findings(base_records, batch=scoped)}
+        new_findings = [f for f in findings if f.key not in base_keys]
+        preexisting = len(findings) - len(new_findings)
+        findings = new_findings
 
-    # Scoped to changed files only - see find_shared_end_dates' docstring for why
-    # comparing against the whole repo is the wrong check (a seat like a US House
-    # district has had many genuinely-unrelated retirees over the decades; only a
-    # single batch of changed files makes a shared date/seat meaningful).
-    if args.changed_files is not None and integrity_targets:
-        print_changed_file_warnings(integrity_targets)
+    for finding in findings:
+        print(finding.message)
 
-    if found_problems:
+    if preexisting:
+        print(
+            f"note: {preexisting} role-date finding(s) in these files already exist "
+            f"at {args.base_ref} and are not this change's to fix. Re-run without "
+            "--base-ref to list them."
+        )
+
+    if any(finding.blocking for finding in findings):
         print(
             "\nRole date integrity problems found (duplicate/dangling role entries).",
             file=sys.stderr,

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -76,22 +76,16 @@ jobs:
             uv run os-people lint "${abbrs[@]}"
           fi
         fi
-    - name: check duplicate people selectively
+    - name: resolve base revision
+      id: base
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-      run: |
-        uv run python .github/scripts/check_duplicate_people.py --changed-files ${ALL_CHANGED_FILES}
-    - name: check role date integrity selectively
-      env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
       run: |
-        # Report only what this change introduced. Every finding describes a bot
-        # mistake being made, so a long-standing one in a file the change merely
-        # reformats is not this author's to fix - see check_role_dates.py's
-        # module docstring. Without a usable base the check reports everything,
-        # which is noisy but never misses a real problem.
-        base_args=()
+        # The two checks below report only what this change introduced. Both
+        # describe a bot mistake being made, so a long-standing one in a file
+        # the change merely reformats is not this author's to fix - see
+        # check_role_dates.py's module docstring. Without a usable base they
+        # report everything, which is noisy but never misses a real problem.
         empty_sha=0000000000000000000000000000000000000000
         if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "${empty_sha}" ]]; then
           # actions/checkout clones at depth 1, so the base commit is usually
@@ -100,13 +94,26 @@ jobs:
             || git fetch --no-tags --depth=1 origin "${BASE_SHA}" \
             || true
           if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            base_args=(--base-ref "${BASE_SHA}")
-          else
-            echo "base ${BASE_SHA} unavailable: reporting all findings"
+            echo "base-args=--base-ref ${BASE_SHA}" >> "${GITHUB_OUTPUT}"
+            exit 0
           fi
+          echo "base ${BASE_SHA} unavailable: reporting all findings"
         fi
+        echo "base-args=" >> "${GITHUB_OUTPUT}"
+    - name: check duplicate people selectively
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        BASE_ARGS: ${{ steps.base.outputs.base-args }}
+      run: |
+        uv run python .github/scripts/check_duplicate_people.py \
+          --changed-files ${ALL_CHANGED_FILES} ${BASE_ARGS}
+    - name: check role date integrity selectively
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        BASE_ARGS: ${{ steps.base.outputs.base-args }}
+      run: |
         uv run python .github/scripts/check_role_dates.py \
-          --changed-files ${ALL_CHANGED_FILES} "${base_args[@]}"
+          --changed-files ${ALL_CHANGED_FILES} ${BASE_ARGS}
     - name: lint committees selectively
       env:
         OS_PEOPLE_DIRECTORY: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -84,8 +84,29 @@ jobs:
     - name: check role date integrity selectively
       env:
         ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
       run: |
-        uv run python .github/scripts/check_role_dates.py --changed-files ${ALL_CHANGED_FILES}
+        # Report only what this change introduced. Every finding describes a bot
+        # mistake being made, so a long-standing one in a file the change merely
+        # reformats is not this author's to fix - see check_role_dates.py's
+        # module docstring. Without a usable base the check reports everything,
+        # which is noisy but never misses a real problem.
+        base_args=()
+        empty_sha=0000000000000000000000000000000000000000
+        if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "${empty_sha}" ]]; then
+          # actions/checkout clones at depth 1, so the base commit is usually
+          # absent locally; fetch just that one commit.
+          git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null \
+            || git fetch --no-tags --depth=1 origin "${BASE_SHA}" \
+            || true
+          if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            base_args=(--base-ref "${BASE_SHA}")
+          else
+            echo "base ${BASE_SHA} unavailable: reporting all findings"
+          fi
+        fi
+        uv run python .github/scripts/check_role_dates.py \
+          --changed-files ${ALL_CHANGED_FILES} "${base_args[@]}"
     - name: lint committees selectively
       env:
         OS_PEOPLE_DIRECTORY: ${{ env.GITHUB_WORKSPACE }}


### PR DESCRIPTION
## Problem

`check_role_dates.py` loads each changed file whole, so a PR that merely reformats a file inherits every long-standing problem in it.

[#4053](https://github.com/openstates/people/pull/4053) (an automated AZ legislator update) changed **no role data at all** — the bot rewrote `'2019-01-14'` as `2019-01-14` and re-sorted `links:` — yet the check failed it on seven pre-existing dangling roles and printed a dozen warnings about Arizona's statutory term-end dates. A repo-wide run of the check reports 8679 findings, so almost any touched file carries some. The result is that the bot's PRs block on data the author never touched.

## Change

Every check in this script describes *a bot mistake being introduced*, so it now reports only findings the change introduced. Given `--base-ref`, the same analysis runs twice — once over the base revision of the changed files, once over the working tree — and only findings absent from the base are reported. Pre-existing findings collapse into a single non-blocking note. Finding keys hold dates as strings so the quoted-to-bare rewrite doesn't read as a new finding.

Two batch warnings also counted the same person more than once. One person holding a seat across consecutive terms was reported as `2 people retired for the same seat: T.J. Shope, T.J. Shope`. Each person now counts once per seat and once per end_date.

The workflow passes the event's base SHA, fetching that one commit since `actions/checkout` is shallow. If the base is unavailable the check falls back to today's behavior of reporting everything.

## Verification

Against #4053's head, based on its own base commit:

```
$ check_role_dates.py --changed-files <12 az files> --base-ref 4d36c33
note: 14 role-date finding(s) in these files already exist at 4d36c33 and are not
this change's to fix. Re-run without --base-ref to list them.
EXIT=0
```

Injecting a genuinely new dangling role and a fabricated shared retirement date into that same branch still fails the check, reporting exactly those two findings and nothing else.