### PR TITLE
lint: follow renames when reading a file's base revision

### DIFF
--- a/.github/scripts/_git_base.py
+++ b/.github/scripts/_git_base.py
@@ -1,0 +1,81 @@
+"""Read a file as it existed at a base revision, following renames.
+
+Shared by check_role_dates.py and check_duplicate_people.py, which both report
+only findings a change introduced and so need each changed file's base revision.
+
+Resolving that by path alone is wrong for this repository: retiring a legislator
+moves their file from `legislature/` to `retired/`, so `git show <base>:<new
+path>` finds nothing, the file looks brand new, and every long-standing problem
+in it is blamed on the change that merely moved it. NH's PR #4074 hit exactly
+that - a moved file's decade-old malformed roles were reported as newly
+introduced. So a path missing at the base is looked up again under its rename
+source before being treated as new.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from functools import cache
+from pathlib import Path
+
+_RENAME_SIMILARITY = "50"
+
+
+def _git() -> str:
+    return shutil.which("git") or "git"
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    # Fixed argv, no shell: every argument is a git ref or repo path supplied by
+    # the caller (CI passes the event's base SHA), not free text.
+    return subprocess.run(  # noqa: S603
+        [_git(), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@cache
+def rename_sources(base_ref: str) -> dict[str, str]:
+    """Map each renamed file's current path to the path it had at base_ref."""
+    result = _run(
+        [
+            "diff",
+            f"--find-renames={_RENAME_SIMILARITY}%",
+            "--diff-filter=R",
+            "--name-status",
+            "-z",
+            base_ref,
+        ]
+    )
+    if result.returncode != 0:
+        return {}
+    # -z output is NUL-separated: status, old path, new path, status, ...
+    fields = result.stdout.split("\0")
+    renames: dict[str, str] = {}
+    index = 0
+    while index + 2 < len(fields):
+        status, old, new = fields[index], fields[index + 1], fields[index + 2]
+        if not status.startswith("R"):
+            break
+        renames[new] = old
+        index += 3
+    return renames
+
+
+def read_at_base(base_ref: str, path: Path) -> str | None:
+    """Return path's contents at base_ref, or None if it did not exist there.
+
+    A file the change renamed is read from its pre-rename path, so moving a
+    person into `retired/` does not make their whole history look new.
+    """
+    posix = path.as_posix()
+    for candidate in (posix, rename_sources(base_ref).get(posix)):
+        if candidate is None:
+            continue
+        result = _run(["show", f"{base_ref}:{candidate}"])
+        if result.returncode == 0:
+            return result.stdout
+    return None

--- a/.github/scripts/check_duplicate_people.py
+++ b/.github/scripts/check_duplicate_people.py
@@ -11,13 +11,12 @@ for the same reasoning applied to role dates.
 from __future__ import annotations
 
 import argparse
-import shutil
-import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 
 import yaml
+from _git_base import read_at_base
 
 _PERSON_DIRS = ("executive", "legislature", "municipalities", "retired")
 
@@ -81,22 +80,16 @@ def check_state(data_dir: Path, state: str) -> dict[tuple[str, str], list[Path]]
 def name_at_base(base_ref: str, path: Path) -> tuple[str, str] | None:
     """Return (given_name, family_name) for path at base_ref, or None if absent.
 
-    None also covers an unreadable or unparseable base revision: the group is
-    then treated as new and reported, rather than silently dropped.
+    Renames are followed, so a person moved from `legislature/` to `retired/` is
+    still recognised as the same pre-existing record. None also covers an
+    unparseable base revision: the group is then treated as new and reported,
+    rather than silently dropped.
     """
-    git = shutil.which("git") or "git"
-    # Fixed argv, no shell: base_ref and path are a git ref and a repo path
-    # supplied by the caller (CI passes the event's base SHA), not free text.
-    result = subprocess.run(  # noqa: S603
-        [git, "show", f"{base_ref}:{path.as_posix()}"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
+    content = read_at_base(base_ref, path)
+    if content is None:
         return None
     try:
-        record = yaml.safe_load(result.stdout) or {}
+        record = yaml.safe_load(content) or {}
     except yaml.YAMLError:
         return None
     return normalize(record.get("given_name")), normalize(record.get("family_name"))

--- a/.github/scripts/check_role_dates.py
+++ b/.github/scripts/check_role_dates.py
@@ -70,14 +70,13 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import shutil
-import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import NamedTuple
 
 import yaml
+from _git_base import read_at_base
 
 _PERSON_DIRS = ("executive", "legislature", "municipalities", "retired")
 
@@ -383,21 +382,15 @@ def load_base_records(base_ref: str, paths: list[Path]) -> dict[Path, dict]:
     A file the change adds has no base revision, so every finding in it is new and
     correctly reported. An unreadable base revision is treated the same way: the
     check falls back to reporting the finding rather than silently dropping it.
+    Renames are followed, so retiring a person - which moves their file from
+    `legislature/` to `retired/` - does not make their whole history look new.
     """
-    git = shutil.which("git") or "git"
     records: dict[Path, dict] = {}
     for path in paths:
-        # Fixed argv, no shell: base_ref and path are a git ref and a repo path
-        # supplied by the caller (CI passes the event's base SHA), not free text.
-        result = subprocess.run(  # noqa: S603
-            [git, "show", f"{base_ref}:{path.as_posix()}"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
+        content = read_at_base(base_ref, path)
+        if content is None:
             continue
-        records[path] = yaml.safe_load(result.stdout) or {}
+        records[path] = yaml.safe_load(content) or {}
     return records
 
 


### PR DESCRIPTION
## Problem

[#4090](https://github.com/openstates/people/pull/4090) made both data checks report only findings a change introduced, by reading each changed file at the base revision. That lookup was by path, and a path is not stable here: retiring a legislator moves their file from `legislature/` to `retired/`. `git show <base>:<new path>` then finds nothing, the file looks brand new, and every long-standing problem in it is blamed on the change that merely moved it.

[#4074](https://github.com/openstates/people/pull/4074) hit this. That branch moved Michael Vose into `retired/`, and the role-date check reported his decade-old malformed roles as newly introduced: an `end_date` before its own `start_date`, duplicate Rockingham 5 entries, duplicate Rockingham 9 entries with no `start_date`. All four are present unchanged at the base. Missouri's [#4072](https://github.com/openstates/people/pull/4072) hit the same artifact on Ian Mackey's dangling district 87 role.

Retirement moves are the single most common thing these automated branches do, so this affects most of them.

## Change

A path missing at the base is now looked up again under its rename source, found via git's own rename detection (`git diff --find-renames --diff-filter=R`). Reading the base revision moved into `_git_base.py`, shared by both checks, since both need identical behavior.

## Verification

On #4074's head, the renamed Vose file on its own:

```
before: 4 errors reported, exit 1
after:  note: 5 role-date finding(s) ... already exist at upstream/main, exit 0
```

The genuinely new duplicate Gary Daniels file that branch adds is still reported, so the check has not simply gone quiet.